### PR TITLE
feat(tui): ask_user suggested answers with a recommended default

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1445,6 +1445,7 @@ func toAgentAskUserQuestions(questions []tools.AskUserQuestion) []AskUserQuestio
 		converted[index] = AskUserQuestion{
 			Question:    question.Question,
 			Options:     append([]string{}, question.Options...),
+			Recommended: question.Recommended,
 			MultiSelect: question.MultiSelect,
 		}
 	}

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -16,7 +16,10 @@ work.
   implementation, verification, and a clear summary.
 - Only stop to ask the user (via the ask_user tool) when you are genuinely
   blocked on a decision that is theirs to make and that you cannot resolve from
-  the code, the request, or sensible defaults.
+  the code, the request, or sensible defaults. When the answer is likely one of a
+  small set, include 2-4 suggested `options` and mark the best as `recommended`
+  (it must be one of the options) so the user can pick quickly; omit options for
+  genuinely open-ended questions.
 
 ## Workflow: plan then act
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -138,10 +138,13 @@ type PermissionEvent struct {
 	CommandPrefix     []string                 `json:"commandPrefix,omitempty"`
 }
 
-// AskUserQuestion is one clarifying question the agent wants answered.
+// AskUserQuestion is one clarifying question the agent wants answered. Options are
+// optional suggested answers an interactive front-end can render as a picker;
+// Recommended (when set) is the suggested default — it should match one of Options.
 type AskUserQuestion struct {
 	Question    string   `json:"question"`
 	Options     []string `json:"options,omitempty"`
+	Recommended string   `json:"recommended,omitempty"`
 	MultiSelect bool     `json:"multiSelect,omitempty"`
 }
 

