### PR TITLE
ci(release): build all 5 platforms (Intel macOS + Linux arm64)

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -20,10 +20,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `zero-release package` builds + smoke-tests natively (host==target), so each
+        # target platform needs its own native runner. These five cover the platforms
+        # install.sh / install.ps1 / the npm wrapper resolve.
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-latest      # linux-x64
+          - ubuntu-24.04-arm   # linux-arm64
+          - macos-latest       # macos-arm64 (Apple Silicon)
+          - macos-13           # macos-x64 (Intel)
+          - windows-latest     # windows-x64
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -27,7 +27,7 @@ jobs:
           - ubuntu-latest      # linux-x64
           - ubuntu-24.04-arm   # linux-arm64
           - macos-latest       # macos-arm64 (Apple Silicon)
-          - macos-13           # macos-x64 (Intel)
+          - macos-15-intel     # macos-x64 (Intel)
           - windows-latest     # windows-x64
 
     steps:


### PR DESCRIPTION
The release matrix built only `ubuntu-latest`/`macos-latest`/`windows-latest` → linux-x64, macos-arm64, windows-x64. Adds `macos-13` (Intel → macos-x64) and `ubuntu-24.04-arm` (linux-arm64) so a `v*` tag publishes archives for **all** platforms `install.sh`/`install.ps1`/the npm wrapper resolve (otherwise Intel-Mac and Linux-arm64 users 404). `zero-release package` builds+smoke-tests natively, so each target needs its own runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded release artifact coverage to include additional platform/architecture targets, improving availability of published downloads.
  * Updated release packaging, verification, and asset publishing to run across the expanded platform set, so checksums and release assets are generated for more environments on release tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->