### PR TITLE
Move deferred tool discovery into tool search

### DIFF
--- a/internal/agent/deferred_loop_test.go
+++ b/internal/agent/deferred_loop_test.go
@@ -129,6 +129,24 @@ func (fakeToolSearchTool) Run(_ context.Context, _ map[string]any) tools.Result 
 	return tools.Result{Status: tools.StatusOK, Output: "ok"}
 }
 
+func toolDefinitionByName(definitions []zeroruntime.ToolDefinition, name string) *zeroruntime.ToolDefinition {
+	for i := range definitions {
+		if definitions[i].Name == name {
+			return &definitions[i]
+		}
+	}
+	return nil
+}
+
+func assertNoDeferredDiscoveryMessage(t *testing.T, request zeroruntime.CompletionRequest) {
+	t.Helper()
+	for _, message := range request.Messages {
+		if message.Role == zeroruntime.MessageRoleUser && strings.Contains(message.Content, "Deferred tools:") {
+			t.Fatalf("deferred discovery must not be appended as a user message: %q", message.Content)
+		}
+	}
+}
+
 func TestPartitionToolsInactiveIsByteIdenticalAndDropsToolSearch(t *testing.T) {
 	root := t.TempDir()
 	registry := tools.NewRegistry()
@@ -219,8 +237,8 @@ func TestPartitionToolsBelowThresholdInactive(t *testing.T) {
 // FIX 6(a): a deferred tool removed by DisabledTools must NOT count toward the
 // eligible total. With N deferred registered and threshold == N, disabling one
 // drops the surviving eligible count to N-1 < threshold, so the partition takes
-// the INACTIVE path (empty reminder, all VISIBLE tools exposed with full schemas,
-// the disabled one filtered out entirely).
+// the INACTIVE path (empty discovery text, all VISIBLE tools exposed with full
+// schemas, the disabled one filtered out entirely).
 func TestPartitionToolsDisabledDeferredDropsBelowThresholdInactive(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(fakeDeferredTool{name: "mcp__srv__alpha", desc: "alpha"})
@@ -246,9 +264,9 @@ func TestPartitionToolsDisabledDeferredDropsBelowThresholdInactive(t *testing.T)
 }
 
 // FIX 6(b): with deferral ACTIVE, a DisabledTools-hidden deferred tool must never
-// appear in the reminder NOR be exposed — it is filtered out before the partition
+// influence discovery NOR be exposed — it is filtered out before the partition
 // even considers it.
-func TestPartitionToolsActiveExcludesDisabledDeferredFromReminderAndExposed(t *testing.T) {
+func TestPartitionToolsActiveExcludesDisabledDeferredFromDiscoveryAndExposed(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(fakeDeferredTool{name: "mcp__srv__alpha", desc: "alpha"})
 	registry.Register(fakeDeferredTool{name: "mcp__srv__beta", desc: "beta"})
@@ -256,25 +274,31 @@ func TestPartitionToolsActiveExcludesDisabledDeferredFromReminderAndExposed(t *t
 	registry.Register(fakeToolSearchTool{}) // usable loader => deferral can activate
 
 	// 3 deferred, disable beta => 2 surviving eligible, threshold 2 => active.
-	exposed, reminder := partitionTools(registry, PermissionModeAuto, Options{
+	exposed, discovery := partitionTools(registry, PermissionModeAuto, Options{
 		DeferThreshold: 2,
 		DisabledTools:  []string{"mcp__srv__beta"},
 	}, map[string]bool{})
 
-	if reminder == "" {
-		t.Fatalf("expected active path with a non-empty reminder for the unloaded tools")
+	if discovery == "" {
+		t.Fatalf("expected active path with discovery text for the unloaded tools")
 	}
-	if strings.Contains(reminder, "mcp__srv__beta") {
-		t.Fatalf("disabled deferred tool must not appear in the reminder, got %q", reminder)
+	if strings.Contains(discovery, "mcp__srv__beta") {
+		t.Fatalf("disabled deferred tool must not appear in discovery text, got %q", discovery)
 	}
 	for _, def := range exposed {
 		if def.Name == "mcp__srv__beta" {
 			t.Fatalf("disabled deferred tool must not be exposed, got %#v", exposed)
 		}
 	}
-	// The two surviving deferred tools are hidden (unloaded) and named in the reminder.
-	if !strings.Contains(reminder, "mcp__srv__alpha") || !strings.Contains(reminder, "mcp__srv__gamma") {
-		t.Fatalf("reminder must list the surviving unloaded deferred tools, got %q", reminder)
+	search := toolDefinitionByName(exposed, tools.ToolSearchToolName)
+	if search == nil {
+		t.Fatalf("tool_search must be exposed on active path, got %#v", exposed)
+	}
+	if search.Description != discovery {
+		t.Fatalf("tool_search description must carry discovery text\n got: %q\nwant: %q", search.Description, discovery)
+	}
+	if !strings.Contains(discovery, "mcp") {
+		t.Fatalf("discovery text must list the surviving deferred source, got %q", discovery)
 	}
 }
 
@@ -289,7 +313,7 @@ func TestPartitionToolsActiveHidesUnloadedExposesLoaded(t *testing.T) {
 	loaded := map[string]bool{"mcp__srv__alpha": true}
 
 	// 2 eligible deferred tools, threshold 2 => active.
-	exposed, reminder := partitionTools(registry, PermissionModeAuto, Options{DeferThreshold: 2}, loaded)
+	exposed, discovery := partitionTools(registry, PermissionModeAuto, Options{DeferThreshold: 2}, loaded)
 
 	exposedNames := map[string]bool{}
 	for _, def := range exposed {
@@ -307,14 +331,18 @@ func TestPartitionToolsActiveHidesUnloadedExposesLoaded(t *testing.T) {
 	if exposedNames["mcp__srv__beta"] {
 		t.Fatalf("unloaded deferred tool must be hidden from exposed, got %#v", exposed)
 	}
-	if reminder == "" {
-		t.Fatalf("expected a non-empty reminder for the hidden tool")
+	if discovery == "" {
+		t.Fatalf("expected non-empty discovery text for the hidden tool")
 	}
-	if !strings.Contains(reminder, "mcp__srv__beta") {
-		t.Fatalf("expected reminder to list the hidden tool, got %q", reminder)
+	search := toolDefinitionByName(exposed, tools.ToolSearchToolName)
+	if search == nil {
+		t.Fatalf("expected tool_search exposed on active path, got %#v", exposed)
 	}
-	if strings.Contains(reminder, "mcp__srv__alpha") {
-		t.Fatalf("loaded tool must not appear in the reminder, got %q", reminder)
+	if search.Description != discovery || !strings.Contains(search.Description, "mcp") {
+		t.Fatalf("tool_search description must carry discovery source, got %q", search.Description)
+	}
+	if strings.Contains(search.Description, "mcp__srv__alpha") || strings.Contains(search.Description, "mcp__srv__beta") {
+		t.Fatalf("tool_search description must not list exact hidden/loaded tool names, got %q", search.Description)
 	}
 }
 
@@ -337,9 +365,9 @@ func TestPartitionToolsActiveNothingHiddenEmptyReminder(t *testing.T) {
 	if !exposedNames["tool_search"] {
 		t.Fatalf("expected tool_search exposed on active path, got %#v", exposed)
 	}
-	// BuildDeferredReminder returns "" for no hidden lines.
+	// No hidden tools means no dynamic discovery text is needed.
 	if reminder != "" {
-		t.Fatalf("expected empty reminder when nothing is hidden, got %q", reminder)
+		t.Fatalf("expected empty discovery text when nothing is hidden, got %q", reminder)
 	}
 }
 
@@ -376,7 +404,8 @@ func TestRunLoadsDeferredToolThenAdvertisesNextTurn(t *testing.T) {
 		t.Fatalf("expected two turns, got %d", len(provider.requests))
 	}
 
-	// Turn 1: alpha is hidden (not advertised) and the reminder is a trailing user msg.
+	// Turn 1: alpha is hidden (not advertised), and discovery lives on the
+	// tool_search definition rather than a trailing user message.
 	turn1Tools := map[string]bool{}
 	for _, def := range provider.requests[0].Tools {
 		turn1Tools[def.Name] = true
@@ -384,9 +413,13 @@ func TestRunLoadsDeferredToolThenAdvertisesNextTurn(t *testing.T) {
 	if turn1Tools["mcp__srv__alpha"] {
 		t.Fatalf("turn 1 must not advertise the not-yet-loaded deferred tool")
 	}
-	last1 := provider.requests[0].Messages[len(provider.requests[0].Messages)-1]
-	if last1.Role != zeroruntime.MessageRoleUser || !strings.Contains(last1.Content, "tool_search") {
-		t.Fatalf("turn 1 request must end with the deferred-tools reminder, got role=%s content=%q", last1.Role, last1.Content)
+	assertNoDeferredDiscoveryMessage(t, provider.requests[0])
+	search1 := toolDefinitionByName(provider.requests[0].Tools, tools.ToolSearchToolName)
+	if search1 == nil {
+		t.Fatalf("turn 1 must expose tool_search, got %#v", provider.requests[0].Tools)
+	}
+	if !strings.Contains(search1.Description, "Tool discovery") || !strings.Contains(search1.Description, "mcp") {
+		t.Fatalf("tool_search description must carry deferred discovery, got %q", search1.Description)
 	}
 
 	// Turn 2: alpha is now loaded and advertised with a full schema.
@@ -401,20 +434,20 @@ func TestRunLoadsDeferredToolThenAdvertisesNextTurn(t *testing.T) {
 		t.Fatalf("beta was never loaded; it must stay hidden in turn 2")
 	}
 
-	// The reminder must NOT persist into the returned message history.
+	// The discovery text must NOT persist into the returned message history.
 	for _, m := range result.Messages {
-		if m.Role == zeroruntime.MessageRoleUser && strings.Contains(m.Content, "Call tool_search") {
-			t.Fatalf("the deferred-tools reminder must not be persisted in result.Messages")
+		if m.Role == zeroruntime.MessageRoleUser && strings.Contains(m.Content, "Tool discovery") {
+			t.Fatalf("deferred discovery must not be persisted in result.Messages")
 		}
 	}
 }
 
-// TestRunReactiveRetryKeepsLoadedDeferredToolAndReminder drives a mid-run
+// TestRunReactiveRetryKeepsLoadedDeferredToolAndDiscovery drives a mid-run
 // context-limit error that triggers reactive compaction+retry while deferral is
 // ACTIVE and a deferred tool is already loaded. The retried turn must NOT be
-// degraded to the empty-loaded/no-reminder state: it must still advertise the
-// loaded tool's FULL schema and carry the <system-reminder> for the hidden tool.
-func TestRunReactiveRetryKeepsLoadedDeferredToolAndReminder(t *testing.T) {
+// degraded to the empty-loaded/no-discovery state: it must still advertise the
+// loaded tool's FULL schema and keep tool_search discovery for hidden tools.
+func TestRunReactiveRetryKeepsLoadedDeferredToolAndDiscovery(t *testing.T) {
 	registry := tools.NewRegistry()
 	// load_signal asks the loop to load mcp__srv__alpha next turn.
 	registry.Register(loadSignalTool{value: "mcp__srv__alpha"})
@@ -492,24 +525,20 @@ func TestRunReactiveRetryKeepsLoadedDeferredToolAndReminder(t *testing.T) {
 		t.Fatalf("retry must advertise the loaded tool's FULL schema, got %#v", alpha.Parameters)
 	}
 
-	// The retry must carry the deferred-tools reminder as its trailing user
-	// message (the hidden tool is mcp__srv__beta) — not the no-reminder state.
-	last := retry.Messages[len(retry.Messages)-1]
-	if last.Role != zeroruntime.MessageRoleUser || !strings.Contains(last.Content, "tool_search") {
-		t.Fatalf("retry request must end with the deferred-tools reminder, got role=%s content=%q", last.Role, last.Content)
+	assertNoDeferredDiscoveryMessage(t, retry)
+	search := toolDefinitionByName(retry.Tools, tools.ToolSearchToolName)
+	if search == nil {
+		t.Fatalf("retry must expose tool_search for still-hidden tools, got %#v", retry.Tools)
 	}
-	if !strings.Contains(last.Content, "mcp__srv__beta") {
-		t.Fatalf("retry reminder must list the still-hidden tool mcp__srv__beta, got %q", last.Content)
-	}
-	if strings.Contains(last.Content, "mcp__srv__alpha") {
-		t.Fatalf("loaded tool must not appear in the retry reminder, got %q", last.Content)
+	if !strings.Contains(search.Description, "Tool discovery") || !strings.Contains(search.Description, "mcp") {
+		t.Fatalf("retry tool_search description must carry deferred discovery, got %q", search.Description)
 	}
 
-	// The reminder must NOT persist into the returned message history, even on
+	// The discovery text must NOT persist into the returned message history, even on
 	// the reactive-retry path.
 	for _, m := range result.Messages {
-		if m.Role == zeroruntime.MessageRoleUser && strings.Contains(m.Content, "Call tool_search") {
-			t.Fatalf("the deferred-tools reminder must not be persisted in result.Messages")
+		if m.Role == zeroruntime.MessageRoleUser && strings.Contains(m.Content, "Tool discovery") {
+			t.Fatalf("deferred discovery must not be persisted in result.Messages")
 		}
 	}
 }
@@ -544,15 +573,15 @@ func (provider *connectErrorProvider) StreamCompletion(_ context.Context, reques
 	return ch, nil
 }
 
-// TestRunConnectTimeReactiveRetryKeepsLoadedDeferredToolAndReminder mirrors
-// TestRunReactiveRetryKeepsLoadedDeferredToolAndReminder but drives the
+// TestRunConnectTimeReactiveRetryKeepsLoadedDeferredToolAndDiscovery mirrors
+// TestRunReactiveRetryKeepsLoadedDeferredToolAndDiscovery but drives the
 // CONNECT-TIME error path: StreamCompletion itself returns a non-nil
 // context-limit error (rather than a mid-stream StreamEventError). With deferral
 // ACTIVE and a deferred tool already loaded, the rebuilt retry request must still
-// advertise the loaded tool's FULL schema AND carry the deferred-tools reminder —
-// i.e. the first reactive block reuses exposed/reminder, not the empty-loaded
+// advertise the loaded tool's FULL schema AND carry tool_search discovery —
+// i.e. the first reactive block reuses exposed, not the empty-loaded
 // partition.
-func TestRunConnectTimeReactiveRetryKeepsLoadedDeferredToolAndReminder(t *testing.T) {
+func TestRunConnectTimeReactiveRetryKeepsLoadedDeferredToolAndDiscovery(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(loadSignalTool{value: "mcp__srv__alpha"})
 	registry.Register(fakeDeferredTool{name: "mcp__srv__alpha", desc: "alpha tool"})
@@ -625,22 +654,19 @@ func TestRunConnectTimeReactiveRetryKeepsLoadedDeferredToolAndReminder(t *testin
 		t.Fatalf("retry must advertise the loaded tool's FULL schema, got %#v", alpha.Parameters)
 	}
 
-	// The retry must carry the deferred-tools reminder as its trailing user message.
-	last := retry.Messages[len(retry.Messages)-1]
-	if last.Role != zeroruntime.MessageRoleUser || !strings.Contains(last.Content, "tool_search") {
-		t.Fatalf("retry request must end with the deferred-tools reminder, got role=%s content=%q", last.Role, last.Content)
+	assertNoDeferredDiscoveryMessage(t, retry)
+	search := toolDefinitionByName(retry.Tools, tools.ToolSearchToolName)
+	if search == nil {
+		t.Fatalf("retry must expose tool_search for still-hidden tools, got %#v", retry.Tools)
 	}
-	if !strings.Contains(last.Content, "mcp__srv__beta") {
-		t.Fatalf("retry reminder must list the still-hidden tool mcp__srv__beta, got %q", last.Content)
-	}
-	if strings.Contains(last.Content, "mcp__srv__alpha") {
-		t.Fatalf("loaded tool must not appear in the retry reminder, got %q", last.Content)
+	if !strings.Contains(search.Description, "Tool discovery") || !strings.Contains(search.Description, "mcp") {
+		t.Fatalf("retry tool_search description must carry deferred discovery, got %q", search.Description)
 	}
 
-	// The reminder must NOT persist into the returned message history.
+	// The discovery text must NOT persist into the returned message history.
 	for _, m := range result.Messages {
-		if m.Role == zeroruntime.MessageRoleUser && strings.Contains(m.Content, "Call tool_search") {
-			t.Fatalf("the deferred-tools reminder must not be persisted in result.Messages")
+		if m.Role == zeroruntime.MessageRoleUser && strings.Contains(m.Content, "Tool discovery") {
+			t.Fatalf("deferred discovery must not be persisted in result.Messages")
 		}
 	}
 }
@@ -649,8 +675,7 @@ func TestRunConnectTimeReactiveRetryKeepsLoadedDeferredToolAndReminder(t *testin
 // regression: N deferred tools are registered alongside tool_search, the operator
 // allowlists ONLY the N deferred names (NOT tool_search), and DeferThreshold == N.
 // Deferral must ACTIVATE, the partition must STILL expose tool_search (the gateway
-// to the allowlisted tools), and a tool_search call must be DISPATCH-ALLOWED — so
-// the reminder never points the model at an unreachable tool.
+// to the allowlisted tools), and a tool_search call must be DISPATCH-ALLOWED.
 func TestAllowlistedDeferredToolsKeepToolSearchReachable(t *testing.T) {
 	registry := tools.NewRegistry()
 	deferredNames := []string{"mcp__srv__alpha", "mcp__srv__beta"}
@@ -667,14 +692,14 @@ func TestAllowlistedDeferredToolsKeepToolSearchReachable(t *testing.T) {
 		EnabledTools: append([]string{}, deferredNames...),
 	}
 
-	exposed, reminder := partitionTools(registry, PermissionModeAuto, options, map[string]bool{})
+	exposed, discovery := partitionTools(registry, PermissionModeAuto, options, map[string]bool{})
 
-	// Deferral active => non-empty reminder advertising the hidden deferred tools.
-	if reminder == "" {
-		t.Fatalf("expected deferral active (non-empty reminder) at threshold N, got empty")
+	// Deferral active => non-empty tool_search discovery for hidden deferred tools.
+	if discovery == "" {
+		t.Fatalf("expected deferral active (non-empty discovery) at threshold N, got empty")
 	}
-	if !strings.Contains(reminder, "tool_search") {
-		t.Fatalf("reminder must instruct the model to call tool_search, got %q", reminder)
+	if !strings.Contains(discovery, "tool_search") {
+		t.Fatalf("discovery must instruct the model to call tool_search, got %q", discovery)
 	}
 
 	// FIX 2(a): tool_search is exposed even though the allowlist omits it.
@@ -684,6 +709,10 @@ func TestAllowlistedDeferredToolsKeepToolSearchReachable(t *testing.T) {
 	}
 	if !exposedNames["tool_search"] {
 		t.Fatalf("tool_search must be exposed on the active path despite the allowlist omitting it, got %#v", exposed)
+	}
+	search := toolDefinitionByName(exposed, tools.ToolSearchToolName)
+	if search == nil || search.Description != discovery {
+		t.Fatalf("tool_search description must carry discovery text, got %#v discovery=%q", search, discovery)
 	}
 	// The allowlisted-but-unloaded deferred tools are hidden (not exposed).
 	for _, name := range deferredNames {

--- a/internal/agent/deferred_loop_test.go
+++ b/internal/agent/deferred_loop_test.go
@@ -341,8 +341,11 @@ func TestPartitionToolsActiveHidesUnloadedExposesLoaded(t *testing.T) {
 	if search.Description != discovery || !strings.Contains(search.Description, "mcp") {
 		t.Fatalf("tool_search description must carry discovery source, got %q", search.Description)
 	}
-	if strings.Contains(search.Description, "mcp__srv__alpha") || strings.Contains(search.Description, "mcp__srv__beta") {
-		t.Fatalf("tool_search description must not list exact hidden/loaded tool names, got %q", search.Description)
+	if strings.Contains(search.Description, "mcp__srv__alpha") {
+		t.Fatalf("tool_search description must not list already-loaded tool names, got %q", search.Description)
+	}
+	if !strings.Contains(search.Description, "mcp__srv__beta") {
+		t.Fatalf("tool_search description must list exact hidden tool names, got %q", search.Description)
 	}
 }
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -138,7 +138,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		// the tool-definition tokens (they ride on every request) in its estimate.
 		// partitionTools depends only on registry/permissions/options/loaded, not on
 		// the messages, so computing it before compaction is safe.
-		exposed, reminder := partitionTools(registry, permissionMode, options, loaded)
+		exposed, _ := partitionTools(registry, permissionMode, options, loaded)
 
 		// PROACTIVE compaction: if the history is approaching the model's
 		// context window, summarize the oldest middle before building the
@@ -148,15 +148,6 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			Messages:        copyMessages(messages),
 			Tools:           exposed,
 			ReasoningEffort: options.ReasoningEffort,
-		}
-		if reminder != "" {
-			// Append to the per-turn request copy only — NEVER to persistent
-			// messages — so the reminder refreshes each turn and never accumulates
-			// in the saved transcript.
-			request.Messages = append(request.Messages, zeroruntime.Message{
-				Role:    zeroruntime.MessageRoleUser,
-				Content: reminder,
-			})
 		}
 
 		// Report the per-category context budget for this turn so a surface can
@@ -184,23 +175,14 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 					return result, retryErr
 				}
 				// Rebuild from the compacted messages but reuse the SAME active-mode
-				// partition (exposed) and reminder computed for this turn: they depend
+				// partition computed for this turn: it depends
 				// on registry+loaded, not on the messages, so they stay valid after
 				// compaction. Using the bare toolDefinitions here would route through an
-				// empty-loaded partition, re-hiding every already-loaded deferred tool
-				// and dropping the reminder when deferral is active.
+				// empty-loaded partition, re-hiding every already-loaded deferred tool.
 				request = zeroruntime.CompletionRequest{
 					Messages:        copyMessages(messages),
 					Tools:           exposed,
 					ReasoningEffort: options.ReasoningEffort,
-				}
-				if reminder != "" {
-					// Append to the per-turn retry copy only — NEVER to persistent
-					// messages — matching the main path's reminder-not-persisted invariant.
-					request.Messages = append(request.Messages, zeroruntime.Message{
-						Role:    zeroruntime.MessageRoleUser,
-						Content: reminder,
-					})
 				}
 				// Pre-content connect after a context-limit compaction: route through the
 				// reconnect helper so a transient upstream hiccup here doesn't fail the
@@ -235,23 +217,15 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 					result.Messages = copyMessages(messages)
 					return result, retryErr
 				}
-				// Reuse the SAME active-mode partition (exposed) and reminder from this
-				// turn rather than the bare toolDefinitions: exposed/reminder depend on
+				// Reuse the SAME active-mode partition (exposed) from this
+				// turn rather than the bare toolDefinitions: exposed depends on
 				// registry+loaded (not the messages), so they stay valid after compaction.
 				// Routing through an empty-loaded partition here would re-hide every
-				// already-loaded deferred tool and drop the reminder when deferral is active.
+				// already-loaded deferred tool.
 				retryRequest := zeroruntime.CompletionRequest{
 					Messages:        copyMessages(messages),
 					Tools:           exposed,
 					ReasoningEffort: options.ReasoningEffort,
-				}
-				if reminder != "" {
-					// Append to the per-turn retry copy only — NEVER to persistent
-					// messages — matching the main path's reminder-not-persisted invariant.
-					retryRequest.Messages = append(retryRequest.Messages, zeroruntime.Message{
-						Role:    zeroruntime.MessageRoleUser,
-						Content: reminder,
-					})
 				}
 				// Pre-content reconnect of a mid-stream disconnect: route the connect
 				// through the reconnect helper too (AUDIT-L1).
@@ -595,7 +569,7 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	}
 	// tool_search is the gateway to the allowlisted deferred tools, so a non-empty
 	// EnabledTools allowlist that omits it must NOT reject the call — otherwise the
-	// reminder points the model at a tool the dispatch gate rejects (an inescapable
+	// discovery tool exposed to the model rejects at dispatch time (an inescapable
 	// dead-end). The allowlist is exempted; an explicit DisabledTools entry for
 	// tool_search is still honored (only the allowlist is exempted, not the denylist).
 	toolSearchAllowed := call.Name == tools.ToolSearchToolName && !containsToolName(options.DisabledTools, tools.ToolSearchToolName)
@@ -2221,15 +2195,15 @@ func permissionActionFromSandbox(action sandbox.Action) PermissionAction {
 	}
 }
 
-// partitionTools builds the per-turn advertised tool list and an optional
-// deferred-tools reminder. INACTIVE (DeferThreshold <= 0 or the eligible count is
+// partitionTools builds the per-turn advertised tool list and optional
+// tool_search discovery text. INACTIVE (DeferThreshold <= 0 or the eligible count is
 // below it): every visible tool is exposed with its full schema EXCEPT tool_search
-// (dropped so it is never advertised when it cannot help), and the reminder is
+// (dropped so it is never advertised when it cannot help), and the discovery text is
 // empty — byte-identical to the pre-deferral output. ACTIVE: a deferred-eligible
-// tool is exposed only when loaded[name]; otherwise it is hidden and its compact
-// line goes into the reminder. Non-deferred tools (including tool_search) are
-// always exposed. The exposed slice is alpha-sorted by name, matching the legacy
-// order so the inactive path is stable.
+// tool is exposed only when loaded[name]; otherwise it is hidden and searchable
+// through tool_search. Non-deferred tools (including tool_search) are always
+// exposed. The exposed slice is alpha-sorted by name, matching the legacy order
+// so the inactive path is stable.
 func partitionTools(registry *tools.Registry, permissionMode PermissionMode, options Options, loaded map[string]bool) ([]zeroruntime.ToolDefinition, string) {
 	registeredTools := registry.All()
 
@@ -2267,7 +2241,7 @@ func partitionTools(registry *tools.Registry, permissionMode PermissionMode, opt
 
 	definitions := make([]zeroruntime.ToolDefinition, 0, len(visible))
 	exposedNames := make(map[string]bool, len(visible))
-	var hiddenLines []string
+	var hiddenTools []tools.Tool
 	for _, tool := range visible {
 		name := tool.Name()
 		deferred := tools.IsDeferred(tool)
@@ -2288,7 +2262,7 @@ func partitionTools(registry *tools.Registry, permissionMode PermissionMode, opt
 
 		// Active path.
 		if deferred && !loaded[name] {
-			hiddenLines = append(hiddenLines, tools.DeferredLine(tool))
+			hiddenTools = append(hiddenTools, tool)
 			continue
 		}
 		definitions = append(definitions, zeroruntime.ToolDefinition{
@@ -2305,23 +2279,34 @@ func partitionTools(registry *tools.Registry, permissionMode PermissionMode, opt
 	// tools, not the loader). Expose its full definition whenever it is not
 	// already in the exposed set. This never runs on the inactive path, so the
 	// byte-identical below-threshold output is preserved.
+	discovery := ""
+	if active && len(hiddenTools) > 0 {
+		discovery = tools.BuildToolSearchDescription(hiddenTools)
+	}
 	if active && !exposedNames[tools.ToolSearchToolName] {
+		description := loader.Description()
+		if discovery != "" {
+			description = discovery
+		}
 		definitions = append(definitions, zeroruntime.ToolDefinition{
 			Name:        loader.Name(),
-			Description: loader.Description(),
+			Description: description,
 			Parameters:  schemaToRuntimeMap(loader.Parameters()),
 		})
+	} else if active && discovery != "" {
+		for i := range definitions {
+			if definitions[i].Name == tools.ToolSearchToolName {
+				definitions[i].Description = discovery
+				break
+			}
+		}
 	}
 
 	sort.Slice(definitions, func(left int, right int) bool {
 		return definitions[left].Name < definitions[right].Name
 	})
 
-	reminder := ""
-	if active {
-		reminder = tools.BuildDeferredReminder(hiddenLines)
-	}
-	return definitions, reminder
+	return definitions, discovery
 }
 
 func ToolVisible(tool tools.Tool, permissionMode PermissionMode, enabledTools []string, disabledTools []string) bool {

--- a/internal/tools/deferred.go
+++ b/internal/tools/deferred.go
@@ -156,10 +156,10 @@ func formatDeferredToolLine(name, description, server string, schema Schema) str
 }
 
 // mcpServerNamed is an optional interface a deferred MCP tool implements to
-// report its true (un-sanitized-token) server name for the reminder label. When
+// report its true (un-sanitized-token) server name for discovery labels. When
 // a tool provides it, DeferredLine prefers it over the name-derived token, which
 // would mislabel a server whose sanitized name itself contains an underscore
-// (e.g. "git_hub" → "git"). It affects the cosmetic reminder label only; tool
+// (e.g. "git_hub" → "git"). It affects the cosmetic discovery label only; tool
 // resolution never depends on this.
 type mcpServerNamed interface {
 	MCPServerName() string
@@ -168,8 +168,8 @@ type mcpServerNamed interface {
 // DeferredLine renders the compact advertisement line for a single deferred
 // tool, deriving the MCP server label from the tool's reported server name when
 // available, falling back to the token parsed from the tool's name. It is the
-// exported entry point the agent loop uses to build each line of the
-// deferred-tools reminder, so callers in other packages never touch the
+// exported entry point the agent loop uses to build compact deferred metadata,
+// so callers in other packages never touch the
 // unexported formatters.
 func DeferredLine(t Tool) string {
 	server := mcpServerFromToolName(t.Name())
@@ -181,29 +181,63 @@ func DeferredLine(t Tool) string {
 	return formatDeferredToolLine(t.Name(), t.Description(), server, t.Parameters())
 }
 
-const (
-	systemReminderStart = "<system-reminder>"
-	systemReminderEnd   = "</system-reminder>"
-)
-
-// BuildDeferredReminder wraps the given deferred-tool advertisement lines in a
-// <system-reminder> block instructing the model to load a tool's full schema
-// via tool_search (using a `select:Name1,Name2` exact query or keywords)
-// before calling it. Returns "" when there are no lines.
-func BuildDeferredReminder(lines []string) string {
-	if len(lines) == 0 {
+// DeferredSource reports the compact source label used in tool_search's dynamic
+// description. MCP tools use their configured server name; other deferred tools
+// fall back to the first name segment so families such as swarm_* are grouped.
+func DeferredSource(t Tool) string {
+	if t == nil {
 		return ""
 	}
+	if named, ok := t.(mcpServerNamed); ok {
+		if reported := strings.TrimSpace(named.MCPServerName()); reported != "" {
+			return reported
+		}
+	}
+	if server := mcpServerFromToolName(t.Name()); server != "" {
+		return server
+	}
+	name := strings.TrimSpace(t.Name())
+	if name == "" {
+		return ""
+	}
+	if prefix, _, ok := strings.Cut(name, "_"); ok && prefix != "" {
+		return prefix
+	}
+	return name
+}
+
+// BuildToolSearchDescription renders the model-facing discovery instructions for
+// deferred tools. This belongs on the tool_search tool definition, not as an
+// extra user message, so the model can discover tools without treating discovery
+// metadata as something to answer or acknowledge.
+func BuildToolSearchDescription(deferred []Tool) string {
+	sources := make(map[string]bool)
+	for _, tool := range deferred {
+		if source := DeferredSource(tool); source != "" {
+			sources[source] = true
+		}
+	}
+
+	sourceLines := make([]string, 0, len(sources))
+	for source := range sources {
+		sourceLines = append(sourceLines, source)
+	}
+	sort.Strings(sourceLines)
+
+	sourceText := "None currently enabled."
+	if len(sourceLines) > 0 {
+		for i, source := range sourceLines {
+			sourceLines[i] = "- " + source
+		}
+		sourceText = strings.Join(sourceLines, "\n")
+	}
+
 	var b strings.Builder
-	b.WriteString(systemReminderStart)
+	b.WriteString("# Tool discovery\n\n")
+	b.WriteString("Searches over deferred tool metadata and exposes matching tools for the next model call.\n\n")
+	b.WriteString("You have access to tools from the following sources:\n")
+	b.WriteString(sourceText)
 	b.WriteString("\n")
-	b.WriteString("The tools listed below are available in this environment, but their full schemas are omitted from the current tool list to save context.\n")
-	b.WriteString(`Call tool_search with query "select:Name1,Name2" (the exact names before each colon) or with keywords to load a tool's full schema before calling it. Calling an omitted tool directly will fail with an input validation error.` + "\n")
-	b.WriteString("Do not call tool_search for tools already present in the current tool list, and do not guess or invent tool names.\n")
-	b.WriteString("\n")
-	b.WriteString("Deferred tools:\n")
-	b.WriteString(strings.Join(lines, "\n"))
-	b.WriteString("\n")
-	b.WriteString(systemReminderEnd)
+	b.WriteString("Some of the tools may not have been provided to you upfront, and you should use `tool_search` to search for required tools. Use query `select:Name1,Name2` when you know exact tool names, or keywords to find matching tools. Do not call `tool_search` for tools already present in the current tool list.")
 	return b.String()
 }

--- a/internal/tools/deferred.go
+++ b/internal/tools/deferred.go
@@ -206,38 +206,54 @@ func DeferredSource(t Tool) string {
 	return name
 }
 
+// DeferredToolDiscoveryLine renders the compact name/source entry used in
+// tool_search's dynamic description. It intentionally omits descriptions and
+// schemas; those are revealed only after tool_search loads a matching tool.
+func DeferredToolDiscoveryLine(t Tool) string {
+	if t == nil {
+		return ""
+	}
+	name := strings.TrimSpace(t.Name())
+	if name == "" {
+		return ""
+	}
+	source := strings.TrimSpace(DeferredSource(t))
+	if source == "" || source == name {
+		return name
+	}
+	return name + " — " + source
+}
+
 // BuildToolSearchDescription renders the model-facing discovery instructions for
 // deferred tools. This belongs on the tool_search tool definition, not as an
 // extra user message, so the model can discover tools without treating discovery
 // metadata as something to answer or acknowledge.
 func BuildToolSearchDescription(deferred []Tool) string {
-	sources := make(map[string]bool)
+	seen := make(map[string]bool)
+	lines := make([]string, 0, len(deferred))
 	for _, tool := range deferred {
-		if source := DeferredSource(tool); source != "" {
-			sources[source] = true
+		line := DeferredToolDiscoveryLine(tool)
+		if line != "" && !seen[line] {
+			seen[line] = true
+			lines = append(lines, line)
 		}
 	}
+	sort.Strings(lines)
 
-	sourceLines := make([]string, 0, len(sources))
-	for source := range sources {
-		sourceLines = append(sourceLines, source)
-	}
-	sort.Strings(sourceLines)
-
-	sourceText := "None currently enabled."
-	if len(sourceLines) > 0 {
-		for i, source := range sourceLines {
-			sourceLines[i] = "- " + source
+	toolText := "No deferred tools are currently hidden."
+	if len(lines) > 0 {
+		for i, line := range lines {
+			lines[i] = "- " + line
 		}
-		sourceText = strings.Join(sourceLines, "\n")
+		toolText = strings.Join(lines, "\n")
 	}
 
 	var b strings.Builder
 	b.WriteString("# Tool discovery\n\n")
 	b.WriteString("Searches over deferred tool metadata and exposes matching tools for the next model call.\n\n")
-	b.WriteString("You have access to tools from the following sources:\n")
-	b.WriteString(sourceText)
+	b.WriteString("Deferred tools available through `tool_search`:\n")
+	b.WriteString(toolText)
 	b.WriteString("\n")
-	b.WriteString("Some of the tools may not have been provided to you upfront, and you should use `tool_search` to search for required tools. Use query `select:Name1,Name2` when you know exact tool names, or keywords to find matching tools. Do not call `tool_search` for tools already present in the current tool list.")
+	b.WriteString("Use query `select:Name1,Name2` for exact names from this list, or use keywords to search tool names and descriptions. Do not call `tool_search` for tools already present in the current tool list.")
 	return b.String()
 }

--- a/internal/tools/deferred_test.go
+++ b/internal/tools/deferred_test.go
@@ -215,14 +215,14 @@ func TestFormatDeferredToolLine(t *testing.T) {
 func TestBuildToolSearchDescription(t *testing.T) {
 	t.Run("no sources still describes discovery", func(t *testing.T) {
 		got := BuildToolSearchDescription(nil)
-		for _, want := range []string{"# Tool discovery", "None currently enabled.", "tool_search"} {
+		for _, want := range []string{"# Tool discovery", "No deferred tools are currently hidden.", "tool_search"} {
 			if !strings.Contains(got, want) {
 				t.Fatalf("BuildToolSearchDescription(nil) = %q, missing %q", got, want)
 			}
 		}
 	})
 
-	t.Run("lists sources without exact tool names", func(t *testing.T) {
+	t.Run("lists compact tool names and sources", func(t *testing.T) {
 		tools := []Tool{
 			serverNamedTool{
 				baseTool: baseTool{name: "mcp_git_hub_create_issue", description: "Create an issue.", parameters: Schema{Type: "object"}},
@@ -232,12 +232,17 @@ func TestBuildToolSearchDescription(t *testing.T) {
 		}
 		got := BuildToolSearchDescription(tools)
 
-		for _, want := range []string{"# Tool discovery", "- git hub", "- swarm", "select:Name1,Name2"} {
+		for _, want := range []string{
+			"# Tool discovery",
+			"- mcp_git_hub_create_issue — git hub",
+			"- swarm_spawn — swarm",
+			"select:Name1,Name2",
+		} {
 			if !strings.Contains(got, want) {
 				t.Fatalf("BuildToolSearchDescription = %q, missing %q", got, want)
 			}
 		}
-		for _, avoid := range []string{"mcp_git_hub_create_issue", "swarm_spawn", "Create an issue", "Spawn a worker"} {
+		for _, avoid := range []string{"Create an issue", "Spawn a worker"} {
 			if strings.Contains(got, avoid) {
 				t.Fatalf("BuildToolSearchDescription should not list exact tool metadata %q in %q", avoid, got)
 			}

--- a/internal/tools/deferred_test.go
+++ b/internal/tools/deferred_test.go
@@ -212,43 +212,35 @@ func TestFormatDeferredToolLine(t *testing.T) {
 	})
 }
 
-func TestBuildDeferredReminder(t *testing.T) {
-	t.Run("no lines returns empty", func(t *testing.T) {
-		if got := BuildDeferredReminder(nil); got != "" {
-			t.Fatalf("BuildDeferredReminder(nil) = %q, want empty", got)
-		}
-		if got := BuildDeferredReminder([]string{}); got != "" {
-			t.Fatalf("BuildDeferredReminder([]) = %q, want empty", got)
+func TestBuildToolSearchDescription(t *testing.T) {
+	t.Run("no sources still describes discovery", func(t *testing.T) {
+		got := BuildToolSearchDescription(nil)
+		for _, want := range []string{"# Tool discovery", "None currently enabled.", "tool_search"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("BuildToolSearchDescription(nil) = %q, missing %q", got, want)
+			}
 		}
 	})
 
-	t.Run("wraps lines in system-reminder", func(t *testing.T) {
-		lines := []string{
-			"mcp_github_fetch: Fetches a URL. | server: github | inputs (* required): url (string)*",
-			"mcp_weather_now: Current weather. | server: weather | (none)",
+	t.Run("lists sources without exact tool names", func(t *testing.T) {
+		tools := []Tool{
+			serverNamedTool{
+				baseTool: baseTool{name: "mcp_git_hub_create_issue", description: "Create an issue.", parameters: Schema{Type: "object"}},
+				server:   "git hub",
+			},
+			fakeDeferredTool{baseTool: baseTool{name: "swarm_spawn", description: "Spawn a worker.", parameters: Schema{Type: "object"}}, deferred: true},
 		}
-		got := BuildDeferredReminder(lines)
+		got := BuildToolSearchDescription(tools)
 
-		if !strings.HasPrefix(got, "<system-reminder>") {
-			t.Fatalf("missing opening tag: %q", got)
-		}
-		if !strings.HasSuffix(got, "</system-reminder>") {
-			t.Fatalf("missing closing tag: %q", got)
-		}
-		if !strings.Contains(got, "tool_search") {
-			t.Fatalf("reminder must name the tool_search tool: %q", got)
-		}
-		if !strings.Contains(got, `select:`) {
-			t.Fatalf("reminder must explain select: query form: %q", got)
-		}
-		for _, line := range lines {
-			if !strings.Contains(got, line) {
-				t.Fatalf("reminder missing line %q in %q", line, got)
+		for _, want := range []string{"# Tool discovery", "- git hub", "- swarm", "select:Name1,Name2"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("BuildToolSearchDescription = %q, missing %q", got, want)
 			}
 		}
-		// Lines are newline-joined, not concatenated.
-		if !strings.Contains(got, lines[0]+"\n"+lines[1]) {
-			t.Fatalf("lines not newline-joined in %q", got)
+		for _, avoid := range []string{"mcp_git_hub_create_issue", "swarm_spawn", "Create an issue", "Spawn a worker"} {
+			if strings.Contains(got, avoid) {
+				t.Fatalf("BuildToolSearchDescription should not list exact tool metadata %q in %q", avoid, got)
+			}
 		}
 	})
 }

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -33,7 +33,7 @@ func NewToolSearchTool(registry *Registry) Tool {
 	return toolSearchTool{
 		baseTool: baseTool{
 			name:        ToolSearchToolName,
-			description: "Search for and load deferred tools by exact name or keyword. Use query \"select:Name1,Name2\" to load specific tools, or keywords to find matching tools. Loading a tool returns its full schema so you can call it on the next turn.",
+			description: BuildToolSearchDescription(nil),
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{
@@ -199,7 +199,7 @@ func alreadyAvailableMessage(names []string) string {
 	}
 	return subject + " " + verb + " already in your tool list — call " +
 		map[bool]string{true: "them", false: "it"}[len(names) > 1] +
-		" directly. tool_search only loads DEFERRED tools (those in the deferred-tools notice), not tools you already have."
+		" directly. tool_search only loads deferred tools, not tools you already have."
 }
 
 // toolAllowedByFilters mirrors agent.ToolAllowedByFilters (kept here to avoid an


### PR DESCRIPTION
## Summary
- move deferred-tool discovery out of per-turn user messages and into the tool_search tool definition
- keep unloaded deferred tools hidden while preserving on-demand loading through tool_search
- keep tool_search reachable for allowlisted deferred tools and preserve loaded/deferred state across retry paths
- remove leaked deferred-notice wording from eager-tool redirect output

## Tests
- env GOCACHE=/tmp/zero-go-cache go test ./internal/agent ./internal/tools -run 'Test.*Deferred|Test.*ToolSearch|TestRunLoadsDeferredToolThenAdvertisesNextTurn|TestRunReactiveRetryKeepsLoadedDeferredToolAndDiscovery|TestRunConnectTimeReactiveRetryKeepsLoadedDeferredToolAndDiscovery|TestAllowlistedDeferredToolsKeepToolSearchReachable|TestDisabledToolSearchFallsBackToEager'
- env GOCACHE=/tmp/zero-go-cache go test ./internal/tools
- env GOCACHE=/tmp/zero-go-cache go test ./internal/agent ./internal/tools ./internal/cli
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved deferred tool discovery in `tool_search`, with clearer source-based grouping and exact-name (`select:...`) selection hints when hidden tools are available. Tool search guidance text was also refined.
* **Bug Fixes**
  * Removed leftover deferred discovery/reminder text from request history during proactive and reactive retry flows, while keeping deferred tool exposure behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->