### PR TITLE
chore: launch-readiness — add MIT LICENSE + reconcile README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gitlawb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ![providers](https://img.shields.io/badge/providers-25%2B-34E2EA)
 ![tests](https://img.shields.io/badge/test%20files-200%2B-43D17A)
 ![status](https://img.shields.io/badge/status-active%20development-E8B84B)
+[![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 </div>
 
@@ -354,7 +355,7 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). Run `go te
 
 ## License
 
-License is being finalized; a `LICENSE` file will be added before the public release.
+Zero is released under the [MIT License](LICENSE) — © 2026 Gitlawb.
 
 ---
 


### PR DESCRIPTION
## Launch-readiness: license + re-verified product-UX blockers

Closes the remaining in-repo launch blockers. **Most blockers from the 2026-06-21 product-UX audit were already fixed in `main`** — each was re-verified against the current tree (not the audit's line numbers). The only STILL-OPEN items were the license file and its README reference.

### Changed here
- **`LICENSE`** — canonical MIT, © 2026 Gitlawb (the repo was marketed as open source with no license file → legally all-rights-reserved).
- **README** — License section now states MIT and links `LICENSE`; added an MIT badge.

### Re-verified FIXED (no change needed)
| Blocker | Evidence |
|---|---|
| go.mod vs README Go version | both `1.25` (no 1.24 drift) |
| `doctor` false "pass" + `map[…]` leak | empty config → `Overall: fail`; lsp detail renders clean `gopls: install with …`, no `map[...]` |
| Auth 401/403 mangled by Redact | curated `auth error: your API key is missing or invalid — run zero auth …`, "Bearer" intact |
| localhost/SSRF breaks local providers | `providers check ollama --connectivity` → ok/200; loopback allowed only for the user's configured base_url; redirect-to-loopback still blocked (test) |
| NO_COLOR for any non-empty value | `run.go` `getenv("NO_COLOR") != ""` |
| SECURITY/CONTRIBUTING/CODE_OF_CONDUCT/CHANGELOG | present; SECURITY routes to GitHub private vuln reporting |

### Gate
`make build` ✅ · `make lint` (fmt-check+vet) ✅ · `go test ./... -race` ✅ (69 packages, 0 failures)

### Manual maintainer steps (cannot be done in-repo)
- **Publish the first GitHub Release** with platform binaries so `scripts/install.sh` / `install.ps1` / the npm wrapper resolve (until then the README correctly points users to build-from-source).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project’s license information to reflect the MIT License.
  * Replaced the placeholder license note in the README with finalized license details and copyright year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->