### PR TITLE
Add local control browser and terminal tools

### DIFF
--- a/bin/zero.js
+++ b/bin/zero.js
@@ -63,6 +63,8 @@ if (!existsSync(nativePath)) {
 const env = { ...process.env };
 if (localControlHelpers) {
   env.ZERO_LOCAL_CONTROL_HELPERS = localControlHelpers;
+} else {
+  delete env.ZERO_LOCAL_CONTROL_HELPERS;
 }
 
 const child = spawnSync(nativePath, process.argv.slice(2), {

--- a/bin/zero.js
+++ b/bin/zero.js
@@ -9,8 +9,49 @@ function zeroBinaryName(platform = process.platform) {
   return platform === 'win32' ? 'zero.exe' : 'zero';
 }
 
+function helperShimNames(name, platform = process.platform) {
+  if (platform === 'win32') {
+    return [`${name}.cmd`, `${name}.exe`, name];
+  }
+  return [name];
+}
+
+function commandForShim(path, platform = process.platform) {
+  if (platform === 'win32' && path.toLowerCase().endsWith('.cmd')) {
+    return {
+      command: process.env.ComSpec || 'cmd.exe',
+      prefixArgs: ['/d', '/s', '/c', `"${path.replace(/"/g, '""')}"`],
+    };
+  }
+  return { command: path, prefixArgs: [] };
+}
+
+function resolveHelper(packageRoot, name) {
+  const binDir = join(packageRoot, 'node_modules', '.bin');
+  for (const shimName of helperShimNames(name)) {
+    const candidate = join(binDir, shimName);
+    if (!existsSync(candidate)) continue;
+    return {
+      ...commandForShim(candidate),
+      pathPrepend: [binDir],
+    };
+  }
+  return null;
+}
+
+function localControlHelperManifest(packageRoot) {
+  const helpers = {};
+  for (const name of ['agent-browser', 'tuistory']) {
+    const helper = resolveHelper(packageRoot, name);
+    if (helper) helpers[name] = helper;
+  }
+  if (Object.keys(helpers).length === 0) return '';
+  return JSON.stringify({ version: 1, helpers });
+}
+
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const nativePath = join(packageRoot, zeroBinaryName());
+const localControlHelpers = localControlHelperManifest(packageRoot);
 
 if (!existsSync(nativePath)) {
   console.error(
@@ -19,8 +60,14 @@ if (!existsSync(nativePath)) {
   process.exit(1);
 }
 
+const env = { ...process.env };
+if (localControlHelpers) {
+  env.ZERO_LOCAL_CONTROL_HELPERS = localControlHelpers;
+}
+
 const child = spawnSync(nativePath, process.argv.slice(2), {
   stdio: 'inherit',
+  env,
 });
 
 if (child.error) {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2147,6 +2147,8 @@ func permissionSupportsPersistentDecision(toolName string) bool {
 	switch toolName {
 	case "bash", "exec_command", "write_stdin", "apply_patch":
 		return false
+	case "browser_install", "browser_launch", "browser_connect", "browser_open", "browser_snapshot", "browser_click", "browser_type", "browser_press", "browser_action", "desktop_windows", "desktop_snapshot", "desktop_action", "terminal_session", "capture_artifact":
+		return false
 	default:
 		return true
 	}

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -56,7 +56,9 @@ func runACP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int
 			if err != nil {
 				return nil, nil, err
 			}
-			return newCoreRegistryScoped(workspaceRoot, scope), engine, nil
+			registry := newCoreRegistryScoped(workspaceRoot, scope)
+			registerLocalControlTools(registry, workspaceRoot, resolved.LocalControl)
+			return registry, engine, nil
 		},
 		ResolveWorkspaceRoot: acpWorkspaceRootResolver(deps),
 		Store:                deps.newSessionStore(),

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/localcontrol"
 	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/observability"
 	"github.com/Gitlawb/zero/internal/plugins"
@@ -553,6 +554,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	}
 
 	registry := newCoreRegistryScoped(workspaceRoot, scope)
+	registerLocalControlTools(registry, workspaceRoot, resolved.LocalControl)
 	specialistRuntime, err := registerSpecialistTools(registry, workspaceRoot, resolved.Swarm.MaxTeamSize)
 	if err != nil {
 		return writeAppError(stderr, "failed to initialize specialist tools: "+err.Error(), 1)
@@ -724,7 +726,69 @@ func newCoreRegistryScoped(workspaceRoot string, scope tools.PathScope) *tools.R
 	for _, tool := range tools.CoreToolsScoped(workspaceRoot, scope) {
 		registry.Register(tool)
 	}
+	registerLocalControlTools(registry, workspaceRoot, config.LocalControlConfig{})
 	return registry
+}
+
+func registerLocalControlTools(registry *tools.Registry, workspaceRoot string, cfg config.LocalControlConfig) {
+	if registry == nil {
+		return
+	}
+	browserOptions := localBrowserOptionsFromConfig(cfg)
+	desktopOptions := localDesktopOptionsFromConfig(cfg)
+	terminalOptions := localTerminalOptionsFromConfig(cfg)
+	for _, tool := range tools.NewLocalBrowserTools(browserOptions) {
+		registry.Register(tool)
+	}
+	for _, tool := range tools.NewLocalDesktopTools(desktopOptions) {
+		registry.Register(tool)
+	}
+	for _, tool := range tools.NewLocalTerminalTools(terminalOptions) {
+		registry.Register(tool)
+	}
+	for _, tool := range tools.NewLocalControlArtifactTools(tools.LocalControlArtifactOptions{
+		Browser:      browserOptions,
+		Desktop:      desktopOptions,
+		Terminal:     terminalOptions,
+		ArtifactsDir: localArtifactsDirFromConfig(workspaceRoot, cfg),
+	}) {
+		registry.Register(tool)
+	}
+}
+
+func localBrowserOptionsFromConfig(cfg config.LocalControlConfig) localcontrol.BrowserOptions {
+	return localcontrol.BrowserOptions{
+		Enabled:    cfg.BrowserEnabled(),
+		Driver:     cfg.Browser.Driver,
+		HelperPath: cfg.Browser.HelperPath,
+	}
+}
+
+func localDesktopOptionsFromConfig(cfg config.LocalControlConfig) localcontrol.DesktopOptions {
+	return localcontrol.DesktopOptions{
+		Enabled:    cfg.DesktopEnabled(),
+		Driver:     cfg.Desktop.Driver,
+		HelperPath: cfg.Desktop.HelperPath,
+	}
+}
+
+func localTerminalOptionsFromConfig(cfg config.LocalControlConfig) localcontrol.TerminalOptions {
+	return localcontrol.TerminalOptions{
+		Enabled:    cfg.TerminalEnabled(),
+		Driver:     cfg.Terminal.Driver,
+		HelperPath: cfg.Terminal.HelperPath,
+	}
+}
+
+func localArtifactsDirFromConfig(workspaceRoot string, cfg config.LocalControlConfig) string {
+	dir := strings.TrimSpace(cfg.ArtifactsDir)
+	if dir == "" {
+		dir = filepath.Join(".zero", "artifacts")
+	}
+	if filepath.IsAbs(dir) {
+		return dir
+	}
+	return filepath.Join(workspaceRoot, dir)
 }
 
 // agentToolRuntime bundles the specialist runtime with the swarm it backs so

--- a/internal/cli/deferred_wiring_test.go
+++ b/internal/cli/deferred_wiring_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -128,8 +127,8 @@ func TestValidateExecToolFiltersAllowsToolSearch(t *testing.T) {
 // TestRunExecListToolsAdvertisesMCPToolsWithoutToolSearch verifies that
 // `exec --list-tools` lists the core + MCP tools WITHOUT tool_search. This is
 // independent of the deferral threshold: --list-tools short-circuits and returns
-// before resolveConfig and registerToolSearchIfEligible ever run (see exec.go),
-// so tool_search is never registered on this path. The threshold gate itself is
+// before registerToolSearchIfEligible runs (see exec.go), so tool_search is
+// never registered on this path. The threshold gate itself is
 // exercised by TestRegisterToolSearchIfEligible{RegistersAtThreshold,
 // SkipsBelowThreshold,SkipsWhenThresholdZero} and the end-to-end at-threshold
 // path in TestTUIRunThreadsDeferThresholdAndRegistersToolSearch.
@@ -141,7 +140,7 @@ func TestRunExecListToolsAdvertisesMCPToolsWithoutToolSearch(t *testing.T) {
 	exitCode := runWithDeps([]string{"exec", "--list-tools"}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) { return cwd, nil },
 		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
-			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+			return execResolvedConfig(), nil
 		},
 		resolveMCPConfig: func(string) (config.MCPConfig, error) {
 			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
@@ -176,7 +175,7 @@ func TestRunExecListToolsHonorsJSONFormat(t *testing.T) {
 	exitCode := runWithDeps([]string{"exec", "--list-tools", "-o", "json"}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) { return cwd, nil },
 		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
-			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+			return execResolvedConfig(), nil
 		},
 		resolveMCPConfig: func(string) (config.MCPConfig, error) { return config.MCPConfig{}, nil },
 		newMCPStore:      func() (*mcp.PermissionStore, error) { return nil, nil },

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -200,6 +200,44 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if options.useSpec {
 		specmode.RegisterDraftTools(registry, workspaceRoot, deps.now)
 	}
+	// Build the model registry once and reuse it across every model-aware
+	// lookup in this exec run (model resolution, reasoning-effort advisory, and
+	// context-window sizing). DefaultRegistry builds the full catalog and
+	// compiles its match patterns, so rebuilding it per lookup is wasteful.
+	// modelRegistry is the zero Registry when the catalog fails to build; the
+	// helpers below degrade to safe no-op behavior in that case.
+	modelRegistry, _ := modelregistry.DefaultRegistry()
+
+	overrides := config.Overrides{}
+	modelOverride := options.model
+	if options.useSpec && options.specModel != "" {
+		modelOverride = options.specModel
+	}
+	if modelOverride != "" {
+		resolvedModel, notice := resolveSelectedModel(modelRegistry, modelOverride)
+		overrides.Provider.Model = resolvedModel
+		if notice != "" {
+			if _, err := fmt.Fprintln(stderr, notice); err != nil {
+				return exitCrash
+			}
+		}
+	}
+	if options.maxTurns > 0 {
+		overrides.MaxTurns = options.maxTurns
+	}
+	resolved, err := deps.resolveConfig(workspaceRoot, overrides)
+	if err != nil {
+		if !options.listTools {
+			if preflightErr := preflightExecSession(options); preflightErr != nil {
+				return writeExecFormatUsageError(stdout, stderr, options.outputFormat, preflightErr.Error())
+			}
+			if _, _, promptErr := resolveExecPrompt(options, workspaceRoot, deps.stdin); promptErr != nil {
+				return writeExecFormatUsageError(stdout, stderr, options.outputFormat, promptErr.Error())
+			}
+		}
+		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
+	}
+	registerLocalControlTools(registry, workspaceRoot, resolved.LocalControl)
 	if err := validateExecToolFilters(options, registry); err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
@@ -228,35 +266,6 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 	sessionTitle := execSessionTitle(options, prompt)
 
-	// Build the model registry once and reuse it across every model-aware
-	// lookup in this exec run (model resolution, reasoning-effort advisory, and
-	// context-window sizing). DefaultRegistry builds the full catalog and
-	// compiles its match patterns, so rebuilding it per lookup is wasteful.
-	// modelRegistry is the zero Registry when the catalog fails to build; the
-	// helpers below degrade to safe no-op behavior in that case.
-	modelRegistry, _ := modelregistry.DefaultRegistry()
-
-	overrides := config.Overrides{}
-	modelOverride := options.model
-	if options.useSpec && options.specModel != "" {
-		modelOverride = options.specModel
-	}
-	if modelOverride != "" {
-		resolvedModel, notice := resolveSelectedModel(modelRegistry, modelOverride)
-		overrides.Provider.Model = resolvedModel
-		if notice != "" {
-			if _, err := fmt.Fprintln(stderr, notice); err != nil {
-				return exitCrash
-			}
-		}
-	}
-	if options.maxTurns > 0 {
-		overrides.MaxTurns = options.maxTurns
-	}
-	resolved, err := deps.resolveConfig(workspaceRoot, overrides)
-	if err != nil {
-		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
-	}
 	if !config.HasProviderProfile(resolved.Provider) {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", "No provider configured. Run `zero setup` (guided), `zero auth` (OAuth providers), set a provider API key env var (e.g. OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY), or add .zero/config.json.")
 	}
@@ -313,7 +322,6 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	for _, tool := range tools.CoreToolsScoped(workspaceRoot, execScope) {
 		registry.Register(tool)
 	}
-	registerLocalControlTools(registry, workspaceRoot, resolved.LocalControl)
 	sandboxEngine, err := buildExecSandboxEngine(workspaceRoot, resolved, deps, execScope)
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "sandbox_error", err.Error())

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -313,6 +313,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	for _, tool := range tools.CoreToolsScoped(workspaceRoot, execScope) {
 		registry.Register(tool)
 	}
+	registerLocalControlTools(registry, workspaceRoot, resolved.LocalControl)
 	sandboxEngine, err := buildExecSandboxEngine(workspaceRoot, resolved, deps, execScope)
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "sandbox_error", err.Error())

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -51,13 +51,18 @@ func TestRunExecListsFilteredToolsWithoutPromptOrProvider(t *testing.T) {
 	cwd := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	providerBuilt := false
 
 	exitCode := runWithDeps([]string{"exec", "--list-tools", "--enabled-tools", "read_file,grep"}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) {
 			return cwd, nil
 		},
 		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
-			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			providerBuilt = true
+			return nil, errors.New("provider should not be constructed for --list-tools")
 		},
 	})
 
@@ -66,6 +71,9 @@ func TestRunExecListsFilteredToolsWithoutPromptOrProvider(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	if providerBuilt {
+		t.Fatal("provider should not be constructed for --list-tools")
 	}
 	for _, want := range []string{"Tools visible to model", "read_file", "grep"} {
 		if !strings.Contains(stdout.String(), want) {
@@ -81,13 +89,18 @@ func TestRunExecListsToolsAsStreamJSONWhenRequested(t *testing.T) {
 	cwd := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	providerBuilt := false
 
 	exitCode := runWithDeps([]string{"exec", "--list-tools", "--output-format", "stream-json", "--enabled-tools", "read_file"}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) {
 			return cwd, nil
 		},
 		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
-			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			providerBuilt = true
+			return nil, errors.New("provider should not be constructed for --list-tools")
 		},
 	})
 
@@ -96,6 +109,9 @@ func TestRunExecListsToolsAsStreamJSONWhenRequested(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	if providerBuilt {
+		t.Fatal("provider should not be constructed for --list-tools")
 	}
 	events := decodeJSONLines(t, stdout.String())
 	if len(events) != 3 {
@@ -115,11 +131,11 @@ func TestRunExecListsToolsAsStreamJSONWhenRequested(t *testing.T) {
 	}
 }
 
-func TestRunExecListsMCPToolsWithoutProviderResolution(t *testing.T) {
+func TestRunExecListsMCPToolsWithoutProviderConstruction(t *testing.T) {
 	cwd := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	providerResolved := false
+	providerBuilt := false
 	closed := false
 
 	exitCode := runWithDeps([]string{"exec", "--list-tools", "--enabled-tools", "mcp_docs_lookup"}, &stdout, &stderr, appDeps{
@@ -127,8 +143,11 @@ func TestRunExecListsMCPToolsWithoutProviderResolution(t *testing.T) {
 			return cwd, nil
 		},
 		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
-			providerResolved = true
-			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			providerBuilt = true
+			return nil, errors.New("provider should not be constructed for --list-tools")
 		},
 		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
 			if workspaceRoot != cwd {
@@ -150,8 +169,8 @@ func TestRunExecListsMCPToolsWithoutProviderResolution(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
-	if providerResolved {
-		t.Fatal("provider config should not be resolved for --list-tools")
+	if providerBuilt {
+		t.Fatal("provider should not be constructed for --list-tools")
 	}
 	if !closed {
 		t.Fatal("MCP runtime was not closed after --list-tools")

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -465,7 +465,7 @@ func TestRunExecModeModelSurfacesDeprecationNoticeViaSharedPath(t *testing.T) {
 func TestRunExecListToolsAppliesModeBeforeListing(t *testing.T) {
 	// applyExecMode now runs before tool-filter validation and the --list-tools
 	// branch, so a --mode preset is expanded for --list-tools. Combining a mode
-	// with --list-tools must still succeed and never resolve a provider.
+	// with --list-tools must still succeed without constructing a provider.
 	cwd := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -475,7 +475,7 @@ func TestRunExecListToolsAppliesModeBeforeListing(t *testing.T) {
 			return cwd, nil
 		},
 		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
-			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+			return execResolvedConfig(), nil
 		},
 	})
 

--- a/internal/cli/local_control_test.go
+++ b/internal/cli/local_control_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/config"
@@ -42,6 +44,46 @@ func TestCoreRegistryHonorsExplicitLocalControlDisable(t *testing.T) {
 		}
 		if tool.Safety().Permission != tools.PermissionDeny {
 			t.Fatalf("%s permission = %s, want deny", name, tool.Safety().Permission)
+		}
+	}
+}
+
+func TestRunExecListToolsHonorsDisabledLocalControlConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cfg := execResolvedConfig()
+	var localControl config.LocalControlConfig
+	if err := json.Unmarshal([]byte(`{"enabled":false}`), &localControl); err != nil {
+		t.Fatalf("unmarshal local control config: %v", err)
+	}
+	cfg.LocalControl = localControl
+
+	exitCode := runWithDeps([]string{"exec", "--list-tools", "-o", "json"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return cfg, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var payload struct {
+		Tools []struct {
+			Name       string `json:"name"`
+			Permission string `json:"permission"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout.String())), &payload); err != nil {
+		t.Fatalf("parse tools JSON: %v\n%s", err, stdout.String())
+	}
+	for _, tool := range payload.Tools {
+		if tool.Name == "browser_open" {
+			t.Fatalf("browser_open should be hidden when local control is disabled, got permission %s", tool.Permission)
 		}
 	}
 }

--- a/internal/cli/local_control_test.go
+++ b/internal/cli/local_control_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestCoreRegistryIncludesDefaultLocalControlTools(t *testing.T) {
+	registry := newCoreRegistry(t.TempDir())
+	for _, name := range []string{"browser_install", "browser_launch", "browser_connect", "browser_open", "browser_snapshot", "browser_click", "browser_type", "browser_press", "terminal_session", "capture_artifact"} {
+		tool, ok := registry.Get(name)
+		if !ok {
+			t.Fatalf("%s not registered", name)
+		}
+		if tool.Safety().Permission != tools.PermissionPrompt {
+			t.Fatalf("%s permission = %s, want prompt", name, tool.Safety().Permission)
+		}
+	}
+	desktop, ok := registry.Get("desktop_action")
+	if !ok {
+		t.Fatal("desktop_action not registered")
+	}
+	if desktop.Safety().Permission != tools.PermissionDeny {
+		t.Fatalf("desktop_action permission = %s, want deny", desktop.Safety().Permission)
+	}
+}
+
+func TestCoreRegistryHonorsExplicitLocalControlDisable(t *testing.T) {
+	registry := newCoreRegistry(t.TempDir())
+	var cfg config.LocalControlConfig
+	if err := json.Unmarshal([]byte(`{"enabled":false}`), &cfg); err != nil {
+		t.Fatalf("unmarshal local control config: %v", err)
+	}
+	registerLocalControlTools(registry, t.TempDir(), cfg)
+	for _, name := range []string{"browser_install", "browser_launch", "browser_connect", "browser_open", "browser_snapshot", "browser_click", "browser_type", "browser_press", "desktop_action", "terminal_session", "capture_artifact"} {
+		tool, ok := registry.Get(name)
+		if !ok {
+			t.Fatalf("%s not registered", name)
+		}
+		if tool.Safety().Permission != tools.PermissionDeny {
+			t.Fatalf("%s permission = %s, want deny", name, tool.Safety().Permission)
+		}
+	}
+}
+
+func TestRegisterLocalControlToolsAppliesDefaults(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	registry := newCoreRegistry(workspaceRoot)
+	registerLocalControlTools(registry, workspaceRoot, config.LocalControlConfig{Enabled: true})
+	for _, name := range []string{"browser_install", "browser_launch", "browser_connect", "browser_open", "browser_snapshot", "browser_click", "browser_type", "browser_press", "terminal_session", "capture_artifact"} {
+		tool, ok := registry.Get(name)
+		if !ok {
+			t.Fatalf("%s not registered", name)
+		}
+		if tool.Safety().Permission != tools.PermissionPrompt {
+			t.Fatalf("%s permission = %s, want prompt", name, tool.Safety().Permission)
+		}
+	}
+	desktop, ok := registry.Get("desktop_action")
+	if !ok {
+		t.Fatal("desktop_action not registered")
+	}
+	if desktop.Safety().Permission != tools.PermissionDeny {
+		t.Fatalf("desktop_action permission = %s, want deny without nested desktop opt-in", desktop.Safety().Permission)
+	}
+}

--- a/internal/config/local_control_test.go
+++ b/internal/config/local_control_test.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveLocalControlFromUserConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{
+		"localControl": {
+			"enabled": true,
+			"browser": {"driver": "agent-browser"},
+			"desktop": {"enabled": true},
+			"terminal": {"enabled": false}
+		}
+	}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if !resolved.LocalControl.Enabled {
+		t.Fatal("localControl.enabled = false, want true")
+	}
+	if !resolved.LocalControl.BrowserEnabled() {
+		t.Fatal("BrowserEnabled = false, want true by default under localControl.enabled")
+	}
+	if !resolved.LocalControl.DesktopEnabled() {
+		t.Fatal("DesktopEnabled = false, want explicit true")
+	}
+	if resolved.LocalControl.TerminalEnabled() {
+		t.Fatal("TerminalEnabled = true, want explicit false")
+	}
+	if resolved.LocalControl.Browser.Driver != "agent-browser" {
+		t.Fatalf("browser driver = %q, want agent-browser", resolved.LocalControl.Browser.Driver)
+	}
+}
+
+func TestResolveLocalControlIgnoresProjectOptIn(t *testing.T) {
+	projectPath := filepath.Join(t.TempDir(), "project.json")
+	if err := os.WriteFile(projectPath, []byte(`{"localControl":{"enabled":true,"desktop":{"enabled":true}}}`), 0o600); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: projectPath})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if resolved.LocalControl.Enabled || resolved.LocalControl.DesktopEnabled() {
+		t.Fatalf("project config enabled gated local control: %#v", resolved.LocalControl)
+	}
+	if !resolved.LocalControl.BrowserEnabled() || !resolved.LocalControl.TerminalEnabled() {
+		t.Fatalf("browser/terminal should remain available by default: %#v", resolved.LocalControl)
+	}
+}
+
+func TestLocalControlDefaultsBrowserAndTerminalOn(t *testing.T) {
+	resolved, err := Resolve(ResolveOptions{})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if !resolved.LocalControl.BrowserEnabled() {
+		t.Fatal("BrowserEnabled = false, want default true")
+	}
+	if !resolved.LocalControl.TerminalEnabled() {
+		t.Fatal("TerminalEnabled = false, want default true")
+	}
+	if resolved.LocalControl.DesktopEnabled() {
+		t.Fatal("DesktopEnabled = true, want explicit opt-in")
+	}
+}
+
+func TestLocalControlExplicitGlobalDisable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"localControl":{"enabled":false}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if resolved.LocalControl.BrowserEnabled() || resolved.LocalControl.TerminalEnabled() || resolved.LocalControl.DesktopEnabled() {
+		t.Fatalf("local control not disabled globally: %#v", resolved.LocalControl)
+	}
+}
+
+func TestLocalControlExplicitFalseSurvivesConfigRewrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{
+		"activeProvider": "openai",
+		"providers": [{"name": "openai", "provider_kind": "openai", "model": "gpt-4.1"}],
+		"localControl": {
+			"enabled": true,
+			"browser": {"enabled": false},
+			"terminal": {"enabled": false}
+		}
+	}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, err := SetFavoriteModels(path, []string{"gpt-4.1"}); err != nil {
+		t.Fatalf("SetFavoriteModels returned error: %v", err)
+	}
+	persisted := readConfigFixture(t, path)
+	if !persisted.LocalControl.enabledSet || !persisted.LocalControl.Enabled {
+		t.Fatalf("localControl enabled not preserved: %#v", persisted.LocalControl)
+	}
+	if !persisted.LocalControl.Browser.enabledSet || persisted.LocalControl.Browser.Enabled {
+		t.Fatalf("browser explicit false not preserved: %#v", persisted.LocalControl.Browser)
+	}
+	if !persisted.LocalControl.Terminal.enabledSet || persisted.LocalControl.Terminal.Enabled {
+		t.Fatalf("terminal explicit false not preserved: %#v", persisted.LocalControl.Terminal)
+	}
+}
+
+func TestEmptyLocalControlIsOmittedFromConfigJSON(t *testing.T) {
+	data, err := json.Marshal(FileConfig{})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if strings.Contains(string(data), "localControl") {
+		t.Fatalf("empty localControl should be omitted, got %s", string(data))
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -109,6 +109,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		Tools:          cfg.Tools,
 		Swarm:          cfg.Swarm,
 		Preferences:    cfg.Preferences,
+		LocalControl:   cfg.LocalControl,
 	}, nil
 }
 
@@ -182,6 +183,7 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	if src.Preferences.FavoriteModels != nil {
 		dst.Preferences.FavoriteModels = normalizeFavoriteModels(src.Preferences.FavoriteModels)
 	}
+	mergeLocalControlConfig(&dst.LocalControl, src.LocalControl)
 }
 
 func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
@@ -225,6 +227,9 @@ func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
 	if src.Swarm.MaxTeamSize != 0 {
 		dst.Swarm.MaxTeamSize = src.Swarm.MaxTeamSize
 	}
+	// Local control is intentionally user-config/override only. A cloned project
+	// must not be able to make browser, desktop, or terminal automation tools
+	// appear in the model's tool surface.
 	return nil
 }
 
@@ -555,6 +560,7 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 		cfg.Tools.DeferThreshold = overrides.Tools.DeferThreshold
 		cfg.Tools.deferThresholdSet = true
 	}
+	mergeLocalControlConfig(&cfg.LocalControl, overrides.LocalControl)
 	for _, provider := range overrides.Providers {
 		mergeProvider(cfg, provider)
 	}
@@ -562,6 +568,32 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 		mergeProvider(cfg, overrides.Provider)
 	}
 	mergeMCPConfig(&cfg.MCP, overrides.MCP)
+}
+
+func mergeLocalControlConfig(dst *LocalControlConfig, src LocalControlConfig) {
+	if src.enabledSet {
+		dst.Enabled = src.Enabled
+		dst.enabledSet = true
+	}
+	mergeLocalControlDriverConfig(&dst.Browser, src.Browser)
+	mergeLocalControlDriverConfig(&dst.Desktop, src.Desktop)
+	mergeLocalControlDriverConfig(&dst.Terminal, src.Terminal)
+	if artifactsDir := strings.TrimSpace(src.ArtifactsDir); artifactsDir != "" {
+		dst.ArtifactsDir = artifactsDir
+	}
+}
+
+func mergeLocalControlDriverConfig(dst *LocalControlDriverConfig, src LocalControlDriverConfig) {
+	if src.enabledSet {
+		dst.Enabled = src.Enabled
+		dst.enabledSet = true
+	}
+	if helperPath := strings.TrimSpace(src.HelperPath); helperPath != "" {
+		dst.HelperPath = helperPath
+	}
+	if driver := strings.TrimSpace(src.Driver); driver != "" {
+		dst.Driver = driver
+	}
 }
 
 func mergeMCPConfig(dst *MCPConfig, src MCPConfig) {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -94,6 +94,57 @@ type PreferencesConfig struct {
 	FavoriteModels []string `json:"favoriteModels,omitempty"`
 }
 
+// LocalControlConfig controls local browser/desktop/terminal automation helpers.
+// Helpers are discovered lazily by the tool that needs them; no setup command or
+// background probe is required during startup.
+type LocalControlConfig struct {
+	Enabled      bool                     `json:"enabled,omitempty"`
+	Browser      LocalControlDriverConfig `json:"browser,omitempty"`
+	Desktop      LocalControlDriverConfig `json:"desktop,omitempty"`
+	Terminal     LocalControlDriverConfig `json:"terminal,omitempty"`
+	ArtifactsDir string                   `json:"artifactsDir,omitempty"`
+	enabledSet   bool
+}
+
+type LocalControlDriverConfig struct {
+	Enabled    bool   `json:"enabled,omitempty"`
+	HelperPath string `json:"helperPath,omitempty"`
+	Driver     string `json:"driver,omitempty"`
+	enabledSet bool
+}
+
+func (cfg LocalControlConfig) BrowserEnabled() bool {
+	return !cfg.Disabled() && (!cfg.Browser.enabledSet || cfg.Browser.Enabled)
+}
+
+func (cfg LocalControlConfig) DesktopEnabled() bool {
+	return !cfg.Disabled() && cfg.Desktop.enabledSet && cfg.Desktop.Enabled
+}
+
+func (cfg LocalControlConfig) TerminalEnabled() bool {
+	return !cfg.Disabled() && (!cfg.Terminal.enabledSet || cfg.Terminal.Enabled)
+}
+
+func (cfg LocalControlConfig) Disabled() bool {
+	return cfg.enabledSet && !cfg.Enabled
+}
+
+func (cfg LocalControlConfig) Empty() bool {
+	return !cfg.Enabled &&
+		!cfg.enabledSet &&
+		cfg.ArtifactsDir == "" &&
+		cfg.Browser.Empty() &&
+		cfg.Desktop.Empty() &&
+		cfg.Terminal.Empty()
+}
+
+func (cfg LocalControlDriverConfig) Empty() bool {
+	return !cfg.Enabled &&
+		!cfg.enabledSet &&
+		cfg.HelperPath == "" &&
+		cfg.Driver == ""
+}
+
 // SwarmConfig tunes the multi-agent swarm. MaxTeamSize caps how many members run
 // concurrently per team; 0 uses the built-in default (8). Spawns past the cap
 // queue and launch as slots free, so lowering it bounds parallelism (and provider
@@ -128,15 +179,46 @@ func (cfg *ToolsConfig) UnmarshalJSON(data []byte) error {
 }
 
 type FileConfig struct {
-	ActiveProvider string            `json:"activeProvider,omitempty"`
-	Providers      []ProviderProfile `json:"providers,omitempty"`
-	MaxTurns       int               `json:"maxTurns,omitempty"`
-	MCP            MCPConfig         `json:"mcp,omitempty"`
-	Sandbox        SandboxConfig     `json:"sandbox,omitempty"`
-	Notify         NotifyConfig      `json:"notify,omitempty"`
-	Tools          ToolsConfig       `json:"tools,omitempty"`
-	Swarm          SwarmConfig       `json:"swarm,omitempty"`
-	Preferences    PreferencesConfig `json:"preferences,omitempty"`
+	ActiveProvider string             `json:"activeProvider,omitempty"`
+	Providers      []ProviderProfile  `json:"providers,omitempty"`
+	MaxTurns       int                `json:"maxTurns,omitempty"`
+	MCP            MCPConfig          `json:"mcp,omitempty"`
+	Sandbox        SandboxConfig      `json:"sandbox,omitempty"`
+	Notify         NotifyConfig       `json:"notify,omitempty"`
+	Tools          ToolsConfig        `json:"tools,omitempty"`
+	Swarm          SwarmConfig        `json:"swarm,omitempty"`
+	Preferences    PreferencesConfig  `json:"preferences,omitempty"`
+	LocalControl   LocalControlConfig `json:"localControl,omitempty"`
+}
+
+func (cfg FileConfig) MarshalJSON() ([]byte, error) {
+	type rawConfig struct {
+		ActiveProvider string              `json:"activeProvider,omitempty"`
+		Providers      []ProviderProfile   `json:"providers,omitempty"`
+		MaxTurns       int                 `json:"maxTurns,omitempty"`
+		MCP            MCPConfig           `json:"mcp,omitempty"`
+		Sandbox        SandboxConfig       `json:"sandbox,omitempty"`
+		Notify         NotifyConfig        `json:"notify,omitempty"`
+		Tools          ToolsConfig         `json:"tools,omitempty"`
+		Swarm          SwarmConfig         `json:"swarm,omitempty"`
+		Preferences    PreferencesConfig   `json:"preferences,omitempty"`
+		LocalControl   *LocalControlConfig `json:"localControl,omitempty"`
+	}
+	raw := rawConfig{
+		ActiveProvider: cfg.ActiveProvider,
+		Providers:      cfg.Providers,
+		MaxTurns:       cfg.MaxTurns,
+		MCP:            cfg.MCP,
+		Sandbox:        cfg.Sandbox,
+		Notify:         cfg.Notify,
+		Tools:          cfg.Tools,
+		Swarm:          cfg.Swarm,
+		Preferences:    cfg.Preferences,
+	}
+	if !cfg.LocalControl.Empty() {
+		raw.LocalControl = &cfg.LocalControl
+	}
+	return json.Marshal(raw)
 }
 
 type ResolveOptions struct {
@@ -156,6 +238,7 @@ type Overrides struct {
 	Sandbox        SandboxConfig
 	Notify         NotifyConfig
 	Tools          ToolsConfig
+	LocalControl   LocalControlConfig
 }
 
 type ResolvedConfig struct {
@@ -169,6 +252,7 @@ type ResolvedConfig struct {
 	Tools          ToolsConfig
 	Swarm          SwarmConfig
 	Preferences    PreferencesConfig
+	LocalControl   LocalControlConfig
 }
 
 type MCPConfig struct {
@@ -214,6 +298,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		Tools           ToolsConfig                `json:"tools"`
 		Swarm           SwarmConfig                `json:"swarm"`
 		Preferences     PreferencesConfig          `json:"preferences"`
+		LocalControl    LocalControlConfig         `json:"localControl"`
 		MCPServers      map[string]MCPServerConfig `json:"mcpServers"`
 		MCPServersSnake map[string]MCPServerConfig `json:"mcp_servers"`
 	}
@@ -239,6 +324,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	cfg.Tools = raw.Tools
 	cfg.Swarm = raw.Swarm
 	cfg.Preferences = raw.Preferences
+	cfg.LocalControl = raw.LocalControl
 	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
 		cfg.MCP.Servers = map[string]MCPServerConfig{}
 	}
@@ -252,6 +338,94 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		cfg.MCP.Servers[name] = server
 	}
 	return nil
+}
+
+func (cfg *LocalControlConfig) UnmarshalJSON(data []byte) error {
+	type rawLocalControl struct {
+		Enabled      *bool                    `json:"enabled"`
+		Browser      LocalControlDriverConfig `json:"browser"`
+		Desktop      LocalControlDriverConfig `json:"desktop"`
+		Terminal     LocalControlDriverConfig `json:"terminal"`
+		ArtifactsDir string                   `json:"artifactsDir"`
+	}
+	var raw rawLocalControl
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*cfg = LocalControlConfig{
+		Browser:      raw.Browser,
+		Desktop:      raw.Desktop,
+		Terminal:     raw.Terminal,
+		ArtifactsDir: raw.ArtifactsDir,
+	}
+	if raw.Enabled != nil {
+		cfg.Enabled = *raw.Enabled
+		cfg.enabledSet = true
+	}
+	return nil
+}
+
+func (cfg LocalControlConfig) MarshalJSON() ([]byte, error) {
+	type rawLocalControl struct {
+		Enabled      *bool                     `json:"enabled,omitempty"`
+		Browser      *LocalControlDriverConfig `json:"browser,omitempty"`
+		Desktop      *LocalControlDriverConfig `json:"desktop,omitempty"`
+		Terminal     *LocalControlDriverConfig `json:"terminal,omitempty"`
+		ArtifactsDir string                    `json:"artifactsDir,omitempty"`
+	}
+	raw := rawLocalControl{
+		ArtifactsDir: cfg.ArtifactsDir,
+	}
+	if cfg.enabledSet || cfg.Enabled {
+		raw.Enabled = &cfg.Enabled
+	}
+	if !cfg.Browser.Empty() {
+		raw.Browser = &cfg.Browser
+	}
+	if !cfg.Desktop.Empty() {
+		raw.Desktop = &cfg.Desktop
+	}
+	if !cfg.Terminal.Empty() {
+		raw.Terminal = &cfg.Terminal
+	}
+	return json.Marshal(raw)
+}
+
+func (cfg *LocalControlDriverConfig) UnmarshalJSON(data []byte) error {
+	type rawDriver struct {
+		Enabled    *bool  `json:"enabled"`
+		HelperPath string `json:"helperPath"`
+		Driver     string `json:"driver"`
+	}
+	var raw rawDriver
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*cfg = LocalControlDriverConfig{
+		HelperPath: raw.HelperPath,
+		Driver:     raw.Driver,
+	}
+	if raw.Enabled != nil {
+		cfg.Enabled = *raw.Enabled
+		cfg.enabledSet = true
+	}
+	return nil
+}
+
+func (cfg LocalControlDriverConfig) MarshalJSON() ([]byte, error) {
+	type rawDriver struct {
+		Enabled    *bool  `json:"enabled,omitempty"`
+		HelperPath string `json:"helperPath,omitempty"`
+		Driver     string `json:"driver,omitempty"`
+	}
+	raw := rawDriver{
+		HelperPath: cfg.HelperPath,
+		Driver:     cfg.Driver,
+	}
+	if cfg.enabledSet || cfg.Enabled {
+		raw.Enabled = &cfg.Enabled
+	}
+	return json.Marshal(raw)
 }
 
 func (server *MCPServerConfig) UnmarshalJSON(data []byte) error {

--- a/internal/contextreport/contextreport.go
+++ b/internal/contextreport/contextreport.go
@@ -221,7 +221,12 @@ func estimateRegistryTools(registry *tools.Registry) (int, int) {
 		return all[left].Name() < all[right].Name()
 	})
 	total := 0
+	count := 0
 	for _, tool := range all {
+		if tool.Safety().Permission == tools.PermissionDeny {
+			continue
+		}
+		count++
 		total += estimateTextTokens(tool.Name())
 		total += estimateTextTokens(tool.Description())
 		if encoded, err := json.Marshal(tool.Parameters()); err == nil {
@@ -229,7 +234,7 @@ func estimateRegistryTools(registry *tools.Registry) (int, int) {
 		}
 		total += toolDefinitionOverheadTokens
 	}
-	return len(all), total
+	return count, total
 }
 
 func readProjectGuidelines(root string, names []string) (string, string) {

--- a/internal/installtest/install_scripts_test.go
+++ b/internal/installtest/install_scripts_test.go
@@ -142,7 +142,11 @@ func newUnixInstallFixture(t *testing.T) unixInstallFixture {
 	writeFile(t, filepath.Join(packageDir, "zero"), []byte("#!/usr/bin/env sh\necho mock-zero\n"), 0o755)
 	writeFile(t, filepath.Join(packageDir, "zero-linux-sandbox"), []byte("#!/usr/bin/env sh\n"), 0o755)
 	writeFile(t, filepath.Join(packageDir, "zero-seccomp"), []byte("#!/usr/bin/env sh\n"), 0o755)
-	writeFile(t, filepath.Join(packageDir, "helpers", "node_modules", ".bin", "agent-browser"), []byte("#!/usr/bin/env sh\n"), 0o755)
+	mustMkdirAll(t, filepath.Join(packageDir, "helpers", "node_modules", "agent-browser", "bin"))
+	writeFile(t, filepath.Join(packageDir, "helpers", "node_modules", "agent-browser", "bin", "agent-browser.js"), []byte("#!/usr/bin/env node\n"), 0o755)
+	if err := os.Symlink("../agent-browser/bin/agent-browser.js", filepath.Join(packageDir, "helpers", "node_modules", ".bin", "agent-browser")); err != nil {
+		t.Fatalf("Symlink agent-browser helper: %v", err)
+	}
 	writeFile(t, filepath.Join(packageDir, "helpers", "node_modules", ".bin", "tuistory"), []byte("#!/usr/bin/env sh\n"), 0o755)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/internal/installtest/install_scripts_test.go
+++ b/internal/installtest/install_scripts_test.go
@@ -31,6 +31,9 @@ func TestUnixInstallerScriptMatchesReleaseContracts(t *testing.T) {
 		`tar -xzf "$archive_path" -C "$extract_dir"`,
 		`find_extracted_binary "$extract_dir"`,
 		`cp "$binary_path" "$ZERO_INSTALL_DIR/zero"`,
+		`copy_optional_file "zero-linux-sandbox"`,
+		`copy_optional_file "zero-seccomp"`,
+		`copy_optional_dir "helpers"`,
 	})
 }
 
@@ -48,6 +51,8 @@ func TestPowerShellInstallerScriptMatchesWindowsReleaseContracts(t *testing.T) {
 		`"zero-windows-command-runner.exe"`,
 		`"zero-windows-sandbox-setup.exe"`,
 		`Copy-Item -Path $sourcePath -Destination (Join-Path $InstallDir $fileName) -Force`,
+		`Find-ZeroOptionalExtractedDirectory -Root $extractDir -DirectoryName "helpers"`,
+		`Copy-Item -Path $helpersPath -Destination $targetHelpersPath -Recurse -Force`,
 	})
 }
 
@@ -67,6 +72,12 @@ func TestUnixInstallerInstallsFromPrefixedReleaseArchiveWithoutNetwork(t *testin
 	installed := readFile(t, filepath.Join(fixture.installDir, "zero"))
 	if !strings.Contains(string(installed), "mock-zero") {
 		t.Fatalf("installed binary = %q, want mock-zero script", string(installed))
+	}
+	if _, err := os.Stat(filepath.Join(fixture.installDir, "helpers", "node_modules", ".bin", "agent-browser")); err != nil {
+		t.Fatalf("installed helper package missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fixture.installDir, "zero-linux-sandbox")); err != nil {
+		t.Fatalf("installed linux sandbox helper missing: %v", err)
 	}
 }
 
@@ -127,7 +138,12 @@ func newUnixInstallFixture(t *testing.T) unixInstallFixture {
 	mustMkdirAll(t, packageDir)
 	mustMkdirAll(t, filepath.Dir(fixture.archivePath))
 	mustMkdirAll(t, fixture.installDir)
+	mustMkdirAll(t, filepath.Join(packageDir, "helpers", "node_modules", ".bin"))
 	writeFile(t, filepath.Join(packageDir, "zero"), []byte("#!/usr/bin/env sh\necho mock-zero\n"), 0o755)
+	writeFile(t, filepath.Join(packageDir, "zero-linux-sandbox"), []byte("#!/usr/bin/env sh\n"), 0o755)
+	writeFile(t, filepath.Join(packageDir, "zero-seccomp"), []byte("#!/usr/bin/env sh\n"), 0o755)
+	writeFile(t, filepath.Join(packageDir, "helpers", "node_modules", ".bin", "agent-browser"), []byte("#!/usr/bin/env sh\n"), 0o755)
+	writeFile(t, filepath.Join(packageDir, "helpers", "node_modules", ".bin", "tuistory"), []byte("#!/usr/bin/env sh\n"), 0o755)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/internal/localcontrol/app_launcher.go
+++ b/internal/localcontrol/app_launcher.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -115,6 +116,9 @@ func (launcher BrowserAppLauncher) LaunchBrowserApp(ctx context.Context, request
 func browserAppLaunchSpec(app string, port int) (browserAppSpec, error) {
 	switch strings.ToLower(strings.TrimSpace(app)) {
 	case "discord":
+		if runtime.GOOS != "linux" {
+			return browserAppSpec{}, fmt.Errorf("discord launch is only supported for Linux flatpak installs")
+		}
 		return browserAppSpec{
 			name:     "discord",
 			command:  "flatpak",

--- a/internal/localcontrol/app_launcher.go
+++ b/internal/localcontrol/app_launcher.go
@@ -1,0 +1,185 @@
+package localcontrol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultDevToolsPort        = 9222
+	defaultDevToolsWaitTimeout = 20 * time.Second
+)
+
+type BrowserAppLaunchOptions struct {
+	Runner      BrowserAppRunner
+	WaitTimeout time.Duration
+}
+
+type BrowserAppLaunchRequest struct {
+	App          string
+	DebugPort    int
+	StopExisting bool
+	Wait         bool
+}
+
+type BrowserAppLaunchResult struct {
+	App         string
+	Command     string
+	Args        []string
+	PID         int
+	DebugPort   int
+	DevToolsURL string
+}
+
+type BrowserAppRunner interface {
+	Run(ctx context.Context, path string, args []string, env []string, timeout time.Duration) (CommandResult, error)
+	StartDetached(ctx context.Context, path string, args []string, env []string) (int, error)
+}
+
+type BrowserAppLauncher struct {
+	runner      BrowserAppRunner
+	waitTimeout time.Duration
+}
+
+type browserAppSpec struct {
+	name     string
+	command  string
+	args     []string
+	env      []string
+	stopPath string
+	stopArgs []string
+}
+
+func NewBrowserAppLauncher(options BrowserAppLaunchOptions) BrowserAppLauncher {
+	if options.Runner == nil {
+		options.Runner = ExecBrowserAppRunner{}
+	}
+	if options.WaitTimeout <= 0 {
+		options.WaitTimeout = defaultDevToolsWaitTimeout
+	}
+	return BrowserAppLauncher{
+		runner:      options.Runner,
+		waitTimeout: options.WaitTimeout,
+	}
+}
+
+func (launcher BrowserAppLauncher) LaunchBrowserApp(ctx context.Context, request BrowserAppLaunchRequest) (BrowserAppLaunchResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	port := request.DebugPort
+	if port == 0 {
+		port = DefaultDevToolsPort
+	}
+	if port < 1024 || port > 65535 {
+		return BrowserAppLaunchResult{}, fmt.Errorf("debug_port must be between 1024 and 65535")
+	}
+	spec, err := browserAppLaunchSpec(request.App, port)
+	if err != nil {
+		return BrowserAppLaunchResult{}, err
+	}
+
+	if request.StopExisting && spec.stopPath != "" {
+		_, _ = launcher.runner.Run(ctx, spec.stopPath, spec.stopArgs, nil, 5*time.Second)
+	}
+
+	pid, err := launcher.runner.StartDetached(ctx, spec.command, spec.args, spec.env)
+	if err != nil {
+		return BrowserAppLaunchResult{}, fmt.Errorf("launch %s: %w", spec.name, err)
+	}
+
+	devToolsURL := "http://127.0.0.1:" + strconv.Itoa(port)
+	if request.Wait {
+		if err := waitForDevTools(ctx, devToolsURL, launcher.waitTimeout); err != nil {
+			return BrowserAppLaunchResult{}, err
+		}
+	}
+
+	return BrowserAppLaunchResult{
+		App:         spec.name,
+		Command:     spec.command,
+		Args:        append([]string(nil), spec.args...),
+		PID:         pid,
+		DebugPort:   port,
+		DevToolsURL: devToolsURL,
+	}, nil
+}
+
+func browserAppLaunchSpec(app string, port int) (browserAppSpec, error) {
+	switch strings.ToLower(strings.TrimSpace(app)) {
+	case "discord":
+		return browserAppSpec{
+			name:     "discord",
+			command:  "flatpak",
+			args:     []string{"run", "--command=com.discordapp.Discord", "com.discordapp.Discord", "--remote-debugging-port=" + strconv.Itoa(port)},
+			stopPath: "flatpak",
+			stopArgs: []string{"kill", "com.discordapp.Discord"},
+		}, nil
+	default:
+		return browserAppSpec{}, fmt.Errorf("app must be one of: discord")
+	}
+}
+
+func waitForDevTools(ctx context.Context, baseURL string, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = defaultDevToolsWaitTimeout
+	}
+	deadline := time.Now().Add(timeout)
+	client := http.Client{Timeout: 750 * time.Millisecond}
+	endpoint := strings.TrimRight(baseURL, "/") + "/json/version"
+	var lastErr error
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+			lastErr = fmt.Errorf("DevTools endpoint returned HTTP %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("DevTools endpoint %s was not ready after %dms: %w", endpoint, timeout.Milliseconds(), lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+}
+
+type ExecBrowserAppRunner struct{}
+
+func (ExecBrowserAppRunner) Run(ctx context.Context, path string, args []string, env []string, timeout time.Duration) (CommandResult, error) {
+	return ExecRunner{}.Run(ctx, path, args, env, timeout)
+}
+
+func (ExecBrowserAppRunner) StartDetached(_ context.Context, path string, args []string, env []string) (int, error) {
+	if strings.TrimSpace(path) == "" {
+		return 0, errors.New("launch command is required")
+	}
+	cmd := exec.Command(path, args...)
+	cmd.Env = mergeEnv(os.Environ(), env)
+	configureDetachedProcess(cmd)
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Process.Release(); err != nil {
+		return pid, err
+	}
+	return pid, nil
+}

--- a/internal/localcontrol/app_launcher_test.go
+++ b/internal/localcontrol/app_launcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +38,7 @@ func (runner *fakeBrowserAppRunner) StartDetached(_ context.Context, path string
 }
 
 func TestBrowserAppLauncherMapsDiscordToFlatpakDevToolsLaunch(t *testing.T) {
+	requireLinuxFlatpakLaunch(t)
 	runner := &fakeBrowserAppRunner{}
 	launcher := NewBrowserAppLauncher(BrowserAppLaunchOptions{Runner: runner})
 
@@ -68,6 +70,7 @@ func TestBrowserAppLauncherMapsDiscordToFlatpakDevToolsLaunch(t *testing.T) {
 }
 
 func TestBrowserAppLauncherDefaultsPortAndCanSkipStop(t *testing.T) {
+	requireLinuxFlatpakLaunch(t)
 	runner := &fakeBrowserAppRunner{}
 	launcher := NewBrowserAppLauncher(BrowserAppLaunchOptions{Runner: runner})
 
@@ -99,9 +102,28 @@ func TestBrowserAppLauncherRejectsUnsupportedApp(t *testing.T) {
 }
 
 func TestBrowserAppLauncherReportsStartFailure(t *testing.T) {
+	requireLinuxFlatpakLaunch(t)
 	launcher := NewBrowserAppLauncher(BrowserAppLaunchOptions{Runner: &fakeBrowserAppRunner{err: errors.New("boom")}})
 	_, err := launcher.LaunchBrowserApp(context.Background(), BrowserAppLaunchRequest{App: "discord", Wait: false})
 	if err == nil || !strings.Contains(err.Error(), "launch discord") {
 		t.Fatalf("error = %v, want launch failure", err)
+	}
+}
+
+func TestBrowserAppLauncherRejectsDiscordOnUnsupportedPlatform(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("discord launch is supported on Linux")
+	}
+	launcher := NewBrowserAppLauncher(BrowserAppLaunchOptions{Runner: &fakeBrowserAppRunner{}})
+	_, err := launcher.LaunchBrowserApp(context.Background(), BrowserAppLaunchRequest{App: "discord", Wait: false})
+	if err == nil || !strings.Contains(err.Error(), "only supported") {
+		t.Fatalf("error = %v, want unsupported platform", err)
+	}
+}
+
+func requireLinuxFlatpakLaunch(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("discord launch uses Linux flatpak")
 	}
 }

--- a/internal/localcontrol/app_launcher_test.go
+++ b/internal/localcontrol/app_launcher_test.go
@@ -1,0 +1,107 @@
+package localcontrol
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeBrowserAppRunner struct {
+	runPath   string
+	runArgs   []string
+	startPath string
+	startArgs []string
+	pid       int
+	err       error
+}
+
+func (runner *fakeBrowserAppRunner) Run(_ context.Context, path string, args []string, _ []string, _ time.Duration) (CommandResult, error) {
+	runner.runPath = path
+	runner.runArgs = append([]string(nil), args...)
+	return CommandResult{Path: path, Args: append([]string(nil), args...), ExitCode: 0}, nil
+}
+
+func (runner *fakeBrowserAppRunner) StartDetached(_ context.Context, path string, args []string, _ []string) (int, error) {
+	runner.startPath = path
+	runner.startArgs = append([]string(nil), args...)
+	if runner.err != nil {
+		return 0, runner.err
+	}
+	if runner.pid == 0 {
+		runner.pid = 4321
+	}
+	return runner.pid, nil
+}
+
+func TestBrowserAppLauncherMapsDiscordToFlatpakDevToolsLaunch(t *testing.T) {
+	runner := &fakeBrowserAppRunner{}
+	launcher := NewBrowserAppLauncher(BrowserAppLaunchOptions{Runner: runner})
+
+	result, err := launcher.LaunchBrowserApp(context.Background(), BrowserAppLaunchRequest{
+		App:          "discord",
+		DebugPort:    9222,
+		StopExisting: true,
+		Wait:         false,
+	})
+	if err != nil {
+		t.Fatalf("LaunchBrowserApp returned error: %v", err)
+	}
+	if runner.runPath != "flatpak" {
+		t.Fatalf("stop path = %q, want flatpak", runner.runPath)
+	}
+	if want := []string{"kill", "com.discordapp.Discord"}; !reflect.DeepEqual(runner.runArgs, want) {
+		t.Fatalf("stop args = %#v, want %#v", runner.runArgs, want)
+	}
+	if runner.startPath != "flatpak" {
+		t.Fatalf("start path = %q, want flatpak", runner.startPath)
+	}
+	wantStartArgs := []string{"run", "--command=com.discordapp.Discord", "com.discordapp.Discord", "--remote-debugging-port=9222"}
+	if !reflect.DeepEqual(runner.startArgs, wantStartArgs) {
+		t.Fatalf("start args = %#v, want %#v", runner.startArgs, wantStartArgs)
+	}
+	if result.PID != 4321 || result.DevToolsURL != "http://127.0.0.1:9222" {
+		t.Fatalf("result = %#v, want pid/devtools URL", result)
+	}
+}
+
+func TestBrowserAppLauncherDefaultsPortAndCanSkipStop(t *testing.T) {
+	runner := &fakeBrowserAppRunner{}
+	launcher := NewBrowserAppLauncher(BrowserAppLaunchOptions{Runner: runner})
+
+	result, err := launcher.LaunchBrowserApp(context.Background(), BrowserAppLaunchRequest{
+		App:  "discord",
+		Wait: false,
+	})
+	if err != nil {
+		t.Fatalf("LaunchBrowserApp returned error: %v", err)
+	}
+	if runner.runPath != "" {
+		t.Fatalf("stop path = %q, want no stop", runner.runPath)
+	}
+	wantStartArgs := []string{"run", "--command=com.discordapp.Discord", "com.discordapp.Discord", "--remote-debugging-port=9222"}
+	if !reflect.DeepEqual(runner.startArgs, wantStartArgs) {
+		t.Fatalf("start args = %#v, want %#v", runner.startArgs, wantStartArgs)
+	}
+	if result.DebugPort != DefaultDevToolsPort {
+		t.Fatalf("debug port = %d, want %d", result.DebugPort, DefaultDevToolsPort)
+	}
+}
+
+func TestBrowserAppLauncherRejectsUnsupportedApp(t *testing.T) {
+	launcher := NewBrowserAppLauncher(BrowserAppLaunchOptions{Runner: &fakeBrowserAppRunner{}})
+	_, err := launcher.LaunchBrowserApp(context.Background(), BrowserAppLaunchRequest{App: "telegram"})
+	if err == nil || !strings.Contains(err.Error(), "app must be one of") {
+		t.Fatalf("error = %v, want unsupported app", err)
+	}
+}
+
+func TestBrowserAppLauncherReportsStartFailure(t *testing.T) {
+	launcher := NewBrowserAppLauncher(BrowserAppLaunchOptions{Runner: &fakeBrowserAppRunner{err: errors.New("boom")}})
+	_, err := launcher.LaunchBrowserApp(context.Background(), BrowserAppLaunchRequest{App: "discord", Wait: false})
+	if err == nil || !strings.Contains(err.Error(), "launch discord") {
+		t.Fatalf("error = %v, want launch failure", err)
+	}
+}

--- a/internal/localcontrol/app_launcher_unix.go
+++ b/internal/localcontrol/app_launcher_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package localcontrol
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedProcess(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}

--- a/internal/localcontrol/app_launcher_windows.go
+++ b/internal/localcontrol/app_launcher_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package localcontrol
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const detachedProcess = 0x00000008
+
+func configureDetachedProcess(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= syscall.CREATE_NEW_PROCESS_GROUP | detachedProcess
+}

--- a/internal/localcontrol/browser.go
+++ b/internal/localcontrol/browser.go
@@ -1,0 +1,443 @@
+package localcontrol
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultBrowserDriver  = "agent-browser"
+	DefaultDesktopDriver  = "cua-driver"
+	DefaultTerminalDriver = "tuistory"
+	DefaultTimeout        = 30 * time.Second
+	EnvHelperManifest     = "ZERO_LOCAL_CONTROL_HELPERS"
+)
+
+type HelperOptions struct {
+	Enabled         bool
+	Driver          string
+	HelperPath      string
+	ConfigPath      string
+	DisabledMessage string
+	MissingHint     string
+	Timeout         time.Duration
+	Runner          CommandRunner
+}
+
+type BrowserOptions = HelperOptions
+type DesktopOptions = HelperOptions
+type TerminalOptions = HelperOptions
+
+type CommandResult struct {
+	Path     string
+	Args     []string
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+func (result CommandResult) Output() string {
+	stdout := strings.TrimRight(result.Stdout, "\n")
+	stderr := strings.TrimRight(result.Stderr, "\n")
+	switch {
+	case stdout == "" && stderr == "":
+		return ""
+	case stdout == "":
+		return stderr
+	case stderr == "":
+		return stdout
+	default:
+		return stdout + "\n" + stderr
+	}
+}
+
+type CommandRunner interface {
+	Run(ctx context.Context, path string, args []string, env []string, timeout time.Duration) (CommandResult, error)
+}
+
+type ResolvedHelper struct {
+	Command    string
+	PrefixArgs []string
+	Env        []string
+}
+
+type Helper struct {
+	options HelperOptions
+}
+
+type Browser struct {
+	helper Helper
+}
+
+type Desktop struct {
+	helper Helper
+}
+
+type Terminal struct {
+	helper Helper
+}
+
+func NewHelper(options HelperOptions) Helper {
+	if options.Timeout <= 0 {
+		options.Timeout = DefaultTimeout
+	}
+	if options.Runner == nil {
+		options.Runner = ExecRunner{}
+	}
+	return Helper{options: options}
+}
+
+func NewBrowser(options BrowserOptions) Browser {
+	if strings.TrimSpace(options.Driver) == "" {
+		options.Driver = DefaultBrowserDriver
+	}
+	options.ConfigPath = "localControl.browser.helperPath"
+	options.DisabledMessage = "local browser control is disabled by user config"
+	options.MissingHint = "install the agent-browser package or set localControl.browser.helperPath"
+	return Browser{helper: NewHelper(options)}
+}
+
+func NewDesktop(options DesktopOptions) Desktop {
+	if strings.TrimSpace(options.Driver) == "" {
+		options.Driver = DefaultDesktopDriver
+	}
+	options.ConfigPath = "localControl.desktop.helperPath"
+	options.DisabledMessage = "local desktop control is disabled; enable localControl.desktop.enabled in user config"
+	options.MissingHint = "install cua-driver or set localControl.desktop.helperPath"
+	return Desktop{helper: NewHelper(options)}
+}
+
+func NewTerminal(options TerminalOptions) Terminal {
+	if strings.TrimSpace(options.Driver) == "" {
+		options.Driver = DefaultTerminalDriver
+	}
+	options.ConfigPath = "localControl.terminal.helperPath"
+	options.DisabledMessage = "local terminal control is disabled by user config"
+	options.MissingHint = "install the tuistory package or set localControl.terminal.helperPath"
+	return Terminal{helper: NewHelper(options)}
+}
+
+func (helper Helper) Enabled() bool {
+	return helper.options.Enabled
+}
+
+func (helper Helper) Run(ctx context.Context, args ...string) (CommandResult, error) {
+	if !helper.options.Enabled {
+		message := strings.TrimSpace(helper.options.DisabledMessage)
+		if message == "" {
+			message = "local control helper is disabled"
+		}
+		return CommandResult{}, errors.New(message)
+	}
+	resolved, err := helper.resolvedHelper()
+	if err != nil {
+		return CommandResult{}, err
+	}
+	runArgs := append([]string{}, resolved.PrefixArgs...)
+	runArgs = append(runArgs, args...)
+	return helper.options.Runner.Run(ctx, resolved.Command, runArgs, resolved.Env, helper.options.Timeout)
+}
+
+func (helper Helper) resolvedHelper() (ResolvedHelper, error) {
+	label := helper.helperLabel()
+	if helperPath := strings.TrimSpace(helper.options.HelperPath); helperPath != "" {
+		if !filepath.IsAbs(helperPath) {
+			abs, err := filepath.Abs(helperPath)
+			if err != nil {
+				return ResolvedHelper{}, fmt.Errorf("resolve %s helper path: %w", label, err)
+			}
+			helperPath = abs
+		}
+		if err := validateHelperFile(label, helperPath); err != nil {
+			return ResolvedHelper{}, err
+		}
+		return ResolvedHelper{Command: helperPath}, nil
+	}
+
+	driver := strings.TrimSpace(helper.options.Driver)
+	if driver == "" {
+		driver = DefaultBrowserDriver
+	}
+	if resolved, ok, err := helperFromManifest(driver); ok || err != nil {
+		return resolved, err
+	}
+	if resolved, ok, err := adjacentHelper(driver); ok || err != nil {
+		return resolved, err
+	}
+	path, err := exec.LookPath(driver)
+	if err != nil {
+		hint := strings.TrimSpace(helper.options.MissingHint)
+		if hint == "" {
+			hint = "install it or configure the helper path"
+		}
+		return ResolvedHelper{}, fmt.Errorf("%s was not found on PATH; %s", driver, hint)
+	}
+	return ResolvedHelper{Command: path}, nil
+}
+
+func (helper Helper) helperLabel() string {
+	driver := strings.TrimSpace(helper.options.Driver)
+	if driver == "" {
+		return "local control"
+	}
+	return driver
+}
+
+func (browser Browser) Enabled() bool {
+	return browser.helper.Enabled()
+}
+
+func (browser Browser) Run(ctx context.Context, args ...string) (CommandResult, error) {
+	return browser.helper.Run(ctx, args...)
+}
+
+func (desktop Desktop) Run(ctx context.Context, args ...string) (CommandResult, error) {
+	return desktop.helper.Run(ctx, args...)
+}
+
+func (desktop Desktop) Enabled() bool {
+	return desktop.helper.Enabled()
+}
+
+func (terminal Terminal) Run(ctx context.Context, args ...string) (CommandResult, error) {
+	return terminal.helper.Run(ctx, args...)
+}
+
+func (terminal Terminal) Enabled() bool {
+	return terminal.helper.Enabled()
+}
+
+type ExecRunner struct{}
+
+var executablePath = os.Executable
+
+func (ExecRunner) Run(ctx context.Context, path string, args []string, env []string, timeout time.Duration) (CommandResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, path, args...)
+	cmd.Env = mergeEnv(os.Environ(), env)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	result := CommandResult{
+		Path:   path,
+		Args:   append([]string(nil), args...),
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if cmd.ProcessState != nil {
+		result.ExitCode = cmd.ProcessState.ExitCode()
+	} else if err != nil {
+		result.ExitCode = -1
+	}
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return result, fmt.Errorf("local control helper timed out after %dms", timeout.Milliseconds())
+	}
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+type helperManifest struct {
+	Version int                      `json:"version"`
+	Helpers map[string]manifestEntry `json:"helpers"`
+}
+
+type manifestEntry struct {
+	Command     string            `json:"command"`
+	PrefixArgs  []string          `json:"prefixArgs"`
+	PathPrepend []string          `json:"pathPrepend"`
+	Env         map[string]string `json:"env"`
+}
+
+func helperFromManifest(driver string) (ResolvedHelper, bool, error) {
+	raw := strings.TrimSpace(os.Getenv(EnvHelperManifest))
+	if raw == "" {
+		return ResolvedHelper{}, false, nil
+	}
+	manifest, err := parseHelperManifest(raw)
+	if err != nil {
+		return ResolvedHelper{}, true, err
+	}
+	entry, ok := manifest.Helpers[driver]
+	if !ok {
+		return ResolvedHelper{}, false, nil
+	}
+	command := strings.TrimSpace(entry.Command)
+	if command == "" {
+		return ResolvedHelper{}, true, fmt.Errorf("%s entry in %s is missing command", driver, EnvHelperManifest)
+	}
+	if filepath.IsAbs(command) {
+		if err := validateHelperFile(driver, command); err != nil {
+			return ResolvedHelper{}, true, err
+		}
+	}
+	return ResolvedHelper{
+		Command:    command,
+		PrefixArgs: cleanStringSlice(entry.PrefixArgs),
+		Env:        manifestEnv(entry),
+	}, true, nil
+}
+
+func parseHelperManifest(raw string) (helperManifest, error) {
+	var manifest helperManifest
+	if err := json.Unmarshal([]byte(raw), &manifest); err != nil {
+		return helperManifest{}, fmt.Errorf("invalid %s JSON: %w", EnvHelperManifest, err)
+	}
+	if manifest.Helpers == nil {
+		manifest.Helpers = map[string]manifestEntry{}
+	}
+	return manifest, nil
+}
+
+func validateHelperFile(label string, path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("%s helper not found at %s: %w", label, path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s helper path is a directory: %s", label, path)
+	}
+	return nil
+}
+
+func adjacentHelper(driver string) (ResolvedHelper, bool, error) {
+	executable, err := executablePath()
+	if err != nil {
+		return ResolvedHelper{}, false, nil
+	}
+	executableDir := filepath.Dir(executable)
+	for _, dir := range []string{
+		executableDir,
+		filepath.Join(executableDir, "helpers"),
+		filepath.Join(executableDir, "helpers", "node_modules", ".bin"),
+		filepath.Join(executableDir, "node_modules", ".bin"),
+	} {
+		for _, name := range helperExecutableNames(driver) {
+			path := filepath.Join(dir, name)
+			if err := validateHelperFile(driver, path); err == nil {
+				return helperCommandForPath(path), true, nil
+			}
+		}
+	}
+	return ResolvedHelper{}, false, nil
+}
+
+func helperExecutableNames(driver string) []string {
+	if runtime.GOOS == "windows" {
+		return []string{driver + ".cmd", driver + ".exe", driver}
+	}
+	return []string{driver}
+}
+
+func helperCommandForPath(path string) ResolvedHelper {
+	if runtime.GOOS == "windows" && strings.EqualFold(filepath.Ext(path), ".cmd") {
+		command := os.Getenv("ComSpec")
+		if strings.TrimSpace(command) == "" {
+			command = "cmd.exe"
+		}
+		return ResolvedHelper{
+			Command:    command,
+			PrefixArgs: []string{"/d", "/s", "/c", `"` + strings.ReplaceAll(path, `"`, `""`) + `"`},
+		}
+	}
+	return ResolvedHelper{Command: path}
+}
+
+func manifestEnv(entry manifestEntry) []string {
+	env := map[string]string{}
+	for key, value := range entry.Env {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			env[key] = value
+		}
+	}
+	pathPrepend := cleanStringSlice(entry.PathPrepend)
+	if len(pathPrepend) > 0 {
+		basePath := env["PATH"]
+		if basePath == "" {
+			basePath = os.Getenv("PATH")
+		}
+		prefix := strings.Join(pathPrepend, string(os.PathListSeparator))
+		if basePath != "" {
+			env["PATH"] = prefix + string(os.PathListSeparator) + basePath
+		} else {
+			env["PATH"] = prefix
+		}
+	}
+	return envMapToList(env)
+}
+
+func mergeEnv(base []string, overlay []string) []string {
+	if len(overlay) == 0 {
+		return base
+	}
+	merged := append([]string{}, base...)
+	index := map[string]int{}
+	for i, item := range merged {
+		if key, _, ok := strings.Cut(item, "="); ok {
+			index[key] = i
+		}
+	}
+	for _, item := range overlay {
+		key, _, ok := strings.Cut(item, "=")
+		if !ok || key == "" {
+			continue
+		}
+		if existing, ok := index[key]; ok {
+			merged[existing] = item
+		} else {
+			index[key] = len(merged)
+			merged = append(merged, item)
+		}
+	}
+	return merged
+}
+
+func cleanStringSlice(values []string) []string {
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			cleaned = append(cleaned, value)
+		}
+	}
+	return cleaned
+}
+
+func envMapToList(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, key+"="+env[key])
+	}
+	return values
+}

--- a/internal/localcontrol/browser.go
+++ b/internal/localcontrol/browser.go
@@ -389,6 +389,13 @@ func manifestEnv(entry manifestEntry) []string {
 	return envMapToList(env)
 }
 
+func normalizeEnvKey(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
+}
+
 func mergeEnv(base []string, overlay []string) []string {
 	if len(overlay) == 0 {
 		return base
@@ -397,7 +404,7 @@ func mergeEnv(base []string, overlay []string) []string {
 	index := map[string]int{}
 	for i, item := range merged {
 		if key, _, ok := strings.Cut(item, "="); ok {
-			index[key] = i
+			index[normalizeEnvKey(key)] = i
 		}
 	}
 	for _, item := range overlay {
@@ -405,10 +412,11 @@ func mergeEnv(base []string, overlay []string) []string {
 		if !ok || key == "" {
 			continue
 		}
-		if existing, ok := index[key]; ok {
+		normalized := normalizeEnvKey(key)
+		if existing, ok := index[normalized]; ok {
 			merged[existing] = item
 		} else {
-			index[key] = len(merged)
+			index[normalized] = len(merged)
 			merged = append(merged, item)
 		}
 	}

--- a/internal/localcontrol/browser_test.go
+++ b/internal/localcontrol/browser_test.go
@@ -1,0 +1,215 @@
+package localcontrol
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeCommandRunner struct {
+	path string
+	args []string
+	env  []string
+}
+
+func (runner *fakeCommandRunner) Run(_ context.Context, path string, args []string, env []string, _ time.Duration) (CommandResult, error) {
+	runner.path = path
+	runner.args = append([]string(nil), args...)
+	runner.env = append([]string(nil), env...)
+	return CommandResult{
+		Path:     path,
+		Args:     append([]string(nil), args...),
+		Stdout:   "ok\n",
+		ExitCode: 0,
+	}, nil
+}
+
+func TestBrowserRunUsesConfiguredHelperPath(t *testing.T) {
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "agent-browser")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	runner := &fakeCommandRunner{}
+	browser := NewBrowser(BrowserOptions{
+		Enabled:    true,
+		HelperPath: helper,
+		Runner:     runner,
+	})
+
+	result, err := browser.Run(context.Background(), "open", "https://example.com")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Output() != "ok" {
+		t.Fatalf("Output = %q, want ok", result.Output())
+	}
+	if runner.path != helper {
+		t.Fatalf("runner path = %q, want %q", runner.path, helper)
+	}
+	if want := []string{"open", "https://example.com"}; !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("runner args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBrowserRunDisabledFailsBeforeDiscovery(t *testing.T) {
+	browser := NewBrowser(BrowserOptions{Enabled: false, HelperPath: "/does/not/exist"})
+	_, err := browser.Run(context.Background(), "snapshot")
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("Run error = %v, want disabled", err)
+	}
+}
+
+func TestBrowserRunMissingHelperPathIsActionable(t *testing.T) {
+	browser := NewBrowser(BrowserOptions{Enabled: true, HelperPath: filepath.Join(t.TempDir(), "missing")})
+	_, err := browser.Run(context.Background(), "snapshot")
+	if err == nil || !strings.Contains(err.Error(), "helper not found") {
+		t.Fatalf("Run error = %v, want missing helper", err)
+	}
+}
+
+func TestBrowserRunUsesHelperManifest(t *testing.T) {
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "node_modules", ".bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	helper := filepath.Join(binDir, "agent-browser")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	t.Setenv(EnvHelperManifest, `{"version":1,"helpers":{"agent-browser":{"command":`+quoteJSON(helper)+`,"pathPrepend":[`+quoteJSON(binDir)+`],"env":{"ZERO_HELPER_TEST":"1"}}}}`)
+
+	runner := &fakeCommandRunner{}
+	browser := NewBrowser(BrowserOptions{
+		Enabled: true,
+		Runner:  runner,
+	})
+
+	if _, err := browser.Run(context.Background(), "snapshot"); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if runner.path != helper {
+		t.Fatalf("runner path = %q, want manifest helper %q", runner.path, helper)
+	}
+	if !envContains(runner.env, "ZERO_HELPER_TEST=1") {
+		t.Fatalf("env = %#v, want ZERO_HELPER_TEST", runner.env)
+	}
+	pathValue := envValue(runner.env, "PATH")
+	if !strings.HasPrefix(pathValue, binDir+string(os.PathListSeparator)) && pathValue != binDir {
+		t.Fatalf("PATH overlay = %q, want prefix %q", pathValue, binDir)
+	}
+}
+
+func TestBrowserRunUsesManifestPrefixArgs(t *testing.T) {
+	runner := &fakeCommandRunner{}
+	t.Setenv(EnvHelperManifest, `{"version":1,"helpers":{"agent-browser":{"command":"cmd.exe","prefixArgs":["/d","/s","/c","C:\\zero\\agent-browser.cmd"]}}}`)
+	browser := NewBrowser(BrowserOptions{
+		Enabled: true,
+		Runner:  runner,
+	})
+
+	if _, err := browser.Run(context.Background(), "open", "https://example.com"); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if runner.path != "cmd.exe" {
+		t.Fatalf("runner path = %q, want cmd.exe", runner.path)
+	}
+	want := []string{"/d", "/s", "/c", `C:\zero\agent-browser.cmd`, "open", "https://example.com"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("runner args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBrowserRunUsesAdjacentPackagedHelper(t *testing.T) {
+	root := t.TempDir()
+	native := filepath.Join(root, "zero")
+	if err := os.WriteFile(native, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write native: %v", err)
+	}
+	helpersDir := filepath.Join(root, "helpers")
+	if err := os.MkdirAll(helpersDir, 0o755); err != nil {
+		t.Fatalf("mkdir helpers: %v", err)
+	}
+	helper := filepath.Join(helpersDir, "agent-browser")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	oldExecutablePath := executablePath
+	executablePath = func() (string, error) { return native, nil }
+	t.Cleanup(func() { executablePath = oldExecutablePath })
+
+	runner := &fakeCommandRunner{}
+	browser := NewBrowser(BrowserOptions{
+		Enabled: true,
+		Runner:  runner,
+	})
+	if _, err := browser.Run(context.Background(), "snapshot"); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if runner.path != helper {
+		t.Fatalf("runner path = %q, want adjacent helper %q", runner.path, helper)
+	}
+}
+
+func TestBrowserRunUsesAdjacentPackagedNodeBinHelper(t *testing.T) {
+	root := t.TempDir()
+	native := filepath.Join(root, "zero")
+	if err := os.WriteFile(native, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write native: %v", err)
+	}
+	binDir := filepath.Join(root, "helpers", "node_modules", ".bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir helper bin: %v", err)
+	}
+	helper := filepath.Join(binDir, "agent-browser")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	oldExecutablePath := executablePath
+	executablePath = func() (string, error) { return native, nil }
+	t.Cleanup(func() { executablePath = oldExecutablePath })
+
+	runner := &fakeCommandRunner{}
+	browser := NewBrowser(BrowserOptions{
+		Enabled: true,
+		Runner:  runner,
+	})
+	if _, err := browser.Run(context.Background(), "snapshot"); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if runner.path != helper {
+		t.Fatalf("runner path = %q, want packaged node bin helper %q", runner.path, helper)
+	}
+}
+
+func quoteJSON(value string) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+func envContains(env []string, want string) bool {
+	for _, item := range env {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func envValue(env []string, key string) string {
+	for _, item := range env {
+		if got, value, ok := strings.Cut(item, "="); ok && got == key {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/localcontrol/browser_test.go
+++ b/internal/localcontrol/browser_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -123,6 +124,27 @@ func TestBrowserRunUsesManifestPrefixArgs(t *testing.T) {
 	want := []string{"/d", "/s", "/c", `C:\zero\agent-browser.cmd`, "open", "https://example.com"}
 	if !reflect.DeepEqual(runner.args, want) {
 		t.Fatalf("runner args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestMergeEnvReplacesPathCaseInsensitivelyOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows env keys are case-insensitive")
+	}
+	env := mergeEnv([]string{`Path=C:\Windows`, "ZERO=1"}, []string{`PATH=C:\Zero`})
+	pathCount := 0
+	for _, item := range env {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok || !strings.EqualFold(key, "PATH") {
+			continue
+		}
+		pathCount++
+		if value != `C:\Zero` {
+			t.Fatalf("PATH value = %q, want C:\\Zero", value)
+		}
+	}
+	if pathCount != 1 {
+		t.Fatalf("PATH entries = %d in %#v, want 1", pathCount, env)
 	}
 }
 

--- a/internal/npmwrapper/npmwrapper_test.go
+++ b/internal/npmwrapper/npmwrapper_test.go
@@ -25,6 +25,7 @@ func TestPackageBinPointsToNodeWrapper(t *testing.T) {
 		Scripts    map[string]string `json:"scripts"`
 		License    string            `json:"license"`
 		Files      []string          `json:"files"`
+		Deps       map[string]string `json:"dependencies"`
 		Repository json.RawMessage   `json:"repository"`
 		Engines    map[string]string `json:"engines"`
 	}
@@ -59,6 +60,11 @@ func TestPackageBinPointsToNodeWrapper(t *testing.T) {
 	}
 	if pkg.Engines["node"] == "" {
 		t.Fatalf("package.json engines.node is empty; the wrapper and installer require a modern Node")
+	}
+	for _, name := range []string{"agent-browser", "tuistory"} {
+		if pkg.Deps[name] == "" {
+			t.Fatalf("package.json dependencies is missing %q", name)
+		}
 	}
 	wantFiles := map[string]bool{"bin/zero.js": false, "scripts/postinstall.mjs": false}
 	for _, f := range pkg.Files {
@@ -258,6 +264,62 @@ func TestNodeWrapperLaunchesNativeBinary(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(output)); got != "mock-zero --version" {
 		t.Fatalf("wrapper output = %q", got)
+	}
+}
+
+func TestNodeWrapperPassesLocalControlHelperManifest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock executable fixture uses a POSIX shell script")
+	}
+	node := requireNode(t)
+	wrapperPath := copyWrapperFixture(t)
+	root := filepath.Dir(filepath.Dir(wrapperPath))
+	nativePath := filepath.Join(root, "zero")
+	if err := os.WriteFile(nativePath, []byte("#!/usr/bin/env sh\nprintf '%s\\n' \"$ZERO_LOCAL_CONTROL_HELPERS\"\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile native fixture: %v", err)
+	}
+	binDir := filepath.Join(root, "node_modules", ".bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll node_modules/.bin: %v", err)
+	}
+	for _, name := range []string{"agent-browser", "tuistory"} {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte("#!/usr/bin/env sh\n"), 0o755); err != nil {
+			t.Fatalf("WriteFile helper %s: %v", name, err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nodeWrapperTimeout())
+	defer cancel()
+	command := nodeWrapperCommand(ctx, node, wrapperPath, "--version")
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("wrapper timed out launching native binary: %v; output: %s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("wrapper returned error: %v; output: %s", err, output)
+	}
+	var manifest struct {
+		Version int `json:"version"`
+		Helpers map[string]struct {
+			Command     string   `json:"command"`
+			PrefixArgs  []string `json:"prefixArgs"`
+			PathPrepend []string `json:"pathPrepend"`
+		} `json:"helpers"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(output))), &manifest); err != nil {
+		t.Fatalf("manifest JSON = %q: %v", output, err)
+	}
+	for _, name := range []string{"agent-browser", "tuistory"} {
+		helper, ok := manifest.Helpers[name]
+		if !ok {
+			t.Fatalf("manifest missing helper %q: %#v", name, manifest.Helpers)
+		}
+		if helper.Command != filepath.Join(binDir, name) {
+			t.Fatalf("%s command = %q, want %q", name, helper.Command, filepath.Join(binDir, name))
+		}
+		if len(helper.PathPrepend) != 1 || helper.PathPrepend[0] != binDir {
+			t.Fatalf("%s pathPrepend = %#v, want [%q]", name, helper.PathPrepend, binDir)
+		}
 	}
 }
 

--- a/internal/npmwrapper/npmwrapper_test.go
+++ b/internal/npmwrapper/npmwrapper_test.go
@@ -314,13 +314,24 @@ func TestNodeWrapperPassesLocalControlHelperManifest(t *testing.T) {
 		if !ok {
 			t.Fatalf("manifest missing helper %q: %#v", name, manifest.Helpers)
 		}
-		if helper.Command != filepath.Join(binDir, name) {
-			t.Fatalf("%s command = %q, want %q", name, helper.Command, filepath.Join(binDir, name))
+		wantCommand := canonicalTestPath(t, filepath.Join(binDir, name))
+		if helper.Command != wantCommand {
+			t.Fatalf("%s command = %q, want %q", name, helper.Command, wantCommand)
 		}
-		if len(helper.PathPrepend) != 1 || helper.PathPrepend[0] != binDir {
-			t.Fatalf("%s pathPrepend = %#v, want [%q]", name, helper.PathPrepend, binDir)
+		wantBinDir := canonicalTestPath(t, binDir)
+		if len(helper.PathPrepend) != 1 || helper.PathPrepend[0] != wantBinDir {
+			t.Fatalf("%s pathPrepend = %#v, want [%q]", name, helper.PathPrepend, wantBinDir)
 		}
 	}
+}
+
+func canonicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("EvalSymlinks %s: %v", path, err)
+	}
+	return realPath
 }
 
 func copyWrapperFixture(t *testing.T) string {

--- a/internal/npmwrapper/npmwrapper_test.go
+++ b/internal/npmwrapper/npmwrapper_test.go
@@ -224,6 +224,7 @@ func TestNodeWrapperReportsMissingNativeBinary(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), nodeWrapperTimeout())
 	defer cancel()
 	command := nodeWrapperCommand(ctx, node, wrapperPath, "--version")
+	command.Env = append(withoutEnvKey(command.Env, "ZERO_LOCAL_CONTROL_HELPERS"), "ZERO_LOCAL_CONTROL_HELPERS=")
 	output, err := command.CombinedOutput()
 	if ctx.Err() != nil {
 		t.Fatalf("wrapper timed out reporting missing native binary: %v; output: %s", ctx.Err(), output)
@@ -309,6 +310,9 @@ func TestNodeWrapperPassesLocalControlHelperManifest(t *testing.T) {
 	if err := json.Unmarshal([]byte(strings.TrimSpace(string(output))), &manifest); err != nil {
 		t.Fatalf("manifest JSON = %q: %v", output, err)
 	}
+	if manifest.Version != 1 {
+		t.Fatalf("manifest version = %d, want 1", manifest.Version)
+	}
 	for _, name := range []string{"agent-browser", "tuistory"} {
 		helper, ok := manifest.Helpers[name]
 		if !ok {
@@ -325,6 +329,34 @@ func TestNodeWrapperPassesLocalControlHelperManifest(t *testing.T) {
 	}
 }
 
+func TestNodeWrapperClearsInheritedLocalControlHelperManifestWhenNoHelpers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock executable fixture uses a POSIX shell script")
+	}
+	node := requireNode(t)
+	wrapperPath := copyWrapperFixture(t)
+	root := filepath.Dir(filepath.Dir(wrapperPath))
+	nativePath := filepath.Join(root, "zero")
+	if err := os.WriteFile(nativePath, []byte("#!/usr/bin/env sh\nif [ -n \"${ZERO_LOCAL_CONTROL_HELPERS+x}\" ]; then printf 'set\\n'; else printf 'unset\\n'; fi\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile native fixture: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nodeWrapperTimeout())
+	defer cancel()
+	command := nodeWrapperCommand(ctx, node, wrapperPath, "--version")
+	command.Env = append(withoutEnvKey(command.Env, "ZERO_LOCAL_CONTROL_HELPERS"), `ZERO_LOCAL_CONTROL_HELPERS={"version":1,"helpers":{"agent-browser":{"command":"stale"}}}`)
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("wrapper timed out launching native binary: %v; output: %s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("wrapper returned error: %v; output: %s", err, output)
+	}
+	if got := strings.TrimSpace(string(output)); got != "unset" {
+		t.Fatalf("ZERO_LOCAL_CONTROL_HELPERS state = %q, want unset", got)
+	}
+}
+
 func canonicalTestPath(t *testing.T, path string) string {
 	t.Helper()
 	realPath, err := filepath.EvalSymlinks(path)
@@ -332,6 +364,18 @@ func canonicalTestPath(t *testing.T, path string) string {
 		t.Fatalf("EvalSymlinks %s: %v", path, err)
 	}
 	return realPath
+}
+
+func withoutEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
 }
 
 func copyWrapperFixture(t *testing.T) string {

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -732,12 +732,22 @@ func stageLocalControlHelpers(ctx context.Context, rootDir string, helpersDir st
 	if err := os.WriteFile(filepath.Join(helpersDir, "package.json"), append(bytes, '\n'), 0o644); err != nil {
 		return fmt.Errorf("write local-control helper package.json: %w", err)
 	}
+	lockfilePath := filepath.Join(rootDir, "package-lock.json")
+	if _, err := os.Stat(lockfilePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("package-lock.json is required to package local-control helpers")
+		}
+		return fmt.Errorf("stat package-lock.json: %w", err)
+	}
+	if err := copyFile(lockfilePath, filepath.Join(helpersDir, "package-lock.json"), 0o644); err != nil {
+		return fmt.Errorf("copy local-control helper package-lock.json: %w", err)
+	}
 
 	npmPath, err := exec.LookPath("npm")
 	if err != nil {
 		return fmt.Errorf("npm is required to package local-control helpers: %w", err)
 	}
-	command := exec.CommandContext(ctx, npmPath, "install", "--omit=dev", "--no-audit", "--no-fund", "--loglevel=error")
+	command := exec.CommandContext(ctx, npmPath, "ci", "--omit=dev", "--no-audit", "--no-fund", "--loglevel=error")
 	command.Dir = helpersDir
 	command.Env = append(os.Environ(), "npm_config_update_notifier=false")
 	output, err := command.CombinedOutput()

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -243,6 +243,9 @@ func Package(ctx context.Context, options PackageOptions) (PackageResult, error)
 	if err := copyPackageFiles(rootDir, stagingDir, artifactPath, stagedBinaryPath, goos, version, helperArtifacts); err != nil {
 		return PackageResult{}, err
 	}
+	if err := stageLocalControlHelpers(ctx, rootDir, filepath.Join(stagingDir, "helpers")); err != nil {
+		return PackageResult{}, err
+	}
 	if err := createArchive(stagingDir, archivePath, goos); err != nil {
 		return PackageResult{}, err
 	}
@@ -707,6 +710,95 @@ func copyPackageFiles(rootDir string, stagingDir string, artifactPath string, st
 	return nil
 }
 
+var localControlHelperPackages = []string{"agent-browser", "tuistory"}
+
+func stageLocalControlHelpers(ctx context.Context, rootDir string, helpersDir string) error {
+	dependencies, err := localControlHelperDependencies(rootDir)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(helpersDir, 0o755); err != nil {
+		return fmt.Errorf("create local-control helper staging dir: %w", err)
+	}
+	manifest := map[string]any{
+		"private":      true,
+		"type":         "module",
+		"dependencies": dependencies,
+	}
+	bytes, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(helpersDir, "package.json"), append(bytes, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write local-control helper package.json: %w", err)
+	}
+
+	npmPath, err := exec.LookPath("npm")
+	if err != nil {
+		return fmt.Errorf("npm is required to package local-control helpers: %w", err)
+	}
+	command := exec.CommandContext(ctx, npmPath, "install", "--omit=dev", "--no-audit", "--no-fund", "--loglevel=error")
+	command.Dir = helpersDir
+	command.Env = append(os.Environ(), "npm_config_update_notifier=false")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return fmt.Errorf("install local-control helper packages: %s", message)
+	}
+	if err := verifyStagedLocalControlHelpers(helpersDir, runtime.GOOS); err != nil {
+		return err
+	}
+	return nil
+}
+
+func localControlHelperDependencies(rootDir string) (map[string]string, error) {
+	bytes, err := os.ReadFile(filepath.Join(rootDir, "package.json"))
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if err := json.Unmarshal(bytes, &payload); err != nil {
+		return nil, fmt.Errorf("parse package.json: %w", err)
+	}
+	dependencies := map[string]string{}
+	for _, name := range localControlHelperPackages {
+		version := strings.TrimSpace(payload.Dependencies[name])
+		if version == "" {
+			return nil, fmt.Errorf("package.json dependency %q is required for packaged local-control helpers", name)
+		}
+		dependencies[name] = version
+	}
+	return dependencies, nil
+}
+
+func verifyStagedLocalControlHelpers(helpersDir string, goos string) error {
+	for _, name := range localControlHelperPackages {
+		found := false
+		for _, shimName := range localControlHelperShimNames(name, goos) {
+			if info, err := os.Stat(filepath.Join(helpersDir, "node_modules", ".bin", shimName)); err == nil && !info.IsDir() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("local-control helper package did not create a %s executable shim", name)
+		}
+	}
+	return nil
+}
+
+func localControlHelperShimNames(name string, goos string) []string {
+	if goos == "windows" {
+		return []string{name + ".cmd", name + ".exe", name}
+	}
+	return []string{name}
+}
+
 func copyFile(source string, destination string, mode fs.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
 		return err
@@ -763,7 +855,14 @@ func createTarGzArchive(stagingDir string, archivePath string) error {
 		if err != nil {
 			return err
 		}
-		header, err := tar.FileInfoHeader(info, "")
+		linkTarget := ""
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+		header, err := tar.FileInfoHeader(info, linkTarget)
 		if err != nil {
 			return err
 		}
@@ -771,7 +870,7 @@ func createTarGzArchive(stagingDir string, archivePath string) error {
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
 		}
-		if entry.IsDir() {
+		if entry.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
 		entryFile, err := os.Open(path)

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -357,6 +357,32 @@ func TestCreateArchivesWithRootPackageFiles(t *testing.T) {
 	})
 }
 
+func TestCreateTarArchivePreservesSymlinkTargets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix symlink archive behavior")
+	}
+	stagingDir := packageStagingFixture(t, "zero")
+	linkPath := filepath.Join(stagingDir, "helpers", "node_modules", ".bin", "agent-browser")
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	linkTarget := "../agent-browser/bin/agent-browser.js"
+	if err := os.Symlink(linkTarget, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	archivePath := filepath.Join(t.TempDir(), "zero-v0.1.0-linux-x64.tar.gz")
+	if err := createArchive(stagingDir, archivePath, "linux"); err != nil {
+		t.Fatalf("createArchive returned error: %v", err)
+	}
+	header := tarArchiveHeaders(t, archivePath)["helpers/node_modules/.bin/agent-browser"]
+	if header == nil {
+		t.Fatal("archive missing symlink header")
+	}
+	if header.Typeflag != tar.TypeSymlink || header.Linkname != linkTarget {
+		t.Fatalf("symlink header type/link = %v/%q, want %v/%q", header.Typeflag, header.Linkname, tar.TypeSymlink, linkTarget)
+	}
+}
+
 func TestCopyPackageFilesStagesLinuxSandboxHelper(t *testing.T) {
 	root := t.TempDir()
 	staging := t.TempDir()
@@ -417,6 +443,57 @@ func TestCopyPackageFilesStagesWindowsSandboxHelpers(t *testing.T) {
 	}
 }
 
+func TestStageLocalControlHelpersUsesPackageDependencies(t *testing.T) {
+	root := t.TempDir()
+	helpers := filepath.Join(t.TempDir(), "helpers")
+	mustWriteFile(t, filepath.Join(root, "package.json"), `{
+  "version": "0.1.0",
+  "dependencies": {
+    "agent-browser": "0.30.1",
+    "tuistory": "0.10.0"
+  }
+}`)
+	fakeBin := t.TempDir()
+	writeFakeNPM(t, fakeBin)
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := stageLocalControlHelpers(context.Background(), root, helpers); err != nil {
+		t.Fatalf("stageLocalControlHelpers: %v", err)
+	}
+	manifestBytes, err := os.ReadFile(filepath.Join(helpers, "package.json"))
+	if err != nil {
+		t.Fatalf("ReadFile helper package.json: %v", err)
+	}
+	manifest := string(manifestBytes)
+	for _, want := range []string{`"agent-browser": "0.30.1"`, `"tuistory": "0.10.0"`} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("helper package.json missing %s:\n%s", want, manifest)
+		}
+	}
+	for _, name := range localControlHelperPackages {
+		found := false
+		for _, shimName := range localControlHelperShimNames(name, runtime.GOOS) {
+			if _, err := os.Stat(filepath.Join(helpers, "node_modules", ".bin", shimName)); err == nil {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing shim for %s", name)
+		}
+	}
+}
+
+func TestLocalControlHelperDependenciesRequiresConfiguredPackages(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), `{"version":"0.1.0","dependencies":{"agent-browser":"0.30.1"}}`)
+
+	_, err := localControlHelperDependencies(root)
+	if err == nil || !strings.Contains(err.Error(), `dependency "tuistory"`) {
+		t.Fatalf("localControlHelperDependencies error = %v, want missing tuistory", err)
+	}
+}
+
 func packageStagingFixture(t *testing.T, binaryName string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -438,6 +515,35 @@ func packageStagingFixture(t *testing.T, binaryName string) string {
 	return dir
 }
 
+func writeFakeNPM(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "npm.cmd")
+		content := `@echo off
+mkdir node_modules 2>NUL
+mkdir node_modules\.bin 2>NUL
+echo @echo off> node_modules\.bin\agent-browser.cmd
+echo @echo off> node_modules\.bin\tuistory.cmd
+exit /b 0
+`
+		mustWriteFile(t, path, content)
+		return
+	}
+	path := filepath.Join(dir, "npm")
+	content := `#!/usr/bin/env sh
+set -eu
+mkdir -p node_modules/.bin
+for name in agent-browser tuistory; do
+  printf '#!/usr/bin/env sh\n' > "node_modules/.bin/$name"
+  chmod 755 "node_modules/.bin/$name"
+done
+`
+	mustWriteFile(t, path, content)
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("Chmod fake npm: %v", err)
+	}
+}
+
 func mustWriteFile(t *testing.T, path string, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -449,6 +555,16 @@ func mustWriteFile(t *testing.T, path string, content string) {
 }
 
 func tarArchiveNames(t *testing.T, archivePath string) map[string]bool {
+	t.Helper()
+	headers := tarArchiveHeaders(t, archivePath)
+	names := map[string]bool{}
+	for name := range headers {
+		names[name] = true
+	}
+	return names
+}
+
+func tarArchiveHeaders(t *testing.T, archivePath string) map[string]*tar.Header {
 	t.Helper()
 	file, err := os.Open(archivePath)
 	if err != nil {
@@ -465,7 +581,7 @@ func tarArchiveNames(t *testing.T, archivePath string) map[string]bool {
 		_ = gzipReader.Close()
 	}()
 	reader := tar.NewReader(gzipReader)
-	names := map[string]bool{}
+	headers := map[string]*tar.Header{}
 	for {
 		header, err := reader.Next()
 		if err != nil {
@@ -474,9 +590,10 @@ func tarArchiveNames(t *testing.T, archivePath string) map[string]bool {
 			}
 			t.Fatalf("tar Next: %v", err)
 		}
-		names[header.Name] = true
+		copied := *header
+		headers[header.Name] = &copied
 	}
-	return names
+	return headers
 }
 
 func zipArchiveNames(t *testing.T, archivePath string) map[string]bool {

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -453,6 +453,24 @@ func TestStageLocalControlHelpersUsesPackageDependencies(t *testing.T) {
     "tuistory": "0.10.0"
   }
 }`)
+	mustWriteFile(t, filepath.Join(root, "package-lock.json"), `{
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "agent-browser": "0.30.1",
+        "tuistory": "0.10.0"
+      }
+    },
+    "node_modules/agent-browser": {
+      "version": "0.30.1"
+    },
+    "node_modules/tuistory": {
+      "version": "0.10.0"
+    }
+  }
+}`)
 	fakeBin := t.TempDir()
 	writeFakeNPM(t, fakeBin)
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -470,6 +488,9 @@ func TestStageLocalControlHelpersUsesPackageDependencies(t *testing.T) {
 			t.Fatalf("helper package.json missing %s:\n%s", want, manifest)
 		}
 	}
+	if _, err := os.Stat(filepath.Join(helpers, "package-lock.json")); err != nil {
+		t.Fatalf("helper package-lock.json was not copied: %v", err)
+	}
 	for _, name := range localControlHelperPackages {
 		found := false
 		for _, shimName := range localControlHelperShimNames(name, runtime.GOOS) {
@@ -481,6 +502,23 @@ func TestStageLocalControlHelpersUsesPackageDependencies(t *testing.T) {
 		if !found {
 			t.Fatalf("missing shim for %s", name)
 		}
+	}
+}
+
+func TestStageLocalControlHelpersRequiresPackageLock(t *testing.T) {
+	root := t.TempDir()
+	helpers := filepath.Join(t.TempDir(), "helpers")
+	mustWriteFile(t, filepath.Join(root, "package.json"), `{
+  "version": "0.1.0",
+  "dependencies": {
+    "agent-browser": "0.30.1",
+    "tuistory": "0.10.0"
+  }
+}`)
+
+	err := stageLocalControlHelpers(context.Background(), root, helpers)
+	if err == nil || !strings.Contains(err.Error(), "package-lock.json is required") {
+		t.Fatalf("stageLocalControlHelpers error = %v, want package-lock requirement", err)
 	}
 }
 
@@ -520,6 +558,10 @@ func writeFakeNPM(t *testing.T, dir string) {
 	if runtime.GOOS == "windows" {
 		path := filepath.Join(dir, "npm.cmd")
 		content := `@echo off
+if not "%1"=="ci" (
+  echo expected npm ci 1>&2
+  exit /b 2
+)
 mkdir node_modules 2>NUL
 mkdir node_modules\.bin 2>NUL
 echo @echo off> node_modules\.bin\agent-browser.cmd
@@ -532,6 +574,10 @@ exit /b 0
 	path := filepath.Join(dir, "npm")
 	content := `#!/usr/bin/env sh
 set -eu
+if [ "${1:-}" != "ci" ]; then
+  echo "expected npm ci" >&2
+  exit 2
+fi
 mkdir -p node_modules/.bin
 for name in agent-browser tuistory; do
   printf '#!/usr/bin/env sh\n' > "node_modules/.bin/$name"

--- a/internal/sandbox/grant_scope.go
+++ b/internal/sandbox/grant_scope.go
@@ -90,9 +90,61 @@ func deriveBrowserHostScope(value any) (string, bool) {
 	}
 	trimmed := strings.TrimSpace(raw)
 	if trimmed != "" && !strings.Contains(trimmed, "://") {
+		if !browserURLLooksLikeBareHost(trimmed) {
+			return "", false
+		}
 		trimmed = "https://" + trimmed
 	}
 	return deriveHostScope(trimmed)
+}
+
+func browserURLLooksLikeBareHost(raw string) bool {
+	if raw == "" || strings.HasPrefix(raw, "//") {
+		return false
+	}
+	authority := raw
+	if cut := strings.IndexAny(authority, "/?#"); cut >= 0 {
+		authority = authority[:cut]
+	}
+	if authority == "" || strings.Contains(authority, "@") {
+		return false
+	}
+	host := authority
+	if strings.HasPrefix(authority, "[") {
+		end := strings.Index(authority, "]")
+		if end <= 1 {
+			return false
+		}
+		host = authority[1:end]
+		if rest := authority[end+1:]; rest != "" {
+			if !strings.HasPrefix(rest, ":") || !isDecimalPort(rest[1:]) {
+				return false
+			}
+		}
+	} else if strings.Contains(authority, ":") {
+		before, after, _ := strings.Cut(authority, ":")
+		if before == "" || !isDecimalPort(after) {
+			return false
+		}
+		host = before
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	return host == "localhost" || strings.Contains(host, ".") || net.ParseIP(host) != nil
+}
+
+func isDecimalPort(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	for _, r := range raw {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // resolveScopeAbs converts a raw scope to an absolute, cleaned path. A relative

--- a/internal/sandbox/grant_scope.go
+++ b/internal/sandbox/grant_scope.go
@@ -41,6 +41,11 @@ var scopeArgKeys = []struct {
 // no scoped argument is present, the value is not a string, or the value points
 // at the workspace root (".") -- in those cases the grant is plainly tool-wide.
 func DeriveScope(toolName string, args map[string]any) (string, ScopeKind) {
+	if toolName == "browser_open" {
+		if host, ok := deriveBrowserHostScope(args["url"]); ok {
+			return host, ScopeHost
+		}
+	}
 	if toolName == "web_fetch" {
 		if host, ok := deriveHostScope(args["url"]); ok {
 			return host, ScopeHost
@@ -76,6 +81,18 @@ func deriveHostScope(value any) (string, bool) {
 	}
 	host := normalizeHostScope(parsed.Hostname())
 	return host, host != ""
+}
+
+func deriveBrowserHostScope(value any) (string, bool) {
+	raw, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed != "" && !strings.Contains(trimmed, "://") {
+		trimmed = "https://" + trimmed
+	}
+	return deriveHostScope(trimmed)
 }
 
 // resolveScopeAbs converts a raw scope to an absolute, cleaned path. A relative

--- a/internal/sandbox/grant_scope_test.go
+++ b/internal/sandbox/grant_scope_test.go
@@ -142,6 +142,9 @@ func TestDeriveScope(t *testing.T) {
 		{name: "web fetch invalid url is tool-wide", tool: "web_fetch", args: map[string]any{"url": "://bad"}, wantRaw: "", wantKind: ScopeToolWide},
 		{name: "browser open url host", tool: "browser_open", args: map[string]any{"url": "https://Example.COM/path?q=1"}, wantRaw: "example.com", wantKind: ScopeHost},
 		{name: "browser open bare host", tool: "browser_open", args: map[string]any{"url": "Example.COM/path"}, wantRaw: "example.com", wantKind: ScopeHost},
+		{name: "browser open loopback bare host with port", tool: "browser_open", args: map[string]any{"url": "localhost:8080/path"}, wantRaw: "localhost", wantKind: ScopeHost},
+		{name: "browser open about blank is tool-wide", tool: "browser_open", args: map[string]any{"url": "about:blank"}, wantRaw: "", wantKind: ScopeToolWide},
+		{name: "browser open javascript url is tool-wide", tool: "browser_open", args: map[string]any{"url": "javascript:alert(1)"}, wantRaw: "", wantKind: ScopeToolWide},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/sandbox/grant_scope_test.go
+++ b/internal/sandbox/grant_scope_test.go
@@ -140,6 +140,8 @@ func TestDeriveScope(t *testing.T) {
 		{name: "whitespace path is tool-wide", tool: "write_file", args: map[string]any{"path": "  "}, wantRaw: "", wantKind: ScopeToolWide},
 		{name: "web fetch url host", tool: "web_fetch", args: map[string]any{"url": "https://Example.COM:443/path?q=1"}, wantRaw: "example.com", wantKind: ScopeHost},
 		{name: "web fetch invalid url is tool-wide", tool: "web_fetch", args: map[string]any{"url": "://bad"}, wantRaw: "", wantKind: ScopeToolWide},
+		{name: "browser open url host", tool: "browser_open", args: map[string]any{"url": "https://Example.COM/path?q=1"}, wantRaw: "example.com", wantKind: ScopeHost},
+		{name: "browser open bare host", tool: "browser_open", args: map[string]any{"url": "Example.COM/path"}, wantRaw: "example.com", wantKind: ScopeHost},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/sandbox/normalize.go
+++ b/internal/sandbox/normalize.go
@@ -30,7 +30,7 @@ func NormalizePermission(value Permission) Permission {
 func NormalizeSideEffect(value SideEffect) SideEffect {
 	normalized := SideEffect(strings.ToLower(strings.TrimSpace(string(value))))
 	switch normalized {
-	case SideEffectRead, SideEffectWrite, SideEffectShell, SideEffectNetwork, SideEffectOutOfWorkspace, SideEffectNone:
+	case SideEffectRead, SideEffectWrite, SideEffectShell, SideEffectNetwork, SideEffectLocalControl, SideEffectLocalBrowser, SideEffectLocalDesktop, SideEffectLocalTerminal, SideEffectOutOfWorkspace, SideEffectNone:
 		return normalized
 	default:
 		return SideEffectOutOfWorkspace

--- a/internal/sandbox/risk.go
+++ b/internal/sandbox/risk.go
@@ -93,6 +93,14 @@ func classifyWithScope(request Request, scope *Scope) Risk {
 		add("shell", RiskHigh)
 	case SideEffectNetwork:
 		add("network", RiskHigh)
+	case SideEffectLocalControl:
+		add("local_control", RiskHigh)
+	case SideEffectLocalBrowser:
+		add("local_browser", RiskHigh)
+	case SideEffectLocalDesktop:
+		add("local_desktop", RiskHigh)
+	case SideEffectLocalTerminal:
+		add("local_terminal", RiskHigh)
 	case SideEffectOutOfWorkspace:
 		add("out_of_workspace", RiskCritical)
 	case SideEffectNone:

--- a/internal/sandbox/risk_hardening_test.go
+++ b/internal/sandbox/risk_hardening_test.go
@@ -230,6 +230,13 @@ func TestClassifyNoneSideEffectIsLowRisk(t *testing.T) {
 	}
 }
 
+func TestClassifyLocalControlSideEffectIsHighRisk(t *testing.T) {
+	risk := Classify(Request{ToolName: "capture_artifact", SideEffect: SideEffectLocalControl})
+	if risk.Level != RiskHigh || !HasRiskCategory(risk, "local_control") {
+		t.Fatalf("local-control side-effect risk = %#v, want high local_control", risk)
+	}
+}
+
 // The following tests cover the AST analyzer wired into classifyWithScope as a
 // second opinion to the regex detectors.
 

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -50,6 +50,10 @@ const (
 	SideEffectWrite          SideEffect = "write"
 	SideEffectShell          SideEffect = "shell"
 	SideEffectNetwork        SideEffect = "network"
+	SideEffectLocalControl   SideEffect = "local_control"
+	SideEffectLocalBrowser   SideEffect = "local_browser"
+	SideEffectLocalDesktop   SideEffect = "local_desktop"
+	SideEffectLocalTerminal  SideEffect = "local_terminal"
 	SideEffectOutOfWorkspace SideEffect = "out_of_workspace"
 	// SideEffectNone marks a control-only tool that performs no read/write/
 	// shell/network effect (e.g. escalate_model). It must be recognized so it is

--- a/internal/tools/local_browser.go
+++ b/internal/tools/local_browser.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"sort"
 	"strconv"
@@ -52,7 +53,7 @@ func newBrowserInstallTool(options localcontrol.BrowserOptions) Tool {
 				},
 				AdditionalProperties: false,
 			},
-			safety: localControlSafety(options.Enabled, SideEffectNetwork, "Downloads browser runtime files for local browser automation."),
+			safety: localControlSafety(options.Enabled, SideEffectLocalBrowser, "Downloads browser runtime files for local browser automation."),
 		},
 		browser: localcontrol.NewBrowser(options),
 	}
@@ -544,9 +545,93 @@ func browserActionArgs(args map[string]any) (string, []string, error) {
 		}
 		return "", nil, fmt.Errorf("%s requires between %d and %d args", command, spec.min, spec.max)
 	}
-	commandArgs := append([]string{}, spec.argv...)
-	commandArgs = append(commandArgs, values...)
+	commandArgs, err := browserActionCommandArgs(command, spec, values)
+	if err != nil {
+		return "", nil, err
+	}
 	return command, commandArgs, nil
+}
+
+func browserActionCommandArgs(command string, spec browserActionSpec, values []string) ([]string, error) {
+	switch command {
+	case "connect":
+		target, err := browserConnectTargetFromString(values[0])
+		if err != nil {
+			return nil, err
+		}
+		commandArgs := append([]string{}, spec.argv...)
+		return append(commandArgs, target), nil
+	case "click", "dblclick", "hover", "check", "uncheck", "scroll_into_view", "get_text", "get_html", "get_value":
+		ref, err := browserRefFromString(values[0])
+		if err != nil {
+			return nil, err
+		}
+		commandArgs := append([]string{}, spec.argv...)
+		return append(commandArgs, ref), nil
+	case "fill", "type", "select":
+		ref, err := browserRefFromString(values[0])
+		if err != nil {
+			return nil, err
+		}
+		commandArgs := append([]string{}, spec.argv...)
+		commandArgs = append(commandArgs, ref)
+		commandArgs = append(commandArgs, values[1:]...)
+		return commandArgs, nil
+	case "drag":
+		fromRef, err := browserRefFromString(values[0])
+		if err != nil {
+			return nil, err
+		}
+		toRef, err := browserRefFromString(values[1])
+		if err != nil {
+			return nil, err
+		}
+		commandArgs := append([]string{}, spec.argv...)
+		return append(commandArgs, fromRef, toRef), nil
+	case "press":
+		key, err := browserKeyFromString(values[0])
+		if err != nil {
+			return nil, err
+		}
+		commandArgs := append([]string{}, spec.argv...)
+		return append(commandArgs, key), nil
+	case "get_attr":
+		ref, err := browserRefFromString(values[0])
+		if err != nil {
+			return nil, err
+		}
+		attr, err := browserSingleToken("attr", values[1])
+		if err != nil {
+			return nil, err
+		}
+		commandArgs := append([]string{}, spec.argv...)
+		return append(commandArgs, ref, attr), nil
+	case "scroll":
+		x, err := browserIntegerToken("x", values[0])
+		if err != nil {
+			return nil, err
+		}
+		y, err := browserIntegerToken("y", values[1])
+		if err != nil {
+			return nil, err
+		}
+		commandArgs := append([]string{}, spec.argv...)
+		return append(commandArgs, x, y), nil
+	case "tab":
+		commandArgs := append([]string{}, spec.argv...)
+		for _, value := range values {
+			arg, err := browserSingleToken("tab argument", value)
+			if err != nil {
+				return nil, err
+			}
+			commandArgs = append(commandArgs, arg)
+		}
+		return commandArgs, nil
+	default:
+		commandArgs := append([]string{}, spec.argv...)
+		commandArgs = append(commandArgs, values...)
+		return commandArgs, nil
+	}
 }
 
 func browserOpenURLArg(args map[string]any) (string, error) {
@@ -576,6 +661,10 @@ func browserConnectTargetArg(args map[string]any) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return browserConnectTargetFromString(target)
+}
+
+func browserConnectTargetFromString(target string) (string, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return "", fmt.Errorf("target is required")
@@ -586,7 +675,54 @@ func browserConnectTargetArg(args map[string]any) (string, error) {
 	if strings.HasPrefix(target, "-") {
 		return "", fmt.Errorf("target must be a CDP port or URL, not an option")
 	}
+	if port, err := strconv.Atoi(target); err == nil && port >= 1 && port <= 65535 {
+		return target, nil
+	}
+	host, err := browserConnectTargetHost(target)
+	if err != nil {
+		return "", err
+	}
+	if !isLoopbackHost(host) {
+		return "", fmt.Errorf("target must be a bare port or loopback host")
+	}
 	return target, nil
+}
+
+func browserConnectTargetHost(target string) (string, error) {
+	parsed, err := url.Parse(target)
+	if err == nil && parsed.Host != "" {
+		if !validBrowserPort(parsed.Port()) {
+			return "", fmt.Errorf("target URL must include a valid port")
+		}
+		return parsed.Hostname(), nil
+	}
+	if !strings.Contains(target, "://") {
+		parsed, err = url.Parse("http://" + target)
+		if err == nil && parsed.Host != "" {
+			if !validBrowserPort(parsed.Port()) {
+				return "", fmt.Errorf("target must include a valid port")
+			}
+			return parsed.Hostname(), nil
+		}
+	}
+	return "", fmt.Errorf("target must be a bare port or loopback host:port/URL")
+}
+
+func validBrowserPort(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	port, err := strconv.Atoi(raw)
+	return err == nil && port >= 1 && port <= 65535
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.Trim(strings.ToLower(strings.TrimSpace(host)), "[]")
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func browserRefArg(args map[string]any) (string, error) {
@@ -594,6 +730,10 @@ func browserRefArg(args map[string]any) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return browserRefFromString(ref)
+}
+
+func browserRefFromString(ref string) (string, error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return "", fmt.Errorf("ref is required")
@@ -627,6 +767,10 @@ func browserKeyArg(args map[string]any) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return browserKeyFromString(key)
+}
+
+func browserKeyFromString(key string) (string, error) {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return "", fmt.Errorf("key is required")
@@ -638,6 +782,31 @@ func browserKeyArg(args map[string]any) (string, error) {
 		return "", fmt.Errorf("key must be a key name, not an option")
 	}
 	return key, nil
+}
+
+func browserSingleToken(name string, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	if strings.ContainsAny(value, " \t\r\n;") {
+		return "", fmt.Errorf("%s must be a single token", name)
+	}
+	if strings.HasPrefix(value, "-") {
+		return "", fmt.Errorf("%s must not be an option", name)
+	}
+	return value, nil
+}
+
+func browserIntegerToken(name string, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	if _, err := strconv.Atoi(value); err != nil {
+		return "", fmt.Errorf("%s must be an integer", name)
+	}
+	return value, nil
 }
 
 func validateBrowserSnapshotSelector(selector string) error {

--- a/internal/tools/local_browser.go
+++ b/internal/tools/local_browser.go
@@ -1,0 +1,789 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/localcontrol"
+)
+
+const localBrowserOutputBudgetBytes = 128 * 1024
+
+type localControlRunner interface {
+	Run(ctx context.Context, args ...string) (localcontrol.CommandResult, error)
+}
+
+type browserAppLauncher interface {
+	LaunchBrowserApp(ctx context.Context, request localcontrol.BrowserAppLaunchRequest) (localcontrol.BrowserAppLaunchResult, error)
+}
+
+func NewLocalBrowserTools(options localcontrol.BrowserOptions) []Tool {
+	return []Tool{
+		newBrowserInstallTool(options),
+		newBrowserLaunchTool(options),
+		newBrowserConnectTool(options),
+		newBrowserOpenTool(options),
+		newBrowserSnapshotTool(options),
+		newBrowserClickTool(options),
+		newBrowserTypeTool(options),
+		newBrowserPressTool(options),
+		newBrowserActionTool(options),
+	}
+}
+
+type browserInstallTool struct {
+	baseTool
+	browser localcontrol.Browser
+}
+
+func newBrowserInstallTool(options localcontrol.BrowserOptions) Tool {
+	return browserInstallTool{
+		baseTool: baseTool{
+			name:        "browser_install",
+			description: "Install the local browser runtime used by browser automation.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"with_deps": {Type: "boolean", Description: "Also install Linux system dependencies when supported by the helper.", Default: false},
+				},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectNetwork, "Downloads browser runtime files for local browser automation."),
+		},
+		browser: localcontrol.NewBrowser(options),
+	}
+}
+
+func (tool browserInstallTool) Run(ctx context.Context, args map[string]any) Result {
+	withDeps, err := boolArg(args, "with_deps", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_install: " + err.Error())
+	}
+	commandArgs := []string{"install"}
+	if withDeps {
+		commandArgs = append(commandArgs, "--with-deps")
+	}
+	return browserCommandResult(ctx, tool.browser, "install", commandArgs)
+}
+
+type browserLaunchTool struct {
+	baseTool
+	browser  localcontrol.Browser
+	launcher browserAppLauncher
+}
+
+func newBrowserLaunchTool(options localcontrol.BrowserOptions) Tool {
+	return newBrowserLaunchToolWithLauncher(options, localcontrol.NewBrowserAppLauncher(localcontrol.BrowserAppLaunchOptions{}))
+}
+
+func newBrowserLaunchToolWithLauncher(options localcontrol.BrowserOptions, launcher browserAppLauncher) Tool {
+	return browserLaunchTool{
+		baseTool: baseTool{
+			name:        "browser_launch",
+			description: "Launch a supported local Chromium/Electron app with Chrome DevTools enabled and attach browser automation to it. Use this for installed Electron apps such as Discord instead of launching GUI apps through shell commands.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"app":           {Type: "string", Description: "Supported local app to launch.", Enum: []string{"discord"}},
+					"debug_port":    {Type: "integer", Description: "Local Chrome DevTools port to expose.", Default: localcontrol.DefaultDevToolsPort, Minimum: intPtr(1024), Maximum: intPtr(65535)},
+					"stop_existing": {Type: "boolean", Description: "Stop the supported app before relaunching it with DevTools enabled.", Default: true},
+					"wait":          {Type: "boolean", Description: "Wait until the DevTools endpoint responds before returning.", Default: true},
+					"connect":       {Type: "boolean", Description: "Attach browser automation to the DevTools endpoint after launch.", Default: true},
+				},
+				Required:             []string{"app"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalBrowser, "Launches a supported local Chromium/Electron app with DevTools enabled and attaches local browser automation."),
+		},
+		browser:  localcontrol.NewBrowser(options),
+		launcher: launcher,
+	}
+}
+
+func (tool browserLaunchTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := browserLaunchRequestArg(args); err != nil {
+		return errorResult("Error: Invalid arguments for browser_launch: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool browserLaunchTool) Run(ctx context.Context, args map[string]any) Result {
+	request, err := browserLaunchRequestArg(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_launch: " + err.Error())
+	}
+	result, err := tool.launcher.LaunchBrowserApp(ctx, request)
+	if err != nil {
+		return errorResult("Error launching browser app: " + err.Error())
+	}
+	output := fmt.Sprintf("Launched %s with DevTools at %s (pid %d).", result.App, result.DevToolsURL, result.PID)
+	connect, err := boolArg(args, "connect", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_launch: " + err.Error())
+	}
+	if !connect {
+		return Result{
+			Status: StatusOK,
+			Output: output + "\n\nNext call browser_connect with target " + strconv.Itoa(result.DebugPort) + ".",
+			Meta: map[string]string{
+				"browser_command": "launch",
+				"app":             result.App,
+				"debug_port":      strconv.Itoa(result.DebugPort),
+				"pid":             strconv.Itoa(result.PID),
+			},
+			Display: Display{Summary: "launch completed", Kind: "browser"},
+		}
+	}
+	connectResult := browserCommandResult(ctx, tool.browser, "connect", []string{"connect", strconv.Itoa(result.DebugPort)})
+	if connectResult.Status == StatusOK {
+		connectResult.Output = output + "\n\nBrowser automation is already connected; use browser_snapshot next.\n\n" + connectResult.Output
+	} else {
+		connectResult.Output = output + "\n\n" + connectResult.Output
+	}
+	if connectResult.Meta == nil {
+		connectResult.Meta = map[string]string{}
+	}
+	connectResult.Meta["app"] = result.App
+	connectResult.Meta["debug_port"] = strconv.Itoa(result.DebugPort)
+	connectResult.Meta["pid"] = strconv.Itoa(result.PID)
+	return connectResult
+}
+
+type browserConnectTool struct {
+	baseTool
+	browser localcontrol.Browser
+}
+
+func newBrowserConnectTool(options localcontrol.BrowserOptions) Tool {
+	return browserConnectTool{
+		baseTool: baseTool{
+			name:        "browser_connect",
+			description: "Attach local browser automation to an existing Chrome/Electron DevTools endpoint. For Electron apps, first launch the app with --remote-debugging-port=<port>, then connect to that port instead of using desktop control.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"target": {Type: "string", Description: "CDP target: a port such as 9222, host:port, http(s) URL, ws(s) URL, or DevTools websocket URL."},
+				},
+				Required:             []string{"target"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalBrowser, "Attaches to a local browser or Electron app exposed over the Chrome DevTools Protocol."),
+		},
+		browser: localcontrol.NewBrowser(options),
+	}
+}
+
+func (tool browserConnectTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := browserConnectTargetArg(args); err != nil {
+		return errorResult("Error: Invalid arguments for browser_connect: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool browserConnectTool) Run(ctx context.Context, args map[string]any) Result {
+	target, err := browserConnectTargetArg(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_connect: " + err.Error())
+	}
+	return browserCommandResult(ctx, tool.browser, "connect", []string{"connect", target})
+}
+
+type browserOpenTool struct {
+	baseTool
+	browser localcontrol.Browser
+}
+
+func newBrowserOpenTool(options localcontrol.BrowserOptions) Tool {
+	return browserOpenTool{
+		baseTool: baseTool{
+			name:        "browser_open",
+			description: "Open a URL in the local browser automation session.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"url": {Type: "string", Description: "HTTP or HTTPS URL to open. Bare hosts are treated as https URLs."},
+				},
+				Required:             []string{"url"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectNetwork, "Opens a URL through the local browser automation helper. For already-running Chrome/Electron apps, use browser_connect instead. If first use reports a missing browser runtime, run browser_install once."),
+		},
+		browser: localcontrol.NewBrowser(options),
+	}
+}
+
+func (tool browserOpenTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := browserOpenURLArg(args); err != nil {
+		return errorResult("Error: Invalid arguments for browser_open: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool browserOpenTool) Run(ctx context.Context, args map[string]any) Result {
+	rawURL, err := browserOpenURLArg(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_open: " + err.Error())
+	}
+	return browserCommandResult(ctx, tool.browser, "open", []string{"open", rawURL})
+}
+
+type browserSnapshotTool struct {
+	baseTool
+	browser localcontrol.Browser
+}
+
+func newBrowserSnapshotTool(options localcontrol.BrowserOptions) Tool {
+	return browserSnapshotTool{
+		baseTool: baseTool{
+			name:        "browser_snapshot",
+			description: "Return an accessibility snapshot from the current local browser automation session.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"interactive":                {Type: "boolean", Description: "Return interactive elements only.", Default: true},
+					"include_cursor_interactive": {Type: "boolean", Description: "Include cursor-interactive elements such as onclick containers.", Default: false},
+					"compact":                    {Type: "boolean", Description: "Use compact snapshot output.", Default: false},
+					"depth":                      {Type: "integer", Description: "Optional tree depth limit.", Minimum: intPtr(0), Maximum: intPtr(20)},
+					"selector":                   {Type: "string", Description: "Optional CSS selector to scope the snapshot."},
+				},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalBrowser, "Reads the current local browser automation session state."),
+		},
+		browser: localcontrol.NewBrowser(options),
+	}
+}
+
+func (tool browserSnapshotTool) Run(ctx context.Context, args map[string]any) Result {
+	commandArgs, err := browserSnapshotCommandArgs(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_snapshot: " + err.Error())
+	}
+	return browserCommandResult(ctx, tool.browser, "snapshot", commandArgs)
+}
+
+func (tool browserSnapshotTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := browserSnapshotCommandArgs(args); err != nil {
+		return errorResult("Error: Invalid arguments for browser_snapshot: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+type browserClickTool struct {
+	baseTool
+	browser localcontrol.Browser
+}
+
+func newBrowserClickTool(options localcontrol.BrowserOptions) Tool {
+	return browserClickTool{
+		baseTool: baseTool{
+			name:        "browser_click",
+			description: "Click a ref from browser_snapshot in the current local browser automation session.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"ref": {Type: "string", Description: "Element ref from browser_snapshot, for example e114."},
+				},
+				Required:             []string{"ref"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalBrowser, "Clicks an element in the local browser automation session."),
+		},
+		browser: localcontrol.NewBrowser(options),
+	}
+}
+
+func (tool browserClickTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := browserRefArg(args); err != nil {
+		return errorResult("Error: Invalid arguments for browser_click: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool browserClickTool) Run(ctx context.Context, args map[string]any) Result {
+	ref, err := browserRefArg(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_click: " + err.Error())
+	}
+	return browserCommandResult(ctx, tool.browser, "click", []string{"click", ref})
+}
+
+type browserTypeTool struct {
+	baseTool
+	browser localcontrol.Browser
+}
+
+func newBrowserTypeTool(options localcontrol.BrowserOptions) Tool {
+	return browserTypeTool{
+		baseTool: baseTool{
+			name:        "browser_type",
+			description: "Type text into a ref from browser_snapshot in the current local browser automation session.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"ref":  {Type: "string", Description: "Element ref from browser_snapshot, for example e114."},
+					"text": {Type: "string", Description: "Text to type into the target element."},
+				},
+				Required:             []string{"ref", "text"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalBrowser, "Types text into an element in the local browser automation session."),
+		},
+		browser: localcontrol.NewBrowser(options),
+	}
+}
+
+func (tool browserTypeTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, _, err := browserTypeArgs(args); err != nil {
+		return errorResult("Error: Invalid arguments for browser_type: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool browserTypeTool) Run(ctx context.Context, args map[string]any) Result {
+	ref, text, err := browserTypeArgs(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_type: " + err.Error())
+	}
+	return browserCommandResult(ctx, tool.browser, "type", []string{"type", ref, text})
+}
+
+type browserPressTool struct {
+	baseTool
+	browser localcontrol.Browser
+}
+
+func newBrowserPressTool(options localcontrol.BrowserOptions) Tool {
+	return browserPressTool{
+		baseTool: baseTool{
+			name:        "browser_press",
+			description: "Press a keyboard key in the current local browser automation session.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"key": {Type: "string", Description: "Key to press, for example Enter, Escape, or Control+L."},
+				},
+				Required:             []string{"key"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalBrowser, "Presses a key in the local browser automation session."),
+		},
+		browser: localcontrol.NewBrowser(options),
+	}
+}
+
+func (tool browserPressTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := browserKeyArg(args); err != nil {
+		return errorResult("Error: Invalid arguments for browser_press: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool browserPressTool) Run(ctx context.Context, args map[string]any) Result {
+	key, err := browserKeyArg(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_press: " + err.Error())
+	}
+	return browserCommandResult(ctx, tool.browser, "press", []string{"press", key})
+}
+
+type browserActionTool struct {
+	baseTool
+	browser localcontrol.Browser
+}
+
+func browserSnapshotCommandArgs(args map[string]any) ([]string, error) {
+	interactive, err := boolArg(args, "interactive", true)
+	if err != nil {
+		return nil, err
+	}
+	includeCursorInteractive, err := boolArg(args, "include_cursor_interactive", false)
+	if err != nil {
+		return nil, err
+	}
+	compact, err := boolArg(args, "compact", false)
+	if err != nil {
+		return nil, err
+	}
+	depth, err := intArg(args, "depth", 0, 0, 20)
+	if err != nil {
+		return nil, err
+	}
+	selector, err := stringArgWithEmpty(args, "selector", "", false, false)
+	if err != nil {
+		return nil, err
+	}
+	selector = strings.TrimSpace(selector)
+	if err := validateBrowserSnapshotSelector(selector); err != nil {
+		return nil, err
+	}
+
+	commandArgs := []string{"snapshot"}
+	if interactive {
+		commandArgs = append(commandArgs, "-i")
+	}
+	if includeCursorInteractive {
+		commandArgs = append(commandArgs, "-C")
+	}
+	if compact {
+		commandArgs = append(commandArgs, "-c")
+	}
+	if depth > 0 {
+		commandArgs = append(commandArgs, "-d", strconv.Itoa(depth))
+	}
+	if selector != "" {
+		commandArgs = append(commandArgs, "-s", selector)
+	}
+	return commandArgs, nil
+}
+
+func newBrowserActionTool(options localcontrol.BrowserOptions) Tool {
+	return browserActionTool{
+		baseTool: baseTool{
+			name:        "browser_action",
+			description: "Run an allowed action against the current local browser automation session.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"command": {Type: "string", Description: "Allowed browser command to run.", Enum: browserActionCommandNames()},
+					"args":    {Type: "array", Items: &PropertySchema{Type: "string"}, Description: "Command arguments. Use refs from browser_snapshot where required."},
+				},
+				Required:             []string{"command"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalBrowser, "Interacts with the local browser automation session."),
+		},
+		browser: localcontrol.NewBrowser(options),
+	}
+}
+
+func (tool browserActionTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, _, err := browserActionArgs(args); err != nil {
+		return errorResult("Error: Invalid arguments for browser_action: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool browserActionTool) Run(ctx context.Context, args map[string]any) Result {
+	command, commandArgs, err := browserActionArgs(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for browser_action: " + err.Error())
+	}
+	return browserCommandResult(ctx, tool.browser, command, commandArgs)
+}
+
+type browserActionSpec struct {
+	argv []string
+	min  int
+	max  int
+}
+
+var browserActionSpecs = map[string]browserActionSpec{
+	"back":                 {argv: []string{"back"}, min: 0, max: 0},
+	"forward":              {argv: []string{"forward"}, min: 0, max: 0},
+	"reload":               {argv: []string{"reload"}, min: 0, max: 0},
+	"close":                {argv: []string{"close"}, min: 0, max: 0},
+	"connect":              {argv: []string{"connect"}, min: 1, max: 1},
+	"click":                {argv: []string{"click"}, min: 1, max: 1},
+	"dblclick":             {argv: []string{"dblclick"}, min: 1, max: 1},
+	"fill":                 {argv: []string{"fill"}, min: 2, max: 2},
+	"type":                 {argv: []string{"type"}, min: 2, max: 2},
+	"press":                {argv: []string{"press"}, min: 1, max: 1},
+	"keyboard_type":        {argv: []string{"keyboard", "type"}, min: 1, max: 1},
+	"keyboard_insert_text": {argv: []string{"keyboard", "inserttext"}, min: 1, max: 1},
+	"hover":                {argv: []string{"hover"}, min: 1, max: 1},
+	"check":                {argv: []string{"check"}, min: 1, max: 1},
+	"uncheck":              {argv: []string{"uncheck"}, min: 1, max: 1},
+	"select":               {argv: []string{"select"}, min: 2, max: 2},
+	"scroll":               {argv: []string{"scroll"}, min: 2, max: 2},
+	"scroll_into_view":     {argv: []string{"scrollintoview"}, min: 1, max: 1},
+	"drag":                 {argv: []string{"drag"}, min: 2, max: 2},
+	"wait":                 {argv: []string{"wait"}, min: 1, max: 3},
+	"get_text":             {argv: []string{"get", "text"}, min: 1, max: 1},
+	"get_html":             {argv: []string{"get", "html"}, min: 1, max: 1},
+	"get_value":            {argv: []string{"get", "value"}, min: 1, max: 1},
+	"get_attr":             {argv: []string{"get", "attr"}, min: 2, max: 2},
+	"get_title":            {argv: []string{"get", "title"}, min: 0, max: 0},
+	"get_url":              {argv: []string{"get", "url"}, min: 0, max: 0},
+	"tab":                  {argv: []string{"tab"}, min: 0, max: 3},
+	"eval":                 {argv: []string{"eval"}, min: 1, max: 1},
+	"dialog_accept":        {argv: []string{"dialog", "accept"}, min: 0, max: 1},
+	"dialog_dismiss":       {argv: []string{"dialog", "dismiss"}, min: 0, max: 0},
+}
+
+func browserActionCommandNames() []string {
+	names := make([]string, 0, len(browserActionSpecs))
+	for name := range browserActionSpecs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func browserActionArgs(args map[string]any) (string, []string, error) {
+	command, err := stringArg(args, "command", "", true)
+	if err != nil {
+		return "", nil, err
+	}
+	command = strings.ToLower(strings.TrimSpace(command))
+	spec, ok := browserActionSpecs[command]
+	if !ok {
+		return "", nil, fmt.Errorf("command must be one of: %s", strings.Join(browserActionCommandNames(), ", "))
+	}
+	values, err := stringArrayArg(args, "args")
+	if err != nil {
+		return "", nil, err
+	}
+	if len(values) < spec.min || len(values) > spec.max {
+		if spec.min == spec.max {
+			return "", nil, fmt.Errorf("%s requires %d args", command, spec.min)
+		}
+		return "", nil, fmt.Errorf("%s requires between %d and %d args", command, spec.min, spec.max)
+	}
+	commandArgs := append([]string{}, spec.argv...)
+	commandArgs = append(commandArgs, values...)
+	return command, commandArgs, nil
+}
+
+func browserOpenURLArg(args map[string]any) (string, error) {
+	rawURL, err := stringArg(args, "url", "", true)
+	if err != nil {
+		return "", err
+	}
+	normalized := strings.TrimSpace(rawURL)
+	if !strings.Contains(normalized, "://") {
+		normalized = "https://" + normalized
+	}
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("url must use http or https")
+	}
+	if strings.TrimSpace(parsed.Host) == "" {
+		return "", fmt.Errorf("url must include a host")
+	}
+	return parsed.String(), nil
+}
+
+func browserConnectTargetArg(args map[string]any) (string, error) {
+	target, err := stringArg(args, "target", "", true)
+	if err != nil {
+		return "", err
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", fmt.Errorf("target is required")
+	}
+	if strings.ContainsAny(target, " \t\r\n;") {
+		return "", fmt.Errorf("target must not contain whitespace or semicolons")
+	}
+	if strings.HasPrefix(target, "-") {
+		return "", fmt.Errorf("target must be a CDP port or URL, not an option")
+	}
+	return target, nil
+}
+
+func browserRefArg(args map[string]any) (string, error) {
+	ref, err := stringArg(args, "ref", "", true)
+	if err != nil {
+		return "", err
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+	if strings.ContainsAny(ref, " \t\r\n;") {
+		return "", fmt.Errorf("ref must be a single browser_snapshot ref")
+	}
+	if strings.HasPrefix(ref, "-") {
+		return "", fmt.Errorf("ref must be a browser_snapshot ref, not an option")
+	}
+	return ref, nil
+}
+
+func browserTypeArgs(args map[string]any) (string, string, error) {
+	ref, err := browserRefArg(args)
+	if err != nil {
+		return "", "", err
+	}
+	text, err := stringArg(args, "text", "", true)
+	if err != nil {
+		return "", "", err
+	}
+	if text == "" {
+		return "", "", fmt.Errorf("text must be a non-empty string")
+	}
+	return ref, text, nil
+}
+
+func browserKeyArg(args map[string]any) (string, error) {
+	key, err := stringArg(args, "key", "", true)
+	if err != nil {
+		return "", err
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", fmt.Errorf("key is required")
+	}
+	if strings.ContainsAny(key, " \t\r\n;") {
+		return "", fmt.Errorf("key must be a single key name")
+	}
+	if strings.HasPrefix(key, "-") {
+		return "", fmt.Errorf("key must be a key name, not an option")
+	}
+	return key, nil
+}
+
+func validateBrowserSnapshotSelector(selector string) error {
+	if selector == "" {
+		return nil
+	}
+	if strings.Contains(selector, "]*") {
+		return fmt.Errorf("selector appears invalid: remove the trailing wildcard after the attribute selector")
+	}
+	if strings.ContainsAny(selector, "\r\n") {
+		return fmt.Errorf("selector must be a single line")
+	}
+	return nil
+}
+
+func browserLaunchRequestArg(args map[string]any) (localcontrol.BrowserAppLaunchRequest, error) {
+	app, err := stringArg(args, "app", "", true)
+	if err != nil {
+		return localcontrol.BrowserAppLaunchRequest{}, err
+	}
+	app = strings.ToLower(strings.TrimSpace(app))
+	switch app {
+	case "discord":
+	default:
+		return localcontrol.BrowserAppLaunchRequest{}, fmt.Errorf("app must be one of: discord")
+	}
+	port, err := intArg(args, "debug_port", localcontrol.DefaultDevToolsPort, 1024, 65535)
+	if err != nil {
+		return localcontrol.BrowserAppLaunchRequest{}, err
+	}
+	stopExisting, err := boolArg(args, "stop_existing", true)
+	if err != nil {
+		return localcontrol.BrowserAppLaunchRequest{}, err
+	}
+	wait, err := boolArg(args, "wait", true)
+	if err != nil {
+		return localcontrol.BrowserAppLaunchRequest{}, err
+	}
+	if _, err := boolArg(args, "connect", true); err != nil {
+		return localcontrol.BrowserAppLaunchRequest{}, err
+	}
+	return localcontrol.BrowserAppLaunchRequest{
+		App:          app,
+		DebugPort:    port,
+		StopExisting: stopExisting,
+		Wait:         wait,
+	}, nil
+}
+
+func stringArrayArg(args map[string]any, key string) ([]string, error) {
+	value, ok := args[key]
+	if !ok || value == nil {
+		return nil, nil
+	}
+	raw, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array of strings", key)
+	}
+	values := make([]string, 0, len(raw))
+	for index, item := range raw {
+		text, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be a string", key, index)
+		}
+		values = append(values, text)
+	}
+	return values, nil
+}
+
+func localControlSafety(enabled bool, sideEffect SideEffect, reason string) Safety {
+	if !enabled {
+		return Safety{
+			SideEffect: sideEffect,
+			Permission: PermissionDeny,
+			Reason:     "Local control is disabled.",
+		}
+	}
+	return promptSafety(sideEffect, reason)
+}
+
+func browserCommandResult(ctx context.Context, browser localcontrol.Browser, command string, args []string) Result {
+	return localControlCommandResult(ctx, browser, "browser", command, args)
+}
+
+func localControlCommandResult(ctx context.Context, runner localControlRunner, kind string, command string, args []string) Result {
+	result, err := runner.Run(ctx, args...)
+	output := result.Output()
+	budget := applyOutputBudget(output, localBrowserOutputBudgetBytes, "narrow the local-control query or request a scoped snapshot")
+	meta := outputBudgetMeta(budget)
+	meta[kind+"_command"] = command
+	if result.ExitCode != 0 {
+		meta["exit_code"] = strconv.Itoa(result.ExitCode)
+	}
+	if err != nil {
+		message := "Error running " + kind + " helper: " + err.Error()
+		if strings.TrimSpace(budget.Output) != "" {
+			message += "\n\n" + budget.Output
+		}
+		if kind == "browser" && command != "install" && browserInstallHintApplies(err.Error()+"\n"+budget.Output) {
+			message += "\n\nIf this is a first-use browser runtime error, call browser_install once, then retry the browser command."
+		}
+		return Result{
+			Status:    StatusError,
+			Output:    message,
+			Truncated: budget.Truncated,
+			Meta:      meta,
+			Display: Display{
+				Summary: command + " failed",
+				Kind:    kind,
+			},
+		}
+	}
+	if strings.TrimSpace(budget.Output) == "" {
+		budget.Output = kind + " command completed."
+	}
+	return Result{
+		Status:    StatusOK,
+		Output:    budget.Output,
+		Truncated: budget.Truncated,
+		Meta:      meta,
+		Display: Display{
+			Summary: command + " completed",
+			Kind:    kind,
+		},
+	}
+}
+
+func browserInstallHintApplies(message string) bool {
+	lower := strings.ToLower(message)
+	if strings.Contains(lower, "cdp error") {
+		return false
+	}
+	if strings.Contains(lower, "was not found on path") {
+		return true
+	}
+	if strings.Contains(lower, "executable doesn't exist") {
+		return true
+	}
+	if strings.Contains(lower, "browser runtime") {
+		return true
+	}
+	if strings.Contains(lower, "please run") && strings.Contains(lower, "install") && strings.Contains(lower, "browser") {
+		return true
+	}
+	if strings.Contains(lower, "could not find") && (strings.Contains(lower, "chromium") || strings.Contains(lower, "chrome") || strings.Contains(lower, "browser")) {
+		return true
+	}
+	return false
+}

--- a/internal/tools/local_browser_test.go
+++ b/internal/tools/local_browser_test.go
@@ -220,6 +220,13 @@ func TestBrowserInstallRunsHelperInstall(t *testing.T) {
 	}
 }
 
+func TestBrowserInstallUsesLocalBrowserSafety(t *testing.T) {
+	tool := newBrowserInstallTool(localcontrol.BrowserOptions{Enabled: true})
+	if tool.Safety().SideEffect != SideEffectLocalBrowser {
+		t.Fatalf("browser_install side effect = %s, want %s", tool.Safety().SideEffect, SideEffectLocalBrowser)
+	}
+}
+
 func TestBrowserConnectRunsHelperConnect(t *testing.T) {
 	runner := &fakeBrowserRunner{}
 	tool := newBrowserConnectTool(localBrowserTestOptions(t, runner))
@@ -233,9 +240,40 @@ func TestBrowserConnectRunsHelperConnect(t *testing.T) {
 	}
 }
 
+func TestBrowserConnectAcceptsLoopbackTargetsBeforePermission(t *testing.T) {
+	tool := newBrowserConnectTool(localcontrol.BrowserOptions{Enabled: true})
+	for _, target := range []string{
+		"9222",
+		"localhost:9222",
+		"127.0.0.1:9222",
+		"http://127.0.0.1:9222/json/version",
+		"ws://[::1]:9222/devtools/browser/abc",
+	} {
+		if result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{"target": target}); rejected {
+			t.Fatalf("target %q rejected before permission: %#v", target, result)
+		}
+	}
+}
+
 func TestBrowserConnectRejectsShellLikeTargetsBeforePermission(t *testing.T) {
 	tool := newBrowserConnectTool(localcontrol.BrowserOptions{Enabled: true})
 	for _, target := range []string{"--version", "9222;rm", "http://127.0.0.1:9222/json list"} {
+		result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{"target": target})
+		if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "browser_connect") {
+			t.Fatalf("target %q reject = (%v, %#v), want target rejection", target, rejected, result)
+		}
+	}
+}
+
+func TestBrowserConnectRejectsRemoteTargetsBeforePermission(t *testing.T) {
+	tool := newBrowserConnectTool(localcontrol.BrowserOptions{Enabled: true})
+	for _, target := range []string{
+		"example.com:9222",
+		"192.168.1.20:9222",
+		"https://example.com:9222/json/version",
+		"ws://example.com:9222/devtools/browser/abc",
+		"localhost:notaport",
+	} {
 		result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{"target": target})
 		if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "browser_connect") {
 			t.Fatalf("target %q reject = (%v, %#v), want target rejection", target, rejected, result)
@@ -296,6 +334,40 @@ func TestBrowserActionMapsAllowedCommand(t *testing.T) {
 	}
 }
 
+func TestBrowserActionConnectAcceptsLoopbackTarget(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newBrowserActionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"command": "connect",
+		"args":    []any{"127.0.0.1:9222"},
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"connect", "127.0.0.1:9222"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBrowserActionScrollAcceptsSignedIntegerDeltas(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newBrowserActionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"command": "scroll",
+		"args":    []any{"0", "-500"},
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"scroll", "0", "-500"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
 func TestBrowserActionRejectsUnknownCommandBeforePermission(t *testing.T) {
 	tool := newBrowserActionTool(localcontrol.BrowserOptions{Enabled: true})
 	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
@@ -303,6 +375,48 @@ func TestBrowserActionRejectsUnknownCommandBeforePermission(t *testing.T) {
 	})
 	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "command must be one of") {
 		t.Fatalf("reject = (%v, %#v), want command rejection", rejected, result)
+	}
+}
+
+func TestBrowserActionRejectsInvalidStructuredArgsBeforePermission(t *testing.T) {
+	tool := newBrowserActionTool(localcontrol.BrowserOptions{Enabled: true})
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "remote connect",
+			args: map[string]any{"command": "connect", "args": []any{"example.com:9222"}},
+			want: "loopback",
+		},
+		{
+			name: "click ref with space",
+			args: map[string]any{"command": "click", "args": []any{"e 1"}},
+			want: "ref",
+		},
+		{
+			name: "type ref option",
+			args: map[string]any{"command": "type", "args": []any{"--ref", "hello"}},
+			want: "ref",
+		},
+		{
+			name: "press key with space",
+			args: map[string]any{"command": "press", "args": []any{"Control L"}},
+			want: "key",
+		},
+		{
+			name: "drag target ref with space",
+			args: map[string]any{"command": "drag", "args": []any{"e1", "e 2"}},
+			want: "ref",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(tc.args)
+			if !rejected || result.Status != StatusError || !strings.Contains(result.Output, tc.want) {
+				t.Fatalf("reject = (%v, %#v), want %q", rejected, result, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/local_browser_test.go
+++ b/internal/tools/local_browser_test.go
@@ -1,0 +1,352 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/localcontrol"
+)
+
+type fakeBrowserRunner struct {
+	args     []string
+	calls    [][]string
+	stdout   string
+	stderr   string
+	exitCode int
+	err      error
+}
+
+type fakeBrowserAppLauncher struct {
+	request localcontrol.BrowserAppLaunchRequest
+	result  localcontrol.BrowserAppLaunchResult
+	err     error
+}
+
+func (runner *fakeBrowserRunner) Run(_ context.Context, path string, args []string, _ []string, _ time.Duration) (localcontrol.CommandResult, error) {
+	runner.args = append([]string(nil), args...)
+	runner.calls = append(runner.calls, append([]string(nil), args...))
+	stdout := runner.stdout
+	if stdout == "" && runner.stderr == "" && runner.err == nil {
+		stdout = "browser ok\n"
+	}
+	return localcontrol.CommandResult{
+		Path:     path,
+		Args:     append([]string(nil), args...),
+		Stdout:   stdout,
+		Stderr:   runner.stderr,
+		ExitCode: runner.exitCode,
+	}, runner.err
+}
+
+func (launcher *fakeBrowserAppLauncher) LaunchBrowserApp(_ context.Context, request localcontrol.BrowserAppLaunchRequest) (localcontrol.BrowserAppLaunchResult, error) {
+	launcher.request = request
+	if launcher.err != nil {
+		return localcontrol.BrowserAppLaunchResult{}, launcher.err
+	}
+	if launcher.result.App == "" {
+		launcher.result = localcontrol.BrowserAppLaunchResult{
+			App:         request.App,
+			PID:         1234,
+			DebugPort:   request.DebugPort,
+			DevToolsURL: "http://127.0.0.1:9222",
+		}
+	}
+	return launcher.result, nil
+}
+
+func localBrowserTestOptions(t *testing.T, runner localcontrol.CommandRunner) localcontrol.BrowserOptions {
+	t.Helper()
+	helper := filepath.Join(t.TempDir(), "agent-browser")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	return localcontrol.BrowserOptions{
+		Enabled:    true,
+		HelperPath: helper,
+		Runner:     runner,
+	}
+}
+
+func TestBrowserLaunchRunsSupportedAppAndConnects(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	launcher := &fakeBrowserAppLauncher{}
+	tool := newBrowserLaunchToolWithLauncher(localBrowserTestOptions(t, runner), launcher)
+
+	result := tool.Run(context.Background(), map[string]any{"app": "discord"})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	wantRequest := localcontrol.BrowserAppLaunchRequest{
+		App:          "discord",
+		DebugPort:    localcontrol.DefaultDevToolsPort,
+		StopExisting: true,
+		Wait:         true,
+	}
+	if !reflect.DeepEqual(launcher.request, wantRequest) {
+		t.Fatalf("launch request = %#v, want %#v", launcher.request, wantRequest)
+	}
+	if want := []string{"connect", "9222"}; !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("browser args = %#v, want %#v", runner.args, want)
+	}
+	if !strings.Contains(result.Output, "Launched discord") {
+		t.Fatalf("output = %q, want launch summary", result.Output)
+	}
+	if !strings.Contains(result.Output, "already connected") {
+		t.Fatalf("output = %q, want connected handoff", result.Output)
+	}
+}
+
+func TestBrowserLaunchCanSkipConnect(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	launcher := &fakeBrowserAppLauncher{}
+	tool := newBrowserLaunchToolWithLauncher(localBrowserTestOptions(t, runner), launcher)
+
+	result := tool.Run(context.Background(), map[string]any{
+		"app":           "discord",
+		"debug_port":    float64(9333),
+		"stop_existing": false,
+		"wait":          false,
+		"connect":       false,
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	wantRequest := localcontrol.BrowserAppLaunchRequest{
+		App:          "discord",
+		DebugPort:    9333,
+		StopExisting: false,
+		Wait:         false,
+	}
+	if !reflect.DeepEqual(launcher.request, wantRequest) {
+		t.Fatalf("launch request = %#v, want %#v", launcher.request, wantRequest)
+	}
+	if runner.args != nil {
+		t.Fatalf("browser args = %#v, want no connect", runner.args)
+	}
+	if !strings.Contains(result.Output, "Next call browser_connect with target 9333") {
+		t.Fatalf("output = %q, want connect hint", result.Output)
+	}
+}
+
+func TestBrowserLaunchRejectsUnsupportedAppBeforePermission(t *testing.T) {
+	tool := newBrowserLaunchToolWithLauncher(localcontrol.BrowserOptions{Enabled: true}, &fakeBrowserAppLauncher{})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{"app": "telegram"})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "app must be one of") {
+		t.Fatalf("reject = (%v, %#v), want app rejection", rejected, result)
+	}
+}
+
+func TestBrowserOpenNormalizesBareHost(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newBrowserOpenTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{"url": "example.com"})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	if want := []string{"open", "https://example.com"}; !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBrowserClickTypeAndPressRunStructuredCommands(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want []string
+	}{
+		{
+			name: "click",
+			args: map[string]any{"ref": "e114"},
+			want: []string{"click", "e114"},
+		},
+		{
+			name: "type",
+			args: map[string]any{"ref": "e114", "text": "hey from zero"},
+			want: []string{"type", "e114", "hey from zero"},
+		},
+		{
+			name: "press",
+			args: map[string]any{"key": "Enter"},
+			want: []string{"press", "Enter"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeBrowserRunner{}
+			var tool Tool
+			switch tc.name {
+			case "click":
+				tool = newBrowserClickTool(localBrowserTestOptions(t, runner))
+			case "type":
+				tool = newBrowserTypeTool(localBrowserTestOptions(t, runner))
+			case "press":
+				tool = newBrowserPressTool(localBrowserTestOptions(t, runner))
+			}
+			result := tool.Run(context.Background(), tc.args)
+			if result.Status != StatusOK {
+				t.Fatalf("status = %s output = %q", result.Status, result.Output)
+			}
+			if !reflect.DeepEqual(runner.args, tc.want) {
+				t.Fatalf("args = %#v, want %#v", runner.args, tc.want)
+			}
+		})
+	}
+}
+
+func TestBrowserTypeRejectsMissingRefBeforePermission(t *testing.T) {
+	tool := newBrowserTypeTool(localcontrol.BrowserOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{"text": "hey from zero"})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "ref is required") {
+		t.Fatalf("reject = (%v, %#v), want ref rejection", rejected, result)
+	}
+}
+
+func TestBrowserInstallRunsHelperInstall(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newBrowserInstallTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{"with_deps": true})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	if want := []string{"install", "--with-deps"}; !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBrowserConnectRunsHelperConnect(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newBrowserConnectTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{"target": "9222"})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	if want := []string{"connect", "9222"}; !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBrowserConnectRejectsShellLikeTargetsBeforePermission(t *testing.T) {
+	tool := newBrowserConnectTool(localcontrol.BrowserOptions{Enabled: true})
+	for _, target := range []string{"--version", "9222;rm", "http://127.0.0.1:9222/json list"} {
+		result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{"target": target})
+		if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "browser_connect") {
+			t.Fatalf("target %q reject = (%v, %#v), want target rejection", target, rejected, result)
+		}
+	}
+}
+
+func TestBrowserOpenRejectsUnsupportedSchemeBeforePermission(t *testing.T) {
+	tool := newBrowserOpenTool(localcontrol.BrowserOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{"url": "file:///etc/passwd"})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "http or https") {
+		t.Fatalf("reject = (%v, %#v), want scheme rejection", rejected, result)
+	}
+}
+
+func TestBrowserSnapshotBuildsStructuredArgs(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newBrowserSnapshotTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"compact":  true,
+		"depth":    float64(3),
+		"selector": "#app",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"snapshot", "-i", "-c", "-d", "3", "-s", "#app"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBrowserSnapshotRejectsObviousInvalidSelectorBeforePermission(t *testing.T) {
+	tool := newBrowserSnapshotTool(localcontrol.BrowserOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
+		"selector": `main[aria-label*="channel"] [role="textbox"]*`,
+	})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "selector appears invalid") {
+		t.Fatalf("reject = (%v, %#v), want selector rejection", rejected, result)
+	}
+}
+
+func TestBrowserActionMapsAllowedCommand(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newBrowserActionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"command": "keyboard_insert_text",
+		"args":    []any{"hello"},
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"keyboard", "inserttext", "hello"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBrowserActionRejectsUnknownCommandBeforePermission(t *testing.T) {
+	tool := newBrowserActionTool(localcontrol.BrowserOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
+		"command": "shell",
+	})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "command must be one of") {
+		t.Fatalf("reject = (%v, %#v), want command rejection", rejected, result)
+	}
+}
+
+func TestBrowserCDPErrorsDoNotSuggestBrowserInstall(t *testing.T) {
+	runner := &fakeBrowserRunner{
+		stdout:   "",
+		stderr:   "✗ CDP error (DOM.describeNode): Object id doesn't reference a Node\n",
+		exitCode: 1,
+		err:      errors.New("exit status 1"),
+	}
+	tool := newBrowserSnapshotTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{})
+	if result.Status != StatusError {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	if strings.Contains(result.Output, "browser_install") {
+		t.Fatalf("output = %q, should not suggest browser_install for CDP errors", result.Output)
+	}
+}
+
+func TestMissingBrowserHelperSuggestsBrowserInstall(t *testing.T) {
+	browser := localcontrol.NewBrowser(localcontrol.BrowserOptions{
+		Enabled: true,
+		Driver:  "definitely-missing-agent-browser",
+	})
+
+	result := browserCommandResult(context.Background(), browser, "snapshot", []string{"snapshot"})
+	if result.Status != StatusError {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "browser_install") {
+		t.Fatalf("output = %q, want browser_install hint", result.Output)
+	}
+}
+
+func TestDisabledBrowserToolsAreDenied(t *testing.T) {
+	var toolset []Tool
+	toolset = append(toolset, NewLocalBrowserTools(localcontrol.BrowserOptions{})...)
+	toolset = append(toolset, NewLocalDesktopTools(localcontrol.DesktopOptions{})...)
+	toolset = append(toolset, NewLocalTerminalTools(localcontrol.TerminalOptions{})...)
+	for _, tool := range toolset {
+		if tool.Safety().Permission != PermissionDeny {
+			t.Fatalf("%s permission = %s, want deny", tool.Name(), tool.Safety().Permission)
+		}
+	}
+}

--- a/internal/tools/local_capture.go
+++ b/internal/tools/local_capture.go
@@ -1,0 +1,427 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/localcontrol"
+)
+
+const defaultArtifactBaseName = "capture"
+
+type LocalControlArtifactOptions struct {
+	Browser      localcontrol.BrowserOptions
+	Desktop      localcontrol.DesktopOptions
+	Terminal     localcontrol.TerminalOptions
+	ArtifactsDir string
+}
+
+func NewLocalControlArtifactTools(options LocalControlArtifactOptions) []Tool {
+	return []Tool{newCaptureArtifactTool(options)}
+}
+
+type captureArtifactTool struct {
+	baseTool
+	browser      localcontrol.Browser
+	desktop      localcontrol.Desktop
+	terminal     localcontrol.Terminal
+	artifactsDir string
+}
+
+func newCaptureArtifactTool(options LocalControlArtifactOptions) Tool {
+	enabled := options.Browser.Enabled || options.Desktop.Enabled || options.Terminal.Enabled
+	return captureArtifactTool{
+		baseTool: baseTool{
+			name:        "capture_artifact",
+			description: "Capture local browser, desktop, or terminal state into the configured artifact directory.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"action":    {Type: "string", Description: "Capture action to run.", Enum: captureArtifactActionNames()},
+					"name":      {Type: "string", Description: "Optional artifact basename. Path separators are ignored."},
+					"full":      {Type: "boolean", Description: "Capture a full-page browser screenshot for browser_screenshot.", Default: false},
+					"annotate":  {Type: "boolean", Description: "Annotate browser screenshots with interactive element labels.", Default: false},
+					"pid":       {Type: "integer", Description: "Target process id for desktop_window_state.", Minimum: intPtr(1)},
+					"window_id": {Type: "integer", Description: "Target window id for desktop_window_state.", Minimum: intPtr(1)},
+					"query":     {Type: "string", Description: "Optional desktop snapshot query/filter."},
+					"session":   {Type: "string", Description: "Terminal session id for terminal_snapshot, or desktop session id for desktop_window_state."},
+					"trim":      {Type: "boolean", Description: "Trim trailing blank terminal screen lines for terminal_snapshot.", Default: true},
+				},
+				Required:             []string{"action"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(enabled, SideEffectLocalControl, "Captures local browser, desktop, or terminal state into the configured artifact directory."),
+		},
+		browser:      localcontrol.NewBrowser(options.Browser),
+		desktop:      localcontrol.NewDesktop(options.Desktop),
+		terminal:     localcontrol.NewTerminal(options.Terminal),
+		artifactsDir: options.ArtifactsDir,
+	}
+}
+
+func (tool captureArtifactTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	request, err := captureArtifactArgs(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for capture_artifact: " + err.Error()), true
+	}
+	if !tool.actionEnabled(request.action) {
+		return errorResult("Error: Local control driver for " + request.action + " is disabled."), true
+	}
+	return Result{}, false
+}
+
+func (tool captureArtifactTool) Run(ctx context.Context, args map[string]any) Result {
+	request, err := captureArtifactArgs(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for capture_artifact: " + err.Error())
+	}
+	if !tool.actionEnabled(request.action) {
+		return errorResult("Error: Local control driver for " + request.action + " is disabled.")
+	}
+
+	path, err := artifactOutputPath(tool.artifactsDir, request.name, request.extension())
+	if err != nil {
+		return errorResult("Error: Failed to prepare artifact path: " + err.Error())
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return errorResult("Error: Failed to create artifact directory: " + err.Error())
+	}
+
+	switch request.action {
+	case "browser_screenshot":
+		return tool.captureBrowserScreenshot(ctx, request, path)
+	case "browser_pdf":
+		return tool.captureBrowserPDF(ctx, request, path)
+	case "desktop_screenshot":
+		return tool.captureDesktopScreenshot(ctx, request, path)
+	case "desktop_window_state":
+		return tool.captureDesktopWindowState(ctx, request, path)
+	case "terminal_snapshot":
+		return tool.captureTerminalSnapshot(ctx, request, path)
+	default:
+		return errorResult("Error: Unsupported capture action " + request.action)
+	}
+}
+
+func (tool captureArtifactTool) actionEnabled(action string) bool {
+	switch actionDriver(action) {
+	case "browser":
+		return tool.browser.Enabled()
+	case "desktop":
+		return tool.desktop.Enabled()
+	case "terminal":
+		return tool.terminal.Enabled()
+	default:
+		return false
+	}
+}
+
+func (tool captureArtifactTool) captureBrowserScreenshot(ctx context.Context, request captureArtifactRequest, path string) Result {
+	commandArgs := []string{"screenshot"}
+	if request.full {
+		commandArgs = append(commandArgs, "--full")
+	}
+	if request.annotate {
+		commandArgs = append(commandArgs, "--annotate")
+	}
+	commandArgs = append(commandArgs, path)
+	return tool.captureHelperArtifact(ctx, tool.browser, "browser", request, path, commandArgs)
+}
+
+func (tool captureArtifactTool) captureBrowserPDF(ctx context.Context, request captureArtifactRequest, path string) Result {
+	return tool.captureHelperArtifact(ctx, tool.browser, "browser", request, path, []string{"pdf", path})
+}
+
+func (tool captureArtifactTool) captureDesktopScreenshot(ctx context.Context, request captureArtifactRequest, path string) Result {
+	payload, err := json.Marshal(map[string]any{"out_file": path})
+	if err != nil {
+		return errorResult("Error: Failed to encode desktop screenshot input: " + err.Error())
+	}
+	return tool.captureHelperArtifact(ctx, tool.desktop, "desktop", request, path, []string{"screenshot", string(payload)})
+}
+
+func (tool captureArtifactTool) captureDesktopWindowState(ctx context.Context, request captureArtifactRequest, path string) Result {
+	input := map[string]any{"pid": request.pid, "window_id": request.windowID}
+	if strings.TrimSpace(request.query) != "" {
+		input["query"] = request.query
+	}
+	if strings.TrimSpace(request.session) != "" {
+		input["session"] = request.session
+	}
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return errorResult("Error: Failed to encode desktop window state input: " + err.Error())
+	}
+	return tool.captureHelperArtifact(ctx, tool.desktop, "desktop", request, path, []string{"get_window_state", string(payload), "--screenshot-out-file", path})
+}
+
+func (tool captureArtifactTool) captureTerminalSnapshot(ctx context.Context, request captureArtifactRequest, path string) Result {
+	commandArgs := []string{"-s", request.session, "snapshot"}
+	if request.trim {
+		commandArgs = append(commandArgs, "--trim")
+	}
+	result, err := tool.terminal.Run(ctx, commandArgs...)
+	output := result.Output()
+	if err != nil {
+		return captureErrorResult("terminal", request, result, err)
+	}
+	if err := os.WriteFile(path, []byte(output), 0o600); err != nil {
+		return errorResult("Error: Failed to write terminal artifact: " + err.Error())
+	}
+	if err := writeArtifactMetadata(path, artifactMetadata{
+		Action: request.action,
+		Driver: "terminal",
+		Path:   path,
+		Args:   commandArgs,
+	}); err != nil {
+		return errorResult("Error: Failed to write artifact metadata: " + err.Error())
+	}
+	return captureOKResult("terminal", request, path, result)
+}
+
+func (tool captureArtifactTool) captureHelperArtifact(ctx context.Context, runner localControlRunner, driver string, request captureArtifactRequest, path string, args []string) Result {
+	result, err := runner.Run(ctx, args...)
+	if err != nil {
+		return captureErrorResult(driver, request, result, err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		return errorResult("Error: Helper completed but artifact was not written: " + err.Error())
+	}
+	if err := writeArtifactMetadata(path, artifactMetadata{
+		Action: request.action,
+		Driver: driver,
+		Path:   path,
+		Args:   args,
+	}); err != nil {
+		return errorResult("Error: Failed to write artifact metadata: " + err.Error())
+	}
+	return captureOKResult(driver, request, path, result)
+}
+
+type captureArtifactRequest struct {
+	action   string
+	name     string
+	full     bool
+	annotate bool
+	pid      int
+	windowID int
+	query    string
+	session  string
+	trim     bool
+}
+
+func (request captureArtifactRequest) extension() string {
+	switch request.action {
+	case "browser_pdf":
+		return ".pdf"
+	case "terminal_snapshot":
+		return ".txt"
+	default:
+		return ".png"
+	}
+}
+
+var captureArtifactActions = map[string]bool{
+	"browser_screenshot":   true,
+	"browser_pdf":          true,
+	"desktop_screenshot":   true,
+	"desktop_window_state": true,
+	"terminal_snapshot":    true,
+}
+
+func captureArtifactActionNames() []string {
+	names := make([]string, 0, len(captureArtifactActions))
+	for name := range captureArtifactActions {
+		names = append(names, name)
+	}
+	sortStrings(names)
+	return names
+}
+
+func captureArtifactArgs(args map[string]any) (captureArtifactRequest, error) {
+	action, err := stringArg(args, "action", "", true)
+	if err != nil {
+		return captureArtifactRequest{}, err
+	}
+	action = strings.ToLower(strings.TrimSpace(action))
+	if !captureArtifactActions[action] {
+		return captureArtifactRequest{}, fmt.Errorf("action must be one of: %s", strings.Join(captureArtifactActionNames(), ", "))
+	}
+	name, err := stringArgWithEmpty(args, "name", "", false, false)
+	if err != nil {
+		return captureArtifactRequest{}, err
+	}
+	request := captureArtifactRequest{action: action, name: name, trim: true}
+	switch action {
+	case "browser_screenshot":
+		request.full, err = boolArg(args, "full", false)
+		if err != nil {
+			return captureArtifactRequest{}, err
+		}
+		request.annotate, err = boolArg(args, "annotate", false)
+		if err != nil {
+			return captureArtifactRequest{}, err
+		}
+	case "desktop_window_state":
+		request.pid, err = requiredIntArg(args, "pid", 1, 0)
+		if err != nil {
+			return captureArtifactRequest{}, err
+		}
+		request.windowID, err = requiredIntArg(args, "window_id", 1, 0)
+		if err != nil {
+			return captureArtifactRequest{}, err
+		}
+		request.query, err = stringArgWithEmpty(args, "query", "", false, false)
+		if err != nil {
+			return captureArtifactRequest{}, err
+		}
+		request.session, err = stringArgWithEmpty(args, "session", "", false, false)
+		if err != nil {
+			return captureArtifactRequest{}, err
+		}
+	case "terminal_snapshot":
+		request.session, err = stringArg(args, "session", "", true)
+		if err != nil {
+			return captureArtifactRequest{}, err
+		}
+		request.trim, err = boolArg(args, "trim", true)
+		if err != nil {
+			return captureArtifactRequest{}, err
+		}
+	}
+	return request, nil
+}
+
+func actionDriver(action string) string {
+	switch {
+	case strings.HasPrefix(action, "browser_"):
+		return "browser"
+	case strings.HasPrefix(action, "desktop_"):
+		return "desktop"
+	case strings.HasPrefix(action, "terminal_"):
+		return "terminal"
+	default:
+		return ""
+	}
+}
+
+type artifactMetadata struct {
+	Action    string    `json:"action"`
+	Driver    string    `json:"driver"`
+	Path      string    `json:"path"`
+	Args      []string  `json:"args"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+func writeArtifactMetadata(path string, metadata artifactMetadata) error {
+	metadata.CreatedAt = time.Now().UTC()
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path+".json", data, 0o600)
+}
+
+func captureOKResult(driver string, request captureArtifactRequest, path string, helperResult localcontrol.CommandResult) Result {
+	output := "Artifact captured: " + path
+	helperOutput := strings.TrimSpace(helperResult.Output())
+	if helperOutput != "" {
+		output += "\n\n" + helperOutput
+	}
+	return Result{
+		Status: StatusOK,
+		Output: output,
+		Meta: map[string]string{
+			"artifact_path": path,
+			"action":        request.action,
+			"driver":        driver,
+		},
+		ChangedFiles: []string{path, path + ".json"},
+		Display: Display{
+			Summary: request.action + " captured",
+			Kind:    "artifact",
+		},
+	}
+}
+
+func captureErrorResult(driver string, request captureArtifactRequest, result localcontrol.CommandResult, err error) Result {
+	output := "Error running " + driver + " helper: " + err.Error()
+	if helperOutput := strings.TrimSpace(result.Output()); helperOutput != "" {
+		output += "\n\n" + helperOutput
+	}
+	meta := map[string]string{
+		"action": request.action,
+		"driver": driver,
+	}
+	if result.ExitCode != 0 {
+		meta["exit_code"] = strconv.Itoa(result.ExitCode)
+	}
+	return Result{
+		Status: StatusError,
+		Output: output,
+		Meta:   meta,
+		Display: Display{
+			Summary: request.action + " failed",
+			Kind:    "artifact",
+		},
+	}
+}
+
+var artifactNameCleanPattern = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+func artifactOutputPath(dir string, name string, extension string) (string, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return "", fmt.Errorf("artifact directory is not configured")
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	base := sanitizeArtifactName(name)
+	if base == "" {
+		base = defaultArtifactBaseName + "-" + time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+	if extension != "" {
+		if ext := filepath.Ext(base); ext != "" {
+			base = strings.TrimSuffix(base, ext)
+		}
+		if base == "" {
+			base = defaultArtifactBaseName + "-" + time.Now().UTC().Format("20060102T150405.000000000Z")
+		}
+		base += extension
+	}
+	path := filepath.Join(absDir, base)
+	rel, err := filepath.Rel(absDir, path)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("artifact path escapes artifact directory")
+	}
+	return path, nil
+}
+
+func sanitizeArtifactName(name string) string {
+	name = filepath.Base(strings.TrimSpace(name))
+	name = strings.TrimPrefix(name, ".")
+	name = artifactNameCleanPattern.ReplaceAllString(name, "-")
+	name = strings.Trim(name, ".-_")
+	return name
+}
+
+func sortStrings(values []string) {
+	for i := 1; i < len(values); i++ {
+		for j := i; j > 0 && values[j] < values[j-1]; j-- {
+			values[j], values[j-1] = values[j-1], values[j]
+		}
+	}
+}

--- a/internal/tools/local_capture.go
+++ b/internal/tools/local_capture.go
@@ -36,7 +36,7 @@ type captureArtifactTool struct {
 }
 
 func newCaptureArtifactTool(options LocalControlArtifactOptions) Tool {
-	enabled := options.Browser.Enabled || options.Desktop.Enabled || options.Terminal.Enabled
+	enabled := strings.TrimSpace(options.ArtifactsDir) != "" && (options.Browser.Enabled || options.Desktop.Enabled || options.Terminal.Enabled)
 	return captureArtifactTool{
 		baseTool: baseTool{
 			name:        "capture_artifact",
@@ -71,6 +71,9 @@ func (tool captureArtifactTool) RejectBeforePermission(args map[string]any) (Res
 	if err != nil {
 		return errorResult("Error: Invalid arguments for capture_artifact: " + err.Error()), true
 	}
+	if strings.TrimSpace(tool.artifactsDir) == "" {
+		return errorResult("Error: capture_artifact is disabled because no artifact directory is configured."), true
+	}
 	if !tool.actionEnabled(request.action) {
 		return errorResult("Error: Local control driver for " + request.action + " is disabled."), true
 	}
@@ -84,6 +87,9 @@ func (tool captureArtifactTool) Run(ctx context.Context, args map[string]any) Re
 	}
 	if !tool.actionEnabled(request.action) {
 		return errorResult("Error: Local control driver for " + request.action + " is disabled.")
+	}
+	if strings.TrimSpace(tool.artifactsDir) == "" {
+		return errorResult("Error: capture_artifact is disabled because no artifact directory is configured.")
 	}
 
 	path, err := artifactOutputPath(tool.artifactsDir, request.name, request.extension())

--- a/internal/tools/local_capture_test.go
+++ b/internal/tools/local_capture_test.go
@@ -1,0 +1,148 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/localcontrol"
+)
+
+type fakeArtifactRunner struct {
+	args   []string
+	stdout string
+}
+
+func (runner *fakeArtifactRunner) Run(_ context.Context, path string, args []string, _ []string, _ time.Duration) (localcontrol.CommandResult, error) {
+	runner.args = append([]string(nil), args...)
+	for _, arg := range args {
+		switch filepath.Ext(arg) {
+		case ".png", ".pdf":
+			_ = os.WriteFile(arg, []byte("artifact"), 0o600)
+		}
+	}
+	stdout := runner.stdout
+	if stdout == "" {
+		stdout = "captured\n"
+	}
+	return localcontrol.CommandResult{
+		Path:     path,
+		Args:     append([]string(nil), args...),
+		Stdout:   stdout,
+		ExitCode: 0,
+	}, nil
+}
+
+func TestCaptureArtifactBrowserScreenshotWritesMetadataAndSanitizesName(t *testing.T) {
+	dir := t.TempDir()
+	runner := &fakeArtifactRunner{}
+	tool := newCaptureArtifactTool(LocalControlArtifactOptions{
+		Browser:      localBrowserTestOptions(t, runner),
+		ArtifactsDir: dir,
+	})
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":   "browser_screenshot",
+		"name":     "../proof.txt",
+		"full":     true,
+		"annotate": true,
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	path := filepath.Join(dir, "proof.png")
+	wantArgs := []string{"screenshot", "--full", "--annotate", path}
+	if !reflect.DeepEqual(runner.args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", runner.args, wantArgs)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("artifact missing: %v", err)
+	}
+	var metadata map[string]any
+	data, err := os.ReadFile(path + ".json")
+	if err != nil {
+		t.Fatalf("metadata missing: %v", err)
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("metadata json: %v", err)
+	}
+	if metadata["action"] != "browser_screenshot" || metadata["driver"] != "browser" || metadata["path"] != path {
+		t.Fatalf("metadata = %#v", metadata)
+	}
+	if !reflect.DeepEqual(result.ChangedFiles, []string{path, path + ".json"}) {
+		t.Fatalf("changed files = %#v", result.ChangedFiles)
+	}
+}
+
+func TestCaptureArtifactTerminalSnapshotWritesOutput(t *testing.T) {
+	dir := t.TempDir()
+	runner := &fakeArtifactRunner{stdout: "screen\n"}
+	tool := newCaptureArtifactTool(LocalControlArtifactOptions{
+		Terminal:     localBrowserTestOptions(t, runner),
+		ArtifactsDir: dir,
+	})
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":  "terminal_snapshot",
+		"session": "demo",
+		"name":    "term",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	wantArgs := []string{"-s", "demo", "snapshot", "--trim"}
+	if !reflect.DeepEqual(runner.args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", runner.args, wantArgs)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "term.txt"))
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	if string(data) != "screen" {
+		t.Fatalf("artifact content = %q, want screen", string(data))
+	}
+}
+
+func TestCaptureArtifactRejectsDisabledDriverBeforePermission(t *testing.T) {
+	tool := newCaptureArtifactTool(LocalControlArtifactOptions{
+		Browser:      localcontrol.BrowserOptions{Enabled: true},
+		ArtifactsDir: t.TempDir(),
+	})
+
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
+		"action": "desktop_screenshot",
+	})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "disabled") {
+		t.Fatalf("reject = (%v, %#v), want disabled desktop rejection", rejected, result)
+	}
+}
+
+func TestCaptureArtifactDesktopWindowStateBuildsDriverArgs(t *testing.T) {
+	dir := t.TempDir()
+	runner := &fakeArtifactRunner{}
+	tool := newCaptureArtifactTool(LocalControlArtifactOptions{
+		Desktop:      localBrowserTestOptions(t, runner),
+		ArtifactsDir: dir,
+	})
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":    "desktop_window_state",
+		"name":      "window",
+		"pid":       float64(123),
+		"window_id": float64(456),
+		"query":     "Save",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	wantPath := filepath.Join(dir, "window.png")
+	wantArgs := []string{"get_window_state", `{"pid":123,"query":"Save","window_id":456}`, "--screenshot-out-file", wantPath}
+	if !reflect.DeepEqual(runner.args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", runner.args, wantArgs)
+	}
+}

--- a/internal/tools/local_capture_test.go
+++ b/internal/tools/local_capture_test.go
@@ -122,6 +122,21 @@ func TestCaptureArtifactRejectsDisabledDriverBeforePermission(t *testing.T) {
 	}
 }
 
+func TestCaptureArtifactRejectsMissingArtifactDirBeforePermission(t *testing.T) {
+	tool := newCaptureArtifactTool(LocalControlArtifactOptions{
+		Browser: localcontrol.BrowserOptions{Enabled: true},
+	})
+	if tool.Safety().Permission != PermissionDeny {
+		t.Fatalf("permission = %s, want deny", tool.Safety().Permission)
+	}
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
+		"action": "browser_screenshot",
+	})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "artifact directory") {
+		t.Fatalf("reject = (%v, %#v), want missing artifact directory", rejected, result)
+	}
+}
+
 func TestCaptureArtifactDesktopWindowStateBuildsDriverArgs(t *testing.T) {
 	dir := t.TempDir()
 	runner := &fakeArtifactRunner{}

--- a/internal/tools/local_desktop.go
+++ b/internal/tools/local_desktop.go
@@ -41,14 +41,17 @@ func newDesktopWindowsTool(options localcontrol.DesktopOptions) Tool {
 	}
 }
 
+func (tool desktopWindowsTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := desktopWindowsInput(args); err != nil {
+		return errorResult("Error: Invalid arguments for desktop_windows: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
 func (tool desktopWindowsTool) Run(ctx context.Context, args map[string]any) Result {
-	input := map[string]any{}
-	if _, ok := args["pid"]; ok {
-		pid, err := intArg(args, "pid", 0, 1, 0)
-		if err != nil {
-			return errorResult("Error: Invalid arguments for desktop_windows: " + err.Error())
-		}
-		input["pid"] = pid
+	input, err := desktopWindowsInput(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for desktop_windows: " + err.Error())
 	}
 	payload, err := json.Marshal(input)
 	if err != nil {
@@ -84,19 +87,17 @@ func newDesktopSnapshotTool(options localcontrol.DesktopOptions) Tool {
 	}
 }
 
+func (tool desktopSnapshotTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := desktopSnapshotInput(args); err != nil {
+		return errorResult("Error: Invalid arguments for desktop_snapshot: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
 func (tool desktopSnapshotTool) Run(ctx context.Context, args map[string]any) Result {
-	input, err := desktopWindowInput(args)
+	input, err := desktopSnapshotInput(args)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for desktop_snapshot: " + err.Error())
-	}
-	for _, key := range []string{"query", "session"} {
-		value, err := stringArgWithEmpty(args, key, "", false, false)
-		if err != nil {
-			return errorResult("Error: Invalid arguments for desktop_snapshot: " + err.Error())
-		}
-		if strings.TrimSpace(value) != "" {
-			input[key] = value
-		}
 	}
 	payload, err := json.Marshal(input)
 	if err != nil {
@@ -184,6 +185,35 @@ func desktopActionArgs(args map[string]any) (string, string, error) {
 		return "", "", err
 	}
 	return command, string(payload), nil
+}
+
+func desktopWindowsInput(args map[string]any) (map[string]any, error) {
+	input := map[string]any{}
+	if _, ok := args["pid"]; ok {
+		pid, err := intArg(args, "pid", 0, 1, 0)
+		if err != nil {
+			return nil, err
+		}
+		input["pid"] = pid
+	}
+	return input, nil
+}
+
+func desktopSnapshotInput(args map[string]any) (map[string]any, error) {
+	input, err := desktopWindowInput(args)
+	if err != nil {
+		return nil, err
+	}
+	for _, key := range []string{"query", "session"} {
+		value, err := stringArgWithEmpty(args, key, "", false, false)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(value) != "" {
+			input[key] = value
+		}
+	}
+	return input, nil
 }
 
 func desktopWindowInput(args map[string]any) (map[string]any, error) {

--- a/internal/tools/local_desktop.go
+++ b/internal/tools/local_desktop.go
@@ -1,0 +1,225 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/localcontrol"
+)
+
+func NewLocalDesktopTools(options localcontrol.DesktopOptions) []Tool {
+	return []Tool{
+		newDesktopWindowsTool(options),
+		newDesktopSnapshotTool(options),
+		newDesktopActionTool(options),
+	}
+}
+
+type desktopWindowsTool struct {
+	baseTool
+	desktop localcontrol.Desktop
+}
+
+func newDesktopWindowsTool(options localcontrol.DesktopOptions) Tool {
+	return desktopWindowsTool{
+		baseTool: baseTool{
+			name:        "desktop_windows",
+			description: "List native desktop windows through the local desktop automation helper.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"pid": {Type: "integer", Description: "Optional process id to list windows for.", Minimum: intPtr(1)},
+				},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalDesktop, "Reads native desktop window metadata."),
+		},
+		desktop: localcontrol.NewDesktop(options),
+	}
+}
+
+func (tool desktopWindowsTool) Run(ctx context.Context, args map[string]any) Result {
+	input := map[string]any{}
+	if _, ok := args["pid"]; ok {
+		pid, err := intArg(args, "pid", 0, 1, 0)
+		if err != nil {
+			return errorResult("Error: Invalid arguments for desktop_windows: " + err.Error())
+		}
+		input["pid"] = pid
+	}
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return errorResult("Error: Failed to encode desktop_windows input: " + err.Error())
+	}
+	return desktopCommandResult(ctx, tool.desktop, "list_windows", []string{"list_windows", string(payload)})
+}
+
+type desktopSnapshotTool struct {
+	baseTool
+	desktop localcontrol.Desktop
+}
+
+func newDesktopSnapshotTool(options localcontrol.DesktopOptions) Tool {
+	return desktopSnapshotTool{
+		baseTool: baseTool{
+			name:        "desktop_snapshot",
+			description: "Read a native desktop window accessibility snapshot through the local desktop automation helper.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"pid":       {Type: "integer", Description: "Target process id.", Minimum: intPtr(1)},
+					"window_id": {Type: "integer", Description: "Target window id.", Minimum: intPtr(1)},
+					"query":     {Type: "string", Description: "Optional query/filter for the snapshot."},
+					"session":   {Type: "string", Description: "Optional desktop automation session id."},
+				},
+				Required:             []string{"pid", "window_id"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalDesktop, "Reads a native desktop window state."),
+		},
+		desktop: localcontrol.NewDesktop(options),
+	}
+}
+
+func (tool desktopSnapshotTool) Run(ctx context.Context, args map[string]any) Result {
+	input, err := desktopWindowInput(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for desktop_snapshot: " + err.Error())
+	}
+	for _, key := range []string{"query", "session"} {
+		value, err := stringArgWithEmpty(args, key, "", false, false)
+		if err != nil {
+			return errorResult("Error: Invalid arguments for desktop_snapshot: " + err.Error())
+		}
+		if strings.TrimSpace(value) != "" {
+			input[key] = value
+		}
+	}
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return errorResult("Error: Failed to encode desktop_snapshot input: " + err.Error())
+	}
+	return desktopCommandResult(ctx, tool.desktop, "get_window_state", []string{"get_window_state", string(payload)})
+}
+
+type desktopActionTool struct {
+	baseTool
+	desktop localcontrol.Desktop
+}
+
+func newDesktopActionTool(options localcontrol.DesktopOptions) Tool {
+	return desktopActionTool{
+		baseTool: baseTool{
+			name:        "desktop_action",
+			description: "Run an allowed native desktop action through the local desktop automation helper.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"command": {Type: "string", Description: "Allowed desktop command to run.", Enum: desktopActionCommandNames()},
+					"input":   {Type: "object", Description: "JSON object passed to the desktop command."},
+				},
+				Required:             []string{"command", "input"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalDesktop, "Interacts with native desktop windows."),
+		},
+		desktop: localcontrol.NewDesktop(options),
+	}
+}
+
+func (tool desktopActionTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, _, err := desktopActionArgs(args); err != nil {
+		return errorResult("Error: Invalid arguments for desktop_action: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool desktopActionTool) Run(ctx context.Context, args map[string]any) Result {
+	command, payload, err := desktopActionArgs(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for desktop_action: " + err.Error())
+	}
+	return desktopCommandResult(ctx, tool.desktop, command, []string{command, payload})
+}
+
+var desktopActionCommands = map[string]bool{
+	"start_session": true,
+	"end_session":   true,
+	"launch_app":    true,
+	"click":         true,
+	"type_text":     true,
+	"press_key":     true,
+	"hotkey":        true,
+	"scroll":        true,
+	"drag":          true,
+}
+
+func desktopActionCommandNames() []string {
+	names := make([]string, 0, len(desktopActionCommands))
+	for name := range desktopActionCommands {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func desktopActionArgs(args map[string]any) (string, string, error) {
+	command, err := stringArg(args, "command", "", true)
+	if err != nil {
+		return "", "", err
+	}
+	command = strings.ToLower(strings.TrimSpace(command))
+	if !desktopActionCommands[command] {
+		return "", "", fmt.Errorf("command must be one of: %s", strings.Join(desktopActionCommandNames(), ", "))
+	}
+	input, err := objectArg(args, "input", true)
+	if err != nil {
+		return "", "", err
+	}
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return "", "", err
+	}
+	return command, string(payload), nil
+}
+
+func desktopWindowInput(args map[string]any) (map[string]any, error) {
+	pid, err := requiredIntArg(args, "pid", 1, 0)
+	if err != nil {
+		return nil, err
+	}
+	windowID, err := requiredIntArg(args, "window_id", 1, 0)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"pid": pid, "window_id": windowID}, nil
+}
+
+func requiredIntArg(args map[string]any, key string, min int, max int) (int, error) {
+	if _, ok := args[key]; !ok {
+		return 0, fmt.Errorf("%s is required", key)
+	}
+	return intArg(args, key, 0, min, max)
+}
+
+func objectArg(args map[string]any, key string, required bool) (map[string]any, error) {
+	value, ok := args[key]
+	if !ok || value == nil {
+		if required {
+			return nil, fmt.Errorf("%s is required", key)
+		}
+		return map[string]any{}, nil
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an object", key)
+	}
+	return object, nil
+}
+
+func desktopCommandResult(ctx context.Context, desktop localcontrol.Desktop, command string, args []string) Result {
+	return localControlCommandResult(ctx, desktop, "desktop", command, args)
+}

--- a/internal/tools/local_desktop_terminal_test.go
+++ b/internal/tools/local_desktop_terminal_test.go
@@ -1,0 +1,236 @@
+package tools
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/localcontrol"
+)
+
+func TestDesktopSnapshotBuildsDriverJSON(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newDesktopSnapshotTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"pid":       float64(123),
+		"window_id": float64(456),
+		"query":     "Save",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"get_window_state", `{"pid":123,"query":"Save","window_id":456}`}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestDesktopActionMapsAllowedCommand(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newDesktopActionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"command": "click",
+		"input": map[string]any{
+			"pid":           float64(123),
+			"window_id":     float64(456),
+			"element_index": float64(7),
+		},
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"click", `{"element_index":7,"pid":123,"window_id":456}`}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestDesktopActionRejectsUnknownCommandBeforePermission(t *testing.T) {
+	tool := newDesktopActionTool(localcontrol.DesktopOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
+		"command": "screenshot",
+		"input":   map[string]any{},
+	})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "command must be one of") {
+		t.Fatalf("reject = (%v, %#v), want command rejection", rejected, result)
+	}
+}
+
+func TestTerminalLaunchBuildsTuistoryArgs(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newTerminalSessionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":  "launch",
+		"session": "demo",
+		"command": "npm start",
+		"cols":    float64(100),
+		"rows":    float64(30),
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"launch", "npm start", "-s", "demo", "--cols", "100", "--rows", "30"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestTerminalPressBuildsTuistoryArgs(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newTerminalSessionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":  "press",
+		"session": "demo",
+		"key":     "Ctrl-C",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"-s", "demo", "press", "ctrl", "c"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestTerminalPressKeysRunsSequentialPresses(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newTerminalSessionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":  "press",
+		"session": "demo",
+		"keys":    []any{"tab", "Return", "ctrl-c"},
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := [][]string{
+		{"-s", "demo", "press", "tab"},
+		{"-s", "demo", "press", "enter"},
+		{"-s", "demo", "press", "ctrl", "c"},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestTerminalSendLineTypesTextThenEnter(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newTerminalSessionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":  "send_line",
+		"session": "demo",
+		"text":    "echo hello",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := [][]string{
+		{"-s", "demo", "type", "echo hello"},
+		{"-s", "demo", "press", "enter"},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestTerminalSendLineWithEmptyTextPressesEnterOnly(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newTerminalSessionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":  "send_line",
+		"session": "demo",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := [][]string{{"-s", "demo", "press", "enter"}}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestTerminalSnapshotHidesCursorByDefault(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newTerminalSessionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":  "snapshot",
+		"session": "demo",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"-s", "demo", "snapshot", "--trim", "--no-cursor"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestTerminalReadBuildsTuistoryArgs(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newTerminalSessionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":     "read",
+		"session":    "demo",
+		"all":        true,
+		"follow":     true,
+		"timeout_ms": float64(3000),
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"-s", "demo", "read", "--all", "--trim", "--follow", "--timeout", "3000"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestTerminalWaitIdleAcceptsTimeout(t *testing.T) {
+	runner := &fakeBrowserRunner{}
+	tool := newTerminalSessionTool(localBrowserTestOptions(t, runner))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"action":     "wait_idle",
+		"session":    "demo",
+		"timeout_ms": float64(2000),
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s output = %q", result.Status, result.Output)
+	}
+	want := []string{"-s", "demo", "wait-idle", "--timeout", "2000"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestTerminalRejectsInvalidKeyBeforePermission(t *testing.T) {
+	tool := newTerminalSessionTool(localcontrol.TerminalOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
+		"action":  "press",
+		"session": "demo",
+		"key":     "hyper",
+	})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "unsupported key") {
+		t.Fatalf("reject = (%v, %#v), want key rejection", rejected, result)
+	}
+}
+
+func TestTerminalRejectsInvalidActionBeforePermission(t *testing.T) {
+	tool := newTerminalSessionTool(localcontrol.TerminalOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
+		"action":  "record",
+		"session": "demo",
+	})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "action must be one of") {
+		t.Fatalf("reject = (%v, %#v), want action rejection", rejected, result)
+	}
+}

--- a/internal/tools/local_desktop_terminal_test.go
+++ b/internal/tools/local_desktop_terminal_test.go
@@ -27,6 +27,25 @@ func TestDesktopSnapshotBuildsDriverJSON(t *testing.T) {
 	}
 }
 
+func TestDesktopWindowsRejectsInvalidPIDBeforePermission(t *testing.T) {
+	tool := newDesktopWindowsTool(localcontrol.DesktopOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{"pid": float64(0)})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "pid") {
+		t.Fatalf("reject = (%v, %#v), want pid rejection", rejected, result)
+	}
+}
+
+func TestDesktopSnapshotRejectsInvalidWindowArgsBeforePermission(t *testing.T) {
+	tool := newDesktopSnapshotTool(localcontrol.DesktopOptions{Enabled: true})
+	result, rejected := tool.(PrePermissionRejecter).RejectBeforePermission(map[string]any{
+		"pid":       float64(123),
+		"window_id": float64(0),
+	})
+	if !rejected || result.Status != StatusError || !strings.Contains(result.Output, "window_id") {
+		t.Fatalf("reject = (%v, %#v), want window_id rejection", rejected, result)
+	}
+}
+
 func TestDesktopActionMapsAllowedCommand(t *testing.T) {
 	runner := &fakeBrowserRunner{}
 	tool := newDesktopActionTool(localBrowserTestOptions(t, runner))

--- a/internal/tools/local_terminal.go
+++ b/internal/tools/local_terminal.go
@@ -1,0 +1,389 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/localcontrol"
+)
+
+func NewLocalTerminalTools(options localcontrol.TerminalOptions) []Tool {
+	return []Tool{newTerminalSessionTool(options)}
+}
+
+type terminalSessionTool struct {
+	baseTool
+	terminal localcontrol.Terminal
+}
+
+func newTerminalSessionTool(options localcontrol.TerminalOptions) Tool {
+	return terminalSessionTool{
+		baseTool: baseTool{
+			name:        "terminal_session",
+			description: "Launch or control a local virtual terminal session through the local terminal automation helper.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"action":     {Type: "string", Description: "Terminal session action.", Enum: terminalActionNames()},
+					"session":    {Type: "string", Description: "Terminal session id."},
+					"command":    {Type: "string", Description: "Command to launch for action=launch."},
+					"text":       {Type: "string", Description: "Text to type for action=type, or text to submit before Enter for action=send_line."},
+					"key":        {Type: "string", Description: "Single key or key chord for action=press, such as enter, tab, or ctrl-c."},
+					"keys":       {Type: "array", Items: &PropertySchema{Type: "string"}, Description: "Sequence of keys or key chords for action=press, such as [\"tab\", \"enter\"] or [\"ctrl-c\", \"enter\"]."},
+					"pattern":    {Type: "string", Description: "Text or regex pattern for action=wait."},
+					"timeout_ms": {Type: "integer", Description: "Wait timeout in milliseconds.", Minimum: intPtr(1)},
+					"cols":       {Type: "integer", Description: "Terminal columns for action=launch.", Default: 120, Minimum: intPtr(20), Maximum: intPtr(300)},
+					"rows":       {Type: "integer", Description: "Terminal rows for action=launch.", Default: 36, Minimum: intPtr(5), Maximum: intPtr(120)},
+					"trim":       {Type: "boolean", Description: "Trim trailing blank screen lines for action=snapshot.", Default: true},
+					"cursor":     {Type: "boolean", Description: "Include the visible cursor in action=snapshot output.", Default: false},
+					"all":        {Type: "boolean", Description: "Return all buffered terminal output for action=read without advancing the read cursor.", Default: false},
+					"follow":     {Type: "boolean", Description: "Block until new process output arrives for action=read.", Default: false},
+				},
+				Required:             []string{"action", "session"},
+				AdditionalProperties: false,
+			},
+			safety: localControlSafety(options.Enabled, SideEffectLocalTerminal, "Launches or interacts with a local virtual terminal session."),
+		},
+		terminal: localcontrol.NewTerminal(options),
+	}
+}
+
+func (tool terminalSessionTool) RejectBeforePermission(args map[string]any) (Result, bool) {
+	if _, err := terminalSessionPlan(args); err != nil {
+		return errorResult("Error: Invalid arguments for terminal_session: " + err.Error()), true
+	}
+	return Result{}, false
+}
+
+func (tool terminalSessionTool) Run(ctx context.Context, args map[string]any) Result {
+	plan, err := terminalSessionPlan(args)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for terminal_session: " + err.Error())
+	}
+	return terminalCommandResult(ctx, tool.terminal, plan)
+}
+
+var terminalActions = map[string]bool{
+	"launch":    true,
+	"read":      true,
+	"type":      true,
+	"press":     true,
+	"send_line": true,
+	"wait":      true,
+	"wait_idle": true,
+	"snapshot":  true,
+	"close":     true,
+}
+
+func terminalActionNames() []string {
+	names := make([]string, 0, len(terminalActions))
+	for name := range terminalActions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+type terminalCommandPlan struct {
+	action   string
+	commands [][]string
+}
+
+func terminalSessionPlan(args map[string]any) (terminalCommandPlan, error) {
+	action, err := stringArg(args, "action", "", true)
+	if err != nil {
+		return terminalCommandPlan{}, err
+	}
+	action = strings.ToLower(strings.TrimSpace(action))
+	if !terminalActions[action] {
+		return terminalCommandPlan{}, fmt.Errorf("action must be one of: %s", strings.Join(terminalActionNames(), ", "))
+	}
+	session, err := stringArg(args, "session", "", true)
+	if err != nil {
+		return terminalCommandPlan{}, err
+	}
+
+	switch action {
+	case "launch":
+		command, err := stringArg(args, "command", "", true)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		cols, err := intArg(args, "cols", 120, 20, 300)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		rows, err := intArg(args, "rows", 36, 5, 120)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		return singleTerminalCommand(action, "launch", command, "-s", session, "--cols", strconv.Itoa(cols), "--rows", strconv.Itoa(rows)), nil
+	case "type":
+		text, err := stringArgWithEmpty(args, "text", "", true, true)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		return singleTerminalCommand(action, "-s", session, "type", text), nil
+	case "send_line":
+		text, err := stringArgWithEmpty(args, "text", "", false, true)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		commands := make([][]string, 0, 2)
+		if text != "" {
+			commands = append(commands, []string{"-s", session, "type", text})
+		}
+		commands = append(commands, []string{"-s", session, "press", "enter"})
+		return terminalCommandPlan{action: action, commands: commands}, nil
+	case "press":
+		commands, err := terminalPressCommands(args, session)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		return terminalCommandPlan{action: action, commands: commands}, nil
+	case "wait":
+		pattern, err := stringArg(args, "pattern", "", true)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		command := []string{"-s", session, "wait", pattern}
+		if _, ok := args["timeout_ms"]; ok {
+			timeoutMS, err := intArg(args, "timeout_ms", 0, 1, 0)
+			if err != nil {
+				return terminalCommandPlan{}, err
+			}
+			command = append(command, "--timeout", strconv.Itoa(timeoutMS))
+		}
+		return terminalCommandPlan{action: action, commands: [][]string{command}}, nil
+	case "wait_idle":
+		command := []string{"-s", session, "wait-idle"}
+		if _, ok := args["timeout_ms"]; ok {
+			timeoutMS, err := intArg(args, "timeout_ms", 0, 1, 0)
+			if err != nil {
+				return terminalCommandPlan{}, err
+			}
+			command = append(command, "--timeout", strconv.Itoa(timeoutMS))
+		}
+		return terminalCommandPlan{action: action, commands: [][]string{command}}, nil
+	case "snapshot":
+		trim, err := boolArg(args, "trim", true)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		cursor, err := boolArg(args, "cursor", false)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		command := []string{"-s", session, "snapshot"}
+		if trim {
+			command = append(command, "--trim")
+		}
+		if !cursor {
+			command = append(command, "--no-cursor")
+		}
+		return terminalCommandPlan{action: action, commands: [][]string{command}}, nil
+	case "read":
+		readAll, err := boolArg(args, "all", false)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		trim, err := boolArg(args, "trim", true)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		follow, err := boolArg(args, "follow", false)
+		if err != nil {
+			return terminalCommandPlan{}, err
+		}
+		command := []string{"-s", session, "read"}
+		if readAll {
+			command = append(command, "--all")
+		}
+		if trim {
+			command = append(command, "--trim")
+		}
+		if follow {
+			command = append(command, "--follow")
+		}
+		if _, ok := args["timeout_ms"]; ok {
+			timeoutMS, err := intArg(args, "timeout_ms", 0, 1, 0)
+			if err != nil {
+				return terminalCommandPlan{}, err
+			}
+			command = append(command, "--timeout", strconv.Itoa(timeoutMS))
+		}
+		return terminalCommandPlan{action: action, commands: [][]string{command}}, nil
+	case "close":
+		return singleTerminalCommand(action, "-s", session, "close"), nil
+	default:
+		return terminalCommandPlan{}, fmt.Errorf("unsupported action %q", action)
+	}
+}
+
+func singleTerminalCommand(action string, args ...string) terminalCommandPlan {
+	return terminalCommandPlan{action: action, commands: [][]string{append([]string(nil), args...)}}
+}
+
+func terminalPressCommands(args map[string]any, session string) ([][]string, error) {
+	if raw, ok := args["keys"]; ok && raw != nil {
+		items, err := stringArrayArg(map[string]any{"keys": raw}, "keys")
+		if err != nil {
+			return nil, err
+		}
+		if len(items) == 0 {
+			return nil, fmt.Errorf("keys must include at least one key")
+		}
+		commands := make([][]string, 0, len(items))
+		for index, item := range items {
+			keys, err := terminalKeyChord(item)
+			if err != nil {
+				return nil, fmt.Errorf("keys[%d]: %w", index, err)
+			}
+			commands = append(commands, append([]string{"-s", session, "press"}, keys...))
+		}
+		return commands, nil
+	}
+	key, err := stringArg(args, "key", "", true)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := terminalKeyChord(key)
+	if err != nil {
+		return nil, err
+	}
+	return [][]string{append([]string{"-s", session, "press"}, keys...)}, nil
+}
+
+func terminalKeyChord(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("key must be a non-empty string")
+	}
+	if key, ok := normalizeTerminalKey(raw); ok {
+		return []string{key}, nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '+' || r == '-' || r == ' ' || r == '\t'
+	})
+	keys := make([]string, 0, len(parts))
+	for _, part := range parts {
+		key, ok := normalizeTerminalKey(part)
+		if !ok {
+			return nil, fmt.Errorf("unsupported key %q", part)
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("key must be a non-empty string")
+	}
+	return keys, nil
+}
+
+func normalizeTerminalKey(raw string) (string, bool) {
+	key := strings.ToLower(strings.TrimSpace(raw))
+	if key == "" {
+		return "", false
+	}
+	collapsed := strings.NewReplacer("_", "", "-", "", " ", "").Replace(key)
+	switch collapsed {
+	case "control":
+		return "ctrl", true
+	case "command", "cmd", "super":
+		return "meta", true
+	case "option":
+		return "alt", true
+	case "return", "newline":
+		return "enter", true
+	case "escape":
+		return "esc", true
+	case "spacebar":
+		return "space", true
+	case "del":
+		return "delete", true
+	case "backspace", "bksp":
+		return "backspace", true
+	case "arrowup":
+		return "up", true
+	case "arrowdown":
+		return "down", true
+	case "arrowleft":
+		return "left", true
+	case "arrowright":
+		return "right", true
+	case "pageup", "pgup":
+		return "pageup", true
+	case "pagedown", "pgdn":
+		return "pagedown", true
+	}
+
+	switch key {
+	case "ctrl", "alt", "shift", "meta", "up", "down", "left", "right", "home", "end", "pageup", "pagedown", "enter", "return", "esc", "tab", "space", "backspace", "delete", "insert":
+		if key == "return" {
+			return "enter", true
+		}
+		return key, true
+	}
+	if len(key) == 1 {
+		ch := key[0]
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') {
+			return key, true
+		}
+	}
+	if len(key) >= 2 && key[0] == 'f' {
+		n, err := strconv.Atoi(key[1:])
+		if err == nil && n >= 1 && n <= 12 {
+			return key, true
+		}
+	}
+	return "", false
+}
+
+func terminalCommandResult(ctx context.Context, terminal localcontrol.Terminal, plan terminalCommandPlan) Result {
+	if len(plan.commands) == 1 {
+		return localControlCommandResult(ctx, terminal, "terminal", plan.action, plan.commands[0])
+	}
+
+	outputs := make([]string, 0, len(plan.commands))
+	meta := map[string]string{"terminal_command": plan.action}
+	for index, args := range plan.commands {
+		result, err := terminal.Run(ctx, args...)
+		output := strings.TrimSpace(result.Output())
+		if output != "" {
+			outputs = append(outputs, output)
+		}
+		if result.ExitCode != 0 {
+			meta["exit_code"] = strconv.Itoa(result.ExitCode)
+		}
+		if err != nil {
+			message := "Error running terminal helper step " + strconv.Itoa(index+1) + " for " + plan.action + ": " + err.Error()
+			if output != "" {
+				message += "\n\n" + output
+			}
+			return Result{
+				Status: StatusError,
+				Output: message,
+				Meta:   meta,
+				Display: Display{
+					Summary: plan.action + " failed",
+					Kind:    "terminal",
+				},
+			}
+		}
+	}
+	output := strings.Join(outputs, "\n")
+	if output == "" {
+		output = "terminal command completed."
+	}
+	return Result{
+		Status: StatusOK,
+		Output: output,
+		Meta:   meta,
+		Display: Display{
+			Summary: plan.action + " completed",
+			Kind:    "terminal",
+		},
+	}
+}

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -21,6 +21,10 @@ const (
 	SideEffectWrite          SideEffect = "write"
 	SideEffectShell          SideEffect = "shell"
 	SideEffectNetwork        SideEffect = "network"
+	SideEffectLocalControl   SideEffect = "local_control"
+	SideEffectLocalBrowser   SideEffect = "local_browser"
+	SideEffectLocalDesktop   SideEffect = "local_desktop"
+	SideEffectLocalTerminal  SideEffect = "local_terminal"
 	SideEffectOutOfWorkspace SideEffect = "out_of_workspace"
 )
 

--- a/internal/tools/types_test.go
+++ b/internal/tools/types_test.go
@@ -10,7 +10,7 @@ func TestSideEffectNoneConstant(t *testing.T) {
 	}
 	// It must be distinct from every existing side-effect value.
 	for _, other := range []SideEffect{
-		SideEffectRead, SideEffectWrite, SideEffectShell, SideEffectNetwork, SideEffectOutOfWorkspace,
+		SideEffectRead, SideEffectWrite, SideEffectShell, SideEffectNetwork, SideEffectLocalControl, SideEffectLocalBrowser, SideEffectLocalDesktop, SideEffectLocalTerminal, SideEffectOutOfWorkspace,
 	} {
 		if SideEffectNone == other {
 			t.Fatalf("SideEffectNone collides with existing side effect %q", other)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,953 @@
+{
+  "name": "@gitlawb/zero",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@gitlawb/zero",
+      "version": "0.1.0",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "os": [
+        "linux",
+        "darwin",
+        "win32"
+      ],
+      "dependencies": {
+        "agent-browser": "^0.30.1",
+        "tuistory": "^0.10.0"
+      },
+      "bin": {
+        "zero": "bin/zero.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
+      "integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.2",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@hono/node-ws": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-ws/-/node-ws-1.3.1.tgz",
+      "integrity": "sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "@hono/node-server": "^1.19.11",
+        "hono": "^4.6.0"
+      }
+    },
+    "node_modules/@opentui/core": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.2.16.tgz",
+      "integrity": "sha512-4vWN15Zc3nsXJlOiHhhpqkBXD+wrNFKxCPtiTiillZYDRre+XsZogVTOOGUDwaBIC23OSxq7imezLmmtShVBEA==",
+      "license": "MIT",
+      "dependencies": {
+        "bun-ffi-structs": "0.2.2",
+        "diff": "9.0.0",
+        "marked": "17.0.1",
+        "string-width": "7.2.0",
+        "strip-ansi": "7.1.2",
+        "yoga-layout": "3.2.1"
+      },
+      "optionalDependencies": {
+        "@opentui/core-darwin-arm64": "0.2.16",
+        "@opentui/core-darwin-x64": "0.2.16",
+        "@opentui/core-linux-arm64": "0.2.16",
+        "@opentui/core-linux-x64": "0.2.16",
+        "@opentui/core-win32-arm64": "0.2.16",
+        "@opentui/core-win32-x64": "0.2.16"
+      },
+      "peerDependencies": {
+        "web-tree-sitter": "0.25.10"
+      }
+    },
+    "node_modules/@opentui/core-darwin-arm64": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.2.16.tgz",
+      "integrity": "sha512-aFb2Yp+oqDu3h6VCWi7xpQ9yjpKSQcROzGGfHgqC6Nd3U+uiLfPJBkmiI87iK0opCggCFj5TkKI004050DmGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-darwin-x64": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.2.16.tgz",
+      "integrity": "sha512-KimiHE0j7EsTB5P8doW0lr1eH5iZKLPKWQO+tmy1VcdYr/TzqhdHSvGuJXrZvfTFi9/rV57Eq0d7964Ri9O0vQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.2.16.tgz",
+      "integrity": "sha512-4fCwRCfTtUgS/5QcSEkSuBjgQymSOUWXgrXG2ycrf3Swi0QhKDA/pVjwLrUJ6eF+/8mQyQSEV72T8MxMO3M2qg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.2.16.tgz",
+      "integrity": "sha512-KgQBGjiucw4e7gM+R8qOzHWBFhjCY1IfCrGjW3Wzxv2hKUlL+mPhelaeJwnEqtNxMUdVTYjlwlu3IHxslXMJWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-win32-arm64": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.2.16.tgz",
+      "integrity": "sha512-C6WqEI3VkXatXraMgSFXZjEXq0pzURGjRpFAJZYmuVDmpqE57o7E80Np2UkdZ6m5kpJDt4mRyu3krc/P825iNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/core-win32-x64": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.2.16.tgz",
+      "integrity": "sha512-kCX3CMTns6DMCFDNTDV4sjmBKyA/iEvzaVhl/jYi4JRIVT2zcy1lo+lhXT5mPgYHmJZu8Uye6j3Zi3c7Z2Me5A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/react": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@opentui/react/-/react-0.2.16.tgz",
+      "integrity": "sha512-6SX8AaG5fY42XG9VF0XhGzOcoxy3KxKup+zhKQBcI+JTZcoMI0nq2t1A/5wrqMSYOThQB//D5VsHmkh/IqOIOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentui/core": "0.2.16",
+        "react-reconciler": "^0.33.0"
+      },
+      "peerDependencies": {
+        "react": ">=19.2.0",
+        "react-devtools-core": "^7.0.1",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.6.2.tgz",
+      "integrity": "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/agent-browser": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.30.1.tgz",
+      "integrity": "sha512-VMIZH90PFe5vmazizovDYUAAGrUWZ+xCqyv9ceuDOuL283a8aRqsshIQ0PY02QcdCpi1b6dwYYZOvUhoCl08Xw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "agent-browser": "bin/agent-browser.js"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "pnpm": ">=11.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/bun-ffi-structs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.2.2.tgz",
+      "integrity": "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/errore": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/errore/-/errore-0.11.0.tgz",
+      "integrity": "sha512-/uJh8o4SYfJAPGSDynpLgKRuRWX5yTSP2BXspHVQu8XmwaX1d6ysxr1cBhjTzC1Um2Xov9BQJ2kigT9lvxHYaA==",
+      "license": "MIT",
+      "bin": {
+        "errore": "dist/cli.js"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==",
+      "license": "MIT"
+    },
+    "node_modules/ghostty-opentui": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ghostty-opentui/-/ghostty-opentui-1.5.0.tgz",
+      "integrity": "sha512-1Kux7BjVtCevjz6Y/tsNPahXmEzJwAc3MqbmsX8chO6CybDG8YOna3gVbQuOgBRte4/CxOtGYJ9rgAKpqGKFPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@resvg/resvg-wasm": "^2.6.2",
+        "strip-ansi": "^7.1.2",
+        "wcwidth": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@opentui/core": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/goke": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/goke/-/goke-6.12.3.tgz",
+      "integrity": "sha512-zB5CsmtGFY0a9VjUmGBhQZOf5C/TGQoAKV2gai7mrj1RIOhfEzAjFF60yRI2M6d6OSWtn03JcV2oBe0x9nIQFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/kill-port-process": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kill-port-process/-/kill-port-process-4.0.2.tgz",
+      "integrity": "sha512-fO8gc45EYJQUQWozPBmdTpsR0GDvldsmrhP2I4FPoNejwyBY4Liiwj9Is7P/5rj6k07ZQ5Ob0g0k2dqQcslW/w==",
+      "license": "ISC",
+      "dependencies": {
+        "get-them-args": "1.3.2",
+        "pid-port": "2.0.1"
+      },
+      "bin": {
+        "kill-port": "dist/bin/kill-port-process.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pid-port": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pid-port/-/pid-port-2.0.1.tgz",
+      "integrity": "sha512-pnLo01AmMclw8l+/gfknsP2N351oe8VkVmCLFUvJZ11NRPPmghJrv0OcwsdgPQxsZkFYwm6hPWW0JKmXYCaXAw==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^9.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-devtools-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-7.0.1.tgz",
+      "integrity": "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "license": "MIT"
+    },
+    "node_modules/string-dedent": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/string-dedent/-/string-dedent-3.0.2.tgz",
+      "integrity": "sha512-M4q+HpHCtGXlbyzYDOcOo7V185dlq6YXvGUPcWZqL4vttCX9gFYoWIOxcPd7v5CAYcTJsGLs3ZJCAH2TXONF/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tuistory": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/tuistory/-/tuistory-0.10.0.tgz",
+      "integrity": "sha512-IrENXm9HK0GaNQgnQnnbgQutSA3xOlpO19u8EfcbUe9TfwnMWswTJ/T4HsEFT6EoOL+ZpnrEk2RZqC5gMMg7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^1.2.0",
+        "@hono/node-server": "^1.19.9",
+        "@hono/node-ws": "^1.3.0",
+        "@opentui/core": "^0.2.12",
+        "@opentui/react": "^0.2.12",
+        "errore": "^0.11.0",
+        "ghostty-opentui": "^1.5.0",
+        "goke": "^6.12.1",
+        "hono": "^4.11.7",
+        "kill-port-process": "^4.0.2",
+        "picocolors": "^1.1.1",
+        "react": "^19",
+        "std-env": "^4.1.0",
+        "string-dedent": "^3.0.1",
+        "zod": "4.3.6"
+      },
+      "bin": {
+        "tuistory": "dist/cli.js"
+      },
+      "optionalDependencies": {
+        "zigpty": "^0.2.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
+    "node_modules/zigpty": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/zigpty/-/zigpty-0.2.1.tgz",
+      "integrity": "sha512-MR9JqJx2wf5f4wz8zpx050AlqrmWeIW+1h0SO5iEyhG3HFRjY5luC3szS2ux2EGuPjE5OU9ZAuiCBeMWBTrqZw==",
+      "optional": true,
+      "workspaces": [
+        "playground"
+      ]
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   "engines": {
     "node": ">=18"
   },
+  "dependencies": {
+    "agent-browser": "^0.30.1",
+    "tuistory": "^0.10.0"
+  },
   "os": [
     "linux",
     "darwin",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -62,6 +62,28 @@ function Find-ZeroExtractedFile {
   throw "Release archive did not contain exactly one $FileName"
 }
 
+function Find-ZeroOptionalExtractedDirectory {
+  param(
+    [string]$Root,
+    [string]$DirectoryName
+  )
+
+  $candidate = Join-Path $Root $DirectoryName
+  if (Test-Path $candidate -PathType Container) {
+    return $candidate
+  }
+
+  $matches = @(Get-ChildItem -Path $Root -Filter $DirectoryName -Directory -Recurse)
+  if ($matches.Count -eq 0) {
+    return $null
+  }
+  if ($matches.Count -eq 1) {
+    return $matches[0].FullName
+  }
+
+  throw "Release archive contained multiple $DirectoryName directories"
+}
+
 if ($Version -eq "latest") {
   $tag = Get-ZeroLatestTag -Repository $Repository -GitHubApi $GitHubApi
 } elseif ($Version.StartsWith("v")) {
@@ -107,6 +129,14 @@ try {
   foreach ($fileName in $requiredFiles) {
     $sourcePath = Find-ZeroExtractedFile -Root $extractDir -FileName $fileName
     Copy-Item -Path $sourcePath -Destination (Join-Path $InstallDir $fileName) -Force
+  }
+  $helpersPath = Find-ZeroOptionalExtractedDirectory -Root $extractDir -DirectoryName "helpers"
+  if ($null -ne $helpersPath) {
+    $targetHelpersPath = Join-Path $InstallDir "helpers"
+    if (Test-Path $targetHelpersPath) {
+      Remove-Item -Path $targetHelpersPath -Recurse -Force
+    }
+    Copy-Item -Path $helpersPath -Destination $targetHelpersPath -Recurse -Force
   }
 
   $targetPath = Join-Path $InstallDir "zero.exe"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -73,7 +73,14 @@ function Find-ZeroOptionalExtractedDirectory {
     return $candidate
   }
 
-  $matches = @(Get-ChildItem -Path $Root -Filter $DirectoryName -Directory -Recurse)
+  $matches = @(
+    Get-ChildItem -Path $Root -Directory | ForEach-Object {
+      $child = Join-Path $_.FullName $DirectoryName
+      if (Test-Path $child -PathType Container) {
+        Get-Item $child
+      }
+    }
+  )
   if ($matches.Count -eq 0) {
     return $null
   }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -124,23 +124,57 @@ verify_checksum() {
   fi
 }
 
-find_extracted_binary() {
+find_extracted_entry() {
   local root="$1"
+  local name="$2"
+  local kind="$3"
   local candidate
 
-  if [ -f "$root/zero" ]; then
-    echo "$root/zero"
+  if [ "$kind" = "dir" ] && [ -d "$root/$name" ]; then
+    echo "$root/$name"
+    return 0
+  fi
+  if [ "$kind" = "file" ] && [ -f "$root/$name" ]; then
+    echo "$root/$name"
     return 0
   fi
 
-  for candidate in "$root"/*/zero; do
-    if [ -f "$candidate" ]; then
+  for candidate in "$root"/*/"$name"; do
+    if [ "$kind" = "dir" ] && [ -d "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+    if [ "$kind" = "file" ] && [ -f "$candidate" ]; then
       echo "$candidate"
       return 0
     fi
   done
 
   return 1
+}
+
+find_extracted_binary() {
+  find_extracted_entry "$1" "zero" "file"
+}
+
+copy_optional_file() {
+  local name="$1"
+  local source_path
+
+  if source_path="$(find_extracted_entry "$extract_dir" "$name" "file")"; then
+    cp "$source_path" "$ZERO_INSTALL_DIR/$name"
+    chmod 755 "$ZERO_INSTALL_DIR/$name"
+  fi
+}
+
+copy_optional_dir() {
+  local name="$1"
+  local source_path
+
+  if source_path="$(find_extracted_entry "$extract_dir" "$name" "dir")"; then
+    rm -rf "$ZERO_INSTALL_DIR/$name"
+    cp -R "$source_path" "$ZERO_INSTALL_DIR/$name"
+  fi
 }
 
 need_command uname
@@ -190,6 +224,9 @@ binary_path="$(find_extracted_binary "$extract_dir")" || fail "release archive d
 mkdir -p "$ZERO_INSTALL_DIR"
 cp "$binary_path" "$ZERO_INSTALL_DIR/zero"
 chmod 755 "$ZERO_INSTALL_DIR/zero"
+copy_optional_file "zero-linux-sandbox"
+copy_optional_file "zero-seccomp"
+copy_optional_dir "helpers"
 
 echo "Installed $ZERO_INSTALL_DIR/zero"
 


### PR DESCRIPTION
## Summary
- Add configurable local browser, desktop, and terminal control helpers with packaged helper discovery for install and release flows.
- Add structured browser actions, terminal session line input/key normalization/read support, and local-control artifact capture.
- Improve sandbox scope/risk handling for local-control commands and shared temporary paths.

## Testing
- GOCACHE=/tmp/zero-go-cache go test ./internal/localcontrol ./internal/tools ./internal/cli ./internal/config -run 'Test.*LocalControl|TestTerminal|TestBrowser|TestDesktop|TestCapture'
- GOCACHE=/tmp/zero-go-cache go test ./internal/localcontrol ./internal/tools ./internal/cli ./internal/config ./internal/agent
- tuistory smoke launched bash, sent interactive input, waited for expected output, and captured a no-cursor snapshot
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local automation tools for browser, desktop, and terminal, including a new capture-artifact tool.
  * Added local app launching support (e.g., Discord) with DevTools readiness polling.
  * Added configurable local-control enablement per surface and support for a configurable artifacts directory.
* **Bug Fixes**
  * Improved safety/permission handling for local automation side effects and denied tools.
  * Improved `browser_open` scope derivation and risk classification for local side effects.
  * Improved `exec --list-tools` so disabled local control surfaces are correctly hidden/denied.
* **Chores**
  * Enhanced packaging/installation to include helper shims and preserve symlinks; optional helper assets are now copied when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->