### PR TITLE
feat(tui): tabbed ask_user questionnaire in the composer with suggested answers

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1503,10 +1503,12 @@ func toAgentAskUserQuestions(questions []tools.AskUserQuestion) []AskUserQuestio
 	converted := make([]AskUserQuestion, len(questions))
 	for index, question := range questions {
 		converted[index] = AskUserQuestion{
-			Question:    question.Question,
-			Options:     append([]string{}, question.Options...),
-			Recommended: question.Recommended,
-			MultiSelect: question.MultiSelect,
+			Question:           question.Question,
+			Header:             question.Header,
+			Options:            append([]string{}, question.Options...),
+			OptionDescriptions: append([]string{}, question.OptionDescriptions...),
+			Recommended:        question.Recommended,
+			MultiSelect:        question.MultiSelect,
 		}
 	}
 	return converted

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -18,8 +18,10 @@ work.
   blocked on a decision that is theirs to make and that you cannot resolve from
   the code, the request, or sensible defaults. When the answer is likely one of a
   small set, include 2-4 suggested `options` and mark the best as `recommended`
-  (it must be one of the options) so the user can pick quickly; omit options for
-  genuinely open-ended questions.
+  (it must be one of the options) so the user can pick quickly; give each option a
+  short `optionDescriptions` line when a one-word label needs context, and a short
+  `header` (2-3 words) per question as its tab label when you ask several. Omit
+  options for genuinely open-ended questions.
 
 ## Workflow: plan then act
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -141,11 +141,16 @@ type PermissionEvent struct {
 // AskUserQuestion is one clarifying question the agent wants answered. Options are
 // optional suggested answers an interactive front-end can render as a picker;
 // Recommended (when set) is the suggested default — it should match one of Options.
+// Header is an optional short tab title for a multi-question prompt (falls back to
+// the question text). OptionDescriptions, when present, holds a one-line description
+// per option aligned by index to Options (empty string = no description).
 type AskUserQuestion struct {
-	Question    string   `json:"question"`
-	Options     []string `json:"options,omitempty"`
-	Recommended string   `json:"recommended,omitempty"`
-	MultiSelect bool     `json:"multiSelect,omitempty"`
+	Question           string   `json:"question"`
+	Header             string   `json:"header,omitempty"`
+	Options            []string `json:"options,omitempty"`
+	OptionDescriptions []string `json:"optionDescriptions,omitempty"`
+	Recommended        string   `json:"recommended,omitempty"`
+	MultiSelect        bool     `json:"multiSelect,omitempty"`
 }
 
 // AskUserRequest is handed to OnAskUser when the model invokes the ask_user tool.

--- a/internal/tools/ask_user.go
+++ b/internal/tools/ask_user.go
@@ -63,12 +63,12 @@ func NewAskUserTool() *askUserTool {
 								},
 								"options": {
 									Type:        "array",
-									Description: "Optional list of 2-4 suggested answer choices for a quick picker. Each item is a string label, or an object {label, description}.",
+									Description: "Optional list of 2-4 suggested answer choices (string labels) for a quick picker.",
 									Items:       &PropertySchema{Type: "string"},
 								},
 								"optionDescriptions": {
 									Type:        "array",
-									Description: "Optional one-line descriptions aligned by index to options (alternative to the object form).",
+									Description: "Optional one-line descriptions aligned by index to options.",
 									Items:       &PropertySchema{Type: "string"},
 								},
 								"recommended": {

--- a/internal/tools/ask_user.go
+++ b/internal/tools/ask_user.go
@@ -10,10 +10,12 @@ import (
 // Options/MultiSelect are presentation hints for an interactive front-end; the
 // tool itself never blocks on input.
 type AskUserQuestion struct {
-	Question    string
-	Options     []string
-	Recommended string
-	MultiSelect bool
+	Question           string
+	Header             string
+	Options            []string
+	OptionDescriptions []string
+	Recommended        string
+	MultiSelect        bool
 }
 
 // askUserNonInteractiveMessage is returned both by the tool's own Run() fallback
@@ -55,9 +57,18 @@ func NewAskUserTool() *askUserTool {
 							Type: "object",
 							Properties: map[string]PropertySchema{
 								"question": {Type: "string", Description: "The non-empty question to ask the user.", MinLength: intPtr(1)},
+								"header": {
+									Type:        "string",
+									Description: "Optional short title (2-3 words) used as this question's tab label in a multi-question prompt.",
+								},
 								"options": {
 									Type:        "array",
-									Description: "Optional list of 2-4 suggested answer choices for a quick picker.",
+									Description: "Optional list of 2-4 suggested answer choices for a quick picker. Each item is a string label, or an object {label, description}.",
+									Items:       &PropertySchema{Type: "string"},
+								},
+								"optionDescriptions": {
+									Type:        "array",
+									Description: "Optional one-line descriptions aligned by index to options (alternative to the object form).",
 									Items:       &PropertySchema{Type: "string"},
 								},
 								"recommended": {
@@ -136,12 +147,14 @@ func ParseAskUserQuestions(args map[string]any) ([]AskUserQuestion, error) {
 		// multiSelect is a UI hint; treat an uncoercible value as the default rather
 		// than failing the whole call (mirrors the best-effort options path).
 		multiSelect, _ := boolArg(object, "multiSelect", false)
-		options := coerceOptionStrings(object["options"]) // best-effort; never errors
+		options, optionDescriptions := coerceAskUserOptions(object["options"], object["optionDescriptions"]) // best-effort; never errors
 		questions = append(questions, AskUserQuestion{
-			Question:    text,
-			Options:     options,
-			Recommended: recommendedOption(object["recommended"], options), // only kept if it matches an option
-			MultiSelect: multiSelect,
+			Question:           text,
+			Header:             firstStringKey(object, "header"),
+			Options:            options,
+			OptionDescriptions: optionDescriptions,
+			Recommended:        recommendedOption(object["recommended"], options), // only kept if it matches an option
+			MultiSelect:        multiSelect,
 		})
 	}
 	return questions, nil
@@ -190,12 +203,70 @@ func recommendedOption(value any, options []string) string {
 	return ""
 }
 
-// coerceOptionStrings turns whatever a model put in "options" into a string slice
-// without ever failing — options are presentation hints, so a malformed shape must
-// not break the whole ask_user call. It delegates to the shared coerceStringSlice
-// so there is a single coercion path across the package.
-func coerceOptionStrings(value any) []string {
-	return coerceStringSlice(value)
+// firstStringKey returns the first non-empty string value among the given keys.
+func firstStringKey(object map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := object[key]; ok {
+			if s, ok := value.(string); ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	return ""
+}
+
+// coerceAskUserOptions extracts option labels and their aligned descriptions from
+// the raw "options" value without ever failing (options are presentation hints, so
+// a malformed shape must not break the call). Each option may be a bare string (no
+// description) or an object {label/value/text, description/desc/detail}. The
+// question-level "optionDescriptions" array (descsValue) fills any description left
+// empty, aligned by index. The returned descriptions slice is nil when every entry
+// is empty, so a plain options list stays single-line.
+func coerceAskUserOptions(optionsValue, descsValue any) (labels []string, descriptions []string) {
+	if items, ok := optionsValue.([]any); ok {
+		for _, item := range items {
+			switch value := item.(type) {
+			case string:
+				if s := strings.TrimSpace(value); s != "" {
+					labels = append(labels, s)
+					descriptions = append(descriptions, "")
+				}
+			case map[string]any:
+				label := firstStringKey(value, "label", "value", "text", "name", "title", "option")
+				if label == "" {
+					continue
+				}
+				labels = append(labels, label)
+				descriptions = append(descriptions, firstStringKey(value, "description", "desc", "detail", "hint", "subtitle"))
+			}
+		}
+	} else {
+		// Non-array shape (e.g. newline-delimited string): reuse the shared coercion.
+		labels = coerceStringSlice(optionsValue)
+		descriptions = make([]string, len(labels))
+	}
+	// Fill any still-empty descriptions from the parallel optionDescriptions array.
+	parallel := coerceStringSlice(descsValue)
+	for index := range labels {
+		if index < len(descriptions) && strings.TrimSpace(descriptions[index]) != "" {
+			continue
+		}
+		if index < len(parallel) {
+			for len(descriptions) <= index {
+				descriptions = append(descriptions, "")
+			}
+			descriptions[index] = parallel[index]
+		}
+	}
+	for len(descriptions) < len(labels) {
+		descriptions = append(descriptions, "")
+	}
+	for _, description := range descriptions {
+		if strings.TrimSpace(description) != "" {
+			return labels, descriptions
+		}
+	}
+	return labels, nil
 }
 
 // FormatAskUserAnswers renders question/answer pairs into a clear, model-readable

--- a/internal/tui/ask_user_prompt.go
+++ b/internal/tui/ask_user_prompt.go
@@ -121,9 +121,11 @@ func (m model) askUserSwitchTab(target int) model {
 	return m
 }
 
-// moveAskUserTab cycles the active tab by delta (Tab / Shift+Tab).
+// moveAskUserTab cycles the active tab by delta (Tab / Shift+Tab). A no-op for a
+// single-question prompt, which has no tab strip / Confirm tab — so Tab can't move
+// it into the hidden Confirm state.
 func (m model) moveAskUserTab(delta int) model {
-	if m.pendingAskUser == nil {
+	if m.pendingAskUser == nil || len(m.pendingAskUser.request.Questions) <= 1 {
 		return m
 	}
 	return m.askUserSwitchTab(m.pendingAskUser.active + delta)

--- a/internal/tui/ask_user_prompt.go
+++ b/internal/tui/ask_user_prompt.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strconv"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -8,29 +9,42 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 )
 
-// ask_user_prompt.go holds the interactive selector for agent-asked questions,
-// mirroring permission_prompt.go. When the current question carries Options the
-// prompt renders a picker (the options plus a trailing "type my own" entry); the
-// cursor starts on the recommended option. Selecting "type my own" — or a question
-// with no options — falls back to the existing free-text composer flow, so there is
-// no regression for open-ended questions.
+// ask_user_prompt.go drives the interactive ask-user questionnaire that renders in
+// the composer region. A multi-question prompt is a row of tabs (one per question
+// plus a trailing Confirm tab): Tab/Shift+Tab switch questions, answers are given in
+// any order, and Confirm submits them all through the loop's answer channel. A
+// single-select question with options is a picker (↑↓ + Enter, cursor on the
+// recommended option) with a trailing "type your own" entry that drops into the
+// composer free-text; a multi-select or open-ended question is plain free-text.
 
-// askUserTypeMyOwnLabel is the trailing selector entry that drops into free-text.
-const askUserTypeMyOwnLabel = "✎ Type my own answer…"
+const askUserTypeMyOwnLabel = "Type your own answer"
 
-// askUserSelectableCount is the number of cursor positions for a question: every
-// option plus the "type my own" entry. Zero when the question has no options (the
-// prompt is plain free-text and the selector is not shown).
-func askUserSelectableCount(question agent.AskUserQuestion) int {
-	if len(question.Options) == 0 {
-		return 0
-	}
-	return len(question.Options) + 1
+// askUserAnswerState is the per-question state in a multi-question prompt.
+type askUserAnswerState struct {
+	cursor   int    // selector index over [options..., type-my-own]
+	typing   bool   // free-text mode for this question
+	typed    string // free-text preserved across tab switches
+	answer   string // committed answer ("" until answered)
+	answered bool
 }
 
-// recommendedAskUserIndex is the cursor position the selector rests on by default:
-// the recommended option when it matches one (the parser guarantees Recommended is
-// either empty or a member of Options), otherwise the first option.
+// newAskUserStates builds the initial per-question state: single-select questions
+// with options open in the picker resting on the recommended option; multi-select
+// and open-ended questions start in free-text.
+func newAskUserStates(questions []agent.AskUserQuestion) []askUserAnswerState {
+	states := make([]askUserAnswerState, len(questions))
+	for index, question := range questions {
+		if len(question.Options) == 0 || question.MultiSelect {
+			states[index].typing = true
+			continue
+		}
+		states[index].cursor = recommendedAskUserIndex(question)
+	}
+	return states
+}
+
+// recommendedAskUserIndex is the cursor the picker rests on by default: the
+// recommended option when it matches one, else the first option.
 func recommendedAskUserIndex(question agent.AskUserQuestion) int {
 	if question.Recommended == "" {
 		return 0
@@ -43,7 +57,11 @@ func recommendedAskUserIndex(question agent.AskUserQuestion) int {
 	return 0
 }
 
-// clampAskUserCursor keeps a cursor index within [0, n).
+// askUserSelectableCount is the options count plus the trailing "type your own" row.
+func askUserSelectableCount(question agent.AskUserQuestion) int {
+	return len(question.Options) + 1
+}
+
 func clampAskUserCursor(cursor, n int) int {
 	if n <= 0 {
 		return 0
@@ -57,116 +75,188 @@ func clampAskUserCursor(cursor, n int) int {
 	return cursor
 }
 
-// askUserCurrentQuestion returns the question the prompt is currently on, and
-// whether the index is valid.
-func (p *pendingAskUserPrompt) askUserCurrentQuestion() (agent.AskUserQuestion, bool) {
-	if p == nil || p.index < 0 || p.index >= len(p.request.Questions) {
-		return agent.AskUserQuestion{}, false
-	}
-	return p.request.Questions[p.index], true
+// confirmTabIndex is the index of the trailing Confirm tab (== number of questions).
+func (p *pendingAskUserPrompt) confirmTabIndex() int {
+	return len(p.request.Questions)
 }
 
-// syncQuestionState initialises the selector/free-text state for the question the
-// prompt is now on. Called when the prompt is created and after each answer
-// advances the index. Only a SINGLE-select question with options enters the picker
-// (resting on the recommended choice). A multi-select question — which a single-pick
-// selector cannot represent — and an open-ended question both use free-text, so a
-// multi-select answer is never silently narrowed to one option.
-func (p *pendingAskUserPrompt) syncQuestionState() {
-	question, ok := p.askUserCurrentQuestion()
-	if !ok || len(question.Options) == 0 || question.MultiSelect {
-		p.typing = true
-		p.cursor = 0
-		return
-	}
-	p.typing = false
-	p.cursor = recommendedAskUserIndex(question)
+// onConfirmTab reports whether the active tab is the Confirm tab.
+func (p *pendingAskUserPrompt) onConfirmTab() bool {
+	return p.active >= len(p.request.Questions)
 }
 
-// moveAskUserCursor advances the highlighted selector entry by delta, wrapping at
-// the ends. A no-op in free-text mode or when no prompt is pending. The cursor lives
-// on the pending prompt pointer, matching movePermissionCursor.
-func (m model) moveAskUserCursor(delta int) model {
+// activeQuestion returns the active question and its state when the active tab is a
+// question (not the Confirm tab).
+func (p *pendingAskUserPrompt) activeQuestion() (agent.AskUserQuestion, *askUserAnswerState, bool) {
+	if p == nil || p.active < 0 || p.active >= len(p.request.Questions) || p.active >= len(p.states) {
+		return agent.AskUserQuestion{}, nil, false
+	}
+	return p.request.Questions[p.active], &p.states[p.active], true
+}
+
+// askUserSwitchTab persists the current question's typed text, moves the active tab
+// to target (wrapping over [0, confirmTab]), and loads the target's typed text into
+// the composer input (or clears it for a picker / the Confirm tab).
+func (m model) askUserSwitchTab(target int) model {
 	pending := m.pendingAskUser
-	if pending == nil || pending.typing {
+	if pending == nil {
 		return m
 	}
-	question, ok := pending.askUserCurrentQuestion()
-	if !ok {
-		return m
+	confirm := pending.confirmTabIndex()
+	switch {
+	case target < 0:
+		target = confirm
+	case target > confirm:
+		target = 0
 	}
-	n := askUserSelectableCount(question)
-	if n <= 0 {
-		return m
+	if _, state, ok := pending.activeQuestion(); ok && state.typing {
+		state.typed = m.input.Value()
 	}
-	cursor := (clampAskUserCursor(pending.cursor, n) + delta) % n
-	if cursor < 0 {
-		cursor += n
+	pending.active = target
+	if target < confirm && pending.states[target].typing {
+		m.input.SetValue(pending.states[target].typed)
+	} else {
+		m.input.SetValue("")
 	}
-	pending.cursor = cursor
 	return m
 }
 
-// confirmAskUser resolves the Enter key for an ask-user prompt. In free-text mode it
-// submits the composer value (the legacy path); in selector mode it either records
-// the highlighted option as the answer, or — when "type my own" is highlighted —
-// switches this question into free-text mode so the user can type freely.
+// moveAskUserTab cycles the active tab by delta (Tab / Shift+Tab).
+func (m model) moveAskUserTab(delta int) model {
+	if m.pendingAskUser == nil {
+		return m
+	}
+	return m.askUserSwitchTab(m.pendingAskUser.active + delta)
+}
+
+// moveAskUserCursor moves the option cursor for the active question (picker mode).
+func (m model) moveAskUserCursor(delta int) model {
+	pending := m.pendingAskUser
+	if pending == nil {
+		return m
+	}
+	question, state, ok := pending.activeQuestion()
+	if !ok || state.typing {
+		return m
+	}
+	n := askUserSelectableCount(question)
+	cursor := (clampAskUserCursor(state.cursor, n) + delta) % n
+	if cursor < 0 {
+		cursor += n
+	}
+	state.cursor = cursor
+	return m
+}
+
+// confirmAskUser handles Enter: on a question it commits the highlighted option or
+// the typed text and advances to the next tab (or switches to free-text when "type
+// your own" is chosen); on the Confirm tab it submits all answers.
 func (m model) confirmAskUser() (tea.Model, tea.Cmd) {
 	pending := m.pendingAskUser
 	if pending == nil {
 		return m, nil
 	}
-	question, ok := pending.askUserCurrentQuestion()
-	if !ok {
-		return m.resolveAskUser(false)
+	if pending.onConfirmTab() {
+		return m.submitAskUser()
 	}
-	if pending.typing || len(question.Options) == 0 {
-		return m.advanceAskUser(strings.TrimSpace(m.input.Value()))
+	question, state, _ := pending.activeQuestion()
+	if state.typing {
+		m.recordActiveAnswer(strings.TrimSpace(m.input.Value()))
+		return m.afterAskUserAnswer()
 	}
-	cursor := clampAskUserCursor(pending.cursor, askUserSelectableCount(question))
+	cursor := clampAskUserCursor(state.cursor, askUserSelectableCount(question))
 	if cursor >= len(question.Options) {
-		// "type my own" — drop into the free-text composer for this question.
-		pending.typing = true
-		m.input.SetValue("")
+		// "type your own" — switch this question into free-text.
+		state.typing = true
+		m.input.SetValue(state.typed)
 		return m, nil
 	}
-	return m.advanceAskUser(question.Options[cursor])
+	m.recordActiveAnswer(question.Options[cursor])
+	return m.afterAskUserAnswer()
 }
 
-// escapeAskUser handles Esc for an ask-user prompt. From the "type my own"
-// free-text state of a question that HAS options, it steps back to the selector
-// (keeping the cursor on the "type my own" entry) rather than cancelling — so Esc is
-// an undo of the free-text drop-in. In every other case (selector mode, or an
-// open-ended question with no options) it cancels the questionnaire as before.
+// afterAskUserAnswer runs after an answer is committed: a single-question prompt
+// submits immediately (no Confirm step); a multi-question prompt advances to the
+// next tab (landing on Confirm after the last question).
+func (m model) afterAskUserAnswer() (tea.Model, tea.Cmd) {
+	if m.pendingAskUser == nil {
+		return m, nil
+	}
+	if len(m.pendingAskUser.request.Questions) <= 1 {
+		return m.submitAskUser()
+	}
+	return m.advanceAskUserTab(), nil
+}
+
+// recordActiveAnswer commits an answer for the active question.
+func (m model) recordActiveAnswer(answer string) {
+	if _, state, ok := m.pendingAskUser.activeQuestion(); ok {
+		state.answer = answer
+		state.answered = true
+	}
+}
+
+// advanceAskUserTab moves to the next tab after committing an answer (the Confirm
+// tab follows the last question), so answering straight through lands on Confirm.
+func (m model) advanceAskUserTab() model {
+	if m.pendingAskUser == nil {
+		return m
+	}
+	return m.askUserSwitchTab(m.pendingAskUser.active + 1)
+}
+
+// escapeAskUser handles Esc: from a single-select "type your own" it steps back to
+// that question's picker; otherwise it dismisses the questionnaire, delivering
+// whatever has been answered so the agent loop unblocks (unanswered stay empty).
 func (m model) escapeAskUser() (tea.Model, tea.Cmd) {
 	pending := m.pendingAskUser
 	if pending == nil {
 		return m, nil
 	}
-	if question, ok := pending.askUserCurrentQuestion(); ok && pending.typing && !question.MultiSelect && len(question.Options) > 0 {
-		pending.typing = false
-		pending.cursor = clampAskUserCursor(pending.cursor, askUserSelectableCount(question))
+	if question, state, ok := pending.activeQuestion(); ok && state.typing && !question.MultiSelect && len(question.Options) > 0 {
+		state.typing = false
+		state.typed = ""
+		state.cursor = clampAskUserCursor(state.cursor, askUserSelectableCount(question))
 		m.input.SetValue("")
 		return m, nil
 	}
-	return m.resolveAskUser(true)
+	return m.submitAskUser()
 }
 
-// advanceAskUser records answer for the current question and moves to the next,
-// resolving the whole questionnaire once the last question is answered. It is the
-// single advance path shared by the free-text submit and the option select, so both
-// feed the same answer channel the agent loop waits on.
-func (m model) advanceAskUser(answer string) (tea.Model, tea.Cmd) {
+// submitAskUser delivers the committed answers (one per question, "" for any left
+// unanswered) through the loop's answer channel and restores the composer.
+func (m model) submitAskUser() (tea.Model, tea.Cmd) {
 	pending := m.pendingAskUser
 	if pending == nil {
 		return m, nil
 	}
-	pending.answers = append(pending.answers, answer)
-	pending.index++
-	m.input.SetValue("")
-	if pending.index >= len(pending.request.Questions) {
-		return m.resolveAskUser(false)
+	answers := make([]string, len(pending.states))
+	for index, state := range pending.states {
+		answers[index] = state.answer
 	}
-	pending.syncQuestionState() // selector vs free-text for the next question
+	if pending.answer != nil {
+		pending.answer(answers)
+	}
+	m.pendingAskUser = nil
+	m.clearComposer()
+	m.clearSuggestions()
 	return m, nil
+}
+
+// askUserTabTitle is the short tab label for a question: its Header if set, else a
+// trimmed-to-fit question, else a positional fallback.
+func askUserTabTitle(question agent.AskUserQuestion, index int) string {
+	if title := strings.TrimSpace(question.Header); title != "" {
+		return title
+	}
+	question.Question = strings.TrimSpace(question.Question)
+	if question.Question == "" {
+		return "Question " + strconv.Itoa(index+1)
+	}
+	const maxLen = 18
+	runes := []rune(question.Question)
+	if len(runes) > maxLen {
+		return strings.TrimSpace(string(runes[:maxLen])) + "…"
+	}
+	return question.Question
 }

--- a/internal/tui/ask_user_test.go
+++ b/internal/tui/ask_user_test.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -10,6 +9,7 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 )
 
+// testAskUserRequest is a two-question request used by model_test.go too.
 func testAskUserRequest() agent.AskUserRequest {
 	return agent.AskUserRequest{
 		ToolCallID: "call_1",
@@ -21,395 +21,312 @@ func testAskUserRequest() agent.AskUserRequest {
 	}
 }
 
-func TestAskUserRequestShowsFocusedPrompt(t *testing.T) {
+func newAskUserModel(t *testing.T, request agent.AskUserRequest, answers *[][]string) model {
+	t.Helper()
 	m := newModel(context.Background(), Options{})
 	m.pending = true
 	m.activeRunID = 7
 	m.width = 96
-
-	updated, cmd := m.Update(askUserRequestMsg{
+	updated, _ := m.Update(askUserRequestMsg{
 		runID:   7,
-		request: testAskUserRequest(),
+		request: request,
+		answer:  func(values []string) { *answers = append(*answers, values) },
 	})
-	next := updated.(model)
+	return updated.(model)
+}
 
-	_ = cmd // the settle pass may emit a benign scrollback flush command
-	if next.pendingAskUser == nil {
-		t.Fatalf("expected ask_user prompt to be pending, got %#v", next)
+func askUserSingle(options []string, recommended string) agent.AskUserRequest {
+	return agent.AskUserRequest{
+		ToolCallID: "call_single",
+		Questions:  []agent.AskUserQuestion{{Question: "Pick one", Options: options, Recommended: recommended}},
 	}
-	if countTranscriptRows(next.transcript, rowAskUser) != 1 {
-		t.Fatalf("expected one ask_user transcript row, got %#v", next.transcript)
+}
+
+func askUserTwoQuestions() agent.AskUserRequest {
+	return agent.AskUserRequest{
+		ToolCallID: "call_2q",
+		Questions: []agent.AskUserQuestion{
+			{Question: "Framework?", Header: "FW", Options: []string{"React", "Vue"}},
+			{Question: "TypeScript?", Header: "TS", Options: []string{"Yes", "No"}},
+		},
+	}
+}
+
+// --- single question (no Confirm step) -------------------------------------
+
+func TestAskUserSinglePickerDefaultsToRecommendedAndSubmits(t *testing.T) {
+	var answers [][]string
+	next := newAskUserModel(t, askUserSingle([]string{"Postgres", "SQLite", "MySQL"}, "SQLite"), &answers)
+
+	if next.pendingAskUser == nil || next.pendingAskUser.states[0].typing {
+		t.Fatalf("expected picker mode for a question with options, got %#v", next.pendingAskUser)
+	}
+	if next.pendingAskUser.states[0].cursor != 1 {
+		t.Fatalf("expected cursor on the recommended option (index 1), got %d", next.pendingAskUser.states[0].cursor)
 	}
 	view := next.View()
-	for _, want := range []string{"Which framework?", "React", "Vue", "question 1 of 2"} {
+	for _, want := range []string{"Postgres", "SQLite", "MySQL", "(recommended)", askUserTypeMyOwnLabel} {
 		assertContains(t, view, want)
 	}
-}
+	// A single question has no tab row / Confirm step.
+	assertNotContains(t, view, "Confirm")
 
-func TestAskUserPromptCollectsAnswersInOrder(t *testing.T) {
-	var answers [][]string
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
-
-	updated, _ := m.Update(askUserRequestMsg{
-		runID:   7,
-		request: testAskUserRequest(),
-		answer: func(values []string) {
-			answers = append(answers, values)
-		},
-	})
-	next := updated.(model)
-
-	// Q1 has options -> selector mode; Enter selects the default (first) option "React"
-	// without any composer input.
-	updated, cmd := next.Update(testKey(tea.KeyEnter))
-	next = updated.(model)
-	if cmd != nil {
-		t.Fatal("expected first answer to advance synchronously")
-	}
-	if next.pendingAskUser == nil {
-		t.Fatal("expected prompt to remain pending after first answer")
-	}
-	if len(answers) != 0 {
-		t.Fatalf("expected no answers delivered until all questions answered, got %#v", answers)
-	}
-
-	// Answer the second (final) question.
-	next.input.SetValue("yes")
-	updated, cmd = next.Update(testKey(tea.KeyEnter))
-	next = updated.(model)
-	if cmd != nil {
-		t.Fatal("expected final answer to resolve synchronously")
-	}
-	if next.pendingAskUser != nil {
-		t.Fatalf("expected prompt to clear after final answer, got %#v", next.pendingAskUser)
-	}
-	if len(answers) != 1 {
-		t.Fatalf("expected one delivery of answers, got %#v", answers)
-	}
-	if len(answers[0]) != 2 || answers[0][0] != "React" || answers[0][1] != "yes" {
-		t.Fatalf("expected answers [React yes], got %#v", answers[0])
-	}
-}
-
-func askUserRecommendedRequest() agent.AskUserRequest {
-	return agent.AskUserRequest{
-		ToolCallID: "call_db",
-		Questions: []agent.AskUserQuestion{
-			{Question: "Which database?", Options: []string{"Postgres", "SQLite", "MySQL"}, Recommended: "SQLite"},
-		},
-	}
-}
-
-// A question with options + a recommended choice renders the selector, rests the
-// cursor on the recommended option, and Enter selects it without typing.
-func TestAskUserSelectorDefaultsToRecommended(t *testing.T) {
-	var answers [][]string
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
-	m.width = 96
-
-	updated, _ := m.Update(askUserRequestMsg{
-		runID:   7,
-		request: askUserRecommendedRequest(),
-		answer:  func(values []string) { answers = append(answers, values) },
-	})
-	next := updated.(model)
-
-	if next.pendingAskUser == nil || next.pendingAskUser.typing {
-		t.Fatalf("expected selector mode for a question with options, got %#v", next.pendingAskUser)
-	}
-	if next.pendingAskUser.cursor != 1 {
-		t.Fatalf("expected cursor to rest on the recommended option (index 1), got %d", next.pendingAskUser.cursor)
-	}
-	for _, want := range []string{"Postgres", "SQLite", "MySQL", "(recommended)", askUserTypeMyOwnLabel} {
-		assertContains(t, next.View(), want)
-	}
-
-	// Enter selects the recommended default — no composer text involved.
-	updated, _ = next.Update(testKey(tea.KeyEnter))
+	updated, _ := next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 	if next.pendingAskUser != nil {
-		t.Fatalf("expected single-question prompt to clear after selecting, got %#v", next.pendingAskUser)
+		t.Fatalf("single question should submit on selection, still pending: %#v", next.pendingAskUser)
 	}
 	if len(answers) != 1 || len(answers[0]) != 1 || answers[0][0] != "SQLite" {
-		t.Fatalf("expected selecting the recommended default to return [SQLite], got %#v", answers)
+		t.Fatalf("expected [SQLite], got %#v", answers)
 	}
 }
 
-// Arrowing to the trailing "type my own" entry switches the question into free-text
-// mode; the typed answer is what gets returned.
-func TestAskUserSelectorTypeMyOwnReturnsTypedText(t *testing.T) {
+func TestAskUserSingleTypeMyOwnSubmitsTypedText(t *testing.T) {
 	var answers [][]string
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
-	m.width = 96
+	next := newAskUserModel(t, askUserSingle([]string{"Postgres", "SQLite", "MySQL"}, "SQLite"), &answers)
 
-	updated, _ := m.Update(askUserRequestMsg{
-		runID:   7,
-		request: askUserRecommendedRequest(),
-		answer:  func(values []string) { answers = append(answers, values) },
-	})
-	next := updated.(model)
-
-	// Cursor starts at index 1 (SQLite); move down twice to the "type my own" entry
-	// (options=3 -> type-my-own index 3).
+	// Move from SQLite (1) to the "type your own" entry (index 3).
 	for i := 0; i < 2; i++ {
-		updated, _ = next.Update(testKey(tea.KeyDown))
+		updated, _ := next.Update(testKey(tea.KeyDown))
 		next = updated.(model)
 	}
-	if next.pendingAskUser.cursor != 3 {
-		t.Fatalf("expected cursor on the 'type my own' entry (index 3), got %d", next.pendingAskUser.cursor)
+	if next.pendingAskUser.states[0].cursor != 3 {
+		t.Fatalf("expected cursor on type-your-own (index 3), got %d", next.pendingAskUser.states[0].cursor)
 	}
-
-	// Enter on "type my own" switches to free-text and delivers nothing yet.
-	updated, _ = next.Update(testKey(tea.KeyEnter))
+	updated, _ := next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
-	if next.pendingAskUser == nil || !next.pendingAskUser.typing {
-		t.Fatalf("expected 'type my own' to switch into free-text typing mode, got %#v", next.pendingAskUser)
+	if !next.pendingAskUser.states[0].typing {
+		t.Fatal("expected 'type your own' to switch into free-text")
 	}
-	if len(answers) != 0 {
-		t.Fatalf("expected no answer delivered when switching to free-text, got %#v", answers)
-	}
-	assertContains(t, next.View(), "type your own answer")
-
-	// The typed answer must appear ONLY in the composer, never echoed inside the ask
-	// card (the double-display bug): the focused card carries no input.
 	next.input.SetValue("CockroachDB")
-	if card := renderFocusedAskUserPrompt(*next.pendingAskUser, next.width); strings.Contains(card, "CockroachDB") {
-		t.Fatalf("ask card must not echo the typed answer; card=\n%s", card)
-	}
-
-	// Submit the typed answer.
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 	if len(answers) != 1 || answers[0][0] != "CockroachDB" {
-		t.Fatalf("expected typed free-text answer [CockroachDB], got %#v", answers)
+		t.Fatalf("expected typed answer [CockroachDB], got %#v", answers)
 	}
 }
 
-// Esc from the "type my own" free-text steps back to the selector for that question
-// — it must NOT cancel the questionnaire or deliver answers; the user can then pick
-// a suggested option instead.
-func TestAskUserTypeMyOwnEscReturnsToSelector(t *testing.T) {
+func TestAskUserTypingInPickerSwitchesToFreeText(t *testing.T) {
 	var answers [][]string
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
-	m.width = 96
+	next := newAskUserModel(t, askUserSingle([]string{"Postgres", "SQLite", "MySQL"}, "SQLite"), &answers)
 
-	updated, _ := m.Update(askUserRequestMsg{
-		runID:   7,
-		request: askUserRecommendedRequest(),
-		answer:  func(values []string) { answers = append(answers, values) },
-	})
-	next := updated.(model)
-
-	// Into "type my own" (index 3) and free-text.
-	for i := 0; i < 2; i++ {
-		updated, _ = next.Update(testKey(tea.KeyDown))
-		next = updated.(model)
+	updated, _ := next.Update(testKeyText("M"))
+	next = updated.(model)
+	if !next.pendingAskUser.states[0].typing {
+		t.Fatal("a printable keystroke should switch the picker into free-text")
 	}
+	if next.input.Value() != "M" {
+		t.Fatalf("the keystroke should be captured, got %q", next.input.Value())
+	}
+	next.input.SetValue("MariaDB")
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
-	if next.pendingAskUser == nil || !next.pendingAskUser.typing {
-		t.Fatal("expected free-text mode after choosing type-my-own")
+	if len(answers) != 1 || answers[0][0] != "MariaDB" {
+		t.Fatalf("expected typed answer [MariaDB], got %#v", answers)
 	}
+}
+
+func TestAskUserSingleNoOptionsIsFreeText(t *testing.T) {
+	var answers [][]string
+	next := newAskUserModel(t, agent.AskUserRequest{
+		ToolCallID: "c",
+		Questions:  []agent.AskUserQuestion{{Question: "Describe the behavior"}},
+	}, &answers)
+
+	if next.pendingAskUser == nil || !next.pendingAskUser.states[0].typing {
+		t.Fatalf("expected free-text for a no-options question, got %#v", next.pendingAskUser)
+	}
+	next.input.SetValue("free-form answer")
+	updated, _ := next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if len(answers) != 1 || answers[0][0] != "free-form answer" {
+		t.Fatalf("expected [free-form answer], got %#v", answers)
+	}
+}
+
+func TestAskUserMultiSelectIsFreeTextWithSuggestions(t *testing.T) {
+	var answers [][]string
+	next := newAskUserModel(t, agent.AskUserRequest{
+		ToolCallID: "c",
+		Questions:  []agent.AskUserQuestion{{Question: "Which checks?", Options: []string{"lint", "test", "typecheck"}, MultiSelect: true}},
+	}, &answers)
+
+	if !next.pendingAskUser.states[0].typing {
+		t.Fatalf("multi-select must use free-text, got %#v", next.pendingAskUser)
+	}
+	assertContains(t, next.View(), "suggested:")
+	assertContains(t, next.View(), "lint")
+	next.input.SetValue("lint, typecheck")
+	updated, _ := next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if len(answers) != 1 || answers[0][0] != "lint, typecheck" {
+		t.Fatalf("expected verbatim multi-answer, got %#v", answers)
+	}
+}
+
+func TestAskUserTypeMyOwnEscReturnsToPicker(t *testing.T) {
+	var answers [][]string
+	next := newAskUserModel(t, askUserSingle([]string{"Postgres", "SQLite", "MySQL"}, "SQLite"), &answers)
+
+	for i := 0; i < 2; i++ { // to type-your-own
+		updated, _ := next.Update(testKey(tea.KeyDown))
+		next = updated.(model)
+	}
+	updated, _ := next.Update(testKey(tea.KeyEnter)) // into free-text
+	next = updated.(model)
 	next.input.SetValue("scratch")
 
-	// Esc returns to the selector, does not cancel, does not deliver.
-	updated, _ = next.Update(testKey(tea.KeyEsc))
+	updated, _ = next.Update(testKey(tea.KeyEsc)) // back to picker
 	next = updated.(model)
 	if next.pendingAskUser == nil {
-		t.Fatal("Esc from type-my-own must NOT cancel the questionnaire")
+		t.Fatal("Esc from type-your-own must not dismiss the prompt")
 	}
-	if next.pendingAskUser.typing {
-		t.Fatal("Esc from type-my-own must return to the selector (typing=false)")
+	if next.pendingAskUser.states[0].typing {
+		t.Fatal("Esc from type-your-own must return to the picker")
 	}
 	if len(answers) != 0 {
-		t.Fatalf("Esc back to the selector must not deliver answers, got %#v", answers)
+		t.Fatalf("Esc back to the picker must not deliver answers, got %#v", answers)
 	}
-	if !next.pending {
-		t.Fatal("the run must keep running after Esc steps back")
-	}
-
-	// From the selector, move up to a real option and select it.
+	// Pick a real option from the picker.
 	updated, _ = next.Update(testKey(tea.KeyUp)) // 3 -> 2 (MySQL)
 	next = updated.(model)
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 	if len(answers) != 1 || answers[0][0] != "MySQL" {
-		t.Fatalf("expected selecting MySQL after returning to the selector, got %#v", answers)
+		t.Fatalf("expected [MySQL] after returning to picker, got %#v", answers)
 	}
 }
 
-// A question with NO options keeps the plain free-text prompt exactly as before (no
-// selector, no regression).
-func TestAskUserNoOptionsIsPlainFreeText(t *testing.T) {
+// --- multi-question (tabs + Confirm) ---------------------------------------
+
+func TestAskUserMultiQuestionTabbedSubmit(t *testing.T) {
 	var answers [][]string
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
-	m.width = 96
+	next := newAskUserModel(t, askUserTwoQuestions(), &answers)
 
-	updated, _ := m.Update(askUserRequestMsg{
-		runID: 7,
-		request: agent.AskUserRequest{
-			ToolCallID: "call_open",
-			Questions:  []agent.AskUserQuestion{{Question: "Describe the desired behavior"}},
-		},
-		answer: func(values []string) { answers = append(answers, values) },
-	})
-	next := updated.(model)
-
-	if next.pendingAskUser == nil || !next.pendingAskUser.typing {
-		t.Fatalf("expected free-text (typing) mode for a question with no options, got %#v", next.pendingAskUser)
+	// Q1: select React (cursor 0), advances to Q2.
+	updated, _ := next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if next.pendingAskUser == nil || next.pendingAskUser.active != 1 {
+		t.Fatalf("expected to advance to Q2 (active=1), got %#v", next.pendingAskUser)
 	}
-	view := next.View()
-	assertContains(t, view, "type an answer")
-	if transcriptContains(next.transcript, askUserTypeMyOwnLabel) {
-		t.Fatalf("a no-options question must not show the selector's type-my-own entry")
+	if len(answers) != 0 {
+		t.Fatalf("must not deliver before Confirm, got %#v", answers)
 	}
-
-	next.input.SetValue("my free-form answer")
+	// Q2: select Yes (cursor 0), advances to Confirm tab.
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
-	if len(answers) != 1 || answers[0][0] != "my free-form answer" {
-		t.Fatalf("expected free-text answer, got %#v", answers)
+	if !next.pendingAskUser.onConfirmTab() {
+		t.Fatalf("expected to land on the Confirm tab, active=%d", next.pendingAskUser.active)
 	}
-}
-
-// A multi-select question can't be a single-pick selector, so it renders as
-// free-text (surfacing the options as suggestions) — the typed answer is returned
-// verbatim and nothing is silently narrowed to one option.
-func TestAskUserMultiSelectFallsBackToFreeText(t *testing.T) {
-	var answers [][]string
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
-	m.width = 96
-
-	updated, _ := m.Update(askUserRequestMsg{
-		runID: 7,
-		request: agent.AskUserRequest{
-			ToolCallID: "call_multi",
-			Questions: []agent.AskUserQuestion{
-				{Question: "Which checks?", Options: []string{"lint", "test", "typecheck"}, MultiSelect: true},
-			},
-		},
-		answer: func(values []string) { answers = append(answers, values) },
-	})
-	next := updated.(model)
-
-	if next.pendingAskUser == nil || !next.pendingAskUser.typing {
-		t.Fatalf("expected multi-select to use free-text, got %#v", next.pendingAskUser)
-	}
-	// Options are surfaced as suggestions, not a single-pick list.
-	assertContains(t, next.View(), "suggested:")
-	assertContains(t, next.View(), "lint")
-
-	next.input.SetValue("lint, typecheck")
+	assertContains(t, next.View(), "Review and submit")
+	// Confirm: submit all.
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
-	if len(answers) != 1 || answers[0][0] != "lint, typecheck" {
-		t.Fatalf("expected the typed multi-answer returned verbatim, got %#v", answers)
+	if next.pendingAskUser != nil {
+		t.Fatalf("Confirm should submit, still pending: %#v", next.pendingAskUser)
+	}
+	if len(answers) != 1 || len(answers[0]) != 2 || answers[0][0] != "React" || answers[0][1] != "Yes" {
+		t.Fatalf("expected [React Yes], got %#v", answers)
 	}
 }
 
-// Typing a printable key while the single-select selector is showing flips straight
-// into free-text (seeding the keystroke) rather than being swallowed and discarded.
-func TestAskUserTypingInSelectorSwitchesToFreeText(t *testing.T) {
+func TestAskUserTabSwitchesQuestions(t *testing.T) {
 	var answers [][]string
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
-	m.width = 96
+	next := newAskUserModel(t, askUserTwoQuestions(), &answers)
 
-	updated, _ := m.Update(askUserRequestMsg{
-		runID:   7,
-		request: askUserRecommendedRequest(), // single-select, 3 options
-		answer:  func(values []string) { answers = append(answers, values) },
-	})
-	next := updated.(model)
-	if next.pendingAskUser.typing {
-		t.Fatal("expected selector mode initially")
+	if next.pendingAskUser.active != 0 {
+		t.Fatalf("expected to start on Q1, got active=%d", next.pendingAskUser.active)
 	}
-
-	// Type a character: it must switch to free-text AND be captured (not swallowed).
-	updated, _ = next.Update(testKeyText("M"))
+	updated, _ := next.Update(testKey(tea.KeyTab))
 	next = updated.(model)
-	if !next.pendingAskUser.typing {
-		t.Fatal("expected a printable keystroke to switch the selector into free-text")
+	if next.pendingAskUser.active != 1 {
+		t.Fatalf("Tab should move to Q2, got active=%d", next.pendingAskUser.active)
 	}
-	if next.input.Value() != "M" {
-		t.Fatalf("expected the keystroke to be captured in the composer, got %q", next.input.Value())
-	}
-
-	// Finish typing and submit; the typed answer wins (not a discarded option).
-	next.input.SetValue("MariaDB")
-	updated, _ = next.Update(testKey(tea.KeyEnter))
+	updated, _ = next.Update(testKey(tea.KeyTab))
 	next = updated.(model)
-	if len(answers) != 1 || answers[0][0] != "MariaDB" {
-		t.Fatalf("expected the typed answer MariaDB, got %#v", answers)
+	if !next.pendingAskUser.onConfirmTab() {
+		t.Fatalf("Tab should move to the Confirm tab, got active=%d", next.pendingAskUser.active)
+	}
+	updated, _ = next.Update(testKey(tea.KeyTab))
+	next = updated.(model)
+	if next.pendingAskUser.active != 0 {
+		t.Fatalf("Tab should wrap to Q1, got active=%d", next.pendingAskUser.active)
+	}
+	updated, _ = next.Update(testKeyShift(tea.KeyTab))
+	next = updated.(model)
+	if !next.pendingAskUser.onConfirmTab() {
+		t.Fatalf("Shift+Tab should wrap back to the Confirm tab, got active=%d", next.pendingAskUser.active)
 	}
 }
 
-func TestAskUserPromptEscDeliversCollectedAnswers(t *testing.T) {
+func TestAskUserEscDismissDeliversPartialAnswers(t *testing.T) {
 	var answers [][]string
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
+	next := newAskUserModel(t, askUserTwoQuestions(), &answers)
 
-	updated, _ := m.Update(askUserRequestMsg{
-		runID:   7,
-		request: testAskUserRequest(),
-		answer: func(values []string) {
-			answers = append(answers, values)
-		},
-	})
-	next := updated.(model)
-
-	// Esc while an ask_user prompt is active cancels the questionnaire and must
-	// still deliver a (partial/empty) answer set so the run never deadlocks.
+	// Answer Q1, advance to Q2, then Esc (Q2 is a picker, so Esc dismisses).
+	updated, _ := next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
 	updated, _ = next.Update(testKey(tea.KeyEsc))
 	next = updated.(model)
-
 	if next.pendingAskUser != nil {
-		t.Fatalf("expected ask_user prompt to clear after Esc, got %#v", next.pendingAskUser)
+		t.Fatalf("Esc on a picker should dismiss, still pending: %#v", next.pendingAskUser)
 	}
-	if len(answers) != 1 {
-		t.Fatalf("expected the answer callback to fire on Esc, got %#v", answers)
+	if len(answers) != 1 || len(answers[0]) != 2 || answers[0][0] != "React" || answers[0][1] != "" {
+		t.Fatalf("expected partial [React, \"\"], got %#v", answers)
 	}
-	// Esc on an ask_user prompt cancels only the questionnaire, not the run, so the
-	// run stays pending and continues with the degraded (empty) answers.
 	if !next.pending {
-		t.Fatal("expected the run to keep running after Esc cancels only the ask_user prompt")
+		t.Fatal("dismiss cancels only the questionnaire; the run keeps running")
 	}
 }
 
+// --- rendering -------------------------------------------------------------
+
+func TestAskUserMultiQuestionShowsTabsAndOptions(t *testing.T) {
+	var answers [][]string
+	next := newAskUserModel(t, agent.AskUserRequest{
+		ToolCallID: "call_v",
+		Questions: []agent.AskUserQuestion{
+			{Question: "Which framework?", Header: "Framework", Options: []string{"React", "Vue"}},
+			{Question: "TypeScript?", Header: "TypeScript"},
+		},
+	}, &answers)
+	view := next.View()
+	for _, want := range []string{"Framework", "TypeScript", "Confirm", "Which framework?", "React", "Vue"} {
+		assertContains(t, view, want)
+	}
+}
+
+func TestAskUserOptionDescriptionsRender(t *testing.T) {
+	var answers [][]string
+	next := newAskUserModel(t, agent.AskUserRequest{
+		ToolCallID: "call_d",
+		Questions: []agent.AskUserQuestion{{
+			Question:           "Which decade?",
+			Options:            []string{"1980s", "1990s"},
+			OptionDescriptions: []string{"Synth-pop, hair metal", "Grunge, Britpop"},
+			Recommended:        "1980s",
+		}},
+	}, &answers)
+	view := next.View()
+	for _, want := range []string{"1980s", "Synth-pop, hair metal", "1990s", "Grunge, Britpop"} {
+		assertContains(t, view, want)
+	}
+}
+
+// --- regressions preserved -------------------------------------------------
+
 func TestAskUserPromptBlocksNormalSubmit(t *testing.T) {
-	m := newModel(context.Background(), Options{})
-	m.pending = true
-	m.activeRunID = 7
-	updated, _ := m.Update(askUserRequestMsg{
-		runID:   7,
-		request: testAskUserRequest(),
-		answer:  func([]string) {},
-	})
-	next := updated.(model)
+	var answers [][]string
+	next := newAskUserModel(t, askUserTwoQuestions(), &answers)
 	next.input.SetValue("/help")
 
-	updated, _ = next.Update(testKey(tea.KeyEnter))
+	updated, _ := next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
-
 	if transcriptContains(next.transcript, "Available commands") {
-		t.Fatalf("ask_user prompt should capture Enter, not run commands: %#v", next.transcript)
+		t.Fatalf("ask_user must capture Enter, not run commands: %#v", next.transcript)
 	}
 	if next.pendingAskUser == nil {
-		t.Fatal("expected ask_user prompt to remain pending after answering one question")
+		t.Fatal("expected the prompt to remain pending after answering Q1 of 2")
 	}
 }
 
@@ -420,23 +337,16 @@ func TestAskUserRequestClearsComposerDraft(t *testing.T) {
 	m.activeRunID = 7
 	m = typeRunes(t, m, "hidden followup")
 	if !m.composerActive || m.composerValue() == "" {
-		t.Fatalf("test setup expected active composer draft, got active=%v value=%q", m.composerActive, m.composerValue())
+		t.Fatalf("setup expected an active composer draft, got active=%v value=%q", m.composerActive, m.composerValue())
 	}
-
 	updated, _ := m.Update(askUserRequestMsg{
-		runID: 7,
-		request: agent.AskUserRequest{
-			ToolCallID: "call_1",
-			Questions:  []agent.AskUserQuestion{{Question: "Proceed?"}},
-		},
-		answer: func(values []string) {
-			answers = append(answers, values)
-		},
+		runID:   7,
+		request: agent.AskUserRequest{ToolCallID: "c", Questions: []agent.AskUserQuestion{{Question: "Proceed?"}}},
+		answer:  func(values []string) { answers = append(answers, values) },
 	})
 	next := updated.(model)
-
 	if next.composerActive || next.composerValue() != "" {
-		t.Fatalf("ask_user should clear composer draft, active=%v value=%q", next.composerActive, next.composerValue())
+		t.Fatalf("ask_user should clear the composer draft, active=%v value=%q", next.composerActive, next.composerValue())
 	}
 	next.input.SetValue("yes")
 	updated, _ = next.Update(testKey(tea.KeyEnter))
@@ -450,6 +360,7 @@ func TestAskUserRequestClearsComposerDraft(t *testing.T) {
 }
 
 func TestAskUserRequestClearsStaleSuggestions(t *testing.T) {
+	var answers [][]string
 	m := newModel(context.Background(), Options{})
 	m.pending = true
 	m.activeRunID = 7
@@ -458,21 +369,31 @@ func TestAskUserRequestClearsStaleSuggestions(t *testing.T) {
 	m.suggestionsAreFiles = true
 
 	updated, _ := m.Update(askUserRequestMsg{
-		runID: 7,
-		request: agent.AskUserRequest{
-			ToolCallID: "call_1",
-			Questions:  []agent.AskUserQuestion{{Question: "Proceed?"}},
-		},
-		answer: func([]string) {},
+		runID:   7,
+		request: agent.AskUserRequest{ToolCallID: "c", Questions: []agent.AskUserQuestion{{Question: "Proceed?"}}},
+		answer:  func(values []string) { answers = append(answers, values) },
 	})
 	next := updated.(model)
-
 	if len(next.suggestions) != 0 || next.suggestionsAreFiles {
-		t.Fatalf("ask_user should clear stale suggestions, got suggestions=%#v files=%v", next.suggestions, next.suggestionsAreFiles)
+		t.Fatalf("ask_user should clear stale suggestions, got %#v files=%v", next.suggestions, next.suggestionsAreFiles)
 	}
-	updated, _ = next.Update(testKey(tea.KeyEnter))
-	next = updated.(model)
-	if len(next.suggestions) != 0 || next.suggestionsAreFiles {
-		t.Fatalf("ask_user resolve should keep suggestions clear, got suggestions=%#v files=%v", next.suggestions, next.suggestionsAreFiles)
+}
+
+func TestAskUserEmptyRequestResolvesImmediately(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: agent.AskUserRequest{ToolCallID: "c"},
+		answer:  func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+	if next.pendingAskUser != nil {
+		t.Fatalf("an empty request must not open a prompt, got %#v", next.pendingAskUser)
+	}
+	if len(answers) != 1 {
+		t.Fatalf("an empty request should resolve immediately, got %#v", answers)
 	}
 }

--- a/internal/tui/ask_user_test.go
+++ b/internal/tui/ask_user_test.go
@@ -197,6 +197,26 @@ func TestAskUserTypeMyOwnEscReturnsToPicker(t *testing.T) {
 	}
 }
 
+// A single-question prompt has no tab strip / Confirm tab, so Tab / Shift+Tab must
+// be no-ops (not advance into the hidden Confirm state).
+func TestAskUserSingleQuestionTabIsNoOp(t *testing.T) {
+	var answers [][]string
+	next := newAskUserModel(t, askUserSingle([]string{"A", "B"}, "A"), &answers)
+	if next.pendingAskUser.active != 0 {
+		t.Fatalf("expected to start on the single question, active=%d", next.pendingAskUser.active)
+	}
+	updated, _ := next.Update(testKey(tea.KeyTab))
+	next = updated.(model)
+	if next.pendingAskUser == nil || next.pendingAskUser.active != 0 {
+		t.Fatalf("Tab on a single-question prompt must be a no-op, active=%d", next.pendingAskUser.active)
+	}
+	updated, _ = next.Update(testKeyShift(tea.KeyTab))
+	next = updated.(model)
+	if next.pendingAskUser.active != 0 {
+		t.Fatalf("Shift+Tab on a single-question prompt must be a no-op, active=%d", next.pendingAskUser.active)
+	}
+}
+
 // --- multi-question (tabs + Confirm) ---------------------------------------
 
 func TestAskUserMultiQuestionTabbedSubmit(t *testing.T) {

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -277,9 +277,11 @@ func TestEnterWithNoSuggestionStillSubmits(t *testing.T) {
 
 func TestSuggestionsSuppressedDuringModals(t *testing.T) {
 	m := newModel(context.Background(), Options{})
+	request := agent.AskUserRequest{Questions: []agent.AskUserQuestion{{Question: "name?"}}}
 	m.pendingAskUser = &pendingAskUserPrompt{
-		request: agent.AskUserRequest{Questions: []agent.AskUserQuestion{{Question: "name?"}}},
+		request: request,
 		answer:  func([]string) {},
+		states:  newAskUserStates(request.Questions),
 	}
 	// Typing while a questionnaire is active feeds the answer field; no overlay.
 	m = typeRunes(t, m, "/mo")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -508,21 +508,17 @@ type askUserRequestMsg struct {
 	answer  func([]string)
 }
 
-// pendingAskUserPrompt tracks an in-progress questionnaire. Answers are collected
-// one question at a time; once every question has an answer (or the user cancels)
-// the answer callback is invoked exactly once.
-//
-// When the current question carries Options, the prompt is in SELECTOR mode: cursor
-// indexes the options plus a trailing "type my own" entry, and starts on the
-// recommended option. Choosing "type my own" (or a question with no options) flips
-// typing=true, falling back to the existing free-text composer input.
+// pendingAskUserPrompt tracks an in-progress questionnaire rendered in the composer
+// region as a row of tabs — one per question plus a trailing Confirm tab. Questions
+// are answered in any order (Tab switches); the answer callback is invoked exactly
+// once when the user submits on the Confirm tab or dismisses (Esc). active is the
+// current tab (0..N-1 = questions, N = Confirm); states holds the per-question
+// picker/free-text state and committed answer. See ask_user_prompt.go.
 type pendingAskUserPrompt struct {
 	request agent.AskUserRequest
 	answer  func([]string)
-	index   int
-	answers []string
-	cursor  int  // selector index over [options..., "type my own"] for the current question
-	typing  bool // true = free-text input mode for the current question
+	active  int
+	states  []askUserAnswerState
 }
 
 type pendingSpecReviewPrompt struct {
@@ -1059,6 +1055,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.pendingPermission != nil {
 				return m.movePermissionCursor(-1), nil
 			}
+			if m.pendingAskUser != nil {
+				return m.moveAskUserTab(-1), nil
+			}
 			// shift+tab toggles the permission mode between Auto and Ask (Unsafe
 			// is intentionally not reachable by a casual keypress — see
 			// nextPermissionMode), but only when nothing modal is up: a permission
@@ -1141,6 +1140,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.pendingPermission != nil {
 				return m.movePermissionCursor(1), nil
 			}
+			if m.pendingAskUser != nil {
+				return m.moveAskUserTab(1), nil
+			}
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
 			}
@@ -1171,7 +1173,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.pendingPermission != nil {
 				return m.movePermissionCursor(1), nil
 			}
-			if m.pendingAskUser != nil && !m.pendingAskUser.typing {
+			if m.pendingAskUser != nil {
 				return m.moveAskUserCursor(1), nil
 			}
 			if m.providerWizard != nil {
@@ -1212,7 +1214,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.pendingPermission != nil {
 				return m.movePermissionCursor(-1), nil
 			}
-			if m.pendingAskUser != nil && !m.pendingAskUser.typing {
+			if m.pendingAskUser != nil {
 				return m.moveAskUserCursor(-1), nil
 			}
 			if m.providerWizard != nil {
@@ -1246,18 +1248,23 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if m.pendingAskUser != nil {
-			// While a questionnaire is active, keys feed the answer text input. In
-			// selector mode a printable keystroke means the user wants to type their
-			// own answer, so flip into free-text first (same as choosing "type my
-			// own") instead of letting the text accumulate invisibly and then be
-			// discarded when Enter selects the highlighted option.
-			if !m.pendingAskUser.typing && keyPrintable(msg) {
-				m.pendingAskUser.typing = true
+			_, state, ok := m.pendingAskUser.activeQuestion()
+			if !ok {
+				return m, nil // Confirm tab: ignore stray keys
+			}
+			// In picker mode a printable keystroke means the user wants to type their
+			// own answer, so flip into free-text first instead of letting the text
+			// accumulate invisibly and then be discarded when Enter picks an option.
+			if !state.typing && keyPrintable(msg) {
+				state.typing = true
 				m.input.SetValue("")
 			}
-			var cmd tea.Cmd
-			m.input, cmd = m.input.Update(msg)
-			return m, cmd
+			if state.typing {
+				var cmd tea.Cmd
+				m.input, cmd = m.input.Update(msg)
+				return m, cmd
+			}
+			return m, nil // picker mode: non-navigation keys do nothing
 		}
 		if m.pendingSpecReview != nil {
 			return m.handleSpecReviewKey(msg)
@@ -1476,9 +1483,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pendingAskUser = &pendingAskUserPrompt{
 			request: msg.request,
 			answer:  msg.answer,
-			answers: make([]string, 0, len(msg.request.Questions)),
+			states:  newAskUserStates(msg.request.Questions),
 		}
-		m.pendingAskUser.syncQuestionState() // selector vs free-text for question 1
 		m.clearComposer()
 		m.clearSuggestions()
 		return m, nil
@@ -1997,6 +2003,15 @@ func (m model) pinnedTitleBar(width int) string {
 
 func (m model) footerView(width int) string {
 	var footer strings.Builder
+	// While an ask-user questionnaire is active it REPLACES the composer box (the
+	// text box becomes the questionnaire): render the tabbed prompt + status line and
+	// skip the plan panel / idle hints / composer for a focused modal.
+	if m.pendingAskUser != nil {
+		footer.WriteString(renderAskUserQuestionnaire(*m.pendingAskUser, m.input.Value(), width))
+		footer.WriteString("\n")
+		footer.WriteString(m.statusLine(width))
+		return footer.String()
+	}
 	// Pinned plan panel: sits directly above the composer so it stays visible
 	// while the transcript scrolls underneath (a streaming turn no longer pushes
 	// the plan off-screen). Budgeted to at most a third of the screen height; a
@@ -3103,30 +3118,6 @@ func (m model) resolvePermission(decision permissionDecision) (tea.Model, tea.Cm
 		})
 	}
 	m.pendingPermission = nil
-	return m, nil
-}
-
-// resolveAskUser delivers the collected answers (padding to one-per-question when
-// cancelled early) and clears the prompt. cancelled answers stay empty so the
-// loop can degrade to its best-assumption path without deadlocking.
-func (m model) resolveAskUser(cancelled bool) (tea.Model, tea.Cmd) {
-	pending := m.pendingAskUser
-	if pending == nil {
-		return m, nil
-	}
-	answers := pending.answers
-	if cancelled {
-		// Record the question currently on screen as unanswered too.
-		m.input.SetValue("")
-	}
-	for len(answers) < len(pending.request.Questions) {
-		answers = append(answers, "")
-	}
-	if pending.answer != nil {
-		pending.answer(answers)
-	}
-	m.pendingAskUser = nil
-	m.clearSuggestions()
 	return m, nil
 }
 

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1230,73 +1230,124 @@ func permissionEventScopeLabel(event *agent.PermissionEvent) string {
 	return "scope"
 }
 
-// renderFocusedAskUserPrompt draws the ask-user questionnaire in the same
-// card language as the permission card, with line borders.
-func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, width int) string {
+// renderAskUserQuestionnaire draws the ask-user prompt that replaces the composer
+// box: a tab row (one per question + a trailing Confirm tab for multi-question
+// prompts), the active question's picker or free-text field, and a key-hint footer.
+// `input` is the live composer value, echoed in free-text mode.
+func renderAskUserQuestionnaire(prompt pendingAskUserPrompt, input string, width int) string {
 	questions := prompt.request.Questions
-	total := len(questions)
-	index := prompt.index
-	if index >= total {
-		index = total - 1
-	}
-	if index < 0 {
-		index = 0
+	if len(questions) == 0 {
+		return styledBlockFill(width, []string{zeroTheme.badge.Render(" ASK ")}, zeroTheme.line, zeroTheme.panel)
 	}
 	fill := zeroTheme.onPanel
-
-	heading := zeroTheme.badge.Render(" ASK ")
-	if header := strings.TrimSpace(prompt.request.Header); header != "" {
-		heading += fill(zeroTheme.ink).Render(" " + header)
+	confirm := len(questions)
+	active := prompt.active
+	if active < 0 {
+		active = 0
 	}
-	lines := []string{heading}
+	if active > confirm {
+		active = confirm
+	}
+	multi := len(questions) > 1
 
-	if total > 0 {
-		question := questions[index]
-		lines = append(lines, fill(zeroTheme.faint).Render(fmt.Sprintf("question %d of %d", index+1, total)))
-		lines = append(lines, fill(zeroTheme.ink).Render(question.Question))
+	var lines []string
+	if header := strings.TrimSpace(prompt.request.Header); header != "" {
+		lines = append(lines, fill(zeroTheme.ink).Render(header))
+	}
 
-		if len(question.Options) > 0 && !prompt.typing {
-			// Selector mode: render each suggested option plus a trailing "type my
-			// own" entry. The highlighted row gets a lime ▸ marker and a reverse
-			// badge label (mirrors the permission popup); the recommended option is
-			// tagged inline.
-			selectable := askUserSelectableCount(question)
-			cursor := clampAskUserCursor(prompt.cursor, selectable)
-			for optionIndex, option := range question.Options {
-				label := option
-				if option == question.Recommended {
-					label += "  (recommended)"
-				}
-				if optionIndex == cursor {
-					lines = append(lines, fill(zeroTheme.accent).Render("▸ ")+zeroTheme.badge.Render(" "+label+" "))
-				} else {
-					lines = append(lines, "  "+fill(zeroTheme.ink).Render(label))
-				}
-			}
-			if cursor >= len(question.Options) {
-				lines = append(lines, fill(zeroTheme.accent).Render("▸ ")+zeroTheme.badge.Render(" "+askUserTypeMyOwnLabel+" "))
-			} else {
-				lines = append(lines, "  "+fill(zeroTheme.muted).Render(askUserTypeMyOwnLabel))
-			}
-			lines = append(lines, fill(zeroTheme.faint).Render("↑↓ move · enter to select · esc to skip the rest"))
-		} else {
-			// Free-text mode. The composer text box below is the single input — do NOT
-			// echo the typed answer inside the card too (that showed it in two places).
+	// Tab row (only for multi-question prompts): each question's short title + a
+	// trailing Confirm tab; the active tab is a lime badge, answered ones get a ✓.
+	if multi {
+		tabs := make([]string, 0, len(questions)+1)
+		for index, question := range questions {
+			title := askUserTabTitle(question, index)
 			switch {
-			case question.MultiSelect && len(question.Options) > 0:
-				// Multi-select can't be a single-pick list; surface the suggestions and
-				// let the user type one or more in their own words.
-				lines = append(lines, fill(zeroTheme.muted).Render("suggested: "+strings.Join(question.Options, ", ")))
-				lines = append(lines, fill(zeroTheme.faint).Render("type your answer(s) below · Enter to submit · Esc to skip the rest"))
-			case len(question.Options) > 0:
-				// Single-select "type my own": Esc steps back to the selector.
-				lines = append(lines, fill(zeroTheme.faint).Render("type your own answer below · Enter to submit · Esc to go back"))
+			case index == active:
+				tabs = append(tabs, zeroTheme.badge.Render(" "+title+" "))
+			case prompt.states[index].answered:
+				tabs = append(tabs, fill(zeroTheme.muted).Render(" ✓ "+title+" "))
 			default:
-				lines = append(lines, fill(zeroTheme.faint).Render("type an answer below · Enter to submit · Esc to skip the rest"))
+				tabs = append(tabs, fill(zeroTheme.faint).Render(" "+title+" "))
 			}
 		}
+		if active == confirm {
+			tabs = append(tabs, zeroTheme.badge.Render(" Confirm "))
+		} else {
+			tabs = append(tabs, fill(zeroTheme.faint).Render(" Confirm "))
+		}
+		lines = append(lines, strings.Join(tabs, " "))
 	}
 
+	// Confirm tab: a review of the collected answers.
+	if active == confirm {
+		lines = append(lines, "")
+		lines = append(lines, fill(zeroTheme.ink).Render("Review and submit:"))
+		for index, question := range questions {
+			answer := strings.TrimSpace(prompt.states[index].answer)
+			rendered := fill(zeroTheme.ink).Render(answer)
+			if answer == "" {
+				rendered = fill(zeroTheme.faint).Render("(no answer)")
+			}
+			lines = append(lines, "  "+fill(zeroTheme.muted).Render(askUserTabTitle(question, index)+": ")+rendered)
+		}
+		lines = append(lines, "")
+		lines = append(lines, fill(zeroTheme.faint).Render("⇆ tab · enter submit · esc dismiss"))
+		return styledBlockFill(width, lines, zeroTheme.line, zeroTheme.panel)
+	}
+
+	question := questions[active]
+	state := prompt.states[active]
+	lines = append(lines, "")
+	lines = append(lines, fill(zeroTheme.ink).Render(question.Question))
+
+	if len(question.Options) > 0 && !state.typing {
+		// Picker: numbered options (with optional descriptions) + a trailing "type
+		// your own" entry; the highlighted row gets a lime ▸ marker and a badge label,
+		// the recommended option is tagged inline.
+		selectable := askUserSelectableCount(question)
+		cursor := clampAskUserCursor(state.cursor, selectable)
+		for index, option := range question.Options {
+			label := fmt.Sprintf("%d. %s", index+1, option)
+			if option == question.Recommended {
+				label += "  (recommended)"
+			}
+			if index == cursor {
+				lines = append(lines, fill(zeroTheme.accent).Render("▸ ")+zeroTheme.badge.Render(" "+label+" "))
+			} else {
+				lines = append(lines, "  "+fill(zeroTheme.ink).Render(label))
+			}
+			if index < len(question.OptionDescriptions) && strings.TrimSpace(question.OptionDescriptions[index]) != "" {
+				lines = append(lines, "     "+fill(zeroTheme.faint).Render(question.OptionDescriptions[index]))
+			}
+		}
+		typeOwn := fmt.Sprintf("%d. %s", len(question.Options)+1, askUserTypeMyOwnLabel)
+		if cursor >= len(question.Options) {
+			lines = append(lines, fill(zeroTheme.accent).Render("▸ ")+zeroTheme.badge.Render(" "+typeOwn+" "))
+		} else {
+			lines = append(lines, "  "+fill(zeroTheme.muted).Render(typeOwn))
+		}
+		lines = append(lines, "")
+		footer := "↑↓ select · enter confirm · esc dismiss"
+		if multi {
+			footer = "⇆ tab · ↑↓ select · enter confirm · esc dismiss"
+		}
+		lines = append(lines, fill(zeroTheme.faint).Render(footer))
+		return styledBlockFill(width, lines, zeroTheme.line, zeroTheme.panel)
+	}
+
+	// Free-text mode: the typed answer is echoed here (this region IS the input now).
+	if question.MultiSelect && len(question.Options) > 0 {
+		lines = append(lines, fill(zeroTheme.muted).Render("suggested: "+strings.Join(question.Options, ", ")))
+	}
+	lines = append(lines, zeroTheme.onPanel(zeroTheme.userPrompt).Render("❯ ")+fill(zeroTheme.ink).Render(input)+fill(zeroTheme.accent).Render("▌"))
+	footer := "enter submit · esc dismiss"
+	switch {
+	case !question.MultiSelect && len(question.Options) > 0:
+		footer = "enter submit · esc back to options"
+	case multi:
+		footer = "⇆ tab · enter submit · esc dismiss"
+	}
+	lines = append(lines, fill(zeroTheme.faint).Render(footer))
 	return styledBlockFill(width, lines, zeroTheme.line, zeroTheme.panel)
 }
 

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1237,9 +1237,12 @@ func permissionEventScopeLabel(event *agent.PermissionEvent) string {
 func renderAskUserQuestionnaire(prompt pendingAskUserPrompt, input string, width int) string {
 	questions := prompt.request.Questions
 	if len(questions) == 0 {
-		return styledBlockFill(width, []string{zeroTheme.badge.Render(" ASK ")}, zeroTheme.line, zeroTheme.panel)
+		return styledBlockFill(width, []string{zeroTheme.badge.Render(" ASK ")}, zeroTheme.lineStrong, lipgloss.NewStyle())
 	}
-	fill := zeroTheme.onPanel
+	// The questionnaire replaces the composer, so it paints on the terminal canvas
+	// (black) like the composer box — not a gray card. fill is an identity wrapper
+	// so existing fill(style) call sites render bare foregrounds on that canvas.
+	fill := func(style lipgloss.Style) lipgloss.Style { return style }
 	confirm := len(questions)
 	active := prompt.active
 	if active < 0 {
@@ -1292,7 +1295,7 @@ func renderAskUserQuestionnaire(prompt pendingAskUserPrompt, input string, width
 		}
 		lines = append(lines, "")
 		lines = append(lines, fill(zeroTheme.faint).Render("⇆ tab · enter submit · esc dismiss"))
-		return styledBlockFill(width, lines, zeroTheme.line, zeroTheme.panel)
+		return styledBlockFill(width, lines, zeroTheme.lineStrong, lipgloss.NewStyle())
 	}
 
 	question := questions[active]
@@ -1332,14 +1335,14 @@ func renderAskUserQuestionnaire(prompt pendingAskUserPrompt, input string, width
 			footer = "⇆ tab · ↑↓ select · enter confirm · esc dismiss"
 		}
 		lines = append(lines, fill(zeroTheme.faint).Render(footer))
-		return styledBlockFill(width, lines, zeroTheme.line, zeroTheme.panel)
+		return styledBlockFill(width, lines, zeroTheme.lineStrong, lipgloss.NewStyle())
 	}
 
 	// Free-text mode: the typed answer is echoed here (this region IS the input now).
 	if question.MultiSelect && len(question.Options) > 0 {
 		lines = append(lines, fill(zeroTheme.muted).Render("suggested: "+strings.Join(question.Options, ", ")))
 	}
-	lines = append(lines, zeroTheme.onPanel(zeroTheme.userPrompt).Render("❯ ")+fill(zeroTheme.ink).Render(input)+fill(zeroTheme.accent).Render("▌"))
+	lines = append(lines, zeroTheme.userPrompt.Render("❯ ")+fill(zeroTheme.ink).Render(input)+fill(zeroTheme.accent).Render("▌"))
 	footer := "enter submit · esc dismiss"
 	switch {
 	case !question.MultiSelect && len(question.Options) > 0:
@@ -1348,7 +1351,7 @@ func renderAskUserQuestionnaire(prompt pendingAskUserPrompt, input string, width
 		footer = "⇆ tab · enter submit · esc dismiss"
 	}
 	lines = append(lines, fill(zeroTheme.faint).Render(footer))
-	return styledBlockFill(width, lines, zeroTheme.line, zeroTheme.panel)
+	return styledBlockFill(width, lines, zeroTheme.lineStrong, lipgloss.NewStyle())
 }
 
 // --- Tool cards -------------------------------------------------------------

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -290,7 +290,8 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 				},
 			})
 		case m.pendingAskUser != nil:
-			items = append(items, transcriptBlockBodyItem(transcriptBodyItemPendingPrompt, -1, renderFocusedAskUserPrompt(*m.pendingAskUser, width)))
+			// The ask-user questionnaire renders in the composer/footer region
+			// (footerView), not as a scrolling transcript card — nothing to emit here.
 		default:
 			items = append(items, transcriptBodyItem{
 				kind:     transcriptBodyItemPendingInterim,


### PR DESCRIPTION
> Builds on #326 (suggested-answers contract, now merged) — this is the tabbed composer redesign requested on top of it.

## Summary
When the agent asks clarifying questions mid-task, the **composer text box becomes an interactive questionnaire** so the user can pick suggested answers instead of always typing.

- **Tabbed multi-question prompt**: each question is a tab (`Tech Stack | MVP Scope | … | Confirm`); **Tab / Shift+Tab** switch questions, answers given in any order, answered tabs marked ✓, and Enter on **Confirm** submits them all. A single question submits on answer (no Confirm step, no tabs).
- **Suggested answers**: numbered options with the recommended one tagged `(recommended)` and pre-selected; **↑↓** move, **Enter** picks. Each option can carry a one-line **description** sub-line. A trailing `Type your own answer` drops into free-text; typing in the picker also switches to free-text; **Esc** from "type your own" returns to the picker.
- **Rendered in the composer region** on the terminal's black canvas with the composer's border (not a card in the transcript, not a gray panel).
- **Multi-select** questions render as free-text with the options shown as suggestions (a single-pick list can't represent them) — nothing is silently narrowed.

## Contract (optional, backward-compatible)
`ask_user` questions gain optional `header` (short tab title), `optionDescriptions` (aligned to `options`, or option objects `{label, description}`), and `recommended` (kept only when it matches an option). The system prompt tells the model it MAY use them; omitting them falls back to plain free-text exactly as before.

## Constraints honored
- **No regression**: open-ended (no-options) questions are plain free-text.
- **Headless safe**: `zero exec` never wires `OnAskUser`, so the selector can't render there — the non-interactive best-assumption fallback is untouched.
- **Keys**: `Tab move · ↑↓ select · Enter confirm · Esc dismiss`.

## Tests & gate
16 ask-user tests (picker default/recommended, type-your-own → free-text, multi-question tabs + Confirm + ordering, Tab navigation, Esc dismiss partial, descriptions render, typing-in-picker switch, no in-card echo) + tool parsing edges. `make build` / `go vet ./...` / `go test ./... -race` / `make lint` — all green (0 fail, 0 races, 70 pkg).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-question ask prompts with question tabs, per-question ✓ status, and a trailing Confirm step.
  * Enhanced prompts to support per-question headers and per-option descriptions, including richer option parsing (labels + optional descriptions).

* **Bug Fixes**
  * Corrected keyboard navigation and submission across single- and multi-question flows.
  * Improved “type your own” and escape behavior to preserve/restore typed input appropriately.
  * Updated display so the questionnaire renders in the composer/footer area instead of the transcript.

* **Tests**
  * Refreshed and expanded ask-user coverage for the new flows and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->