--- a/internal/tools/ask_user.go
+++ b/internal/tools/ask_user.go
@@ -12,6 +12,7 @@ import (
 type AskUserQuestion struct {
 	Question    string
 	Options     []string
+	Recommended string
 	MultiSelect bool
 }
 
@@ -35,6 +36,9 @@ func NewAskUserTool() *askUserTool {
 			name: "ask_user",
 			description: "Ask the user one or more clarifying questions and wait for their answers. " +
 				"Use ONLY for genuinely blocking ambiguity that you cannot resolve from the workspace or reasonable assumptions. " +
+				"When the answer is likely one of a small set, you MAY include 2-4 suggested `options` and mark one as `recommended` " +
+				"(it must match one of the options) — an interactive front-end shows these as a quick picker with a \"type my own\" fallback. " +
+				"Options are optional: omit them for open-ended questions. " +
 				"If no interactive user is available, this returns guidance to proceed with your best assumption instead of blocking.",
 			parameters: Schema{
 				Type: "object",
@@ -53,8 +57,12 @@ func NewAskUserTool() *askUserTool {
 								"question": {Type: "string", Description: "The non-empty question to ask the user.", MinLength: intPtr(1)},
 								"options": {
 									Type:        "array",
-									Description: "Optional list of suggested answer choices.",
+									Description: "Optional list of 2-4 suggested answer choices for a quick picker.",
 									Items:       &PropertySchema{Type: "string"},
+								},
+								"recommended": {
+									Type:        "string",
+									Description: "Optional recommended choice; must match one of options. Preselected as the default in the picker.",
 								},
 								"multiSelect": {
 									Type:        "boolean",
@@ -128,9 +136,11 @@ func ParseAskUserQuestions(args map[string]any) ([]AskUserQuestion, error) {
 		// multiSelect is a UI hint; treat an uncoercible value as the default rather
 		// than failing the whole call (mirrors the best-effort options path).
 		multiSelect, _ := boolArg(object, "multiSelect", false)
+		options := coerceOptionStrings(object["options"]) // best-effort; never errors
 		questions = append(questions, AskUserQuestion{
 			Question:    text,
-			Options:     coerceOptionStrings(object["options"]), // best-effort; never errors
+			Options:     options,
+			Recommended: recommendedOption(object["recommended"], options), // only kept if it matches an option
 			MultiSelect: multiSelect,
 		})
 	}
@@ -151,6 +161,33 @@ func questionTextArg(object map[string]any) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("question is required")
+}
+
+// recommendedOption returns the model's recommended choice ONLY when it resolves to
+// one of the supplied options (exact, then case-insensitive trim match). It returns
+// the canonical option text (not the model's raw spelling) so the front-end can
+// match it by equality, and "" when there is no usable recommendation — keeping the
+// invariant that Recommended is always either empty or a member of Options.
+func recommendedOption(value any, options []string) string {
+	raw, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" || len(options) == 0 {
+		return ""
+	}
+	for _, option := range options {
+		if option == raw {
+			return option
+		}
+	}
+	for _, option := range options {
+		if strings.EqualFold(strings.TrimSpace(option), raw) {
+			return option
+		}
+	}
+	return ""
 }
 
 // coerceOptionStrings turns whatever a model put in "options" into a string slice

--- a/internal/tools/ask_user_test.go
+++ b/internal/tools/ask_user_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -40,7 +41,7 @@ func TestParseAskUserRecommended(t *testing.T) {
 			if len(parsed) != 1 {
 				t.Fatalf("expected one question, got %d", len(parsed))
 			}
-			if strings.Join(parsed[0].Options, ",") != strings.Join(c.wantOptions, ",") {
+			if !slices.Equal(parsed[0].Options, c.wantOptions) {
 				t.Fatalf("options = %#v, want %#v", parsed[0].Options, c.wantOptions)
 			}
 			if parsed[0].Recommended != c.wantRec {

--- a/internal/tools/ask_user_test.go
+++ b/internal/tools/ask_user_test.go
@@ -7,6 +7,56 @@ import (
 	"testing"
 )
 
+func TestParseAskUserRecommended(t *testing.T) {
+	// recommended is kept only when it resolves to one of the options (canonical
+	// option text), case-insensitively; otherwise it is dropped so Recommended stays
+	// either empty or a member of Options.
+	cases := []struct {
+		name        string
+		options     []any
+		recommended any
+		wantOptions []string
+		wantRec     string
+	}{
+		{"exact match", []any{"Postgres", "SQLite"}, "SQLite", []string{"Postgres", "SQLite"}, "SQLite"},
+		{"case-insensitive maps to canonical", []any{"Postgres", "SQLite"}, "sqlite", []string{"Postgres", "SQLite"}, "SQLite"},
+		{"non-member dropped", []any{"Postgres", "SQLite"}, "Mongo", []string{"Postgres", "SQLite"}, ""},
+		{"no options drops recommended", nil, "SQLite", nil, ""},
+		{"non-string recommended ignored", []any{"A", "B"}, 3, []string{"A", "B"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			question := map[string]any{"question": "Which one?"}
+			if c.options != nil {
+				question["options"] = c.options
+			}
+			if c.recommended != nil {
+				question["recommended"] = c.recommended
+			}
+			parsed, err := ParseAskUserQuestions(map[string]any{"questions": []any{question}})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(parsed) != 1 {
+				t.Fatalf("expected one question, got %d", len(parsed))
+			}
+			if strings.Join(parsed[0].Options, ",") != strings.Join(c.wantOptions, ",") {
+				t.Fatalf("options = %#v, want %#v", parsed[0].Options, c.wantOptions)
+			}
+			if parsed[0].Recommended != c.wantRec {
+				t.Fatalf("recommended = %q, want %q", parsed[0].Recommended, c.wantRec)
+			}
+		})
+	}
+}
+
+func TestAskUserToolAdvertisesRecommended(t *testing.T) {
+	schema := NewAskUserTool().Parameters()
+	if _, ok := schema.Properties["questions"].Items.Properties["recommended"]; !ok {
+		t.Fatal("expected question item to document a recommended field")
+	}
+}
+
 func TestAskUserToolSafetyIsReadOnly(t *testing.T) {
 	safety := NewAskUserTool().Safety()
 	if safety.Permission != PermissionAllow {

--- a/internal/tui/ask_user_prompt.go
+++ b/internal/tui/ask_user_prompt.go
@@ -131,6 +131,25 @@ func (m model) confirmAskUser() (tea.Model, tea.Cmd) {
 	return m.advanceAskUser(question.Options[cursor])
 }
 
+// escapeAskUser handles Esc for an ask-user prompt. From the "type my own"
+// free-text state of a question that HAS options, it steps back to the selector
+// (keeping the cursor on the "type my own" entry) rather than cancelling — so Esc is
+// an undo of the free-text drop-in. In every other case (selector mode, or an
+// open-ended question with no options) it cancels the questionnaire as before.
+func (m model) escapeAskUser() (tea.Model, tea.Cmd) {
+	pending := m.pendingAskUser
+	if pending == nil {
+		return m, nil
+	}
+	if question, ok := pending.askUserCurrentQuestion(); ok && pending.typing && len(question.Options) > 0 {
+		pending.typing = false
+		pending.cursor = clampAskUserCursor(pending.cursor, askUserSelectableCount(question))
+		m.input.SetValue("")
+		return m, nil
+	}
+	return m.resolveAskUser(true)
+}
+
 // advanceAskUser records answer for the current question and moves to the next,
 // resolving the whole questionnaire once the last question is answered. It is the
 // single advance path shared by the free-text submit and the option select, so both

--- a/internal/tui/ask_user_prompt.go
+++ b/internal/tui/ask_user_prompt.go
@@ -1,0 +1,151 @@
+package tui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/agent"
+)
+
+// ask_user_prompt.go holds the interactive selector for agent-asked questions,
+// mirroring permission_prompt.go. When the current question carries Options the
+// prompt renders a picker (the options plus a trailing "type my own" entry); the
+// cursor starts on the recommended option. Selecting "type my own" — or a question
+// with no options — falls back to the existing free-text composer flow, so there is
+// no regression for open-ended questions.
+
+// askUserTypeMyOwnLabel is the trailing selector entry that drops into free-text.
+const askUserTypeMyOwnLabel = "✎ Type my own answer…"
+
+// askUserSelectableCount is the number of cursor positions for a question: every
+// option plus the "type my own" entry. Zero when the question has no options (the
+// prompt is plain free-text and the selector is not shown).
+func askUserSelectableCount(question agent.AskUserQuestion) int {
+	if len(question.Options) == 0 {
+		return 0
+	}
+	return len(question.Options) + 1
+}
+
+// recommendedAskUserIndex is the cursor position the selector rests on by default:
+// the recommended option when it matches one (the parser guarantees Recommended is
+// either empty or a member of Options), otherwise the first option.
+func recommendedAskUserIndex(question agent.AskUserQuestion) int {
+	if question.Recommended == "" {
+		return 0
+	}
+	for index, option := range question.Options {
+		if option == question.Recommended {
+			return index
+		}
+	}
+	return 0
+}
+
+// clampAskUserCursor keeps a cursor index within [0, n).
+func clampAskUserCursor(cursor, n int) int {
+	if n <= 0 {
+		return 0
+	}
+	if cursor < 0 {
+		return 0
+	}
+	if cursor >= n {
+		return n - 1
+	}
+	return cursor
+}
+
+// askUserCurrentQuestion returns the question the prompt is currently on, and
+// whether the index is valid.
+func (p *pendingAskUserPrompt) askUserCurrentQuestion() (agent.AskUserQuestion, bool) {
+	if p == nil || p.index < 0 || p.index >= len(p.request.Questions) {
+		return agent.AskUserQuestion{}, false
+	}
+	return p.request.Questions[p.index], true
+}
+
+// syncQuestionState initialises the selector/free-text state for the question the
+// prompt is now on. Called when the prompt is created and after each answer
+// advances the index. A question with options enters selector mode resting on the
+// recommended choice; one without options is plain free-text.
+func (p *pendingAskUserPrompt) syncQuestionState() {
+	question, ok := p.askUserCurrentQuestion()
+	if !ok || len(question.Options) == 0 {
+		p.typing = true
+		p.cursor = 0
+		return
+	}
+	p.typing = false
+	p.cursor = recommendedAskUserIndex(question)
+}
+
+// moveAskUserCursor advances the highlighted selector entry by delta, wrapping at
+// the ends. A no-op in free-text mode or when no prompt is pending. The cursor lives
+// on the pending prompt pointer, matching movePermissionCursor.
+func (m model) moveAskUserCursor(delta int) model {
+	pending := m.pendingAskUser
+	if pending == nil || pending.typing {
+		return m
+	}
+	question, ok := pending.askUserCurrentQuestion()
+	if !ok {
+		return m
+	}
+	n := askUserSelectableCount(question)
+	if n <= 0 {
+		return m
+	}
+	cursor := (clampAskUserCursor(pending.cursor, n) + delta) % n
+	if cursor < 0 {
+		cursor += n
+	}
+	pending.cursor = cursor
+	return m
+}
+
+// confirmAskUser resolves the Enter key for an ask-user prompt. In free-text mode it
+// submits the composer value (the legacy path); in selector mode it either records
+// the highlighted option as the answer, or — when "type my own" is highlighted —
+// switches this question into free-text mode so the user can type freely.
+func (m model) confirmAskUser() (tea.Model, tea.Cmd) {
+	pending := m.pendingAskUser
+	if pending == nil {
+		return m, nil
+	}
+	question, ok := pending.askUserCurrentQuestion()
+	if !ok {
+		return m.resolveAskUser(false)
+	}
+	if pending.typing || len(question.Options) == 0 {
+		return m.advanceAskUser(strings.TrimSpace(m.input.Value()))
+	}
+	cursor := clampAskUserCursor(pending.cursor, askUserSelectableCount(question))
+	if cursor >= len(question.Options) {
+		// "type my own" — drop into the free-text composer for this question.
+		pending.typing = true
+		m.input.SetValue("")
+		return m, nil
+	}
+	return m.advanceAskUser(question.Options[cursor])
+}
+
+// advanceAskUser records answer for the current question and moves to the next,
+// resolving the whole questionnaire once the last question is answered. It is the
+// single advance path shared by the free-text submit and the option select, so both
+// feed the same answer channel the agent loop waits on.
+func (m model) advanceAskUser(answer string) (tea.Model, tea.Cmd) {
+	pending := m.pendingAskUser
+	if pending == nil {
+		return m, nil
+	}
+	pending.answers = append(pending.answers, answer)
+	pending.index++
+	m.input.SetValue("")
+	if pending.index >= len(pending.request.Questions) {
+		return m.resolveAskUser(false)
+	}
+	pending.syncQuestionState() // selector vs free-text for the next question
+	return m, nil
+}

--- a/internal/tui/ask_user_prompt.go
+++ b/internal/tui/ask_user_prompt.go
@@ -68,11 +68,13 @@ func (p *pendingAskUserPrompt) askUserCurrentQuestion() (agent.AskUserQuestion, 
 
 // syncQuestionState initialises the selector/free-text state for the question the
 // prompt is now on. Called when the prompt is created and after each answer
-// advances the index. A question with options enters selector mode resting on the
-// recommended choice; one without options is plain free-text.
+// advances the index. Only a SINGLE-select question with options enters the picker
+// (resting on the recommended choice). A multi-select question — which a single-pick
+// selector cannot represent — and an open-ended question both use free-text, so a
+// multi-select answer is never silently narrowed to one option.
 func (p *pendingAskUserPrompt) syncQuestionState() {
 	question, ok := p.askUserCurrentQuestion()
-	if !ok || len(question.Options) == 0 {
+	if !ok || len(question.Options) == 0 || question.MultiSelect {
 		p.typing = true
 		p.cursor = 0
 		return
@@ -141,7 +143,7 @@ func (m model) escapeAskUser() (tea.Model, tea.Cmd) {
 	if pending == nil {
 		return m, nil
 	}
-	if question, ok := pending.askUserCurrentQuestion(); ok && pending.typing && len(question.Options) > 0 {
+	if question, ok := pending.askUserCurrentQuestion(); ok && pending.typing && !question.MultiSelect && len(question.Options) > 0 {
 		pending.typing = false
 		pending.cursor = clampAskUserCursor(pending.cursor, askUserSelectableCount(question))
 		m.input.SetValue("")

--- a/internal/tui/ask_user_test.go
+++ b/internal/tui/ask_user_test.go
@@ -60,8 +60,8 @@ func TestAskUserPromptCollectsAnswersInOrder(t *testing.T) {
 	})
 	next := updated.(model)
 
-	// Answer the first question.
-	next.input.SetValue("React")
+	// Q1 has options -> selector mode; Enter selects the default (first) option "React"
+	// without any composer input.
 	updated, cmd := next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 	if cmd != nil {
@@ -89,6 +89,133 @@ func TestAskUserPromptCollectsAnswersInOrder(t *testing.T) {
 	}
 	if len(answers[0]) != 2 || answers[0][0] != "React" || answers[0][1] != "yes" {
 		t.Fatalf("expected answers [React yes], got %#v", answers[0])
+	}
+}
+
+func askUserRecommendedRequest() agent.AskUserRequest {
+	return agent.AskUserRequest{
+		ToolCallID: "call_db",
+		Questions: []agent.AskUserQuestion{
+			{Question: "Which database?", Options: []string{"Postgres", "SQLite", "MySQL"}, Recommended: "SQLite"},
+		},
+	}
+}
+
+// A question with options + a recommended choice renders the selector, rests the
+// cursor on the recommended option, and Enter selects it without typing.
+func TestAskUserSelectorDefaultsToRecommended(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	m.width = 96
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: askUserRecommendedRequest(),
+		answer:  func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+
+	if next.pendingAskUser == nil || next.pendingAskUser.typing {
+		t.Fatalf("expected selector mode for a question with options, got %#v", next.pendingAskUser)
+	}
+	if next.pendingAskUser.cursor != 1 {
+		t.Fatalf("expected cursor to rest on the recommended option (index 1), got %d", next.pendingAskUser.cursor)
+	}
+	for _, want := range []string{"Postgres", "SQLite", "MySQL", "(recommended)", askUserTypeMyOwnLabel} {
+		assertContains(t, next.View(), want)
+	}
+
+	// Enter selects the recommended default — no composer text involved.
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if next.pendingAskUser != nil {
+		t.Fatalf("expected single-question prompt to clear after selecting, got %#v", next.pendingAskUser)
+	}
+	if len(answers) != 1 || len(answers[0]) != 1 || answers[0][0] != "SQLite" {
+		t.Fatalf("expected selecting the recommended default to return [SQLite], got %#v", answers)
+	}
+}
+
+// Arrowing to the trailing "type my own" entry switches the question into free-text
+// mode; the typed answer is what gets returned.
+func TestAskUserSelectorTypeMyOwnReturnsTypedText(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: askUserRecommendedRequest(),
+		answer:  func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+
+	// Cursor starts at index 1 (SQLite); move down twice to the "type my own" entry
+	// (options=3 -> type-my-own index 3).
+	for i := 0; i < 2; i++ {
+		updated, _ = next.Update(testKey(tea.KeyDown))
+		next = updated.(model)
+	}
+	if next.pendingAskUser.cursor != 3 {
+		t.Fatalf("expected cursor on the 'type my own' entry (index 3), got %d", next.pendingAskUser.cursor)
+	}
+
+	// Enter on "type my own" switches to free-text and delivers nothing yet.
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if next.pendingAskUser == nil || !next.pendingAskUser.typing {
+		t.Fatalf("expected 'type my own' to switch into free-text typing mode, got %#v", next.pendingAskUser)
+	}
+	if len(answers) != 0 {
+		t.Fatalf("expected no answer delivered when switching to free-text, got %#v", answers)
+	}
+	assertContains(t, next.View(), "type an answer")
+
+	// Type a custom answer and submit.
+	next.input.SetValue("CockroachDB")
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if len(answers) != 1 || answers[0][0] != "CockroachDB" {
+		t.Fatalf("expected typed free-text answer [CockroachDB], got %#v", answers)
+	}
+}
+
+// A question with NO options keeps the plain free-text prompt exactly as before (no
+// selector, no regression).
+func TestAskUserNoOptionsIsPlainFreeText(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	m.width = 96
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID: 7,
+		request: agent.AskUserRequest{
+			ToolCallID: "call_open",
+			Questions:  []agent.AskUserQuestion{{Question: "Describe the desired behavior"}},
+		},
+		answer: func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+
+	if next.pendingAskUser == nil || !next.pendingAskUser.typing {
+		t.Fatalf("expected free-text (typing) mode for a question with no options, got %#v", next.pendingAskUser)
+	}
+	view := next.View()
+	assertContains(t, view, "type an answer")
+	if transcriptContains(next.transcript, askUserTypeMyOwnLabel) {
+		t.Fatalf("a no-options question must not show the selector's type-my-own entry")
+	}
+
+	next.input.SetValue("my free-form answer")
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if len(answers) != 1 || answers[0][0] != "my free-form answer" {
+		t.Fatalf("expected free-text answer, got %#v", answers)
 	}
 }
 

--- a/internal/tui/ask_user_test.go
+++ b/internal/tui/ask_user_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -145,6 +146,7 @@ func TestAskUserSelectorTypeMyOwnReturnsTypedText(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.pending = true
 	m.activeRunID = 7
+	m.width = 96
 
 	updated, _ := m.Update(askUserRequestMsg{
 		runID:   7,
@@ -172,14 +174,75 @@ func TestAskUserSelectorTypeMyOwnReturnsTypedText(t *testing.T) {
 	if len(answers) != 0 {
 		t.Fatalf("expected no answer delivered when switching to free-text, got %#v", answers)
 	}
-	assertContains(t, next.View(), "type an answer")
+	assertContains(t, next.View(), "type your own answer")
 
-	// Type a custom answer and submit.
+	// The typed answer must appear ONLY in the composer, never echoed inside the ask
+	// card (the double-display bug): the focused card carries no input.
 	next.input.SetValue("CockroachDB")
+	if card := renderFocusedAskUserPrompt(*next.pendingAskUser, next.width); strings.Contains(card, "CockroachDB") {
+		t.Fatalf("ask card must not echo the typed answer; card=\n%s", card)
+	}
+
+	// Submit the typed answer.
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 	if len(answers) != 1 || answers[0][0] != "CockroachDB" {
 		t.Fatalf("expected typed free-text answer [CockroachDB], got %#v", answers)
+	}
+}
+
+// Esc from the "type my own" free-text steps back to the selector for that question
+// — it must NOT cancel the questionnaire or deliver answers; the user can then pick
+// a suggested option instead.
+func TestAskUserTypeMyOwnEscReturnsToSelector(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	m.width = 96
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: askUserRecommendedRequest(),
+		answer:  func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+
+	// Into "type my own" (index 3) and free-text.
+	for i := 0; i < 2; i++ {
+		updated, _ = next.Update(testKey(tea.KeyDown))
+		next = updated.(model)
+	}
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if next.pendingAskUser == nil || !next.pendingAskUser.typing {
+		t.Fatal("expected free-text mode after choosing type-my-own")
+	}
+	next.input.SetValue("scratch")
+
+	// Esc returns to the selector, does not cancel, does not deliver.
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
+	if next.pendingAskUser == nil {
+		t.Fatal("Esc from type-my-own must NOT cancel the questionnaire")
+	}
+	if next.pendingAskUser.typing {
+		t.Fatal("Esc from type-my-own must return to the selector (typing=false)")
+	}
+	if len(answers) != 0 {
+		t.Fatalf("Esc back to the selector must not deliver answers, got %#v", answers)
+	}
+	if !next.pending {
+		t.Fatal("the run must keep running after Esc steps back")
+	}
+
+	// From the selector, move up to a real option and select it.
+	updated, _ = next.Update(testKey(tea.KeyUp)) // 3 -> 2 (MySQL)
+	next = updated.(model)
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if len(answers) != 1 || answers[0][0] != "MySQL" {
+		t.Fatalf("expected selecting MySQL after returning to the selector, got %#v", answers)
 	}
 }
 

--- a/internal/tui/ask_user_test.go
+++ b/internal/tui/ask_user_test.go
@@ -282,6 +282,81 @@ func TestAskUserNoOptionsIsPlainFreeText(t *testing.T) {
 	}
 }
 
+// A multi-select question can't be a single-pick selector, so it renders as
+// free-text (surfacing the options as suggestions) — the typed answer is returned
+// verbatim and nothing is silently narrowed to one option.
+func TestAskUserMultiSelectFallsBackToFreeText(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	m.width = 96
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID: 7,
+		request: agent.AskUserRequest{
+			ToolCallID: "call_multi",
+			Questions: []agent.AskUserQuestion{
+				{Question: "Which checks?", Options: []string{"lint", "test", "typecheck"}, MultiSelect: true},
+			},
+		},
+		answer: func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+
+	if next.pendingAskUser == nil || !next.pendingAskUser.typing {
+		t.Fatalf("expected multi-select to use free-text, got %#v", next.pendingAskUser)
+	}
+	// Options are surfaced as suggestions, not a single-pick list.
+	assertContains(t, next.View(), "suggested:")
+	assertContains(t, next.View(), "lint")
+
+	next.input.SetValue("lint, typecheck")
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if len(answers) != 1 || answers[0][0] != "lint, typecheck" {
+		t.Fatalf("expected the typed multi-answer returned verbatim, got %#v", answers)
+	}
+}
+
+// Typing a printable key while the single-select selector is showing flips straight
+// into free-text (seeding the keystroke) rather than being swallowed and discarded.
+func TestAskUserTypingInSelectorSwitchesToFreeText(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	m.width = 96
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: askUserRecommendedRequest(), // single-select, 3 options
+		answer:  func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+	if next.pendingAskUser.typing {
+		t.Fatal("expected selector mode initially")
+	}
+
+	// Type a character: it must switch to free-text AND be captured (not swallowed).
+	updated, _ = next.Update(testKeyText("M"))
+	next = updated.(model)
+	if !next.pendingAskUser.typing {
+		t.Fatal("expected a printable keystroke to switch the selector into free-text")
+	}
+	if next.input.Value() != "M" {
+		t.Fatalf("expected the keystroke to be captured in the composer, got %q", next.input.Value())
+	}
+
+	// Finish typing and submit; the typed answer wins (not a discarded option).
+	next.input.SetValue("MariaDB")
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if len(answers) != 1 || answers[0][0] != "MariaDB" {
+		t.Fatalf("expected the typed answer MariaDB, got %#v", answers)
+	}
+}
+
 func TestAskUserPromptEscDeliversCollectedAnswers(t *testing.T) {
 	var answers [][]string
 	m := newModel(context.Background(), Options{})

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1246,8 +1246,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if m.pendingAskUser != nil {
-			// While a questionnaire is active, all other keys feed the text input
-			// (the answer field); nothing else should react.
+			// While a questionnaire is active, keys feed the answer text input. In
+			// selector mode a printable keystroke means the user wants to type their
+			// own answer, so flip into free-text first (same as choosing "type my
+			// own") instead of letting the text accumulate invisibly and then be
+			// discarded when Enter selects the highlighted option.
+			if !m.pendingAskUser.typing && keyPrintable(msg) {
+				m.pendingAskUser.typing = true
+				m.input.SetValue("")
+			}
 			var cmd tea.Cmd
 			m.input, cmd = m.input.Update(msg)
 			return m, cmd
@@ -3097,16 +3104,6 @@ func (m model) resolvePermission(decision permissionDecision) (tea.Model, tea.Cm
 	}
 	m.pendingPermission = nil
 	return m, nil
-}
-
-// submitAskUserAnswer records the answer to the current question and advances to
-// the next one; once every question is answered it delivers the full answer set.
-func (m model) submitAskUserAnswer() (tea.Model, tea.Cmd) {
-	if m.pendingAskUser == nil {
-		return m, nil
-	}
-	// Free-text path: the answer is whatever is in the composer.
-	return m.advanceAskUser(strings.TrimSpace(m.input.Value()))
 }
 
 // resolveAskUser delivers the collected answers (padding to one-per-question when

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -511,11 +511,18 @@ type askUserRequestMsg struct {
 // pendingAskUserPrompt tracks an in-progress questionnaire. Answers are collected
 // one question at a time; once every question has an answer (or the user cancels)
 // the answer callback is invoked exactly once.
+//
+// When the current question carries Options, the prompt is in SELECTOR mode: cursor
+// indexes the options plus a trailing "type my own" entry, and starts on the
+// recommended option. Choosing "type my own" (or a question with no options) flips
+// typing=true, falling back to the existing free-text composer input.
 type pendingAskUserPrompt struct {
 	request agent.AskUserRequest
 	answer  func([]string)
 	index   int
 	answers []string
+	cursor  int  // selector index over [options..., "type my own"] for the current question
+	typing  bool // true = free-text input mode for the current question
 }
 
 type pendingSpecReviewPrompt struct {
@@ -1014,7 +1021,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.confirmPermissionCursor()
 			}
 			if m.pendingAskUser != nil {
-				return m.submitAskUserAnswer()
+				return m.confirmAskUser()
 			}
 			if m.pendingSpecReview != nil {
 				return m, nil
@@ -1163,6 +1170,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.pendingPermission != nil {
 				return m.movePermissionCursor(1), nil
 			}
+			if m.pendingAskUser != nil && !m.pendingAskUser.typing {
+				return m.moveAskUserCursor(1), nil
+			}
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
 			}
@@ -1200,6 +1210,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.pendingPermission != nil {
 				return m.movePermissionCursor(-1), nil
+			}
+			if m.pendingAskUser != nil && !m.pendingAskUser.typing {
+				return m.moveAskUserCursor(-1), nil
 			}
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
@@ -1457,6 +1470,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			answer:  msg.answer,
 			answers: make([]string, 0, len(msg.request.Questions)),
 		}
+		m.pendingAskUser.syncQuestionState() // selector vs free-text for question 1
 		m.clearComposer()
 		m.clearSuggestions()
 		return m, nil
@@ -3087,17 +3101,11 @@ func (m model) resolvePermission(decision permissionDecision) (tea.Model, tea.Cm
 // submitAskUserAnswer records the answer to the current question and advances to
 // the next one; once every question is answered it delivers the full answer set.
 func (m model) submitAskUserAnswer() (tea.Model, tea.Cmd) {
-	pending := m.pendingAskUser
-	if pending == nil {
+	if m.pendingAskUser == nil {
 		return m, nil
 	}
-	pending.answers = append(pending.answers, strings.TrimSpace(m.input.Value()))
-	pending.index++
-	m.input.SetValue("")
-	if pending.index >= len(pending.request.Questions) {
-		return m.resolveAskUser(false)
-	}
-	return m, nil
+	// Free-text path: the answer is whatever is in the composer.
+	return m.advanceAskUser(strings.TrimSpace(m.input.Value()))
 }
 
 // resolveAskUser delivers the collected answers (padding to one-per-question when

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -962,11 +962,12 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.transcriptDetailed = false
 				return m, nil
 			}
-			// An active questionnaire is cancelled (not the whole run): deliver
-			// whatever answers were collected so the agent loop unblocks and
-			// degrades to its best-assumption path.
+			// Esc on an ask-user prompt: from the "type my own" free-text it steps
+			// back to the selector for that question; otherwise it cancels the
+			// questionnaire (not the run), delivering whatever answers were collected
+			// so the agent loop unblocks and degrades to its best-assumption path.
 			if m.pendingAskUser != nil {
-				return m.resolveAskUser(true)
+				return m.escapeAskUser()
 			}
 			if m.pendingSpecReview != nil {
 				return m.cancelSpecReview()

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1280,15 +1280,20 @@ func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, width int) string {
 			}
 			lines = append(lines, fill(zeroTheme.faint).Render("↑↓ move · enter to select · esc to skip"))
 		} else {
-			// Free-text mode (no options, or "type my own" chosen). The composer text
-			// box below is the single input — do NOT echo the typed answer inside the
-			// card too (that showed the text in two places). "Type my own" can step
-			// back to the selector with Esc; an open-ended question's Esc skips it.
-			hint := "type an answer below · Enter to submit · Esc to skip"
-			if len(question.Options) > 0 {
-				hint = "type your own answer below · Enter to submit · Esc to go back"
+			// Free-text mode. The composer text box below is the single input — do NOT
+			// echo the typed answer inside the card too (that showed it in two places).
+			switch {
+			case question.MultiSelect && len(question.Options) > 0:
+				// Multi-select can't be a single-pick list; surface the suggestions and
+				// let the user type one or more in their own words.
+				lines = append(lines, fill(zeroTheme.muted).Render("suggested: "+strings.Join(question.Options, ", ")))
+				lines = append(lines, fill(zeroTheme.faint).Render("type your answer(s) below · Enter to submit · Esc to skip"))
+			case len(question.Options) > 0:
+				// Single-select "type my own": Esc steps back to the selector.
+				lines = append(lines, fill(zeroTheme.faint).Render("type your own answer below · Enter to submit · Esc to go back"))
+			default:
+				lines = append(lines, fill(zeroTheme.faint).Render("type an answer below · Enter to submit · Esc to skip"))
 			}
-			lines = append(lines, fill(zeroTheme.faint).Render(hint))
 		}
 	}
 

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1278,7 +1278,7 @@ func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, width int) string {
 			} else {
 				lines = append(lines, "  "+fill(zeroTheme.muted).Render(askUserTypeMyOwnLabel))
 			}
-			lines = append(lines, fill(zeroTheme.faint).Render("↑↓ move · enter to select · esc to skip"))
+			lines = append(lines, fill(zeroTheme.faint).Render("↑↓ move · enter to select · esc to skip the rest"))
 		} else {
 			// Free-text mode. The composer text box below is the single input — do NOT
 			// echo the typed answer inside the card too (that showed it in two places).
@@ -1287,12 +1287,12 @@ func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, width int) string {
 				// Multi-select can't be a single-pick list; surface the suggestions and
 				// let the user type one or more in their own words.
 				lines = append(lines, fill(zeroTheme.muted).Render("suggested: "+strings.Join(question.Options, ", ")))
-				lines = append(lines, fill(zeroTheme.faint).Render("type your answer(s) below · Enter to submit · Esc to skip"))
+				lines = append(lines, fill(zeroTheme.faint).Render("type your answer(s) below · Enter to submit · Esc to skip the rest"))
 			case len(question.Options) > 0:
 				// Single-select "type my own": Esc steps back to the selector.
 				lines = append(lines, fill(zeroTheme.faint).Render("type your own answer below · Enter to submit · Esc to go back"))
 			default:
-				lines = append(lines, fill(zeroTheme.faint).Render("type an answer below · Enter to submit · Esc to skip"))
+				lines = append(lines, fill(zeroTheme.faint).Render("type an answer below · Enter to submit · Esc to skip the rest"))
 			}
 		}
 	}

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1232,7 +1232,7 @@ func permissionEventScopeLabel(event *agent.PermissionEvent) string {
 
 // renderFocusedAskUserPrompt draws the ask-user questionnaire in the same
 // card language as the permission card, with line borders.
-func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, input string, width int) string {
+func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, width int) string {
 	questions := prompt.request.Questions
 	total := len(questions)
 	index := prompt.index
@@ -1280,13 +1280,15 @@ func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, input string, width
 			}
 			lines = append(lines, fill(zeroTheme.faint).Render("↑↓ move · enter to select · esc to skip"))
 		} else {
-			// Free-text mode (no options, or "type my own" chosen): echo the
-			// in-progress answer inside the card, cursor included — unchanged from the
-			// original plain prompt so open-ended questions behave exactly as before.
-			answer := zeroTheme.onPanel(zeroTheme.userPrompt).Render("❯ ") +
-				fill(zeroTheme.ink).Render(input) + fill(zeroTheme.accent).Render("▌")
-			lines = append(lines, answer)
-			lines = append(lines, fill(zeroTheme.faint).Render("type an answer, Enter to submit · Esc to skip"))
+			// Free-text mode (no options, or "type my own" chosen). The composer text
+			// box below is the single input — do NOT echo the typed answer inside the
+			// card too (that showed the text in two places). "Type my own" can step
+			// back to the selector with Esc; an open-ended question's Esc skips it.
+			hint := "type an answer below · Enter to submit · Esc to skip"
+			if len(question.Options) > 0 {
+				hint = "type your own answer below · Enter to submit · Esc to go back"
+			}
+			lines = append(lines, fill(zeroTheme.faint).Render(hint))
 		}
 	}
 

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1254,16 +1254,41 @@ func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, input string, width
 		question := questions[index]
 		lines = append(lines, fill(zeroTheme.faint).Render(fmt.Sprintf("question %d of %d", index+1, total)))
 		lines = append(lines, fill(zeroTheme.ink).Render(question.Question))
-		if len(question.Options) > 0 {
-			lines = append(lines, fill(zeroTheme.muted).Render("options: "+strings.Join(question.Options, ", ")))
+
+		if len(question.Options) > 0 && !prompt.typing {
+			// Selector mode: render each suggested option plus a trailing "type my
+			// own" entry. The highlighted row gets a lime ▸ marker and a reverse
+			// badge label (mirrors the permission popup); the recommended option is
+			// tagged inline.
+			selectable := askUserSelectableCount(question)
+			cursor := clampAskUserCursor(prompt.cursor, selectable)
+			for optionIndex, option := range question.Options {
+				label := option
+				if option == question.Recommended {
+					label += "  (recommended)"
+				}
+				if optionIndex == cursor {
+					lines = append(lines, fill(zeroTheme.accent).Render("▸ ")+zeroTheme.badge.Render(" "+label+" "))
+				} else {
+					lines = append(lines, "  "+fill(zeroTheme.ink).Render(label))
+				}
+			}
+			if cursor >= len(question.Options) {
+				lines = append(lines, fill(zeroTheme.accent).Render("▸ ")+zeroTheme.badge.Render(" "+askUserTypeMyOwnLabel+" "))
+			} else {
+				lines = append(lines, "  "+fill(zeroTheme.muted).Render(askUserTypeMyOwnLabel))
+			}
+			lines = append(lines, fill(zeroTheme.faint).Render("↑↓ move · enter to select · esc to skip"))
+		} else {
+			// Free-text mode (no options, or "type my own" chosen): echo the
+			// in-progress answer inside the card, cursor included — unchanged from the
+			// original plain prompt so open-ended questions behave exactly as before.
+			answer := zeroTheme.onPanel(zeroTheme.userPrompt).Render("❯ ") +
+				fill(zeroTheme.ink).Render(input) + fill(zeroTheme.accent).Render("▌")
+			lines = append(lines, answer)
+			lines = append(lines, fill(zeroTheme.faint).Render("type an answer, Enter to submit · Esc to skip"))
 		}
 	}
-	// Echo the in-progress answer inside the card so the user sees what they
-	// are typing where they are answering, cursor included.
-	answer := zeroTheme.onPanel(zeroTheme.userPrompt).Render("❯ ") +
-		fill(zeroTheme.ink).Render(input) + fill(zeroTheme.accent).Render("▌")
-	lines = append(lines, answer)
-	lines = append(lines, fill(zeroTheme.faint).Render("type an answer, Enter to submit · Esc to skip"))
 
 	return styledBlockFill(width, lines, zeroTheme.line, zeroTheme.panel)
 }

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -290,7 +290,7 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 				},
 			})
 		case m.pendingAskUser != nil:
-			items = append(items, transcriptBlockBodyItem(transcriptBodyItemPendingPrompt, -1, renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width)))
+			items = append(items, transcriptBlockBodyItem(transcriptBodyItemPendingPrompt, -1, renderFocusedAskUserPrompt(*m.pendingAskUser, width)))
 		default:
 			items = append(items, transcriptBodyItem{
 				kind:     transcriptBodyItemPendingInterim,


### PR DESCRIPTION
## Summary
Adds optional suggested answers to the `ask_user` tool: a question can carry 2-4 `options` with one marked `recommended`, and the interactive TUI renders a picker (arrow keys, lime cursor, recommended default, `Type your own answer` fallback). Optional and backward-compatible — open-ended questions stay free-text; headless `zero exec` is unaffected.

_Follow-up: the tabbed, composer-rendered redesign (multi-question tabs + Confirm, option descriptions, black canvas) is in #327._
