### PR TITLE
fix(tui): paint transcript selection once, not twice

### DIFF
--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1925,6 +1925,71 @@ func TestSelectionHighlightUsesGutterShiftedCoordinate(t *testing.T) {
 	}
 }
 
+// TestTranscriptSelectionPaintsHighlightOnceNotTwice guards the "two highlights"
+// bug: assistant/user/reasoning rows used to self-paint the selection in the
+// UNSHIFTED coordinate AND finalizeTranscriptBodyRow re-painted it in the
+// gutter-shifted coordinate, so a single selection lit up in two places (the
+// real one plus a copy shifted right by the reading gutter). The highlight must
+// land exactly once.
+func TestTranscriptSelectionPaintsHighlightOnceNotTwice(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.width, m.height = 160, 30
+	m.altScreen = true
+	m.transcript = append(m.transcript, transcriptRow{
+		kind: rowAssistant, text: "alpha beta gamma delta epsilon zeta", final: true,
+	})
+	width := m.chatColumnWidth()
+	if transcriptGutter(width) <= 0 {
+		t.Fatalf("need a positive reading gutter at width %d", width)
+	}
+
+	findRow := func(mm model) (transcriptBodyItem, bool) {
+		for _, it := range mm.transcriptBodyItems(width, "") {
+			if it.kind == transcriptBodyItemRow && it.rowIndex >= 0 {
+				return it, true
+			}
+		}
+		return transcriptBodyItem{}, false
+	}
+
+	row, ok := findRow(m)
+	if !ok {
+		t.Fatal("no assistant row item")
+	}
+	var line transcriptSelectableLine
+	for _, sl := range row.render(0).selectable {
+		if sl.text != "" {
+			line = sl
+			break
+		}
+	}
+	if line.text == "" || lipgloss.Width(line.text) < 5 {
+		t.Fatalf("expected a selectable text line of width >= 5, got %+v", line)
+	}
+
+	// Select the first 5 columns of that line (in the gutter-shifted coordinate the
+	// mouse hands to anchor/cursor).
+	m.transcriptSelection = transcriptSelectionState{
+		active: true,
+		anchor: transcriptSelectionPoint{bodyY: line.bodyY, x: line.textStart},
+		cursor: transcriptSelectionPoint{bodyY: line.bodyY, x: line.textStart + 5},
+	}
+	row2, ok := findRow(m)
+	if !ok {
+		t.Fatal("no assistant row item with selection active")
+	}
+	out := strings.Join(row2.render(0).lines, "\n")
+
+	sentinel := zeroTheme.selection.Render("\x00")
+	open := sentinel[:strings.IndexByte(sentinel, 0)]
+	if open == "" {
+		t.Fatal("selection style emitted no opening sequence to count")
+	}
+	if got := strings.Count(out, open); got != 1 {
+		t.Fatalf("selection highlight painted %d times, want exactly 1 (the two-highlights bug):\n%q", got, out)
+	}
+}
+
 func TestReasoningAfterToolCardGetsBlankSeparator(t *testing.T) {
 	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
 	m.width, m.height = 120, 40

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -696,15 +696,11 @@ func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width in
 		}
 		selectable = append(selectable, meta)
 	}
-	if !m.transcriptSelection.active {
-		return m.renderRow(row, width, rowContext{}), selectable
-	}
-	lines := make([]string, 0, len(wrapped)+1)
-	lines = append(lines, "")
-	for _, meta := range selectable {
-		lines = append(lines, renderUserPromptStyledLine(m.renderTranscriptSelectableText(meta, zeroTheme.ink.Bold(true)), contentWidth))
-	}
-	return strings.Join(lines, "\n"), selectable
+	// The selection highlight is painted once, at the body-item level, AFTER the
+	// reading-column gutter shift (finalizeTranscriptBodyRow) — in the same shifted
+	// coordinate the mouse maps to. Self-painting here (unshifted) double-painted the
+	// highlight gutter cells off from the finalize pass (the "two highlights" bug).
+	return m.renderRow(row, width, rowContext{}), selectable
 }
 
 func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
@@ -732,29 +728,11 @@ func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, wid
 		}
 		selectable = append(selectable, meta)
 	}
-	if !m.transcriptSelection.active {
-		return m.renderRow(row, width, rowContext{}), selectable
-	}
-	lines := make([]string, 0, len(wrapped)+1)
-	// Interim narration and the final answer both render bright (ink); only
-	// reasoning bodies stay muted. Mirrors renderAssistantRow.
-	textStyle := zeroTheme.ink
-	for index, line := range wrapped {
-		meta := selectable[index]
-		rendered := m.renderTranscriptSelectableMarkdownText(meta, line, textStyle)
-		if !row.final {
-			prefix := "  "
-			if index == 0 {
-				prefix = zeroTheme.accent.Render("●") + " "
-			}
-			rendered = fitStyledLine(prefix+rendered, width)
-		}
-		lines = append(lines, rendered)
-	}
-	if row.final && row.turnElapsed >= longTurnBookend {
-		lines = append(lines, doneLine(row))
-	}
-	return strings.Join(lines, "\n"), selectable
+	// The selection highlight is painted once, at the body-item level, AFTER the
+	// reading-column gutter shift (finalizeTranscriptBodyRow) — in the same shifted
+	// coordinate the mouse maps to. Self-painting here (unshifted) double-painted the
+	// highlight gutter cells off from the finalize pass (the "two highlights" bug).
+	return m.renderRow(row, width, rowContext{}), selectable
 }
 
 func (m model) renderSelectableReasoningRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
