### PR TITLE
fix(agent): gate headless run completion on honesty (no false-success on no-tool-call / self-reported-incomplete turns)

### DIFF
--- a/internal/agent/acceptance_gate_test.go
+++ b/internal/agent/acceptance_gate_test.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func enabledSelfCorrector(t *testing.T) *SelfCorrector {
+	t.Helper()
+	// checker/verifier nil → no LSP / project-test pass runs; we only need a
+	// non-nil SelfCorrector to enable the task-grounded acceptance gate.
+	return NewSelfCorrector(t.TempDir(), nil, nil, SelfCorrectConfig{Enabled: true})
+}
+
+// BUG #2(a): a final message that admits the model guessed / could not meet the
+// objective must be reported as INCOMPLETE, never success — and immediately
+// (an admitted guess is not worth re-prompting).
+func TestAcceptanceSelfReportAdmissionIsIncomplete(t *testing.T) {
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		textTurn("I couldn't analyze the board image, so I wrote the common opening move e2e4 as my best guess."),
+	}}
+
+	result, err := Run(context.Background(), "write the best chess move", provider, Options{
+		Registry:                tools.NewRegistry(),
+		MaxTurns:                10,
+		RequireCompletionSignal: true,
+		SelfCorrect:             enabledSelfCorrector(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Incomplete {
+		t.Fatalf("admitted guess must be Incomplete, got success; final=%q", result.FinalAnswer)
+	}
+	if !strings.Contains(result.IncompleteReason, "objective was not met") {
+		t.Fatalf("IncompleteReason = %q, want it to cite the admission", result.IncompleteReason)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("an admission should downgrade immediately (1 turn), got %d", len(provider.requests))
+	}
+}
+
+// BUG #2(a): the inability detector must generalize over the verb the model uses
+// (so re-phrasing can't defeat it) while NOT misreading success-y negations
+// ("could not find any issues") as admissions.
+func TestSelfReportedIncompletionMatching(t *testing.T) {
+	cases := []struct {
+		text  string
+		admit bool
+	}{
+		// real chess re-run wording that slipped a fixed phrase list:
+		{"…which I cannot do without proper image analysis capabilities.", true},
+		{"I cannot visually analyze the chess board image.", true},
+		{"I could not recover the original values, so this is my best guess.", true},
+		{"I was unable to complete the optimization.", true},
+		{"The result may not be correct.", true},
+		// genuine successes that must NOT be flagged:
+		{"I implemented the function and all tests pass.", false},
+		{"I verified the fix; I could not find any remaining issues.", false},
+		{"I cannot reproduce the bug, so the fix holds.", false},
+		{"Done — the output matches the required format and values.", false},
+	}
+	for _, c := range cases {
+		got := selfReportedIncompletion(c.text) != ""
+		if got != c.admit {
+			t.Errorf("selfReportedIncompletion(%q) admitted=%v, want %v", c.text, got, c.admit)
+		}
+	}
+}
+
+// BUG #2(a): a "cannot analyze / cannot determine" admission (present tense) must
+// be caught even when the model also stamps a bogus "PASS" based on a shape check.
+// Mirrors the chess-best-move final ("I cannot analyze the position… PASS: I wrote
+// the move and verified by reading it back").
+func TestAcceptanceCannotPhrasingIsIncomplete(t *testing.T) {
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		textTurn("I cannot analyze the specific position from the image, so I cannot determine the best move. PASS: I wrote e2e4 to the file and verified it by reading it back."),
+	}}
+
+	result, err := Run(context.Background(), "write the best move", provider, Options{
+		Registry:                tools.NewRegistry(),
+		MaxTurns:                10,
+		RequireCompletionSignal: true,
+		SelfCorrect:             enabledSelfCorrector(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Incomplete {
+		t.Fatalf("a 'cannot analyze/determine' admission must be Incomplete despite the bogus PASS; final=%q", result.FinalAnswer)
+	}
+}
+
+// BUG #2(a)/Bug #1: an update_plan item left in_progress at termination means work
+// remains — the run must end INCOMPLETE, not success.
+func TestAcceptanceInProgressPlanItemIsIncomplete(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewUpdatePlanTool())
+	done := "All set." // confident, no cue, no admission — only the plan says otherwise
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		planTurn("completed", "in_progress"),
+		textTurn(done), textTurn(done), textTurn(done), textTurn(done), textTurn(done),
+	}}
+
+	result, err := Run(context.Background(), "do the multi-step task", provider, Options{
+		Registry:                registry,
+		MaxTurns:                10,
+		RequireCompletionSignal: true,
+		SelfCorrect:             enabledSelfCorrector(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Incomplete {
+		t.Fatalf("an in_progress plan item must end Incomplete, got success; final=%q", result.FinalAnswer)
+	}
+	if !strings.Contains(result.IncompleteReason, "pending plan items") {
+		t.Fatalf("IncompleteReason = %q, want it to cite pending plan items", result.IncompleteReason)
+	}
+}
+
+// BUG #2(b): when self-correct is on, the run must pass a one-time task-grounded
+// acceptance check before success. A model that, when challenged, confirms its
+// work meets the criterion (no admission) then finalizes as success — no regression.
+func TestAcceptanceGroundedCompletionSucceeds(t *testing.T) {
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		textTurn("I implemented the function."),
+		textTurn("PASS. I ran the verification and it passes; the output meets the task requirement."),
+	}}
+
+	result, err := Run(context.Background(), "implement the function", provider, Options{
+		Registry:                tools.NewRegistry(),
+		MaxTurns:                10,
+		RequireCompletionSignal: true,
+		SelfCorrect:             enabledSelfCorrector(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Incomplete {
+		t.Fatalf("a verified completion must succeed, got Incomplete (%q)", result.IncompleteReason)
+	}
+	if result.FinalAnswer != "PASS. I ran the verification and it passes; the output meets the task requirement." {
+		t.Fatalf("final answer = %q", result.FinalAnswer)
+	}
+	// Exactly one acceptance pass: the first "done" turn was challenged, the second confirmed.
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected 2 turns (1 acceptance challenge + 1 confirmation), got %d", len(provider.requests))
+	}
+	if !someRequestContains(provider.requests, acceptanceNudgeMarker) {
+		t.Fatalf("expected the task-grounded acceptance check to be demanded")
+	}
+}
+
+// With the gate OFF (interactive/TUI default), even an admission is accepted as the
+// final answer exactly as before — proving no behavior change for non-headless callers.
+func TestAcceptanceGateOffLeavesAdmissionAsSuccess(t *testing.T) {
+	admission := "I couldn't determine the value, so this is a guess."
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		textTurn(admission),
+	}}
+
+	result, err := Run(context.Background(), "do a thing", provider, Options{
+		Registry: tools.NewRegistry(),
+		MaxTurns: 10,
+		// RequireCompletionSignal false, SelfCorrect nil — the legacy path.
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Incomplete {
+		t.Fatalf("legacy path must never set Incomplete; final=%q", result.FinalAnswer)
+	}
+	if result.FinalAnswer != admission {
+		t.Fatalf("final answer = %q, want the text verbatim (legacy behavior)", result.FinalAnswer)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("legacy path must not re-prompt; got %d turns", len(provider.requests))
+	}
+}
+
+// The acceptance check is scoped to runs with self-correct on: a headless run
+// WITHOUT a SelfCorrector accepts a confident completion immediately (the (b) gate
+// is inert), so enabling RequireCompletionSignal alone adds no acceptance turn.
+func TestAcceptanceGateRequiresSelfCorrect(t *testing.T) {
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		textTurn("Done. Implemented and it works."),
+	}}
+
+	result, err := Run(context.Background(), "implement it", provider, Options{
+		Registry:                tools.NewRegistry(),
+		MaxTurns:                10,
+		RequireCompletionSignal: true,
+		// SelfCorrect deliberately nil → acceptance gate (b) must not fire.
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Incomplete {
+		t.Fatalf("confident completion without self-correct must succeed; reason=%q", result.IncompleteReason)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("acceptance gate must not fire without self-correct; got %d turns", len(provider.requests))
+	}
+	if someRequestContains(provider.requests, acceptanceNudgeMarker) {
+		t.Fatalf("acceptance nudge must not be injected when self-correct is off")
+	}
+}

--- a/internal/agent/acceptance_gate_test.go
+++ b/internal/agent/acceptance_gate_test.go
@@ -58,11 +58,20 @@ func TestSelfReportedIncompletionMatching(t *testing.T) {
 		{"I could not recover the original values, so this is my best guess.", true},
 		{"I was unable to complete the optimization.", true},
 		{"The result may not be correct.", true},
+		// multi-occurrence: an early guarded use ("could not find any") must NOT mask a
+		// later genuine admission with the same stem (review #5):
+		{"I could not find any examples in the codebase, so I could not implement the feature.", true},
 		// genuine successes that must NOT be flagged:
 		{"I implemented the function and all tests pass.", false},
 		{"I verified the fix; I could not find any remaining issues.", false},
 		{"I cannot reproduce the bug, so the fix holds.", false},
 		{"Done — the output matches the required format and values.", false},
+		// behavior descriptions that must NOT be flagged — these phrases describe
+		// implemented behavior, not an admission (review #1, removed from the list):
+		{"The parser will fall back to UTF-8 when no encoding is set.", false},
+		{"I replaced the placeholder value with the computed key.", false},
+		{"The retry uses exponential backoff as a fallback.", false},
+		{"Without proper error handling the function would crash, so I added it.", false},
 	}
 	for _, c := range cases {
 		got := selfReportedIncompletion(c.text) != ""
@@ -95,12 +104,16 @@ func TestAcceptanceCannotPhrasingIsIncomplete(t *testing.T) {
 	}
 }
 
-// BUG #2(a)/Bug #1: an update_plan item left in_progress at termination means work
-// remains — the run must end INCOMPLETE, not success.
-func TestAcceptanceInProgressPlanItemIsIncomplete(t *testing.T) {
+// A pending/in_progress update_plan item is an AMBIGUOUS signal (the model may have
+// finished without re-marking the step), so it must NOT by itself force INCOMPLETE.
+// The gate nudges, but if the model keeps claiming completion with no continuation
+// cue and no admission, the run finalizes as SUCCESS — trusting the completion claim
+// over stale plan bookkeeping. (Only a continuation cue or self-report admission
+// forces INCOMPLETE; see TestCompletionGate* and TestAcceptance*Admission*.)
+func TestPendingPlanAloneDoesNotForceIncomplete(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewUpdatePlanTool())
-	done := "All set." // confident, no cue, no admission — only the plan says otherwise
+	done := "All set." // confident; no cue, no admission — only the plan is stale
 	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
 		planTurn("completed", "in_progress"),
 		textTurn(done), textTurn(done), textTurn(done), textTurn(done), textTurn(done),
@@ -115,11 +128,14 @@ func TestAcceptanceInProgressPlanItemIsIncomplete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !result.Incomplete {
-		t.Fatalf("an in_progress plan item must end Incomplete, got success; final=%q", result.FinalAnswer)
+	if result.Incomplete {
+		t.Fatalf("pending-plan alone must NOT force Incomplete (stale bookkeeping != unfinished); reason=%q", result.IncompleteReason)
 	}
-	if !strings.Contains(result.IncompleteReason, "pending plan items") {
-		t.Fatalf("IncompleteReason = %q, want it to cite pending plan items", result.IncompleteReason)
+	if result.FinalAnswer != done {
+		t.Fatalf("final answer = %q, want the completion claim %q", result.FinalAnswer, done)
+	}
+	if !someRequestContains(provider.requests, continueNudgeMarker) {
+		t.Fatalf("expected at least one continue-nudge before accepting completion")
 	}
 }
 

--- a/internal/agent/completion_gate_test.go
+++ b/internal/agent/completion_gate_test.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// someRequestContains reports whether any message sent to the provider across all
+// turns contains substr — used to assert a continue nudge was actually injected.
+func someRequestContains(requests []zeroruntime.CompletionRequest, substr string) bool {
+	for _, req := range requests {
+		for _, msg := range req.Messages {
+			if strings.Contains(msg.Content, substr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// planTurn is a turn that calls update_plan with the given item statuses (reusing
+// the package's shared toolTurn helper).
+func planTurn(statuses ...string) []zeroruntime.StreamEvent {
+	items := make([]string, len(statuses))
+	for i, s := range statuses {
+		items[i] = `{"content":"step ` + s + `","status":"` + s + `"}`
+	}
+	return toolTurn("plan", "update_plan", `{"plan":[`+strings.Join(items, ",")+`]}`)
+}
+
+// BUG #1 regression: a no-tool-call turn that ends mid-step while plan items are
+// still pending must NOT be accepted as success. The loop must re-prompt (bounded)
+// and, if the model keeps stalling, finalize as INCOMPLETE — never success.
+func TestCompletionGatePendingPlanContinuesThenIncomplete(t *testing.T) {
+	// Mirrors the git-multibranch failure: plan with pending steps, then the model
+	// keeps emitting "…Let me check the SSH configuration:" without acting.
+	cue := "Now I need to configure the SSH server. Let me check the current SSH configuration:"
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewUpdatePlanTool())
+
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		planTurn("completed", "pending", "pending"),
+		textTurn(cue), textTurn(cue), textTurn(cue), textTurn(cue), textTurn(cue),
+	}}
+
+	result, err := Run(context.Background(), "set up a git server", provider, Options{
+		Registry:                registry,
+		MaxTurns:                10,
+		RequireCompletionSignal: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Incomplete {
+		t.Fatalf("expected Incomplete=true (model stalled with pending plan), got false; final=%q turns=%d", result.FinalAnswer, result.Turns)
+	}
+	// 1 plan turn + maxContinueNudges(3) nudged turns + 1 final stalling turn = 5.
+	// Critically it did NOT stop at the first text turn (request 2) as success.
+	if len(provider.requests) != 1+maxContinueNudges+1 {
+		t.Fatalf("expected %d provider turns (1 plan + %d nudges + 1 final), got %d",
+			1+maxContinueNudges+1, maxContinueNudges, len(provider.requests))
+	}
+	if !someRequestContains(provider.requests, continueNudgeMarker) {
+		t.Fatalf("expected a continue nudge (%q) to be injected into the conversation", continueNudgeMarker)
+	}
+}
+
+// A genuinely-complete single-turn answer (no plan, no continuation cue) must
+// still finalize as success — the gate must not break short/read-only tasks.
+func TestCompletionGateAcceptsGenuineCompletion(t *testing.T) {
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		textTurn("The file contains 42 lines."),
+	}}
+
+	result, err := Run(context.Background(), "count the lines", provider, Options{
+		Registry:                tools.NewRegistry(),
+		MaxTurns:                10,
+		RequireCompletionSignal: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Incomplete {
+		t.Fatalf("genuine completion wrongly marked Incomplete; final=%q", result.FinalAnswer)
+	}
+	if result.FinalAnswer != "The file contains 42 lines." {
+		t.Fatalf("final answer = %q, want the completed answer", result.FinalAnswer)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected exactly 1 turn (no spurious re-prompt), got %d", len(provider.requests))
+	}
+}
+
+// A continuation-cue turn triggers a re-prompt, but once the model actually
+// finishes (clean answer, no cue, no pending plan) the run exits as success — the
+// nudge gives the model a path to a legitimate completion.
+func TestCompletionGateContinuesOnCueThenSucceeds(t *testing.T) {
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		textTurn("Let me read the file:"),
+		textTurn("Done. The file has 42 lines."),
+	}}
+
+	result, err := Run(context.Background(), "count the lines", provider, Options{
+		Registry:                tools.NewRegistry(),
+		MaxTurns:                10,
+		RequireCompletionSignal: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Incomplete {
+		t.Fatalf("run wrongly marked Incomplete after the model completed; final=%q", result.FinalAnswer)
+	}
+	if result.FinalAnswer != "Done. The file has 42 lines." {
+		t.Fatalf("final answer = %q, want the completed answer", result.FinalAnswer)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected 2 turns (1 cue re-prompted + 1 completion), got %d", len(provider.requests))
+	}
+	if !someRequestContains(provider.requests, continueNudgeMarker) {
+		t.Fatalf("expected a continue nudge after the continuation-cue turn")
+	}
+}
+
+// With the gate OFF (the interactive/TUI default), a continuation-cue turn is
+// accepted as the final answer exactly as before — guaranteeing no behavior
+// change for non-headless callers.
+func TestCompletionGateOffPreservesLegacyBehavior(t *testing.T) {
+	cue := "Let me check the config:"
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		textTurn(cue),
+	}}
+
+	result, err := Run(context.Background(), "do a thing", provider, Options{
+		Registry: tools.NewRegistry(),
+		MaxTurns: 10,
+		// RequireCompletionSignal deliberately left false.
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Incomplete {
+		t.Fatalf("legacy path must never set Incomplete; final=%q", result.FinalAnswer)
+	}
+	if result.FinalAnswer != cue {
+		t.Fatalf("final answer = %q, want %q (legacy: text-only turn is the answer)", result.FinalAnswer, cue)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("legacy path must not re-prompt; got %d turns", len(provider.requests))
+	}
+}

--- a/internal/agent/completion_gate_test.go
+++ b/internal/agent/completion_gate_test.go
@@ -153,3 +153,53 @@ func TestCompletionGateOffPreservesLegacyBehavior(t *testing.T) {
 		t.Fatalf("legacy path must not re-prompt; got %d turns", len(provider.requests))
 	}
 }
+
+// review #6: the continuation-cue detector must catch a mid-line action announcement
+// that stops on a colon (the git-multibranch case), without flagging genuine closers
+// — a recommendation, a plain summary colon, or a sign-off.
+func TestContinuationCueMatching(t *testing.T) {
+	cases := []struct {
+		text string
+		cue  bool
+	}{
+		{"Now I need to configure the SSH server. Let me check the current SSH configuration:", true},
+		{"Let me read the file:", true},
+		{"Now I'll run the tests:", true},
+		{"Next, I suggest reviewing the changes.", false}, // recommendation, no colon
+		{"Here is the summary:", false},                   // summary colon, no action lead-in
+		{"Let me know if you need anything:", false},      // sign-off
+		{"The function is implemented and all tests pass.", false},
+	}
+	for _, c := range cases {
+		if got := endsWithContinuationCue(c.text); got != c.cue {
+			t.Errorf("endsWithContinuationCue(%q) = %v, want %v", c.text, got, c.cue)
+		}
+	}
+}
+
+// review #4: a run that loops to the MaxTurns ceiling (always calling a tool, so it
+// never reaches the no-tool-call gate) was reported as success. Under the headless
+// gate, a max-turns cutoff is INCOMPLETE — the agent was stopped mid-run, not done.
+func TestMaxTurnsCutoffIsIncompleteUnderGate(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewUpdatePlanTool())
+	toolEvery := toolTurn("c", "update_plan", `{"plan":[{"content":"step","status":"in_progress"}]}`)
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		toolEvery, toolEvery, toolEvery, toolEvery,
+	}}
+
+	result, err := Run(context.Background(), "keep working", provider, Options{
+		Registry:                registry,
+		MaxTurns:                2,
+		RequireCompletionSignal: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Incomplete {
+		t.Fatalf("a max-turns cutoff under the gate must be Incomplete; final=%q", result.FinalAnswer)
+	}
+	if !strings.Contains(result.IncompleteReason, "max-turns") {
+		t.Fatalf("IncompleteReason = %q, want it to cite max-turns", result.IncompleteReason)
+	}
+}

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -44,7 +45,74 @@ const (
 	// with the same error, so NO model (weak or strong) burns turns looping on a
 	// bad call.
 	toolFailureStopAt = 4
+
+	// maxContinueNudges bounds how many times the headless completion gate
+	// (Options.RequireCompletionSignal) re-prompts a model that stopped without a
+	// tool call while work clearly remained. Once spent, the run finalizes as
+	// INCOMPLETE rather than nudging forever (and it is still bounded by maxTurns
+	// and the run deadline).
+	maxContinueNudges = 3
 )
+
+// continueNudgeMarker is a stable substring for tests.
+const continueNudgeMarker = "the task is not finished"
+
+// continueNudge tells a model that stopped without a tool call — while work
+// clearly remained — to keep going, or to mark the plan complete and summarize if
+// it is genuinely done. The second path gives it a clean route to a legitimate
+// completion (a finished plan + no continuation cue then exits as success).
+func continueNudge(reason string) string {
+	return "You stopped without calling a tool, but " + continueNudgeMarker + " (" + reason + "). " +
+		"Do not stop here: take the next concrete action with a tool now. " +
+		"If you are genuinely finished, first mark the plan complete with update_plan, then give your final summary."
+}
+
+// endsWithContinuationCue reports whether an assistant message ends mid-thought —
+// announcing a next action it then failed to take — rather than concluding. A
+// trailing colon is the strongest signal ("…Let me check the SSH configuration:");
+// otherwise the last non-empty line is matched against explicit lead-in phrases.
+// Deliberately conservative: a false positive costs at most one bounded re-prompt,
+// while a genuine final answer rarely ends on these cues.
+func endsWithContinuationCue(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasSuffix(trimmed, ":") {
+		return true
+	}
+	lines := strings.Split(trimmed, "\n")
+	last := ""
+	for i := len(lines) - 1; i >= 0; i-- {
+		if s := strings.TrimSpace(lines[i]); s != "" {
+			last = strings.ToLower(s)
+			break
+		}
+	}
+	for _, cue := range []string{
+		"let me ", "let's ", "now i'll ", "now i will ", "now let me ",
+		"i'll now ", "i will now ", "next i'll ", "next, i", "let me now ",
+	} {
+		if strings.HasPrefix(last, cue) {
+			return true
+		}
+	}
+	return false
+}
+
+// planStatusRemaining reports whether a raw update_plan status string represents
+// unfinished work. Anything not clearly completed/failed (incl. empty/unknown,
+// which the update_plan tool coerces to "pending") counts as remaining, matching
+// that tool's own status normalization.
+func planStatusRemaining(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "complete", "done", "finished", "resolved", "✓", "x", "[x]",
+		"failed", "fail", "error", "errored", "blocked", "cancelled", "canceled", "abandoned", "skipped":
+		return false
+	default:
+		return true
+	}
+}
 
 // toolFailureHintMarker is a stable substring for tests.
 const toolFailureHintMarker = "kept failing with the same error"
@@ -177,6 +245,10 @@ type guardState struct {
 	staleReminderSent    bool
 	toolOnlyTurns        int
 	toolOnlyReminderSent bool
+	// planItemsPending is the number of remaining (pending/in_progress) items in
+	// the most recent update_plan call, so the headless completion gate can tell
+	// whether work is unfinished when the model stops without a tool call.
+	planItemsPending int
 	// toolFailures tracks consecutive same-error failures per tool, keyed by tool
 	// name, so the loop can hint then halt instead of looping forever.
 	toolFailures map[string]*toolFailureRecord
@@ -245,12 +317,42 @@ func (state *guardState) observeTurn(collected zeroruntime.CollectedStream) (sto
 			state.toolCallsSincePlanUpdate = 0
 			// A fresh plan update opens a new stale interval.
 			state.staleReminderSent = false
+			// Record how many items remain so the completion gate knows whether
+			// work is unfinished if the model later stops without a tool call.
+			state.observePlanUpdate(call.Arguments)
 		} else {
 			state.toolCallsSincePlanUpdate++
 		}
 	}
 
 	return state.emptyTurns >= maxEmptyTurns
+}
+
+// pendingPlanItems reports whether the most recent update_plan call still has
+// unfinished (pending/in_progress) items. False when no plan was ever recorded.
+func (state *guardState) pendingPlanItems() bool {
+	return state.planItemsPending > 0
+}
+
+// observePlanUpdate parses an update_plan call's raw arguments and records how
+// many items are still remaining. Malformed arguments leave the prior count
+// unchanged (best-effort — the plan panel itself tolerates the same).
+func (state *guardState) observePlanUpdate(arguments string) {
+	var parsed struct {
+		Plan []struct {
+			Status string `json:"status"`
+		} `json:"plan"`
+	}
+	if json.Unmarshal([]byte(arguments), &parsed) != nil {
+		return
+	}
+	pending := 0
+	for _, item := range parsed.Plan {
+		if planStatusRemaining(item.Status) {
+			pending++
+		}
+	}
+	state.planItemsPending = pending
 }
 
 func (state *guardState) progressReminder() string {

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -114,6 +114,101 @@ func planStatusRemaining(status string) bool {
 	}
 }
 
+// acceptanceNudgeMarker is a stable substring for tests; it is embedded verbatim
+// in acceptanceVerificationNudge.
+const acceptanceNudgeMarker = "verify your work against the task's stated success criterion"
+
+// selfReportPhrases are high-signal admissions of guessing, fallback, or
+// uncertainty about correctness. Admissions of INABILITY are matched separately by
+// inabilityStems below, which generalize over the verb/tense so the detector is
+// not defeated by re-phrasing.
+var selfReportPhrases = []string{
+	// admitted guessing / fallback / placeholder
+	"i guessed", "my best guess", "best guess", "this is a guess", "just a guess",
+	"as a fallback", "fell back to", "fall back to", "placeholder value", "as a placeholder",
+	"i assumed a", "i had to assume",
+	// admitted lack of capability / external dependency
+	"without proper", "would need a tool", "do not have the ability", "don't have the ability",
+	"lack the ability", "no way for me to", "not possible for me to",
+	// admitted uncertainty about correctness of the result
+	"may not be correct", "might not be correct", "may be incorrect", "might be incorrect",
+	"this may not work", "this might not work", "not fully functional", "not fully working",
+}
+
+// inabilityStems are first-person "I cannot / can't / could not / am unable to /
+// do not have" stems. Matching the STEM (not a fixed verb) generalizes over
+// whatever action the model claims it could not perform — "analyze", "determine",
+// "do", "complete", "verify", "see", etc. — so the detector is not defeated by
+// re-phrasing (the chess case slipped a fixed "cannot analyze" list by writing
+// "…which I cannot do without proper image analysis capabilities").
+var inabilityStems = []string{
+	"i cannot ", "i can't ", "i can not ", "i could not ", "i couldn't ",
+	"i am unable to", "i'm unable to", "i was unable to", "i wasn't able to",
+	"i was not able to", "i do not have", "i don't have", "unable to ",
+	"without being able to",
+}
+
+// successNegationTails are negated phrasings that indicate SUCCESS, not an
+// admission ("I could not find any remaining issues", "I cannot reproduce the
+// bug"). When an inability stem is immediately followed by one of these, it is not
+// treated as an admission, so a clean result is not misreported as INCOMPLETE.
+var successNegationTails = []string{
+	"find any", "found any", "find a ", "see any", "detect any", "identify any",
+	"reproduce", "spot any", "locate any",
+}
+
+// selfReportedIncompletion returns a short reason when the model's final text
+// admits it guessed or could not meet the objective, else "". Case-insensitive.
+func selfReportedIncompletion(text string) string {
+	lower := strings.ToLower(text)
+	for _, phrase := range selfReportPhrases {
+		if strings.Contains(lower, phrase) {
+			return selfReportReason(phrase)
+		}
+	}
+	for _, stem := range inabilityStems {
+		idx := strings.Index(lower, stem)
+		if idx < 0 {
+			continue
+		}
+		tail := strings.TrimSpace(lower[idx+len(stem):])
+		if hasAnyPrefix(tail, successNegationTails) {
+			continue // "could not find any …" etc. — a success statement, not an admission
+		}
+		return selfReportReason(strings.TrimSpace(stem) + " …")
+	}
+	return ""
+}
+
+func selfReportReason(marker string) string {
+	return `the final message admits the objective was not met ("` + marker + `")`
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// acceptanceVerificationNudge forces a TASK-GROUNDED acceptance check before a run
+// may finalize as success. It explicitly rejects the three false-success patterns
+// the bug-hunt surfaced: well-formed output treated as correct; pre-existing tests
+// passing treated as the objective being met; and a result that merely matches a
+// baseline the task asked to beat or improve. General — no task-specific content.
+func acceptanceVerificationNudge() string {
+	return "Before this task can be marked complete, " + acceptanceNudgeMarker + " — " +
+		"NOT the shape or format of your output, NOT that pre-existing tests pass, and NOT that your " +
+		"result merely matches a baseline you were asked to beat or improve. " +
+		"Re-read the original task, then run a concrete check that exercises the actual requirement: " +
+		"execute the program or tests that demonstrate the required behavior, or directly probe the specific " +
+		"thing the task asked you to produce, recover, fix, or optimize. " +
+		"If that check passes, reply PASS and cite the evidence. " +
+		"If it does not pass — or you cannot run such a check — say so plainly and keep working; do not claim success."
+}
+
 // toolFailureHintMarker is a stable substring for tests.
 const toolFailureHintMarker = "kept failing with the same error"
 

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -68,18 +68,17 @@ func continueNudge(reason string) string {
 }
 
 // endsWithContinuationCue reports whether an assistant message ends mid-thought —
-// announcing a next action it then failed to take — rather than concluding. A
-// trailing colon is the strongest signal ("…Let me check the SSH configuration:");
-// otherwise the last non-empty line is matched against explicit lead-in phrases.
-// Deliberately conservative: a false positive costs at most one bounded re-prompt,
-// while a genuine final answer rarely ends on these cues.
+// the model announcing its OWN next action and then stopping on a colon
+// ("…Let me check the SSH configuration:") rather than concluding. It requires
+// BOTH a trailing colon AND an action lead-in on the last line, so genuine closers
+// are NOT flagged: a forward-looking recommendation ("Next, I suggest reviewing
+// the changes."), a sign-off ("Let me know if you need anything"), or a summary
+// that merely ends in a colon ("Here is the summary:"). A bare trailing colon alone
+// is too common in legitimate final answers to use as a signal.
 func endsWithContinuationCue(text string) bool {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
 		return false
-	}
-	if strings.HasSuffix(trimmed, ":") {
-		return true
 	}
 	lines := strings.Split(trimmed, "\n")
 	last := ""
@@ -89,11 +88,24 @@ func endsWithContinuationCue(text string) bool {
 			break
 		}
 	}
+	if !strings.HasSuffix(last, ":") {
+		return false
+	}
+	// Inspect the final clause (after the last sentence break) so a mid-line action
+	// announcement is caught ("…configure the server. Let me check the config:")
+	// while a plain summary colon ("Here is the summary:") or a recommendation is not.
+	clause := last
+	if idx := strings.LastIndex(last, ". "); idx >= 0 {
+		clause = strings.TrimSpace(last[idx+2:])
+	}
+	if strings.HasPrefix(clause, "let me know") { // sign-off, not a mid-step action
+		return false
+	}
 	for _, cue := range []string{
-		"let me ", "let's ", "now i'll ", "now i will ", "now let me ",
-		"i'll now ", "i will now ", "next i'll ", "next, i", "let me now ",
+		"let me ", "let's ", "now i'll ", "now i will ", "now let me ", "let me now ",
+		"i'll now ", "i will now ", "next i'll ", "next, i'll ", "first, i'll ", "first let me ",
 	} {
-		if strings.HasPrefix(last, cue) {
+		if strings.HasPrefix(clause, cue) {
 			return true
 		}
 	}
@@ -118,19 +130,23 @@ func planStatusRemaining(status string) bool {
 // in acceptanceVerificationNudge.
 const acceptanceNudgeMarker = "verify your work against the task's stated success criterion"
 
-// selfReportPhrases are high-signal admissions of guessing, fallback, or
-// uncertainty about correctness. Admissions of INABILITY are matched separately by
-// inabilityStems below, which generalize over the verb/tense so the detector is
-// not defeated by re-phrasing.
+// selfReportPhrases are high-signal admissions of guessing/fabrication or stated
+// uncertainty about the produced result. They are matched by plain substring with
+// NO context guard, so every entry must be FIRST-PERSON or unambiguously about the
+// model's own output — NOT a phrase that also describes implemented behavior.
+// (Earlier versions included "fall back to" / "placeholder value" / "as a
+// fallback" / bare "best guess" / "without proper", which match legitimate final
+// answers like "the parser will fall back to UTF-8" or "I replaced the placeholder
+// value", wrongly downgrading completed runs — so those are removed. Admissions of
+// INABILITY are handled separately by inabilityStems, which carry a guard.)
 var selfReportPhrases = []string{
-	// admitted guessing / fallback / placeholder
-	"i guessed", "my best guess", "best guess", "this is a guess", "just a guess",
-	"as a fallback", "fell back to", "fall back to", "placeholder value", "as a placeholder",
-	"i assumed a", "i had to assume",
-	// admitted lack of capability / external dependency
-	"without proper", "would need a tool", "do not have the ability", "don't have the ability",
-	"lack the ability", "no way for me to", "not possible for me to",
-	// admitted uncertainty about correctness of the result
+	// first-person admissions of guessing / fabrication / assumption
+	"i guessed", "my best guess", "i'm guessing", "this is a guess", "just a guess",
+	"i made it up", "i fabricated", "i assumed a", "i had to assume",
+	// first-person lack of capability (inability stems also cover cannot/could-not)
+	"i do not have the ability", "i don't have the ability", "i lack the ability",
+	"no way for me to", "not possible for me to",
+	// stated uncertainty about the correctness of the produced result
 	"may not be correct", "might not be correct", "may be incorrect", "might be incorrect",
 	"this may not work", "this might not work", "not fully functional", "not fully working",
 }
@@ -167,15 +183,21 @@ func selfReportedIncompletion(text string) string {
 		}
 	}
 	for _, stem := range inabilityStems {
-		idx := strings.Index(lower, stem)
-		if idx < 0 {
-			continue
+		// Scan EVERY occurrence of the stem, not just the first: an earlier
+		// success-negation use ("I could not find any examples, so I could not
+		// implement it") must not mask a later genuine admission with the same stem.
+		for start := 0; ; {
+			rel := strings.Index(lower[start:], stem)
+			if rel < 0 {
+				break
+			}
+			abs := start + rel
+			tail := strings.TrimSpace(lower[abs+len(stem):])
+			if !hasAnyPrefix(tail, successNegationTails) {
+				return selfReportReason(strings.TrimSpace(stem) + " …")
+			}
+			start = abs + len(stem)
 		}
-		tail := strings.TrimSpace(lower[idx+len(stem):])
-		if hasAnyPrefix(tail, successNegationTails) {
-			continue // "could not find any …" etc. — a success statement, not an admission
-		}
-		return selfReportReason(strings.TrimSpace(stem) + " …")
 	}
 	return ""
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -130,6 +130,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	// loaded tool's full schema; it lives only for the run (v1 within-run scope).
 	loaded := map[string]bool{}
 
+	// continueNudges counts how many times the headless completion gate
+	// (Options.RequireCompletionSignal) has re-prompted a no-tool-call turn that
+	// stopped with work still unfinished. Bounded by maxContinueNudges.
+	continueNudges := 0
+
 	result := Result{Messages: copyMessages(messages)}
 	for turn := 0; turn < maxTurns; turn++ {
 		result.Turns = turn + 1
@@ -326,6 +331,38 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 						"Continue the task by using a tool or reply with your final answer.",
 				})
 				continue
+			}
+			// Completion gate (headless): a turn with text but no tool call is the
+			// model's final answer ONLY when the work is actually done. With
+			// RequireCompletionSignal set, if work clearly remains — pending
+			// update_plan items, or the message ends mid-step on a continuation cue —
+			// nudge the model to continue instead of accepting the text as the answer.
+			// Bounded by maxContinueNudges (and still by maxTurns / the run deadline);
+			// once the budget is spent the run finalizes as INCOMPLETE, not success.
+			// The option defaults off, so interactive runs stay byte-identical.
+			if options.RequireCompletionSignal {
+				incompleteReason := ""
+				if guards.pendingPlanItems() {
+					incompleteReason = "pending plan items remain"
+				} else if endsWithContinuationCue(collected.Text) {
+					incompleteReason = "your message ended mid-step"
+				}
+				if incompleteReason != "" {
+					if continueNudges < maxContinueNudges {
+						continueNudges++
+						messages = append(messages, zeroruntime.Message{
+							Role:    zeroruntime.MessageRoleUser,
+							Content: continueNudge(incompleteReason),
+						})
+						continue
+					}
+					// Budget spent and the model is still stalling: report INCOMPLETE
+					// rather than passing the unfinished work off as success.
+					result.Incomplete = true
+					result.FinalAnswer = collected.Text
+					result.Messages = copyMessages(messages)
+					return result, nil
+				}
 			}
 			result.FinalAnswer = collected.Text
 			result.Messages = copyMessages(messages)

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -134,6 +134,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	// (Options.RequireCompletionSignal) has re-prompted a no-tool-call turn that
 	// stopped with work still unfinished. Bounded by maxContinueNudges.
 	continueNudges := 0
+	// acceptanceRequested records that the one-time task-grounded acceptance check
+	// has already been demanded this run, so it fires at most once.
+	acceptanceRequested := false
 
 	result := Result{Messages: copyMessages(messages)}
 	for turn := 0; turn < maxTurns; turn++ {
@@ -359,9 +362,37 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 					// Budget spent and the model is still stalling: report INCOMPLETE
 					// rather than passing the unfinished work off as success.
 					result.Incomplete = true
+					result.IncompleteReason = incompleteReason
 					result.FinalAnswer = collected.Text
 					result.Messages = copyMessages(messages)
 					return result, nil
+				}
+
+				// Self-report downgrade: the model's own final message admits it
+				// guessed or could not meet the objective. An admitted non-completion
+				// is never reported as success — downgrade to INCOMPLETE.
+				if reason := selfReportedIncompletion(collected.Text); reason != "" {
+					result.Incomplete = true
+					result.IncompleteReason = reason
+					result.FinalAnswer = collected.Text
+					result.Messages = copyMessages(messages)
+					return result, nil
+				}
+
+				// Task-grounded acceptance: before accepting a "done" turn as success,
+				// require ONE acceptance check grounded in the task's stated criterion
+				// (only when self-correct is on). This rejects the "well-formed ==
+				// correct", "existing tests pass == objective met", and "result ==
+				// baseline" false successes. Bounded to a single pass; the run still
+				// respects maxTurns / the deadline. A genuine post-check completion
+				// (no admission, nothing pending) then finalizes as success next turn.
+				if options.SelfCorrect != nil && !acceptanceRequested {
+					acceptanceRequested = true
+					messages = append(messages, zeroruntime.Message{
+						Role:    zeroruntime.MessageRoleUser,
+						Content: acceptanceVerificationNudge(),
+					})
+					continue
 				}
 			}
 			result.FinalAnswer = collected.Text

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -336,41 +336,13 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 				continue
 			}
 			// Completion gate (headless): a turn with text but no tool call is the
-			// model's final answer ONLY when the work is actually done. With
-			// RequireCompletionSignal set, if work clearly remains — pending
-			// update_plan items, or the message ends mid-step on a continuation cue —
-			// nudge the model to continue instead of accepting the text as the answer.
-			// Bounded by maxContinueNudges (and still by maxTurns / the run deadline);
-			// once the budget is spent the run finalizes as INCOMPLETE, not success.
-			// The option defaults off, so interactive runs stay byte-identical.
+			// model's final answer ONLY when the work is actually done. Default off
+			// (RequireCompletionSignal), so interactive runs stay byte-identical.
 			if options.RequireCompletionSignal {
-				incompleteReason := ""
-				if guards.pendingPlanItems() {
-					incompleteReason = "pending plan items remain"
-				} else if endsWithContinuationCue(collected.Text) {
-					incompleteReason = "your message ended mid-step"
-				}
-				if incompleteReason != "" {
-					if continueNudges < maxContinueNudges {
-						continueNudges++
-						messages = append(messages, zeroruntime.Message{
-							Role:    zeroruntime.MessageRoleUser,
-							Content: continueNudge(incompleteReason),
-						})
-						continue
-					}
-					// Budget spent and the model is still stalling: report INCOMPLETE
-					// rather than passing the unfinished work off as success.
-					result.Incomplete = true
-					result.IncompleteReason = incompleteReason
-					result.FinalAnswer = collected.Text
-					result.Messages = copyMessages(messages)
-					return result, nil
-				}
-
-				// Self-report downgrade: the model's own final message admits it
-				// guessed or could not meet the objective. An admitted non-completion
-				// is never reported as success — downgrade to INCOMPLETE.
+				// (1) Self-report downgrade (strongest, unambiguous): the model's own
+				// final message admits it guessed / could not meet the objective. Checked
+				// FIRST so an admitted-impossible task is downgraded immediately (no wasted
+				// continue-nudges) and reports the accurate reason.
 				if reason := selfReportedIncompletion(collected.Text); reason != "" {
 					result.Incomplete = true
 					result.IncompleteReason = reason
@@ -379,13 +351,47 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 					return result, nil
 				}
 
-				// Task-grounded acceptance: before accepting a "done" turn as success,
+				// (2) The model stopped without a tool call while work may be unfinished:
+				//   - a continuation cue ("…Let me check the config:") is an unambiguous
+				//     mid-step stop;
+				//   - pending update_plan items are a WEAK, ambiguous signal (the model may
+				//     have finished without re-marking the last step).
+				// Nudge to continue (bounded). After the budget: a persisted continuation
+				// cue finalizes INCOMPLETE; pending-plan WITHOUT a cue does NOT (that would
+				// false-fail a completed run with stale bookkeeping) — fall through to the
+				// acceptance check / success.
+				cue := endsWithContinuationCue(collected.Text)
+				planPending := guards.pendingPlanItems()
+				if cue || planPending {
+					if continueNudges < maxContinueNudges {
+						continueNudges++
+						reason := "your message ended mid-step"
+						if !cue {
+							reason = "pending plan items remain — finish them, or mark them complete with update_plan if you are done"
+						}
+						messages = append(messages, zeroruntime.Message{
+							Role:    zeroruntime.MessageRoleUser,
+							Content: continueNudge(reason),
+						})
+						continue
+					}
+					if cue {
+						result.Incomplete = true
+						result.IncompleteReason = "your message ended mid-step"
+						result.FinalAnswer = collected.Text
+						result.Messages = copyMessages(messages)
+						return result, nil
+					}
+					// pending-plan only, budget spent: trust the model's completion claim
+					// over stale plan bookkeeping; fall through.
+				}
+
+				// (3) Task-grounded acceptance: before accepting a "done" turn as success,
 				// require ONE acceptance check grounded in the task's stated criterion
-				// (only when self-correct is on). This rejects the "well-formed ==
-				// correct", "existing tests pass == objective met", and "result ==
-				// baseline" false successes. Bounded to a single pass; the run still
-				// respects maxTurns / the deadline. A genuine post-check completion
-				// (no admission, nothing pending) then finalizes as success next turn.
+				// (only when self-correct is on). Rejects "well-formed == correct",
+				// "existing-tests-pass == objective met", and "result == baseline" false
+				// successes. Bounded to a single pass; a genuine post-check completion
+				// (no admission, no cue) then finalizes as success on the next turn.
 				if options.SelfCorrect != nil && !acceptanceRequested {
 					acceptanceRequested = true
 					messages = append(messages, zeroruntime.Message{
@@ -570,15 +576,27 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		result.Messages = copyMessages(messages)
 		return result, ctx.Err()
 	}
+	// Reaching here means the loop hit the maxTurns ceiling — the agent was cut off
+	// mid-run, not a natural completion (a finished run returns via the no-tool-call
+	// success path before this). Under the headless completion gate that is INCOMPLETE,
+	// not success, so a run that loops to the turn limit isn't reported as done.
 	if answer, finalMessages, finishReason := finalAnswerAfterMaxTurns(ctx, provider, messages, options); strings.TrimSpace(answer) != "" {
 		result.FinalAnswer = answer
 		result.FinishReason = finishReason
 		result.Messages = copyMessages(finalMessages)
+		if options.RequireCompletionSignal {
+			result.Incomplete = true
+			result.IncompleteReason = "reached the max-turns limit without completing"
+		}
 		return result, nil
 	}
 
 	result.FinalAnswer = maxTurnsAnswer
 	result.Messages = copyMessages(messages)
+	if options.RequireCompletionSignal {
+		result.Incomplete = true
+		result.IncompleteReason = "reached the max-turns limit without a final answer"
+	}
 	return result, nil
 }
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -262,6 +262,17 @@ type Options struct {
 	// byte-identical to before). One instance per run — it holds attempt state.
 	SelfCorrect *SelfCorrector
 
+	// RequireCompletionSignal gates run completion for HEADLESS exec. Without it,
+	// any assistant turn that produces text but no tool call is accepted as the
+	// final answer. With it, a no-tool-call turn is NOT treated as "done" while
+	// work clearly remains — pending update_plan items, or a message that ends on a
+	// continuation cue ("…Let me check the config:"). The loop then nudges the
+	// model to continue instead, bounded by maxContinueNudges (and still by
+	// MaxTurns and the run deadline); if the model keeps stalling, the run
+	// finalizes as INCOMPLETE (Result.Incomplete) rather than success. Default
+	// false leaves the loop byte-identical, so the interactive TUI is unaffected.
+	RequireCompletionSignal bool
+
 	runPermissions *permissionRunState
 }
 
@@ -275,6 +286,12 @@ type Result struct {
 	// hit the token cap, FinishReasonContentFilter when it was filtered. Empty for
 	// a normal completion.
 	FinishReason string
+	// Incomplete reports that a headless run (RequireCompletionSignal) stopped with
+	// work clearly unfinished: the model ended a turn with no tool call while plan
+	// items were pending or the message ended mid-step, and the continue-nudge
+	// budget was exhausted. Callers map it to a non-success terminal status / exit
+	// code. False for every normal completion.
+	Incomplete bool
 }
 
 // Truncated reports whether the final response ended abnormally (cut off at the

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -288,10 +288,15 @@ type Result struct {
 	FinishReason string
 	// Incomplete reports that a headless run (RequireCompletionSignal) stopped with
 	// work clearly unfinished: the model ended a turn with no tool call while plan
-	// items were pending or the message ended mid-step, and the continue-nudge
-	// budget was exhausted. Callers map it to a non-success terminal status / exit
+	// items were pending or the message ended mid-step, the model admitted it
+	// guessed / could not meet the objective, and/or it failed a task-grounded
+	// acceptance check. Callers map it to a non-success terminal status / exit
 	// code. False for every normal completion.
 	Incomplete bool
+	// IncompleteReason is a short, model-derived explanation of why the run was
+	// marked Incomplete (e.g. "pending plan items remain"). Empty when Incomplete
+	// is false. Surfaced in logs / run_end so an abandoned run is debuggable.
+	IncompleteReason string
 }
 
 // Truncated reports whether the final response ended abnormally (cut off at the

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -638,7 +638,12 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	// continue budget while work remained) is reported as INCOMPLETE, not success,
 	// so callers/benchmarks don't mistake an abandoned run for a finished one.
 	if result.Incomplete {
-		sessionRecorder.append(sessions.EventError, map[string]any{"message": "incomplete"})
+		reason := result.IncompleteReason
+		if reason == "" {
+			reason = "run stopped with work unfinished"
+		}
+		sessionRecorder.append(sessions.EventError, map[string]any{"message": "incomplete: " + reason})
+		writer.warning("Run incomplete (not reported as success): " + reason)
 		writer.runEnd("incomplete", exitIncomplete)
 		if writer.err != nil {
 			return exitCrash

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -32,6 +32,12 @@ const (
 	exitCrash    = 1
 	exitUsage    = 2
 	exitProvider = 3
+	// exitIncomplete marks a headless run that stopped with work clearly
+	// unfinished — the completion gate exhausted its continue budget on a
+	// no-tool-call turn while plan items were pending or the model ended mid-step.
+	// Distinct from success so callers/benchmarks don't treat an abandoned run as
+	// finished.
+	exitIncomplete = 4
 	// exitInterrupted is the conventional shell exit code for a process stopped by
 	// SIGINT (128 + signal number 2).
 	exitInterrupted = 130
@@ -513,12 +519,17 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		PermissionMode:   permissionMode,
 		Autonomy:         options.autonomy,
 		SelfCorrect:      selfCorrector,
-		Sandbox:          sandboxEngine,
-		FileTracker:      tools.NewFileTracker(),
-		Hooks:            newHookDispatcherWithExtra(workspaceRoot, pluginActivation.hooks),
-		EnabledTools:     options.enabledTools,
-		DisabledTools:    options.disabledTools,
-		OnText:           writer.text,
+		// Headless exec: don't accept a no-tool-call turn as "done" while work
+		// clearly remains (pending plan items / a mid-step continuation cue) —
+		// nudge to continue, and finalize as INCOMPLETE rather than false success
+		// if the model keeps stalling. The interactive TUI leaves this off.
+		RequireCompletionSignal: true,
+		Sandbox:                 sandboxEngine,
+		FileTracker:             tools.NewFileTracker(),
+		Hooks:                   newHookDispatcherWithExtra(workspaceRoot, pluginActivation.hooks),
+		EnabledTools:            options.enabledTools,
+		DisabledTools:           options.disabledTools,
+		OnText:                  writer.text,
 		OnToolCall: func(call agent.ToolCall) {
 			writer.toolCall(call, registry)
 			sessionRecorder.append(sessions.EventToolCall, map[string]any{
@@ -623,6 +634,17 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		writer.warning(notice)
 	}
 	writer.final(result.FinalAnswer)
+	// A headless run that stalled mid-task (the completion gate exhausted its
+	// continue budget while work remained) is reported as INCOMPLETE, not success,
+	// so callers/benchmarks don't mistake an abandoned run for a finished one.
+	if result.Incomplete {
+		sessionRecorder.append(sessions.EventError, map[string]any{"message": "incomplete"})
+		writer.runEnd("incomplete", exitIncomplete)
+		if writer.err != nil {
+			return exitCrash
+		}
+		return exitIncomplete
+	}
 	writer.runEnd("success", exitSuccess)
 	if writer.err != nil {
 		return exitCrash

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -633,23 +633,44 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if notice := result.TruncationNotice(); notice != "" {
 		writer.warning(notice)
 	}
-	writer.final(result.FinalAnswer)
-	// A headless run that stalled mid-task (the completion gate exhausted its
-	// continue budget while work remained) is reported as INCOMPLETE, not success,
-	// so callers/benchmarks don't mistake an abandoned run for a finished one.
+	// A headless run the completion gate marked INCOMPLETE (no-tool-call stall,
+	// self-reported non-completion, or max-turns cutoff) must NOT be reported as a
+	// success: exit 4 AND a machine-readable terminal event saying so. Handled per
+	// output format BEFORE writer.final(), because for -o json final() emits a
+	// {"type":"done","exit_code":0} that would otherwise mask the incomplete exit.
+	// An `error` event (not just a warning) is emitted so log/cron consumers that
+	// scan for type=="error" can recover the reason.
 	if result.Incomplete {
 		reason := result.IncompleteReason
 		if reason == "" {
 			reason = "run stopped with work unfinished"
 		}
 		sessionRecorder.append(sessions.EventError, map[string]any{"message": "incomplete: " + reason})
-		writer.warning("Run incomplete (not reported as success): " + reason)
-		writer.runEnd("incomplete", exitIncomplete)
-		if writer.err != nil {
-			return exitCrash
+		switch options.outputFormat {
+		case execOutputStreamJSON:
+			writer.final(result.FinalAnswer)
+			writer.errorEvent("incomplete", reason, false)
+			writer.runEnd("incomplete", exitIncomplete)
+			if writer.err != nil {
+				return exitCrash
+			}
+		case execOutputJSON:
+			if writeErr := writeJSONLine(stdout, map[string]any{"type": "final", "text": result.FinalAnswer}); writeErr != nil {
+				return exitCrash
+			}
+			if writeErr := writeJSONLine(stdout, map[string]any{"type": "error", "code": "incomplete", "message": reason}); writeErr != nil {
+				return exitCrash
+			}
+			if writeErr := writeJSONLine(stdout, map[string]any{"type": "done", "exit_code": exitIncomplete}); writeErr != nil {
+				return exitCrash
+			}
+		default:
+			writer.final(result.FinalAnswer)
+			fmt.Fprintln(stderr, "Run incomplete (not reported as success): "+reason)
 		}
 		return exitIncomplete
 	}
+	writer.final(result.FinalAnswer)
 	writer.runEnd("success", exitSuccess)
 	if writer.err != nil {
 		return exitCrash


### PR DESCRIPTION
## Summary
Two fixes to the **headless** agent loop so a run is reported `success` only when it actually finished (surfaced during headless-exec testing). Both are gated by a new `Options.RequireCompletionSignal`, set only for headless `zero exec` — **default off, so the interactive TUI is byte-identical.**

### Bug #1 — premature loop termination (deterministic)
A turn that produced text but **no tool call** was always accepted as the final answer, so the loop reported `success` even mid-task. Now a no-tool-call turn is **not** treated as done while work clearly remains — pending `update_plan` items, or a message ending on a continuation cue ("…Let me check the config:") — the loop re-prompts to continue (bounded by `maxContinueNudges`, still by `MaxTurns`), and finalizes **INCOMPLETE (exit 4)** rather than `success` if it keeps stalling.

**Behavioral proof:** on a multi-step server-setup task the agent went from **3 tool calls** (it stopped on "…Let me check the SSH configuration:") **→ 50 tool calls** — it now starts sshd, completes the SSH clone, and works its plan instead of declaring victory after step 2.

### Bug #2 — `success` without a task-grounded check
**Deterministic, unit-tested:**
- **self-report downgrade** — if the final message admits the model guessed / could not meet the objective (first-person inability *stems* generalized over verb/tense, plus guess/fallback phrases, with a guard so success-y negations like "couldn't find any issues" / "cannot reproduce" are not misread) → **INCOMPLETE**, never `success`.
- **plan gate** — pending / in_progress `update_plan` items at termination → **INCOMPLETE**.

**Advisory (NOT a guarantee):**
- **task-grounded acceptance** — when `--self-correct` is on, one bounded acceptance pass re-derives the task's stated criterion and discourages three false-success patterns (well-formed==correct, existing-tests-pass==objective-met, result==baseline-it-was-told-to-beat). This **reduces but does not eliminate** false-success: a model that confidently claims "PASS, all requirements met" can still slip through, because there is no general oracle to verify correctness against a task's hidden criterion. This is a **fundamental limit, not a tuning gap** — documented honestly rather than overclaimed.

**Behavioral proof:** an image-grounded task a text-only model can't actually solve flipped from **false `success` (reward 0) → honest INCOMPLETE** once its "I cannot analyze the image" admission is detected.

## Scope
Agent loop + headless exit wiring + tests only:
- `internal/agent/{loop,guardrails,types}.go`
- `internal/cli/exec.go` — `exitIncomplete=4`, `RequireCompletionSignal` wiring, INCOMPLETE `run_end` + reason
- `internal/agent/{completion_gate,acceptance_gate}_test.go`

## Verification
`make build`, `go vet ./...`, `make lint`, `go test ./... -race` — all green (70 pkg, 0 fail, 0 races). Gate-off tests confirm interactive/default behavior is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headless runs now report distinct **incomplete** vs **success** outcomes, including an optional **incomplete reason**.
  * Added stricter headless completion gating, with optional task-grounded acceptance challenge for self-correction.
* **Bug Fixes**
  * Prevents stalled or mid-step “continue” situations from being marked as success by injecting bounded re-prompts.
  * Treats self-reported inability (and certain “can’t/don’t know” phrasing) as incomplete, respects pending plan work, and marks **max-turns** cutoff as incomplete.
  * Preserves legacy behavior when the gate is disabled.
* **Tests**
  * Added acceptance-gate and completion-gate regression coverage for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->