@@ -784,10 +762,9 @@ func (m model) renderSelectableReasoningBlock(rowIndex int, text string, expande
 		text:      headerPlain,
 		toggle:    true,
 	}
+	// Selection highlight is painted once at the body-item level (finalizeTranscriptBodyRow),
+	// in the gutter-shifted coordinate the mouse maps to — never self-painted here.
 	headerRendered := header
-	if _, _, ok := m.selectedColumnsForTranscriptLine(headerMeta); ok {
-		headerRendered = m.renderTranscriptSelectableText(headerMeta, zeroTheme.faint)
-	}
 	lines := []string{headerRendered}
 	selectable := []transcriptSelectableLine{headerMeta}
 	if expanded {
@@ -825,30 +802,10 @@ func (m model) renderSelectableReasoningBlock(rowIndex int, text string, expande
 			}
 			selectable = append(selectable, meta)
 			rendered := styleAssistantMarkdownLine(line, zeroTheme.sayText)
-			if _, _, ok := m.selectedColumnsForTranscriptLine(meta); ok {
-				rendered = m.renderTranscriptSelectableText(meta, zeroTheme.sayText)
-			}
 			lines = append(lines, fitStyledLine("  "+rendered, width))
 		}
 	}
 	return lines, selectable
-}
-
-func (m model) renderTranscriptSelectableMarkdownText(line transcriptSelectableLine, styledText string, base lipgloss.Style) string {
-	if _, _, ok := m.selectedColumnsForTranscriptLine(line); ok {
-		return m.renderTranscriptSelectableText(line, base)
-	}
-	return styleAssistantMarkdownLine(styledText, base)
-}
-
-func (m model) renderTranscriptSelectableText(line transcriptSelectableLine, base lipgloss.Style) string {
-	start, end, ok := m.selectedColumnsForTranscriptLine(line)
-	if !ok {
-		return base.Render(line.text)
-	}
-	before, rest := splitPlainAtDisplayWidth(line.text, start)
-	middle, after := splitPlainAtDisplayWidth(rest, end-start)
-	return base.Render(before) + zeroTheme.selection.Render(middle) + base.Render(after)
 }
 
 func (m model) selectedColumnsForTranscriptLine(line transcriptSelectableLine) (int, int, bool) {


### PR DESCRIPTION
## Problem

Selecting text in the transcript highlighted it in **two places** — the real
selection plus a copy shifted right by the reading-column gutter. In the report,
selecting "help" also lit up "today".

## Root cause

Assistant, user, and reasoning rows **self-painted** the selection highlight in
their `renderSelectable*` functions using the **unshifted** `textStart`. But the
selection points (`anchor.x`/`cursor.x`) are in the **gutter-shifted** screen
coordinate the mouse maps to. So:

1. the self-paint landed gutter cells *into* the text (wrong position), then
2. `finalizeTranscriptBodyRow` painted the highlight **again** at the correct
   shifted position.

→ two highlights, one reading-gutter apart.

The rendered / tool-result / specialist rows were already migrated to
"paint once at finalize, post-shift" (see the comments there); these three rows
were simply left behind when the gutter shift was introduced.

## Fix

Stop self-painting in `renderSelectableUserRow`, `renderSelectableAssistantRow`,
and `renderSelectableReasoningBlock`. They now return the canonical `renderRow`
output — which is already line-aligned with the selectable spans they build — and
let `finalizeTranscriptBodyRow` be the **single** painter, in the same shifted
coordinate the mouse uses. The now-dead `renderTranscriptSelectableText` /
`renderTranscriptSelectableMarkdownText` helpers are removed.

Net: −55 lines of duplicated/miscoordinated paint logic.

## Test

`TestTranscriptSelectionPaintsHighlightOnceNotTwice` selects a sub-range of an
assistant row and asserts the selection style is emitted **exactly once**. It
fails on the pre-fix code (painted 3×, including the gutter-shifted "ta ga" copy
when only "alpha" was selected) and passes after.

`go build ./...`, `go vet ./internal/tui/`, `gofmt -l`, and the full
`go test ./internal/tui/` suite are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transcript text selection so highlights render only once and align correctly with the visible text.
  * Improved selection behavior across user, assistant, and reasoning rows, including header and body content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->