### PR TITLE
feat: encrypted provider credentials + provider-aware /model

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -514,6 +514,13 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	if err != nil {
 		return writeAppError(stderr, "failed to resolve user config path: "+err.Error(), 1)
 	}
+	// Fail-soft, one-time: move any inline plaintext API keys in config.json into
+	// the encrypted credential store (interactive runs only; headless exec keeps
+	// its existing behavior). Non-fatal — a missing keyring or write error leaves
+	// the inline key in place and this run still uses the already-resolved key.
+	if store, storeErr := config.ProviderKeyStoreAt(filepath.Dir(userConfigPath)); storeErr == nil {
+		_, _ = config.MigratePlaintextProviderKeys(userConfigPath, store)
+	}
 	doctorUserConfigPath := ""
 	projectConfigPath := ""
 	if resolveOptions, optErr := config.DefaultResolveOptions(workspaceRoot); optErr == nil {
@@ -640,6 +647,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		ProviderName:         resolved.Provider.Name,
 		ModelName:            resolved.Provider.Model,
 		ProviderProfile:      resolved.Provider,
+		SavedProviders:       usableSavedProviders(resolved.Providers),
 		FavoriteModels:       resolved.Preferences.FavoriteModels,
 		RecapsEnabled:        resolved.Preferences.RecapsEnabled(),
 		Provider:             provider,
@@ -715,7 +723,16 @@ func buildProvider(resolved config.ResolvedConfig, deps appDeps) (zeroruntime.Pr
 	if !config.HasProviderProfile(resolved.Provider) {
 		return nil, nil
 	}
-	return deps.newProvider(resolved.Provider)
+	// Load the API key from the encrypted credential store when it isn't already
+	// resolved from inline config or an env var. This keeps the resolver pure (no
+	// I/O) and is a no-op for env/inline-key providers and when nothing is stored.
+	profile := resolved.Provider
+	if path, perr := deps.userConfigPath(); perr == nil {
+		if store, err := config.ProviderKeyStoreAt(filepath.Dir(path)); err == nil {
+			profile = config.ApplyStoredAPIKey(profile, store)
+		}
+	}
+	return deps.newProvider(profile)
 }
 
 func newCoreRegistry(workspaceRoot string) *tools.Registry {
@@ -1051,7 +1068,7 @@ func splitLeadingThemeFlag(args []string) (string, []string, error) {
 // setup result is not env-resolved, so checking APIKey alone would wrongly flag every
 // env-var-based provider as keyless.
 func profileHasCredential(profile config.ProviderProfile) bool {
-	if strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != "" {
+	if strings.TrimSpace(profile.APIKey) != "" || profile.APIKeyStored || strings.TrimSpace(profile.AuthHeaderValue) != "" {
 		return true
 	}
 	if env := strings.TrimSpace(profile.APIKeyEnv); env != "" {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/provideroauth"
 	"github.com/Gitlawb/zero/internal/redaction"
@@ -336,6 +337,19 @@ func runAuthLogout(args []string, stdout io.Writer, stderr io.Writer, deps appDe
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
+	// Also drop any stored API key and its marker so `auth logout` clears the whole
+	// credential (OAuth token AND key), not just the OAuth side. Surface deletion
+	// failures rather than reporting success while a credential remains.
+	keyRemoved, keyErr := config.ForgetProviderKey(provider)
+	if keyErr != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(keyErr, redaction.Options{}), exitCrash)
+	}
+	if configPath, perr := deps.userConfigPath(); perr == nil {
+		if _, clearErr := config.ClearProviderKeyStored(configPath, provider); clearErr != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(clearErr, redaction.Options{}), exitCrash)
+		}
+	}
+	removed = removed || keyRemoved
 	if parsed.json {
 		payload := struct {
 			Provider string `json:"provider"`
@@ -346,7 +360,7 @@ func runAuthLogout(args []string, stdout io.Writer, stderr io.Writer, deps appDe
 		}
 		return exitSuccess
 	}
-	msg := fmt.Sprintf("No OAuth login stored for %s.\n", provider)
+	msg := fmt.Sprintf("No stored credential for %s.\n", provider)
 	if removed {
 		msg = fmt.Sprintf("Logged out of %s.\n", provider)
 	}

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -72,7 +72,7 @@ func TestRunAuthLogoutNothing(t *testing.T) {
 	if code := runWithDeps([]string{"auth", "logout", "demo"}, &stdout, &stderr, appDeps{}); code != exitSuccess {
 		t.Fatalf("exit = %d stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "No OAuth login stored for demo") {
+	if !strings.Contains(stdout.String(), "No stored credential for demo") {
 		t.Fatalf("logout output = %q", stdout.String())
 	}
 }

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -51,7 +51,9 @@ func runProvidersAdd(args []string, stdout io.Writer, stderr io.Writer, deps app
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
-	cfg, err := config.UpsertProvider(configPath, profile, options.setActive)
+	// Persist with the key moved into the encrypted credential store (capture flip);
+	// the local profile keeps the key for the verification build below.
+	cfg, err := config.UpsertProvider(configPath, config.SecureProviderProfile(profile, configPath), options.setActive)
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
@@ -486,7 +488,7 @@ func validateProviderRuntimeReady(profile config.ProviderProfile) error {
 }
 
 func providerProfileHasCredential(profile config.ProviderProfile) bool {
-	return strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != ""
+	return strings.TrimSpace(profile.APIKey) != "" || profile.APIKeyStored || strings.TrimSpace(profile.AuthHeaderValue) != ""
 }
 
 func providerKindForDescriptor(descriptor providercatalog.Descriptor) config.ProviderKind {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -263,7 +263,9 @@ func saveSetupProvider(deps appDeps, selection tui.SetupSelection, options setup
 	if err != nil {
 		return tui.SetupResult{}, err
 	}
-	if _, err := config.UpsertProvider(configPath, profile, true); err != nil {
+	// Persist with the key moved into the encrypted credential store (capture flip);
+	// the returned profile keeps the key for this run's immediate use.
+	if _, err := config.UpsertProvider(configPath, config.SecureProviderProfile(profile, configPath), true); err != nil {
 		return tui.SetupResult{}, err
 	}
 	return tui.SetupResult{ConfigPath: configPath, Provider: profile}, nil
@@ -379,6 +381,50 @@ func firstUsableProvider(providers []config.ProviderProfile) (config.ProviderPro
 		return localFallback, true
 	}
 	return config.ProviderProfile{}, false
+}
+
+// usableSavedProviders filters configured providers to those the user can actually
+// use: an inline/stored/env key, an auth header, a stored OAuth login, or a no-auth
+// local provider. This keeps /model from listing providers that are merely present
+// in config.json but never authenticated (e.g. a default openai entry with no key).
+func usableSavedProviders(providers []config.ProviderProfile) []config.ProviderProfile {
+	logins := oauthLoggedInProviders()
+	store, storeErr := config.ProviderKeyStore()
+	usable := make([]config.ProviderProfile, 0, len(providers))
+	for _, profile := range providers {
+		if !config.HasProviderProfile(profile) {
+			continue
+		}
+		// A provider whose only credential is the APIKeyStored marker counts as usable
+		// only when the key is actually retrievable — the keyring/file entry may have
+		// been deleted, leaving a stale marker that would otherwise list it in /model.
+		if profile.APIKeyStored && strings.TrimSpace(profile.APIKey) == "" {
+			if storeErr == nil {
+				if key, ok, err := store.Get(profile.Name); err == nil && ok && strings.TrimSpace(key) != "" {
+					usable = append(usable, profile)
+					continue
+				}
+			}
+			// Marker present but key missing/unreadable: fall through and judge the
+			// profile on its other signals (env var, OAuth, local) with the marker off.
+			withoutMarker := profile
+			withoutMarker.APIKeyStored = false
+			if _, missing := setupMissingCredentialEnv(withoutMarker); !missing {
+				usable = append(usable, profile)
+			} else if providerHasOAuthLogin(profile, logins) {
+				usable = append(usable, profile)
+			}
+			continue
+		}
+		if _, missing := setupMissingCredentialEnv(profile); !missing {
+			usable = append(usable, profile)
+			continue
+		}
+		if providerHasOAuthLogin(profile, logins) {
+			usable = append(usable, profile)
+		}
+	}
+	return usable
 }
 
 // providerProfileIsLocal reports whether a provider points at a local endpoint

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -103,6 +103,9 @@ func TestSetupProviderOptionsUseRuntimeSupportedCatalog(t *testing.T) {
 }
 
 func TestSaveSetupProviderStoresPastedAPIKey(t *testing.T) {
+	// Use the encrypted-file backend in the temp config dir so the test never
+	// touches the real OS keychain.
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 
 	result, err := saveSetupProvider(appDeps{
@@ -132,8 +135,20 @@ func TestSaveSetupProviderStoresPastedAPIKey(t *testing.T) {
 	if len(cfg.Providers) != 1 {
 		t.Fatalf("Providers = %#v, want one provider", cfg.Providers)
 	}
-	if cfg.Providers[0].APIKey != "sk-pasted-secret" || cfg.Providers[0].APIKeyEnv != "" {
-		t.Fatalf("stored provider credentials = APIKey %q APIKeyEnv %q, want pasted key only", cfg.Providers[0].APIKey, cfg.Providers[0].APIKeyEnv)
+	// The capture flip: config.json must NOT hold the cleartext key — it carries the
+	// APIKeyStored marker, and the secret lives in the co-located credential store.
+	if cfg.Providers[0].APIKey != "" || cfg.Providers[0].APIKeyEnv != "" {
+		t.Fatalf("config must not persist the key: APIKey %q APIKeyEnv %q", cfg.Providers[0].APIKey, cfg.Providers[0].APIKeyEnv)
+	}
+	if !cfg.Providers[0].APIKeyStored {
+		t.Fatal("expected APIKeyStored marker in config")
+	}
+	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key, ok, _ := store.Get("ollama-cloud"); !ok || key != "sk-pasted-secret" {
+		t.Fatalf("stored key = %q,%v; want sk-pasted-secret in the credential store", key, ok)
 	}
 }
 

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -1,0 +1,177 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/credstore"
+)
+
+// ProviderKeyStoreAt opens the encrypted credential store whose file backend lives
+// in dir. The backend resolves keyring-first, then encrypted-file, with a plaintext
+// opt-out via ZERO_CRED_STORAGE. The dir parameter exists so tests can point the file
+// backend at a temp directory; production always uses the user config directory
+// (ProviderKeyStore) because provider API keys are user-scoped by design — they are
+// only ever captured under the user config, never project config (a cloned repo must
+// not carry keys), so runtime lookups deliberately use the user store regardless of
+// where a provider profile was resolved from.
+func ProviderKeyStoreAt(dir string) (*credstore.Store, error) {
+	return credstore.New(credstore.Options{Dir: dir})
+}
+
+// ProviderKeyStore opens the credential store beside the default user config.
+func ProviderKeyStore() (*credstore.Store, error) {
+	configPath, err := DefaultUserConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	return ProviderKeyStoreAt(filepath.Dir(configPath))
+}
+
+// APIKeyGetter is the read surface of the credential store; *credstore.Store
+// satisfies it. Kept here so callers can inject a fake in tests.
+type APIKeyGetter interface {
+	Get(provider string) (string, bool, error)
+}
+
+// APIKeySetter is the write surface of the credential store.
+type APIKeySetter interface {
+	Set(provider, key string) error
+}
+
+// SecureProviderProfile moves an inline APIKey on the profile into the credential
+// store co-located with configPath, returning a profile with APIKeyStored set and
+// APIKey cleared so the secret is never written to config.json. On any store error
+// (e.g. no keyring) it returns the profile unchanged — the inline key persists and
+// the startup migration retries later — so capturing a provider never fails on a
+// flaky credential backend.
+func SecureProviderProfile(profile ProviderProfile, configPath string) ProviderProfile {
+	if strings.TrimSpace(profile.APIKey) == "" || strings.TrimSpace(profile.Name) == "" {
+		return profile
+	}
+	store, err := ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		return profile
+	}
+	if err := store.Set(profile.Name, profile.APIKey); err != nil {
+		return profile
+	}
+	secured := profile
+	secured.APIKey = ""
+	secured.APIKeyStored = true
+	return secured
+}
+
+// ForgetProviderKey removes a provider's stored API key from the credential store,
+// reporting whether one existed. Used by the lifecycle "remove key" / auth logout.
+func ForgetProviderKey(provider string) (bool, error) {
+	store, err := ProviderKeyStore()
+	if err != nil {
+		return false, err
+	}
+	return store.Delete(provider)
+}
+
+// ClearProviderKeyStored unsets the APIKeyStored marker for a provider in the
+// config at path, so credential checks no longer claim a stored key after one is
+// removed. No-op when path/provider is empty, the config is absent, or the marker
+// is already unset.
+func ClearProviderKeyStored(path, provider string) (bool, error) {
+	path = strings.TrimSpace(path)
+	provider = strings.TrimSpace(provider)
+	if path == "" || provider == "" {
+		return false, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false, fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	changed := false
+	for index := range cfg.Providers {
+		if strings.EqualFold(strings.TrimSpace(cfg.Providers[index].Name), provider) && cfg.Providers[index].APIKeyStored {
+			cfg.Providers[index].APIKeyStored = false
+			changed = true
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	return true, writeConfigFile(path, cfg)
+}
+
+// MigratePlaintextProviderKeys moves any inline plaintext API key in the config at
+// path into the credential store, marking the profile APIKeyStored and stripping
+// the inline secret — but ONLY after the store write succeeds, so a failed Set
+// leaves the plaintext key in place and never strands a credential. Returns how
+// many keys were migrated; a no-op (0, nil) when path is empty/absent or nothing
+// needs migrating. Safe to run on every startup (idempotent).
+func MigratePlaintextProviderKeys(path string, store APIKeySetter) (int, error) {
+	path = strings.TrimSpace(path)
+	if path == "" || store == nil {
+		return 0, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return 0, fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	migrated := 0
+	for index := range cfg.Providers {
+		profile := &cfg.Providers[index]
+		key := strings.TrimSpace(profile.APIKey)
+		if key == "" || strings.TrimSpace(profile.Name) == "" {
+			continue
+		}
+		if err := store.Set(profile.Name, key); err != nil {
+			// Leave the plaintext key untouched; a failed Set must not strand it.
+			continue
+		}
+		profile.APIKey = ""
+		profile.APIKeyStored = true
+		migrated++
+	}
+	if migrated == 0 {
+		return 0, nil
+	}
+	if err := writeConfigFile(path, cfg); err != nil {
+		return migrated, fmt.Errorf("rewrite config after migration %s: %w", path, err)
+	}
+	return migrated, nil
+}
+
+// ApplyStoredAPIKey fills profile.APIKey from the credential store when it is not
+// already resolved — an inline config key or a resolved APIKeyEnv always wins, so
+// this only supplies a key for providers whose secret lives in the store. A nil
+// store, a miss, or a store error leaves the profile unchanged.
+func ApplyStoredAPIKey(profile ProviderProfile, store APIKeyGetter) ProviderProfile {
+	// Only load for profiles that opted into stored-key auth (APIKeyStored). Without
+	// this gate a stale keyring/file entry could silently reactivate credentials for a
+	// profile that no longer uses the store.
+	if store == nil || !profile.APIKeyStored || strings.TrimSpace(profile.APIKey) != "" {
+		return profile
+	}
+	name := strings.TrimSpace(profile.Name)
+	if name == "" {
+		return profile
+	}
+	if key, ok, err := store.Get(name); err == nil && ok && strings.TrimSpace(key) != "" {
+		profile.APIKey = key
+	}
+	return profile
+}

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -1,0 +1,174 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeKeyGetter struct {
+	keys map[string]string
+	err  error
+}
+
+func (f fakeKeyGetter) Get(provider string) (string, bool, error) {
+	if f.err != nil {
+		return "", false, f.err
+	}
+	v, ok := f.keys[provider]
+	return v, ok, nil
+}
+
+// fakeKeySetter records Set calls; setErr (when non-nil) makes Set fail.
+type fakeKeySetter struct {
+	keys   map[string]string
+	setErr error
+}
+
+func (f *fakeKeySetter) Set(provider, key string) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.keys[provider] = key
+	return nil
+}
+
+func TestApplyStoredAPIKey(t *testing.T) {
+	store := fakeKeyGetter{keys: map[string]string{"openai": "sk-stored"}}
+
+	// Stored marker + empty key => filled from the store.
+	got := ApplyStoredAPIKey(ProviderProfile{Name: "openai", APIKeyStored: true}, store)
+	if got.APIKey != "sk-stored" {
+		t.Fatalf("expected stored key to fill empty APIKey, got %q", got.APIKey)
+	}
+
+	// No APIKeyStored marker => store is NOT consulted (don't reactivate a stale key).
+	got = ApplyStoredAPIKey(ProviderProfile{Name: "openai"}, store)
+	if got.APIKey != "" {
+		t.Fatalf("expected no load without APIKeyStored, got %q", got.APIKey)
+	}
+
+	// Inline key present => store is NOT consulted (inline wins).
+	got = ApplyStoredAPIKey(ProviderProfile{Name: "openai", APIKeyStored: true, APIKey: "sk-inline"}, store)
+	if got.APIKey != "sk-inline" {
+		t.Fatalf("inline key must win, got %q", got.APIKey)
+	}
+
+	// Marker set but no stored key for this provider => unchanged (empty).
+	got = ApplyStoredAPIKey(ProviderProfile{Name: "anthropic", APIKeyStored: true}, store)
+	if got.APIKey != "" {
+		t.Fatalf("expected no key for unstored provider, got %q", got.APIKey)
+	}
+
+	// Nil store => unchanged.
+	got = ApplyStoredAPIKey(ProviderProfile{Name: "openai", APIKeyStored: true}, nil)
+	if got.APIKey != "" {
+		t.Fatalf("nil store must leave profile unchanged, got %q", got.APIKey)
+	}
+
+	// Empty name => unchanged (don't query the store).
+	got = ApplyStoredAPIKey(ProviderProfile{APIKeyStored: true}, store)
+	if got.APIKey != "" {
+		t.Fatalf("empty name must not be filled, got %q", got.APIKey)
+	}
+}
+
+func TestMigratePlaintextProviderKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	cfgJSON := `{"activeProvider":"openai","providers":[` +
+		`{"name":"openai","apiKey":"sk-PLAINTEXT","model":"gpt"},` +
+		`{"name":"local","baseURL":"http://localhost"},` +
+		`{"name":"acme","apiKeyEnv":"ACME_KEY"}]}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeKeySetter{keys: map[string]string{}}
+
+	n, err := MigratePlaintextProviderKeys(path, store)
+	if err != nil || n != 1 {
+		t.Fatalf("migrate = %d,%v; want 1,nil", n, err)
+	}
+	if store.keys["openai"] != "sk-PLAINTEXT" {
+		t.Fatalf("key not moved to store: %v", store.keys)
+	}
+	raw, _ := os.ReadFile(path)
+	if strings.Contains(string(raw), "sk-PLAINTEXT") {
+		t.Fatalf("plaintext key still in config.json:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "apiKeyStored") {
+		t.Fatalf("apiKeyStored marker not written:\n%s", raw)
+	}
+	// Idempotent: a second run migrates nothing.
+	if n2, _ := MigratePlaintextProviderKeys(path, store); n2 != 0 {
+		t.Fatalf("second migrate = %d, want 0", n2)
+	}
+}
+
+func TestMigrateLeavesKeyWhenStoreSetFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"providers":[{"name":"openai","apiKey":"sk-KEEP"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeKeySetter{keys: map[string]string{}, setErr: errors.New("keychain locked")}
+	n, err := MigratePlaintextProviderKeys(path, store)
+	if err != nil || n != 0 {
+		t.Fatalf("migrate with failing store = %d,%v; want 0,nil", n, err)
+	}
+	raw, _ := os.ReadFile(path)
+	if !strings.Contains(string(raw), "sk-KEEP") {
+		t.Fatalf("a failed Set must not strand the key; config.json:\n%s", raw)
+	}
+}
+
+func TestClearProviderKeyStored(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"providers":[{"name":"openai","apiKeyStored":true},{"name":"other","apiKeyStored":true}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cleared, err := ClearProviderKeyStored(path, "openai")
+	if err != nil || !cleared {
+		t.Fatalf("clear = %v,%v; want true,nil", cleared, err)
+	}
+	raw, _ := os.ReadFile(path)
+	// openai's marker is gone; other's remains.
+	var cfg FileConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range cfg.Providers {
+		if p.Name == "openai" && p.APIKeyStored {
+			t.Fatal("openai marker should be cleared")
+		}
+		if p.Name == "other" && !p.APIKeyStored {
+			t.Fatal("other marker should be untouched")
+		}
+	}
+	// Idempotent: clearing again reports no change.
+	if cleared, _ := ClearProviderKeyStored(path, "openai"); cleared {
+		t.Fatal("second clear should report no change")
+	}
+	// Unknown provider: no change.
+	if cleared, _ := ClearProviderKeyStored(path, "nope"); cleared {
+		t.Fatal("unknown provider should report no change")
+	}
+}
+
+func TestProviderProfileAPIKeyStoredRoundTrips(t *testing.T) {
+	// The apiKeyStored marker survives JSON decode (custom UnmarshalJSON).
+	var p ProviderProfile
+	if err := p.UnmarshalJSON([]byte(`{"name":"openai","apiKeyStored":true}`)); err != nil {
+		t.Fatal(err)
+	}
+	if !p.APIKeyStored {
+		t.Fatal("expected apiKeyStored=true to decode")
+	}
+	if p.APIKey != "" {
+		t.Fatalf("no inline key expected, got %q", p.APIKey)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -21,13 +21,18 @@ const (
 )
 
 type ProviderProfile struct {
-	Name            string            `json:"name"`
-	Provider        string            `json:"provider,omitempty"`
-	ProviderKind    ProviderKind      `json:"provider_kind,omitempty"`
-	CatalogID       string            `json:"catalogID,omitempty"`
-	BaseURL         string            `json:"baseURL,omitempty"`
-	APIKey          string            `json:"apiKey,omitempty"`
-	APIKeyEnv       string            `json:"apiKeyEnv,omitempty"`
+	Name         string       `json:"name"`
+	Provider     string       `json:"provider,omitempty"`
+	ProviderKind ProviderKind `json:"provider_kind,omitempty"`
+	CatalogID    string       `json:"catalogID,omitempty"`
+	BaseURL      string       `json:"baseURL,omitempty"`
+	APIKey       string       `json:"apiKey,omitempty"`
+	APIKeyEnv    string       `json:"apiKeyEnv,omitempty"`
+	// APIKeyStored marks that this provider's API key lives in the encrypted
+	// credential store (internal/credstore), not inline in APIKey. The effective
+	// key is loaded from the store at provider-build time; config.json holds only
+	// this marker, never the secret.
+	APIKeyStored    bool              `json:"apiKeyStored,omitempty"`
 	APIFormat       string            `json:"apiFormat,omitempty"`
 	AuthHeader      string            `json:"authHeader,omitempty"`
 	AuthScheme      string            `json:"authScheme,omitempty"`
@@ -485,6 +490,8 @@ func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {
 		APIKeySnake          string            `json:"api_key"`
 		APIKeyEnv            string            `json:"apiKeyEnv"`
 		APIKeyEnvSnake       string            `json:"api_key_env"`
+		APIKeyStored         bool              `json:"apiKeyStored"`
+		APIKeyStoredSnake    bool              `json:"api_key_stored"`
 		APIFormat            string            `json:"apiFormat"`
 		APIFormatSnake       string            `json:"api_format"`
 		AuthHeader           string            `json:"authHeader"`
@@ -514,6 +521,7 @@ func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {
 	profile.BaseURL = strings.TrimSpace(firstNonEmpty(raw.BaseURL, raw.BaseURLSnake))
 	profile.APIKey = firstNonEmpty(raw.APIKey, raw.APIKeySnake)
 	profile.APIKeyEnv = strings.TrimSpace(firstNonEmpty(raw.APIKeyEnv, raw.APIKeyEnvSnake))
+	profile.APIKeyStored = raw.APIKeyStored || raw.APIKeyStoredSnake
 	profile.APIFormat = strings.TrimSpace(firstNonEmpty(raw.APIFormat, raw.APIFormatSnake))
 	profile.AuthHeader = strings.TrimSpace(firstNonEmpty(raw.AuthHeader, raw.AuthHeaderSnake))
 	profile.AuthScheme = strings.TrimSpace(firstNonEmpty(raw.AuthScheme, raw.AuthSchemeSnake))

--- a/internal/credstore/credstore.go
+++ b/internal/credstore/credstore.go
@@ -1,0 +1,265 @@
+// Package credstore persists provider API keys outside config.json so secrets are
+// not written to disk in cleartext. It resolves one backend at construction: the OS
+// keyring on macOS (the `security` keychain), otherwise an AES-256-GCM encrypted file
+// (the Linux secret-tool keyring needs a running secret service that is absent on
+// headless/CI machines, so it is opt-in via ZERO_CRED_STORAGE=keyring). A plaintext
+// file is available only as an explicit ZERO_CRED_STORAGE=file opt-out. OAuth tokens
+// stay in internal/oauth; this store is for raw API keys.
+package credstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/keyring"
+	"github.com/Gitlawb/zero/internal/securefile"
+)
+
+const (
+	keyringService = "zero"
+	keyringPrefix  = "apikey:" // keyring account = "apikey:<provider>"
+
+	encryptedFileName = "credentials.enc"
+	plaintextFileName = "credentials.json"
+)
+
+// KeyringClient is the minimal OS-keyring surface the store needs;
+// *keyring.Keyring satisfies it. Injectable for tests.
+type KeyringClient interface {
+	Available() bool
+	Set(service, account, secret string) error
+	Get(service, account string) (string, bool, error)
+	Delete(service, account string) (bool, error)
+}
+
+// Options configures the credential store.
+type Options struct {
+	// Dir is the per-user data directory for the file backends.
+	Dir string
+	// Storage selects the backend: "" (auto), "keyring", "encrypted-file", or "file"
+	// (plaintext opt-out). When empty it falls back to ZERO_CRED_STORAGE, then auto:
+	// keyring on macOS (the `security` keychain is reliable and needs no daemon),
+	// encrypted-file everywhere else (Linux `secret-tool` needs a running secret
+	// service that is absent on headless/CI boxes and would block/error). Linux/other
+	// users can still opt into the keyring with ZERO_CRED_STORAGE=keyring.
+	Storage string
+	// Keyring is the keyring client; nil => keyring.New().
+	Keyring KeyringClient
+	// Env reads environment variables; nil => os.Getenv.
+	Env func(string) string
+	// GOOS overrides the platform for auto backend resolution; "" => runtime.GOOS.
+	// Exists so tests can exercise the per-OS default deterministically.
+	GOOS string
+}
+
+// Store reads/writes provider API keys via the resolved backend.
+type Store struct {
+	backend string // "keyring", "encrypted-file", or "file"
+	kr      KeyringClient
+	file    string
+	crypter *securefile.Crypter // non-nil only for "encrypted-file"
+}
+
+// New resolves the backend. It never silently downgrades to plaintext: "file" must
+// be chosen explicitly; auto mode picks keyring then encrypted-file.
+func New(options Options) (*Store, error) {
+	env := options.Env
+	if env == nil {
+		env = os.Getenv
+	}
+	kr := options.Keyring
+	if kr == nil {
+		kr = keyring.New()
+	}
+	goos := strings.TrimSpace(options.GOOS)
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	storage := strings.TrimSpace(options.Storage)
+	if storage == "" {
+		storage = strings.TrimSpace(env("ZERO_CRED_STORAGE"))
+	}
+	if storage == "" {
+		// Keyring is the default only on macOS, where `security` is reliable and needs
+		// no running daemon. Elsewhere (Linux secret-tool, headless/CI) default to the
+		// encrypted file; keyring stays available via an explicit ZERO_CRED_STORAGE.
+		if goos == "darwin" && kr.Available() {
+			storage = "keyring"
+		} else {
+			storage = "encrypted-file"
+		}
+	}
+
+	switch storage {
+	case "keyring":
+		if !kr.Available() {
+			return nil, fmt.Errorf("credstore: keyring requested but no OS keyring backend on this platform; use encrypted-file")
+		}
+		return &Store{backend: "keyring", kr: kr}, nil
+	case "encrypted-file":
+		if strings.TrimSpace(options.Dir) == "" {
+			return nil, fmt.Errorf("credstore: Dir is required for encrypted-file storage")
+		}
+		path := filepath.Join(options.Dir, encryptedFileName)
+		return &Store{backend: "encrypted-file", file: path, crypter: securefile.NewCrypter(path + ".secret")}, nil
+	case "file":
+		if strings.TrimSpace(options.Dir) == "" {
+			return nil, fmt.Errorf("credstore: Dir is required for file storage")
+		}
+		return &Store{backend: "file", file: filepath.Join(options.Dir, plaintextFileName)}, nil
+	default:
+		return nil, fmt.Errorf("credstore: unknown storage %q (want \"keyring\", \"encrypted-file\", or \"file\")", storage)
+	}
+}
+
+// Backend reports the resolved backend ("keyring", "encrypted-file", "file"), for
+// display ("how is this key stored").
+func (s *Store) Backend() string { return s.backend }
+
+// Encrypted reports whether secrets are protected at rest (keyring or AES file).
+func (s *Store) Encrypted() bool { return s.backend == "keyring" || s.backend == "encrypted-file" }
+
+// Set stores (or overwrites) the API key for provider.
+func (s *Store) Set(provider, key string) error {
+	provider = normalizeProvider(provider)
+	if provider == "" {
+		return fmt.Errorf("credstore: provider is required")
+	}
+	if s.backend == "keyring" {
+		return s.kr.Set(keyringService, keyringPrefix+provider, key)
+	}
+	data, err := s.read()
+	if err != nil {
+		return err
+	}
+	data[provider] = key
+	return s.write(data)
+}
+
+// Get returns the API key for provider and whether one is stored.
+func (s *Store) Get(provider string) (string, bool, error) {
+	provider = normalizeProvider(provider)
+	if provider == "" {
+		return "", false, nil
+	}
+	if s.backend == "keyring" {
+		return s.kr.Get(keyringService, keyringPrefix+provider)
+	}
+	data, err := s.read()
+	if err != nil {
+		return "", false, err
+	}
+	key, ok := data[provider]
+	return key, ok, nil
+}
+
+// Delete removes the API key for provider, reporting whether one existed.
+func (s *Store) Delete(provider string) (bool, error) {
+	provider = normalizeProvider(provider)
+	if provider == "" {
+		return false, nil
+	}
+	if s.backend == "keyring" {
+		return s.kr.Delete(keyringService, keyringPrefix+provider)
+	}
+	data, err := s.read()
+	if err != nil {
+		return false, err
+	}
+	if _, ok := data[provider]; !ok {
+		return false, nil
+	}
+	delete(data, provider)
+	return true, s.write(data)
+}
+
+// Providers lists providers with a stored key (sorted), for display/audit.
+func (s *Store) Providers() ([]string, error) {
+	if s.backend == "keyring" {
+		// The OS keyring has no enumerate-by-prefix in our minimal surface; callers
+		// that need a list pass known provider names to Get. Return empty here.
+		return nil, nil
+	}
+	data, err := s.read()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(data))
+	for name := range data {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// --- file backends (encrypted-file / file) ---------------------------------
+
+func (s *Store) read() (map[string]string, error) {
+	raw, err := os.ReadFile(s.file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("credstore: read %s: %w", s.file, err)
+	}
+	if s.crypter != nil {
+		raw, err = s.crypter.Open(raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+	data := map[string]string{}
+	if len(raw) == 0 {
+		return data, nil
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("credstore: parse %s: %w", s.file, err)
+	}
+	return data, nil
+}
+
+func (s *Store) write(data map[string]string) error {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("credstore: encode: %w", err)
+	}
+	if s.crypter != nil {
+		payload, err = s.crypter.Seal(payload)
+		if err != nil {
+			return err
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(s.file), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.file), filepath.Base(s.file)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("credstore: temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("credstore: chmod: %w", err)
+	}
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("credstore: write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("credstore: write: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.file); err != nil {
+		return fmt.Errorf("credstore: publish: %w", err)
+	}
+	return nil
+}
+
+func normalizeProvider(provider string) string {
+	return strings.ToLower(strings.TrimSpace(provider))
+}

--- a/internal/credstore/credstore_test.go
+++ b/internal/credstore/credstore_test.go
@@ -1,0 +1,174 @@
+package credstore
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// fakeKeyring is an in-memory KeyringClient so tests never touch the real OS
+// keychain.
+type fakeKeyring struct {
+	available bool
+	data      map[string]string
+}
+
+func newFakeKeyring(available bool) *fakeKeyring {
+	return &fakeKeyring{available: available, data: map[string]string{}}
+}
+func (f *fakeKeyring) Available() bool { return f.available }
+func (f *fakeKeyring) Set(service, account, secret string) error {
+	f.data[service+"/"+account] = secret
+	return nil
+}
+func (f *fakeKeyring) Get(service, account string) (string, bool, error) {
+	v, ok := f.data[service+"/"+account]
+	return v, ok, nil
+}
+func (f *fakeKeyring) Delete(service, account string) (bool, error) {
+	k := service + "/" + account
+	_, ok := f.data[k]
+	delete(f.data, k)
+	return ok, nil
+}
+
+func noEnv(string) string { return "" }
+
+func roundTrip(t *testing.T, s *Store) {
+	t.Helper()
+	if _, ok, _ := s.Get("openai"); ok {
+		t.Fatal("expected no key initially")
+	}
+	if err := s.Set("OpenAI", "sk-abc-123"); err != nil { // mixed case normalizes
+		t.Fatalf("set: %v", err)
+	}
+	got, ok, err := s.Get("openai")
+	if err != nil || !ok || got != "sk-abc-123" {
+		t.Fatalf("get = %q,%v,%v; want sk-abc-123,true,nil", got, ok, err)
+	}
+	if err := s.Set("openai", "sk-new-456"); err != nil { // overwrite
+		t.Fatal(err)
+	}
+	if got, _, _ := s.Get("openai"); got != "sk-new-456" {
+		t.Fatalf("overwrite get = %q, want sk-new-456", got)
+	}
+	existed, err := s.Delete("openai")
+	if err != nil || !existed {
+		t.Fatalf("delete = %v,%v; want true,nil", existed, err)
+	}
+	if _, ok, _ := s.Get("openai"); ok {
+		t.Fatal("expected key gone after delete")
+	}
+	if existed, _ := s.Delete("openai"); existed {
+		t.Fatal("delete of absent key should report not-existed")
+	}
+}
+
+func TestKeyringBackendRoundTrip(t *testing.T) {
+	s, err := New(Options{Storage: "keyring", Keyring: newFakeKeyring(true), Env: noEnv})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Backend() != "keyring" || !s.Encrypted() {
+		t.Fatalf("backend=%q encrypted=%v", s.Backend(), s.Encrypted())
+	}
+	roundTrip(t, s)
+}
+
+func TestEncryptedFileBackendRoundTripAndAtRest(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(Options{Storage: "encrypted-file", Dir: dir, Keyring: newFakeKeyring(false), Env: noEnv})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Encrypted() {
+		t.Fatal("encrypted-file must report Encrypted()")
+	}
+	if err := s.Set("anthropic", "sk-ant-SECRET"); err != nil {
+		t.Fatal(err)
+	}
+	// The on-disk file must NOT contain the plaintext key, and must be 0600.
+	raw, err := os.ReadFile(filepath.Join(dir, encryptedFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "sk-ant-SECRET") {
+		t.Fatal("encrypted-file leaked the plaintext key on disk")
+	}
+	if runtime.GOOS != "windows" { // Windows doesn't honor Unix permission bits
+		info, _ := os.Stat(filepath.Join(dir, encryptedFileName))
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("perm = %o, want 600", info.Mode().Perm())
+		}
+	}
+	if got, ok, _ := s.Get("anthropic"); !ok || got != "sk-ant-SECRET" {
+		t.Fatalf("get = %q,%v", got, ok)
+	}
+	roundTrip(t, s)
+}
+
+func TestPlaintextFileBackendIsOptOut(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(Options{Storage: "file", Dir: dir, Keyring: newFakeKeyring(false), Env: noEnv})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Encrypted() {
+		t.Fatal("plaintext file must NOT report Encrypted()")
+	}
+	roundTrip(t, s)
+}
+
+func TestAutoPrefersKeyringThenEncryptedFile(t *testing.T) {
+	// macOS + keyring available -> keyring
+	s, err := New(Options{Dir: t.TempDir(), Keyring: newFakeKeyring(true), GOOS: "darwin", Env: noEnv})
+	if err != nil || s.Backend() != "keyring" {
+		t.Fatalf("auto on darwin with keyring = %q,%v; want keyring", s.Backend(), err)
+	}
+	// macOS but keyring unavailable -> encrypted-file (never plaintext)
+	s2, err := New(Options{Dir: t.TempDir(), Keyring: newFakeKeyring(false), GOOS: "darwin", Env: noEnv})
+	if err != nil || s2.Backend() != "encrypted-file" {
+		t.Fatalf("auto on darwin without keyring = %q,%v; want encrypted-file", s2.Backend(), err)
+	}
+	// Non-macOS (e.g. Linux) -> encrypted-file even when a keyring is available, since
+	// secret-tool needs a running secret service (keyring stays opt-in via env).
+	s3, err := New(Options{Dir: t.TempDir(), Keyring: newFakeKeyring(true), GOOS: "linux", Env: noEnv})
+	if err != nil || s3.Backend() != "encrypted-file" {
+		t.Fatalf("auto on linux = %q,%v; want encrypted-file", s3.Backend(), err)
+	}
+}
+
+func TestKeyringRequestedButUnavailableErrors(t *testing.T) {
+	if _, err := New(Options{Storage: "keyring", Keyring: newFakeKeyring(false), Env: noEnv}); err == nil {
+		t.Fatal("expected error when keyring requested but unavailable")
+	}
+}
+
+func TestEnvSelectsStorage(t *testing.T) {
+	dir := t.TempDir()
+	env := func(k string) string {
+		if k == "ZERO_CRED_STORAGE" {
+			return "encrypted-file"
+		}
+		return ""
+	}
+	s, err := New(Options{Dir: dir, Keyring: newFakeKeyring(true), Env: env}) // keyring available, but env forces encrypted-file
+	if err != nil || s.Backend() != "encrypted-file" {
+		t.Fatalf("env override = %q,%v; want encrypted-file", s.Backend(), err)
+	}
+}
+
+func TestProvidersListsFileBackend(t *testing.T) {
+	s, _ := New(Options{Storage: "encrypted-file", Dir: t.TempDir(), Keyring: newFakeKeyring(false), Env: noEnv})
+	_ = s.Set("openai", "a")
+	_ = s.Set("gemini", "b")
+	names, err := s.Providers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 2 || names[0] != "gemini" || names[1] != "openai" {
+		t.Fatalf("providers = %v, want [gemini openai]", names)
+	}
+}

--- a/internal/securefile/secret_access_other.go
+++ b/internal/securefile/secret_access_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package securefile
+
+func isTransientSecretAccessError(error) bool {
+	return false
+}

--- a/internal/securefile/secret_access_windows.go
+++ b/internal/securefile/secret_access_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package securefile
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isTransientSecretAccessError(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}

--- a/internal/securefile/securefile.go
+++ b/internal/securefile/securefile.go
@@ -1,0 +1,193 @@
+// Package securefile provides AES-256-GCM encryption-at-rest for small on-disk
+// blobs under a per-user random secret persisted (0600) beside the data file. The
+// on-disk blob is nonce || ciphertext; GCM provides confidentiality AND tamper
+// detection, so a corrupted/forged file fails closed on Open. It is a neutral,
+// reusable extraction of the OAuth token store's encrypted-file backend, shared by
+// the credential store (and available to other callers).
+package securefile
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// secretBytes is the AES-256 key length kept in the per-user secret file.
+	secretBytes = 32
+
+	secretRetryAttempts = 500
+	secretRetryDelay    = 2 * time.Millisecond
+)
+
+// Crypter encrypts a blob at rest with AES-256-GCM under a per-user random secret
+// persisted (0600) at secretPath.
+type Crypter struct {
+	secretPath string
+}
+
+// NewCrypter returns a Crypter whose key lives at secretPath (created on first
+// Seal). Keep secretPath beside the data file (e.g. data + ".secret").
+func NewCrypter(secretPath string) *Crypter {
+	return &Crypter{secretPath: secretPath}
+}
+
+// aead loads (or, when create is set, generates) the secret and returns the GCM
+// AEAD. Open passes create=false so a missing secret is a hard error rather than
+// silently minting a new key that could never decrypt the existing file.
+func (c *Crypter) aead(create bool) (cipher.AEAD, error) {
+	secret, err := loadOrCreateSecret(c.secretPath, create)
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(secret)
+	if err != nil {
+		return nil, fmt.Errorf("securefile: build cipher: %w", err)
+	}
+	return cipher.NewGCM(block)
+}
+
+// Seal encrypts plaintext, prefixing a fresh random nonce. It creates the secret
+// on first use.
+func (c *Crypter) Seal(plaintext []byte) ([]byte, error) {
+	gcm, err := c.aead(true)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("securefile: generate nonce: %w", err)
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Open decrypts a nonce||ciphertext blob, failing closed on a missing secret, a
+// short blob, or a failed authentication tag (tampering / wrong key).
+func (c *Crypter) Open(blob []byte) ([]byte, error) {
+	gcm, err := c.aead(false)
+	if err != nil {
+		return nil, err
+	}
+	if len(blob) < gcm.NonceSize() {
+		return nil, errors.New("securefile: encrypted file is too short")
+	}
+	nonce, ciphertext := blob[:gcm.NonceSize()], blob[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("securefile: decrypt (wrong secret or tampered): %w", err)
+	}
+	return plaintext, nil
+}
+
+// loadOrCreateSecret reads the 32-byte secret at path. When create is set and the
+// file is absent, it generates a random secret and creates the file atomically
+// (0600). A wrong-sized existing secret fails closed (corruption).
+func loadOrCreateSecret(path string, create bool) ([]byte, error) {
+	if data, err := readSecretFileRetry(path); err == nil {
+		return data, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if !create {
+		return nil, fmt.Errorf("securefile: secret %s is missing; cannot decrypt the file", path)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	return createSecretFile(path)
+}
+
+func createSecretFile(path string) ([]byte, error) {
+	lockPath := path + ".lock"
+	var lastErr error
+	for attempt := 0; attempt < secretRetryAttempts; attempt++ {
+		lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_ = lock.Close()
+			defer os.Remove(lockPath)
+			if data, rerr := readSecretFileRetry(path); rerr == nil {
+				return data, nil
+			} else if !errors.Is(rerr, os.ErrNotExist) {
+				return nil, rerr
+			}
+			return writeNewSecretFile(path)
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("securefile: create secret lock: %w", err)
+		}
+		if data, rerr := readSecretFileRetry(path); rerr == nil {
+			return data, nil
+		} else {
+			lastErr = rerr
+		}
+		time.Sleep(secretRetryDelay)
+	}
+	if lastErr != nil {
+		return nil, fmt.Errorf("securefile: timed out waiting for secret %s: %w", path, lastErr)
+	}
+	return nil, fmt.Errorf("securefile: timed out waiting for secret lock %s", lockPath)
+}
+
+func writeNewSecretFile(path string) ([]byte, error) {
+	secret := make([]byte, secretBytes)
+	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
+		return nil, fmt.Errorf("securefile: generate secret: %w", err)
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return nil, fmt.Errorf("securefile: create secret temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("securefile: chmod secret temp file: %w", err)
+	}
+	if _, werr := tmp.Write(secret); werr != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("securefile: write secret: %w", werr)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		return nil, fmt.Errorf("securefile: write secret: %w", cerr)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return nil, fmt.Errorf("securefile: publish secret: %w", err)
+	}
+	return secret, nil
+}
+
+func readSecretFileRetry(path string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt < secretRetryAttempts; attempt++ {
+		data, err := readSecretFile(path)
+		if !isTransientSecretAccessError(err) {
+			return data, err
+		}
+		lastErr = err
+		time.Sleep(secretRetryDelay)
+	}
+	return nil, fmt.Errorf("securefile: timed out waiting for secret %s: %w", path, lastErr)
+}
+
+// readSecretFile reads and validates the secret at path, returning a wrapped
+// os.ErrNotExist when it is absent so callers can branch on creation.
+func readSecretFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("securefile: read secret: %w", err)
+	}
+	if len(data) != secretBytes {
+		return nil, fmt.Errorf("securefile: secret at %s has unexpected size %d", path, len(data))
+	}
+	return data, nil
+}

--- a/internal/securefile/securefile_test.go
+++ b/internal/securefile/securefile_test.go
@@ -1,0 +1,82 @@
+package securefile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	secret := filepath.Join(t.TempDir(), "k.secret")
+	c := NewCrypter(secret)
+	plain := []byte(`{"openai":{"type":"api","key":"sk-test-123"}}`)
+	blob, err := c.Seal(plain)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if string(blob) == string(plain) {
+		t.Fatal("blob must not equal plaintext")
+	}
+	// The secret file is created 0600.
+	info, err := os.Stat(secret)
+	if err != nil {
+		t.Fatalf("secret not created: %v", err)
+	}
+	// Windows doesn't honor Unix permission bits (Chmod only toggles read-only), so
+	// the 0600 guarantee only holds on Unix.
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("secret perm = %o, want 600", perm)
+		}
+	}
+	got, err := c.Open(blob)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if string(got) != string(plain) {
+		t.Fatalf("round-trip = %q, want %q", got, plain)
+	}
+}
+
+func TestOpenTamperedFailsClosed(t *testing.T) {
+	c := NewCrypter(filepath.Join(t.TempDir(), "k.secret"))
+	blob, err := c.Seal([]byte("secret-data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob[len(blob)-1] ^= 0xff // flip a ciphertext bit
+	if _, err := c.Open(blob); err == nil {
+		t.Fatal("expected tampered blob to fail authentication")
+	}
+}
+
+func TestOpenMissingSecretFailsClosed(t *testing.T) {
+	c := NewCrypter(filepath.Join(t.TempDir(), "absent.secret"))
+	if _, err := c.Open([]byte("0123456789012")); err == nil {
+		t.Fatal("expected open with no secret to fail, not mint a new key")
+	}
+}
+
+func TestOpenShortBlobFails(t *testing.T) {
+	c := NewCrypter(filepath.Join(t.TempDir(), "k.secret"))
+	if _, err := c.Seal([]byte("x")); err != nil { // create the secret
+		t.Fatal(err)
+	}
+	if _, err := c.Open([]byte("short")); err == nil {
+		t.Fatal("expected too-short blob to fail")
+	}
+}
+
+func TestWrongSecretCannotDecrypt(t *testing.T) {
+	dir := t.TempDir()
+	a := NewCrypter(filepath.Join(dir, "a.secret"))
+	blob, err := a.Seal([]byte("data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := NewCrypter(filepath.Join(dir, "b.secret")) // different secret
+	if _, err := b.Open(blob); err == nil {
+		t.Fatal("expected decryption under a different secret to fail")
+	}
+}

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/providermodelcatalog"
 	"github.com/Gitlawb/zero/internal/providers"
+	"github.com/Gitlawb/zero/internal/redaction"
 	zsearch "github.com/Gitlawb/zero/internal/search"
 )
 
@@ -414,6 +416,9 @@ func (m model) handleModelCommand(args string) (model, string) {
 		nextProfile = m.normalizeProfileForProvider(provider)
 	}
 	nextProfile.Model = target.modelID
+	// Reload the credential: a stored-key provider's profile carries an empty APIKey
+	// (the resolver is pure), so without this the rebuilt provider would send no key.
+	nextProfile = m.profileWithCredential(nextProfile)
 	metadata, err := providers.ResolveRuntimeMetadata(nextProfile, providers.Options{})
 	if err != nil {
 		return m, "Model\n" + err.Error()
@@ -473,6 +478,82 @@ func (m model) handleModelCommand(args string) (model, string) {
 	return m, strings.Join(lines, "\n")
 }
 
+// switchProviderModel switches the active provider to providerName (one of the
+// saved providers) and sets modelID, rebuilding the provider client. The /model
+// picker calls this when a model from a non-active provider is chosen, so the
+// picker can list every saved provider and switch across them (like a unified
+// provider+model selector). The key is loaded from the encrypted store / env.
+func (m model) switchProviderModel(providerName, modelID string) (model, string) {
+	if m.pending {
+		return m, "Model\nCannot switch providers while a run is active."
+	}
+	if m.newProvider == nil {
+		return m, "Model\nProvider rebuild is not available for this TUI session."
+	}
+	target, ok := m.savedProviderByName(providerName)
+	if !ok {
+		return m, "Model\nunknown provider " + strconv.Quote(providerName)
+	}
+	target = m.profileWithCredential(target)
+	target.Model = strings.TrimSpace(modelID)
+	descriptor, hasDescriptor := m.descriptorForProfile(target)
+	// Gate on the resolved credential, not the APIKeyStored marker: if the stored key
+	// was deleted/unreadable the marker can still be set, and building a keyless
+	// provider would only fail later with a 401. Local/no-auth providers need no key.
+	if strings.TrimSpace(target.APIKey) == "" && strings.TrimSpace(target.AuthHeaderValue) == "" && !(hasDescriptor && descriptor.Local) {
+		return m, "Model\nprovider " + strconv.Quote(providerName) + " has no usable credential — run setup or `zero auth login " + providerName + "`."
+	}
+	next, err := m.newProvider(target)
+	if err != nil {
+		return m, "Model\n" + redaction.RedactString(err.Error(), redaction.Options{ExtraSecretValues: []string{target.APIKey}})
+	}
+	m.provider = next
+	m.providerProfile = target
+	m.providerName = target.Name
+	m.modelName = target.Model
+	if strings.TrimSpace(m.userConfigPath) != "" {
+		_, _ = config.SetActiveProvider(m.userConfigPath, target.Name)
+		_, _ = config.SetProviderModel(m.userConfigPath, target.Name, target.Model)
+	}
+	return m, fmt.Sprintf("Model\nSwitched to %s · %s", target.Name, target.Model)
+}
+
+// profileWithCredential fills a profile's APIKey for provider construction the same
+// way the runtime resolves it: a stored key (encrypted credstore), then an env var,
+// then a stored OAuth bearer for token-login providers. The config resolver is pure
+// (no secret I/O), so a stored-key profile carries an empty APIKey until this runs —
+// every place that rebuilds the provider (model switch, provider switch) must call
+// this or the request goes out with no key.
+func (m model) profileWithCredential(profile config.ProviderProfile) config.ProviderProfile {
+	if strings.TrimSpace(profile.APIKey) == "" {
+		if store, err := config.ProviderKeyStore(); err == nil {
+			profile = config.ApplyStoredAPIKey(profile, store)
+		}
+	}
+	if strings.TrimSpace(profile.APIKey) == "" && strings.TrimSpace(profile.APIKeyEnv) != "" {
+		profile.APIKey = strings.TrimSpace(os.Getenv(profile.APIKeyEnv))
+	}
+	if descriptor, ok := m.descriptorForProfile(profile); ok && strings.TrimSpace(profile.APIKey) == "" && descriptor.OAuth && !descriptor.OAuthMintsKey {
+		if token := oauthStoredToken(m.ctx, descriptor.ID); token != "" {
+			profile.APIKey = token
+		}
+	}
+	return profile
+}
+
+func (m model) savedProviderByName(name string) (config.ProviderProfile, bool) {
+	name = strings.TrimSpace(name)
+	for _, profile := range m.savedProviders {
+		if strings.EqualFold(strings.TrimSpace(profile.Name), name) {
+			return profile, true
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(m.providerProfile.Name), name) {
+		return m.providerProfile, true
+	}
+	return config.ProviderProfile{}, false
+}
+
 func (m model) persistSelectedModel(profile config.ProviderProfile) (bool, error) {
 	path := strings.TrimSpace(m.userConfigPath)
 	if path == "" {
@@ -510,11 +591,9 @@ func (m model) resolveModelSwitchTarget(registry modelregistry.Registry, args st
 		}, true
 	}
 	if provider, ok := m.activeProviderDescriptor(); ok {
-		if m.modelPickerLiveProviderID == provider.ID {
-			for _, model := range m.modelPickerLiveModels {
-				if strings.EqualFold(model.ID, strings.TrimSpace(args)) {
-					return modelSwitchTarget{modelID: model.ID}, true
-				}
+		for _, model := range m.modelPickerLiveByProvider[provider.ID] {
+			if strings.EqualFold(model.ID, strings.TrimSpace(args)) {
+				return modelSwitchTarget{modelID: model.ID}, true
 			}
 		}
 		for _, model := range providermodelcatalog.Models(provider) {

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -467,7 +467,7 @@ func providerNextActionLines(profile config.ProviderProfile, snapshot zerocomman
 }
 
 func providerProfileHasCredential(profile config.ProviderProfile) bool {
-	return strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != ""
+	return strings.TrimSpace(profile.APIKey) != "" || profile.APIKeyStored || strings.TrimSpace(profile.AuthHeaderValue) != ""
 }
 
 func providerCredentialRequired(profile config.ProviderProfile, providerKind string) bool {
@@ -656,7 +656,7 @@ func (m model) configText() string {
 				Lines: []string{
 					"provider: " + displayValue(m.providerName, "none"),
 					"model: " + displayValue(m.modelName, "none"),
-					"api key: " + apiKeyState(strings.TrimSpace(m.providerProfile.APIKey) != ""),
+					"api key: " + apiKeyState(strings.TrimSpace(m.providerProfile.APIKey) != "" || m.providerProfile.APIKeyStored),
 				},
 			},
 		},

--- a/internal/tui/image_attach.go
+++ b/internal/tui/image_attach.go
@@ -112,14 +112,16 @@ func (m model) modelSupportsVisionTUI() bool {
 	// Check the discovered model list (from models.dev) for InputModalities
 	// containing "image". This covers custom/ollama/cloud models not in the
 	// curated catalog — models.dev knows their capabilities.
-	for _, dm := range m.modelPickerLiveModels {
-		if strings.EqualFold(strings.TrimSpace(dm.ID), trimmed) {
-			for _, modality := range dm.InputModalities {
-				if strings.EqualFold(strings.TrimSpace(modality), "image") {
-					return true
+	for _, models := range m.modelPickerLiveByProvider {
+		for _, dm := range models {
+			if strings.EqualFold(strings.TrimSpace(dm.ID), trimmed) {
+				for _, modality := range dm.InputModalities {
+					if strings.EqualFold(strings.TrimSpace(modality), "image") {
+						return true
+					}
 				}
+				return false // found the model in discovered list, no image modality
 			}
-			return false // found the model in discovered list, no image modality
 		}
 	}
 	// Fall back to the name heuristic for models not in the catalog or

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -51,6 +51,7 @@ type model struct {
 	providerName           string
 	modelName              string
 	providerProfile        config.ProviderProfile
+	savedProviders         []config.ProviderProfile
 	provider               zeroruntime.Provider
 	newProvider            func(config.ProviderProfile) (zeroruntime.Provider, error)
 	probeProviderHealth    func(context.Context, providerhealth.Options) providerhealth.Result
@@ -297,8 +298,10 @@ type model struct {
 	modelPickerLoading           bool
 	modelPickerLoadingProviderID string
 	modelPickerLoadError         string
-	modelPickerLiveProviderID    string
-	modelPickerLiveModels        []providermodeldiscovery.Model
+	// modelPickerLiveByProvider holds live-discovered models per provider (keyed by
+	// catalog descriptor ID), so /model shows each provider's real current models —
+	// the same list the provider-setup wizard discovers — not the static catalog.
+	modelPickerLiveByProvider map[string][]providermodeldiscovery.Model
 
 	// pendingImages holds image attachments staged by /image for the next user
 	// turn; pendingImageLabels are their display names (base(path)) for the chip
@@ -613,6 +616,7 @@ func newModel(ctx context.Context, options Options) model {
 		userConfigPath:         options.UserConfigPath,
 		doctorUserConfigPath:   doctorUserConfigPath,
 		projectConfigPath:      options.ProjectConfigPath,
+		savedProviders:         options.SavedProviders,
 		gitBranch:              gitBranch(cwd),
 		providerName:           options.ProviderName,
 		modelName:              options.ModelName,
@@ -3167,7 +3171,12 @@ func (m model) choosePicker() (tea.Model, tea.Cmd) {
 	switch picker.kind {
 	case pickerModel:
 		text := ""
-		m, text = m.handleModelCommand(item.Value)
+		if owner := strings.TrimSpace(item.OwnerProvider); owner != "" && !strings.EqualFold(owner, strings.TrimSpace(m.providerName)) {
+			// A model from another saved provider: switch provider + model together.
+			m, text = m.switchProviderModel(owner, item.Value)
+		} else {
+			m, text = m.handleModelCommand(item.Value)
+		}
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 	case pickerEffort:
 		text := ""

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -27,6 +27,7 @@ type Options struct {
 	ProviderName           string
 	ModelName              string
 	ProviderProfile        config.ProviderProfile
+	SavedProviders         []config.ProviderProfile // all configured providers, for the /model multi-provider list
 	FavoriteModels         []string
 	RecapsEnabled          bool
 	Provider               zeroruntime.Provider

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -35,10 +35,14 @@ type pickerItem struct {
 	Label    string
 	Value    string
 	Meta     string
-	Provider string
-	Remote   bool
-	Local    bool
-	Favorite bool
+	Provider string // display tag (catalog id / locality)
+	// OwnerProvider is the saved provider profile name a model belongs to, so the
+	// /model picker can switch providers when a model from a non-active provider is
+	// chosen. Empty for non-model items.
+	OwnerProvider string
+	Remote        bool
+	Local         bool
+	Favorite      bool
 }
 
 // commandPicker is a generic single-select overlay reused by /model, /effort,
@@ -122,10 +126,24 @@ func (m model) newModelPicker() *commandPicker {
 		recent = append(recent, m.modelPickerRecentItem(registry, activeModel))
 	}
 
+	activeProvider := strings.TrimSpace(m.providerName)
 	catalog := []pickerItem{}
-	if provider, ok := m.activeProviderDescriptor(); ok {
-		catalog = append(catalog, m.providerCatalogModelPickerItems(provider, activeModel)...)
-	} else {
+	// List every saved provider's models, grouped per provider (one contiguous
+	// section each), so /model shows all configured providers and you can switch
+	// across them. Dedup by group so two profiles resolving to the same provider
+	// don't produce a repeated section.
+	seenGroup := map[string]bool{}
+	for _, profile := range m.modelPickerProviders() {
+		descriptor, hasDescriptor := m.descriptorForProfile(profile)
+		group := modelPickerProviderGroup(profile, descriptor, hasDescriptor)
+		if seenGroup[group] {
+			continue
+		}
+		seenGroup[group] = true
+		catalog = append(catalog, m.savedProviderModelPickerItems(profile, activeProvider, activeModel)...)
+	}
+	if len(catalog) == 0 {
+		// No saved providers resolved any models: fall back to the full registry.
 		for _, entry := range registry.List(modelregistry.ListOptions{}) {
 			if entry.ID == activeModel {
 				continue
@@ -140,6 +158,99 @@ func (m model) newModelPicker() *commandPicker {
 	return &commandPicker{kind: pickerModel, title: "Choose a model", items: items, allItems: append([]pickerItem{}, items...), selected: 0}
 }
 
+// modelPickerProviders returns the providers to list in /model: all saved
+// providers, falling back to the active profile when none were threaded in.
+func (m model) modelPickerProviders() []config.ProviderProfile {
+	if len(m.savedProviders) > 0 {
+		return m.savedProviders
+	}
+	if config.HasProviderProfile(m.providerProfile) {
+		return []config.ProviderProfile{m.providerProfile}
+	}
+	return nil
+}
+
+// savedProviderModelPickerItems lists one saved provider's models as a group,
+// tagging each with the owning provider so selection can switch providers. The
+// active provider prefers its live-discovered models when available.
+func (m model) savedProviderModelPickerItems(profile config.ProviderProfile, activeProvider, activeModel string) []pickerItem {
+	providerName := strings.TrimSpace(profile.Name)
+	isActive := providerName != "" && strings.EqualFold(providerName, activeProvider)
+	descriptor, hasDescriptor := m.descriptorForProfile(profile)
+	group := modelPickerProviderGroup(profile, descriptor, hasDescriptor)
+
+	var raw []pickerItem
+	switch {
+	case hasDescriptor && len(m.modelPickerLiveByProvider[descriptor.ID]) > 0:
+		for _, model := range m.modelPickerLiveByProvider[descriptor.ID] {
+			if strings.TrimSpace(model.ID) == "" {
+				continue
+			}
+			raw = append(raw, discoveredModelPickerItem(descriptor, model, group))
+		}
+	case hasDescriptor && descriptor.Local:
+		// Local providers (e.g. Ollama) only have the models you've actually pulled.
+		// Never fall back to the static catalog — that would list models you don't
+		// have. Until live discovery returns them, this provider shows no rows.
+	case hasDescriptor:
+		for _, model := range providermodelcatalog.Models(descriptor) {
+			if strings.TrimSpace(model.ID) == "" {
+				continue
+			}
+			raw = append(raw, providerModelPickerItem(descriptor, model, group))
+		}
+	default:
+		// Custom provider without a catalog: surface its single configured model.
+		if mdl := strings.TrimSpace(profile.Model); mdl != "" {
+			raw = append(raw, pickerItem{Label: modelPickerDisplayName(mdl, ""), Value: mdl})
+		}
+	}
+
+	out := make([]pickerItem, 0, len(raw))
+	for _, item := range raw {
+		// The active model is already shown under "Recent" for the active provider.
+		if isActive && item.Value == activeModel {
+			continue
+		}
+		item.Group = group
+		item.OwnerProvider = providerName
+		out = append(out, item)
+	}
+	return out
+}
+
+// descriptorForProfile resolves a profile's catalog descriptor the same way the
+// active provider is resolved — by CatalogID, then base URL, then a synthesized
+// custom descriptor, then name/kind candidates — so every saved provider (not just
+// the active one) lists its models.
+func (m model) descriptorForProfile(profile config.ProviderProfile) (providercatalog.Descriptor, bool) {
+	if descriptor, ok := providercatalog.Get(profile.CatalogID); ok && !genericProviderCatalogID(descriptor.ID) {
+		return descriptor, true
+	}
+	if descriptor, ok := providerDescriptorByBaseURL(profile.BaseURL); ok {
+		return descriptor, true
+	}
+	if descriptor, ok := customProviderDescriptorForProfile(profile); ok {
+		return descriptor, true
+	}
+	for _, candidate := range []string{profile.Name, profile.Provider, string(profile.ProviderKind)} {
+		if descriptor, ok := providercatalog.Get(candidate); ok {
+			return descriptor, true
+		}
+	}
+	return providercatalog.Descriptor{}, false
+}
+
+func modelPickerProviderGroup(profile config.ProviderProfile, descriptor providercatalog.Descriptor, hasDescriptor bool) string {
+	if hasDescriptor && strings.TrimSpace(descriptor.Name) != "" {
+		return descriptor.Name
+	}
+	if name := strings.TrimSpace(profile.Name); name != "" {
+		return name
+	}
+	return "Provider"
+}
+
 func (m model) openModelPicker() (model, tea.Cmd) {
 	picker := m.newModelPicker()
 	if picker == nil {
@@ -147,17 +258,66 @@ func (m model) openModelPicker() (model, tea.Cmd) {
 	}
 	m.picker = picker
 	m.clearModelPickerLoadState()
-	provider, ok := m.activeProviderDescriptor()
-	if !ok || (m.modelPickerLiveProviderID == provider.ID && len(m.modelPickerLiveModels) > 0) {
-		return m, nil
+	// Live-discover every usable provider's real models in the background. The list
+	// shows immediately from the static catalog and each provider's section refreshes
+	// as its discovery returns — no blocking overlay.
+	return m, m.modelPickerDiscoveryCmds()
+}
+
+// modelPickerDiscoveryCmds dispatches a live model-discovery command for each
+// usable provider (deduped by catalog descriptor), so /model shows the same real
+// models the provider-setup wizard discovers.
+func (m model) modelPickerDiscoveryCmds() tea.Cmd {
+	cmds := []tea.Cmd{}
+	seen := map[string]bool{}
+	for _, profile := range m.modelPickerProviders() {
+		descriptor, ok := m.descriptorForProfile(profile)
+		if !ok || seen[descriptor.ID] {
+			continue
+		}
+		seen[descriptor.ID] = true
+		if cmd := m.modelPickerProviderDiscoveryCmd(descriptor, profile); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	}
-	cmd := m.modelPickerDiscoveryCmd()
-	if cmd == nil {
-		return m, nil
+	if len(cmds) == 0 {
+		return nil
 	}
-	m.modelPickerLoading = true
-	m.modelPickerLoadingProviderID = provider.ID
-	return m, cmd
+	return tea.Batch(cmds...)
+}
+
+// modelPickerProviderDiscoveryCmd discovers one provider's live models, resolving
+// its credential the same way the wizard does: a stored/inline/env key, or a stored
+// OAuth bearer for token-login providers (e.g. xAI).
+func (m model) modelPickerProviderDiscoveryCmd(descriptor providercatalog.Descriptor, profile config.ProviderProfile) tea.Cmd {
+	authed := profile
+	if store, err := config.ProviderKeyStore(); err == nil {
+		authed = config.ApplyStoredAPIKey(authed, store)
+	}
+	key := strings.TrimSpace(authed.APIKey)
+	if key == "" && strings.TrimSpace(authed.APIKeyEnv) != "" {
+		key = strings.TrimSpace(os.Getenv(authed.APIKeyEnv))
+	}
+	needOAuth := key == "" && descriptor.OAuth && !descriptor.OAuthMintsKey
+	discover := m.discoverProviderModels
+	if discover == nil {
+		discover = func(ctx context.Context, p config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return providermodeldiscovery.DiscoverCatalog(ctx, descriptor, p, providermodeldiscovery.Options{})
+		}
+	}
+	providerID := descriptor.ID
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(m.ctx, 8*time.Second)
+		defer cancel()
+		k := key
+		if needOAuth {
+			if resolved := oauthStoredToken(ctx, providerID); resolved != "" {
+				k = resolved
+			}
+		}
+		models, err := discover(ctx, providerWizardDiscoveryProfile(descriptor, k))
+		return modelPickerModelsDiscoveredMsg{providerID: providerID, models: models, err: err}
+	}
 }
 
 func (m model) modelPickerIsLoading() bool {
@@ -220,34 +380,6 @@ func (m model) modelPickerRecentItem(registry modelregistry.Registry, modelID st
 		return providerModelPickerItem(provider, providermodelcatalog.Model{ID: modelID}, "Recent")
 	}
 	return pickerItem{Group: "Recent", Label: modelPickerDisplayName(modelID, ""), Value: modelID}
-}
-
-func (m model) providerCatalogModelPickerItems(provider providercatalog.Descriptor, activeModel string) []pickerItem {
-	if m.modelPickerLiveProviderID == provider.ID && len(m.modelPickerLiveModels) > 0 {
-		return m.liveProviderModelPickerItems(provider, activeModel)
-	}
-	models := providermodelcatalog.Models(provider)
-	items := make([]pickerItem, 0, len(models))
-	group := provider.Name + " catalog"
-	for _, model := range models {
-		if strings.TrimSpace(model.ID) == "" || model.ID == activeModel {
-			continue
-		}
-		items = append(items, providerModelPickerItem(provider, model, group))
-	}
-	return items
-}
-
-func (m model) liveProviderModelPickerItems(provider providercatalog.Descriptor, activeModel string) []pickerItem {
-	items := make([]pickerItem, 0, len(m.modelPickerLiveModels))
-	group := provider.Name + " catalog"
-	for _, model := range m.modelPickerLiveModels {
-		if strings.TrimSpace(model.ID) == "" || model.ID == activeModel {
-			continue
-		}
-		items = append(items, discoveredModelPickerItem(provider, model, group))
-	}
-	return items
 }
 
 func registryModelPickerItem(entry modelregistry.ModelEntry, group string) pickerItem {
@@ -356,26 +488,7 @@ func modelPickerTitleWord(word string) string {
 }
 
 func (m model) activeProviderDescriptor() (providercatalog.Descriptor, bool) {
-	if descriptor, ok := providercatalog.Get(m.providerProfile.CatalogID); ok && !genericProviderCatalogID(descriptor.ID) {
-		return descriptor, true
-	}
-	if descriptor, ok := providerDescriptorByBaseURL(m.providerProfile.BaseURL); ok {
-		return descriptor, true
-	}
-	if descriptor, ok := customProviderDescriptorForProfile(m.providerProfile); ok {
-		return descriptor, true
-	}
-	for _, candidate := range []string{
-		m.providerProfile.Name,
-		m.providerName,
-		m.providerProfile.Provider,
-		string(m.providerProfile.ProviderKind),
-	} {
-		if descriptor, ok := providercatalog.Get(candidate); ok {
-			return descriptor, true
-		}
-	}
-	return providercatalog.Descriptor{}, false
+	return m.descriptorForProfile(m.providerProfile)
 }
 
 func customProviderDescriptorForProfile(profile config.ProviderProfile) (providercatalog.Descriptor, bool) {
@@ -452,34 +565,6 @@ type modelPickerModelsDiscoveredMsg struct {
 	err        error
 }
 
-func (m model) modelPickerDiscoveryCmd() tea.Cmd {
-	provider, ok := m.activeProviderDescriptor()
-	if !ok {
-		return nil
-	}
-	profile := m.modelPickerDiscoveryProfile(provider)
-	discover := m.discoverProviderModels
-	if discover == nil {
-		discover = func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
-			return providermodeldiscovery.DiscoverCatalog(ctx, provider, profile, providermodeldiscovery.Options{})
-		}
-	}
-	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(m.ctx, 8*time.Second)
-		defer cancel()
-		models, err := discover(ctx, profile)
-		return modelPickerModelsDiscoveredMsg{providerID: provider.ID, models: models, err: err}
-	}
-}
-
-func (m model) modelPickerDiscoveryProfile(provider providercatalog.Descriptor) config.ProviderProfile {
-	profile := m.normalizeProfileForProvider(provider)
-	if strings.TrimSpace(profile.Model) == "" {
-		profile.Model = provider.DefaultModel
-	}
-	return profile
-}
-
 func (m model) normalizeProfileForProvider(provider providercatalog.Descriptor) config.ProviderProfile {
 	profile := m.providerProfile
 	normalizeIdentity := profileMatchesProviderBaseURL(profile, provider) ||
@@ -515,25 +600,18 @@ func profileMatchesProviderBaseURL(profile config.ProviderProfile, provider prov
 }
 
 func (m model) applyModelPickerModelsDiscovered(msg modelPickerModelsDiscoveredMsg) model {
-	provider, ok := m.activeProviderDescriptor()
-	if !ok || provider.ID != msg.providerID {
-		return m
-	}
-	wasLoading := m.modelPickerLoadingProviderID == msg.providerID
-	if wasLoading {
-		m.modelPickerLoading = false
-		m.modelPickerLoadingProviderID = ""
-	}
+	m.modelPickerLoading = false
+	m.modelPickerLoadingProviderID = ""
 	if msg.err != nil || len(msg.models) == 0 {
-		if m.picker != nil && m.picker.kind == pickerModel && wasLoading {
-			m.modelPickerLoadError = "Using built-in model list"
-		}
 		return m
 	}
-	m.modelPickerLoadError = ""
-	m.modelPickerLiveProviderID = msg.providerID
-	m.modelPickerLiveModels = append([]providermodeldiscovery.Model{}, msg.models...)
-	if m.picker != nil && m.picker.kind == pickerModel && wasLoading {
+	if m.modelPickerLiveByProvider == nil {
+		m.modelPickerLiveByProvider = map[string][]providermodeldiscovery.Model{}
+	}
+	m.modelPickerLiveByProvider[msg.providerID] = append([]providermodeldiscovery.Model{}, msg.models...)
+	// Rebuild the open picker so this provider's section shows its live models,
+	// preserving the current query + selection.
+	if m.picker != nil && m.picker.kind == pickerModel {
 		selectedValue := ""
 		query := m.picker.query
 		if item, ok := m.picker.current(); ok {

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -37,8 +37,8 @@ func TestModelPickerDetectsOllamaCloudFromBaseURL(t *testing.T) {
 		t.Fatal("expected model picker")
 	}
 	groups := pickerGroups(picker.items)
-	if !contains(groups, "Ollama Cloud catalog") {
-		t.Fatalf("picker groups = %#v, want Ollama Cloud catalog", groups)
+	if !contains(groups, "Ollama Cloud") {
+		t.Fatalf("picker groups = %#v, want Ollama Cloud", groups)
 	}
 	got := pickerValues(picker.items)
 	if !contains(got, "qwen3-coder:480b") {
@@ -128,8 +128,8 @@ func TestModelPickerTreatsCustomOpenAIEndpointAsCustomProvider(t *testing.T) {
 		t.Fatalf("discovery profile = %#v, want custom OpenAI-compatible identity", captured)
 	}
 	groups := pickerGroups(next.picker.items)
-	if !contains(groups, "Custom OpenAI-compatible catalog") {
-		t.Fatalf("picker groups = %#v, want custom catalog group", groups)
+	if !contains(groups, "Custom OpenAI-compatible") {
+		t.Fatalf("picker groups = %#v, want custom provider group", groups)
 	}
 	got := pickerValues(next.picker.items)
 	if !contains(got, "custom-coder-plus") {
@@ -163,23 +163,24 @@ func TestModelPickerShowsLoadingUntilDiscoveryCompletes(t *testing.T) {
 	updated, cmd := m.Update(testKey(tea.KeyEnter))
 	m = updated.(model)
 	if cmd == nil {
-		t.Fatal("expected opening the model picker to start discovery")
+		t.Fatal("expected opening the model picker to start background discovery")
 	}
-	loading := plainRender(t, m.pickerOverlay(100))
-	assertContains(t, loading, "Checking available models...")
-	assertNotContains(t, loading, "Live Cloud A")
-
-	updated, _ = m.Update(testKey(tea.KeyEnter))
-	m = updated.(model)
+	// The list shows immediately (no blocking overlay) before discovery returns.
+	immediate := plainRender(t, m.pickerOverlay(100))
+	assertNotContains(t, immediate, "Checking available models...")
+	assertNotContains(t, immediate, "Live Cloud A")
 	if m.picker == nil {
-		t.Fatal("Enter while loading should not choose the fallback list")
+		t.Fatal("picker should be open immediately")
 	}
 
-	updated, _ = m.Update(cmd())
+	// When the provider's discovery returns, its section shows the live models.
+	updated, _ = m.Update(modelPickerModelsDiscoveredMsg{
+		providerID: "ollama-cloud",
+		models:     []providermodeldiscovery.Model{{ID: "live-cloud-a", Description: "Live Cloud A"}},
+	})
 	m = updated.(model)
 	loaded := plainRender(t, m.pickerOverlay(100))
 	assertContains(t, loaded, "Live Cloud A")
-	assertNotContains(t, loaded, "Checking available models...")
 }
 
 func TestModelPickerMetadataOmitsCredentialEnv(t *testing.T) {
@@ -195,13 +196,14 @@ func TestModelPickerMetadataOmitsCredentialEnv(t *testing.T) {
 			Model:        "minimax-m3",
 		},
 	})
-	m.modelPickerLiveProviderID = "ollama-cloud"
-	m.modelPickerLiveModels = []providermodeldiscovery.Model{
-		{
-			ID:            "cogito-2.1:671b",
-			ContextWindow: 163840,
-			ToolCall:      true,
-			Reasoning:     true,
+	m.modelPickerLiveByProvider = map[string][]providermodeldiscovery.Model{
+		"ollama-cloud": {
+			{
+				ID:            "cogito-2.1:671b",
+				ContextWindow: 163840,
+				ToolCall:      true,
+				Reasoning:     true,
+			},
 		},
 	}
 	m.picker = m.newModelPicker()
@@ -246,11 +248,14 @@ func TestModelPickerFallsBackWhenDiscoveryFails(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected opening the model picker to start discovery")
 	}
-	updated, _ = m.Update(cmd())
+	// A failed discovery leaves the static catalog list in place — no crash, no block.
+	updated, _ = m.Update(modelPickerModelsDiscoveredMsg{providerID: "ollama-cloud", models: nil, err: errors.New("offline")})
 	m = updated.(model)
 	view := plainRender(t, m.pickerOverlay(100))
-	assertContains(t, view, "Using built-in model list")
 	assertNotContains(t, view, "Checking available models...")
+	if m.picker == nil || len(m.picker.items) == 0 {
+		t.Fatal("static catalog list should remain after a failed discovery")
+	}
 }
 
 func TestModelPickerAppliesLiveDiscoveredModelID(t *testing.T) {
@@ -272,8 +277,7 @@ func TestModelPickerAppliesLiveDiscoveredModelID(t *testing.T) {
 			return &fakeProvider{}, nil
 		},
 	})
-	m.modelPickerLiveProviderID = "ollama-cloud"
-	m.modelPickerLiveModels = []providermodeldiscovery.Model{{ID: "glm-5.1", Description: "GLM 5.1"}}
+	m.modelPickerLiveByProvider = map[string][]providermodeldiscovery.Model{"ollama-cloud": {{ID: "glm-5.1", Description: "GLM 5.1"}}}
 	m.picker = m.newModelPicker()
 	m.picker.selected = pickerIndex(m.picker.items, "glm-5.1")
 
@@ -306,8 +310,7 @@ func TestModelSwitchNormalizesDetectedOllamaCloudProfile(t *testing.T) {
 			return &fakeProvider{}, nil
 		},
 	})
-	m.modelPickerLiveProviderID = "ollama-cloud"
-	m.modelPickerLiveModels = []providermodeldiscovery.Model{{ID: "glm-5.1", Description: "GLM 5.1"}}
+	m.modelPickerLiveByProvider = map[string][]providermodeldiscovery.Model{"ollama-cloud": {{ID: "glm-5.1", Description: "GLM 5.1"}}}
 	m.input.SetValue("/model glm-5.1")
 
 	updated, _ := m.Update(testKey(tea.KeyEnter))
@@ -446,8 +449,8 @@ func TestModelPickerShowsRecentThenActiveProviderCatalog(t *testing.T) {
 	if picker.items[0].Value != "google/gemini-2.5-pro" {
 		t.Fatalf("first picker value = %q, want active recent model", picker.items[0].Value)
 	}
-	if picker.items[1].Group != "OpenRouter catalog" {
-		t.Fatalf("second picker group = %q, want OpenRouter catalog", picker.items[1].Group)
+	if picker.items[1].Group != "OpenRouter" {
+		t.Fatalf("second picker group = %q, want OpenRouter", picker.items[1].Group)
 	}
 	got := pickerValues(picker.items)
 	if !contains(got, "anthropic/claude-sonnet-4.5") || !contains(got, "minimax/minimax-m2.1") {
@@ -725,6 +728,39 @@ func pickerValues(items []pickerItem) []string {
 		values = append(values, item.Value)
 	}
 	return values
+}
+
+func TestModelPickerListsAllSavedProviders(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName:    "openai",
+		ModelName:       "gpt-5.1",
+		ProviderProfile: config.ProviderProfile{Name: "openai", CatalogID: "openai", Model: "gpt-5.1"},
+		SavedProviders: []config.ProviderProfile{
+			{Name: "openai", CatalogID: "openai", Model: "gpt-5.1"},
+			{Name: "xai", CatalogID: "xai", Model: "grok-4"},
+		},
+	})
+	picker := m.newModelPicker()
+	if picker == nil {
+		t.Fatal("expected model picker")
+	}
+	// More than one provider section is listed (not just the active provider).
+	if groups := pickerGroups(picker.items); len(groups) < 2 {
+		t.Fatalf("expected multiple provider groups, got %#v", groups)
+	}
+	// Models from both saved providers are present and tagged with their owner so
+	// selection can switch providers.
+	owners := map[string]bool{}
+	for _, item := range picker.items {
+		if item.OwnerProvider != "" {
+			owners[strings.ToLower(item.OwnerProvider)] = true
+		}
+	}
+	for _, want := range []string{"openai", "xai"} {
+		if !owners[want] {
+			t.Fatalf("expected models owned by %q; owners=%v", want, owners)
+		}
+	}
 }
 
 func pickerGroups(items []pickerItem) []string {

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode"
@@ -237,6 +238,7 @@ type providerWizardStep int
 const (
 	providerWizardStepMethod providerWizardStep = iota
 	providerWizardStepProvider
+	providerWizardStepManageKey
 	providerWizardStepEndpoint
 	providerWizardStepName
 	providerWizardStepCredential
@@ -300,10 +302,13 @@ type providerWizardState struct {
 	modelLoadError   string
 	discoveryToken   int
 	selectedMethod   int
-	oauthMode        bool
-	oauthPending     bool
-	oauthAttemptID   int
-	oauthErr         string
+	// Manage-key step: shown when the selected provider already has a stored key.
+	manageKeyCursor    int
+	manageProviderName string
+	oauthMode          bool
+	oauthPending       bool
+	oauthAttemptID     int
+	oauthErr           string
 	// Device-code login (RFC 8628) state while an OAuth login is in flight.
 	oauthDevice           bool
 	deviceUserCode        string
@@ -593,6 +598,24 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		}
 		return m, nil
 	}
+	// Manage-key step: keep/replace/remove a provider's stored key.
+	if m.providerWizard.step == providerWizardStepManageKey {
+		switch {
+		case keyIs(msg, tea.KeyEsc) || keyIs(msg, tea.KeyLeft):
+			m.providerWizard.step = providerWizardStepProvider
+			m.providerWizard.err = ""
+			return m, nil
+		case keyIs(msg, tea.KeyUp):
+			m.providerWizard.manageKeyCursor = (m.providerWizard.manageKeyCursor + 2) % 3
+			return m, nil
+		case keyIs(msg, tea.KeyDown) || keyIs(msg, tea.KeyTab):
+			m.providerWizard.manageKeyCursor = (m.providerWizard.manageKeyCursor + 1) % 3
+			return m, nil
+		case keyIs(msg, tea.KeyEnter):
+			return m.applyManageKeyChoice()
+		}
+		return m, nil
+	}
 	// On the OAuth provider list, "d" forces device-code login for a device-capable
 	// provider (xAI) — useful on a desktop when the browser flow won't work.
 	if m.providerWizard.step == providerWizardStepProvider && m.providerWizard.oauthMode &&
@@ -869,8 +892,13 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 		m.provider = nextProvider
 	}
 	if strings.TrimSpace(m.userConfigPath) != "" {
+		// Capture flip: move the freshly entered key into the encrypted credential
+		// store before persisting, so config.json never holds the cleartext. The
+		// provider was already built above from runtimeProfile, which has the key.
+		secret := profile.APIKey
+		profile = config.SecureProviderProfile(profile, m.userConfigPath)
 		if _, err := config.UpsertProvider(m.userConfigPath, profile, true); err != nil {
-			wizard.err = redaction.RedactString(err.Error(), redaction.Options{ExtraSecretValues: []string{profile.APIKey}})
+			wizard.err = redaction.RedactString(err.Error(), redaction.Options{ExtraSecretValues: []string{secret, profile.APIKey}})
 			return m, nil
 		}
 	}
@@ -879,6 +907,57 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 	m.modelName = profile.Model
 	m.providerWizard = nil
 	return m, nil
+}
+
+// wizardProviderStoredKey reports the saved provider name that has a key in the
+// credential store matching the wizard-selected descriptor, so the wizard can offer
+// keep/replace/remove instead of forcing a new key entry.
+func (m model) wizardProviderStoredKey(provider providercatalog.Descriptor) (string, bool) {
+	for _, profile := range m.savedProviders {
+		if !profile.APIKeyStored {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(profile.Name), strings.TrimSpace(provider.Name)) ||
+			strings.EqualFold(strings.TrimSpace(profile.CatalogID), strings.TrimSpace(provider.ID)) ||
+			strings.EqualFold(strings.TrimSpace(profile.Name), strings.TrimSpace(provider.ID)) {
+			return profile.Name, true
+		}
+	}
+	return "", false
+}
+
+// applyManageKeyChoice acts on the keep/replace/remove selection. Keep closes the
+// wizard (nothing changes); Replace routes to credential entry (overwrites on save);
+// Remove deletes the stored key and its marker.
+func (m model) applyManageKeyChoice() (model, tea.Cmd) {
+	wizard := m.providerWizard
+	if wizard == nil {
+		return m, nil
+	}
+	name := strings.TrimSpace(wizard.manageProviderName)
+	switch wizard.manageKeyCursor {
+	case 1: // Replace
+		wizard.apiKey = ""
+		wizard.err = ""
+		wizard.step = providerWizardStepCredential
+		return m, nil
+	case 2: // Remove
+		if strings.TrimSpace(m.userConfigPath) != "" {
+			if store, err := config.ProviderKeyStoreAt(filepath.Dir(m.userConfigPath)); err == nil {
+				_, _ = store.Delete(name)
+			}
+			_, _ = config.ClearProviderKeyStored(m.userConfigPath, name)
+		} else {
+			_, _ = config.ForgetProviderKey(name)
+		}
+		m.providerWizard = nil
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Provider\nRemoved the stored key for " + name + ". Re-add it any time with /provider."})
+		return m, nil
+	default: // Keep
+		m.providerWizard = nil
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Provider\nKept the saved key for " + name + "."})
+		return m, nil
+	}
 }
 
 func providerWizardRuntimeProfile(profile config.ProviderProfile) config.ProviderProfile {
@@ -927,6 +1006,8 @@ func (wizard *providerWizardState) render(width int) string {
 		lines = append(lines, wizard.renderMethodStep(innerWidth)...)
 	case providerWizardStepProvider:
 		lines = append(lines, wizard.renderProviderStep(innerWidth)...)
+	case providerWizardStepManageKey:
+		lines = append(lines, wizard.renderManageKeyStep(innerWidth)...)
 	case providerWizardStepEndpoint:
 		lines = append(lines, wizard.renderEndpointStep(innerWidth)...)
 	case providerWizardStepName:
@@ -963,6 +1044,8 @@ func (wizard *providerWizardState) footer() string {
 			return "↑/↓ move   Enter/→ continue   ← back   Esc close"
 		}
 		return "↑/↓ move   Enter continue   ← back   Esc close"
+	case providerWizardStepManageKey:
+		return "↑/↓ move   Enter select   Esc back"
 	case providerWizardStepEndpoint:
 		if canRight {
 			return "Enter/→ continue   ← back   Esc close"
@@ -1058,6 +1141,33 @@ func (wizard *providerWizardState) renderMethodStep(width int) []string {
 		surface := transparentSurface
 		marker := surface(zeroTheme.faintest).Render("  ")
 		if index == wizard.selectedMethod {
+			surface = zeroTheme.onSel
+			marker = surface(zeroTheme.accent).Render("❯ ")
+		}
+		lines = append(lines, fitStyledLine(marker+surface(zeroTheme.ink).Render(option.label), width))
+		lines = append(lines, fitStyledLine("    "+zeroTheme.faint.Render(option.subtitle), width))
+	}
+	return lines
+}
+
+// renderManageKeyStep shows keep/replace/remove for a provider that already has a
+// key in the encrypted credential store.
+func (wizard *providerWizardState) renderManageKeyStep(width int) []string {
+	name := strings.TrimSpace(wizard.manageProviderName)
+	if name == "" {
+		name = wizard.currentProvider().Name
+	}
+	options := []struct{ label, subtitle string }{
+		{"Keep current key", "A key is already saved (encrypted) for " + name + "."},
+		{"Replace key", "Enter a new key; it overwrites the stored one."},
+		{"Remove key", "Delete the stored key for " + name + "."},
+	}
+	wizard.manageKeyCursor = clampInt(wizard.manageKeyCursor, 0, len(options)-1)
+	lines := []string{zeroTheme.accent.Render(name + " already has a saved key")}
+	for index, option := range options {
+		surface := transparentSurface
+		marker := surface(zeroTheme.faintest).Render("  ")
+		if index == wizard.manageKeyCursor {
 			surface = zeroTheme.onSel
 			marker = surface(zeroTheme.accent).Render("❯ ")
 		}

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -40,6 +40,17 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 		attemptID := m.providerWizard.beginOAuthAttempt(false)
 		return m, providerWizardOAuthCmdFor(provider, attemptID)
 	}
+	// A non-OAuth provider that already has a key in the credential store: offer
+	// keep/replace/remove before re-entering credentials.
+	if m.providerWizard.step == providerWizardStepProvider && !m.providerWizard.oauthMode {
+		if name, ok := m.wizardProviderStoredKey(m.providerWizard.currentProvider()); ok {
+			m.providerWizard.manageProviderName = name
+			m.providerWizard.manageKeyCursor = 0
+			m.providerWizard.err = ""
+			m.providerWizard.step = providerWizardStepManageKey
+			return m, nil
+		}
+	}
 	previous := m.providerWizard.step
 	m.providerWizard.advance()
 	if m.providerWizard.step == providerWizardStepModel && previous != providerWizardStepModel {

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -641,6 +641,8 @@ func TestProviderWizardAppliesPastedKeyToCurrentSession(t *testing.T) {
 
 func TestProviderWizardPersistsPastedKeyToUserConfig(t *testing.T) {
 	const secret = "ollama-secret-123"
+	// Encrypted-file backend in the temp config dir keeps the test off the real keychain.
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 	var captured config.ProviderProfile
 	m := newModel(context.Background(), Options{
@@ -681,11 +683,19 @@ func TestProviderWizardPersistsPastedKeyToUserConfig(t *testing.T) {
 	if profile.Name != "ollama-cloud" || profile.CatalogID != "ollama-cloud" {
 		t.Fatalf("persisted provider identity = %#v, want ollama-cloud", profile)
 	}
-	if profile.APIKey != secret {
-		t.Fatalf("persisted APIKey = %q, want pasted secret", profile.APIKey)
+	// Capture flip: the secret lives in the credential store, not config.json.
+	if profile.APIKey != "" || profile.APIKeyEnv != "" {
+		t.Fatalf("config must not persist the key: APIKey %q APIKeyEnv %q", profile.APIKey, profile.APIKeyEnv)
 	}
-	if profile.APIKeyEnv != "" {
-		t.Fatalf("persisted APIKeyEnv = %q, want empty for pasted key", profile.APIKeyEnv)
+	if !profile.APIKeyStored {
+		t.Fatal("expected APIKeyStored marker in persisted config")
+	}
+	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key, ok, _ := store.Get("ollama-cloud"); !ok || key != secret {
+		t.Fatalf("stored key = %q,%v; want the pasted secret in the credential store", key, ok)
 	}
 }
 
@@ -1084,6 +1094,66 @@ func providerWizardModelIDs(models []providerWizardModel) []string {
 		ids = append(ids, model.ID)
 	}
 	return ids
+}
+
+func TestWizardProviderStoredKey(t *testing.T) {
+	m := model{savedProviders: []config.ProviderProfile{
+		{Name: "acme", CatalogID: "acme-cloud", APIKeyStored: true},
+		{Name: "nokey"},
+	}}
+	if name, ok := m.wizardProviderStoredKey(providercatalog.Descriptor{Name: "acme"}); !ok || name != "acme" {
+		t.Fatalf("match by name = %q,%v", name, ok)
+	}
+	if name, ok := m.wizardProviderStoredKey(providercatalog.Descriptor{ID: "acme-cloud"}); !ok || name != "acme" {
+		t.Fatalf("match by catalog id = %q,%v", name, ok)
+	}
+	if _, ok := m.wizardProviderStoredKey(providercatalog.Descriptor{Name: "nokey"}); ok {
+		t.Fatal("provider without a stored key must not match")
+	}
+}
+
+func TestProviderWizardManageKeyRemove(t *testing.T) {
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"acme","apiKeyStored":true}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("acme", "sk-secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newModel(context.Background(), Options{UserConfigPath: configPath})
+	m.providerWizard = &providerWizardState{step: providerWizardStepManageKey, manageProviderName: "acme", manageKeyCursor: 2}
+	next, _ := m.applyManageKeyChoice()
+	if next.providerWizard != nil {
+		t.Fatal("remove should close the wizard")
+	}
+	if _, ok, _ := store.Get("acme"); ok {
+		t.Fatal("remove should delete the key from the credential store")
+	}
+}
+
+func TestProviderWizardManageKeyReplaceAndKeep(t *testing.T) {
+	m := newModel(context.Background(), Options{UserConfigPath: filepath.Join(t.TempDir(), "config.json")})
+
+	m.providerWizard = &providerWizardState{step: providerWizardStepManageKey, manageProviderName: "acme", manageKeyCursor: 1}
+	next, _ := m.applyManageKeyChoice()
+	if next.providerWizard == nil || next.providerWizard.step != providerWizardStepCredential {
+		t.Fatal("replace should route to the credential step")
+	}
+
+	m.providerWizard = &providerWizardState{step: providerWizardStepManageKey, manageProviderName: "acme", manageKeyCursor: 0}
+	next, _ = m.applyManageKeyChoice()
+	if next.providerWizard != nil {
+		t.Fatal("keep should close the wizard without changes")
+	}
 }
 
 func readProviderWizardConfigFixture(t *testing.T, path string) config.FileConfig {

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -1549,26 +1549,16 @@ func TestModelPickerRowsCarryCapabilityMeta(t *testing.T) {
 	}
 }
 
-func TestModelPickerRowShowsProviderTag(t *testing.T) {
+func TestModelPickerRowOmitsProviderTag(t *testing.T) {
+	// The provider is shown as a section header above each group, so a row renders
+	// just the model label — no repeated right-aligned provider tag.
 	item := pickerItem{Label: "Claude Sonnet 4.6", Value: "claude-sonnet-4-6", Provider: "anthropic", Remote: true}
 	got := plainRender(t, renderModelPickerRow(60, false, item))
 	if !strings.Contains(got, "Claude Sonnet 4.6") {
 		t.Fatalf("row = %q, missing model label", got)
 	}
-	if !strings.Contains(got, "anthropic") {
-		t.Fatalf("row = %q, missing right-aligned provider tag", got)
-	}
-	// The provider tag must trail the model name, not lead it.
-	if strings.Index(got, "anthropic") < strings.Index(got, "Claude") {
-		t.Fatalf("row = %q, provider tag should be right-aligned after the model name", got)
-	}
-}
-
-func TestModelPickerRowDropsProviderTagWhenNarrow(t *testing.T) {
-	item := pickerItem{Label: "Claude Sonnet 4.6", Value: "claude-sonnet-4-6", Provider: "anthropic"}
-	got := plainRender(t, renderModelPickerRow(12, false, item))
 	if strings.Contains(got, "anthropic") {
-		t.Fatalf("narrow row = %q, should drop the provider tag rather than crowd the model name", got)
+		t.Fatalf("row = %q, should not repeat the provider tag (now a section header)", got)
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -774,7 +774,12 @@ func (m model) modelPickerOverlay(width int) string {
 		lines = append(lines, fillPaletteLine(searchPrefix+zeroTheme.faint.Render(status), innerWidth, transparentSurface))
 	}
 	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+	lastGroup := ""
 	for index, item := range visible {
+		if item.Group != "" && item.Group != lastGroup {
+			lines = append(lines, fillPaletteLine(zeroTheme.accent.Bold(true).Render(item.Group), innerWidth, transparentSurface))
+			lastGroup = item.Group
+		}
 		lines = append(lines, renderModelPickerRow(innerWidth, start+index == m.picker.selected, item))
 	}
 	if len(visible) == 0 {
@@ -881,19 +886,9 @@ func renderModelPickerRow(width int, selected bool, item pickerItem) string {
 		prefix = "* "
 	}
 	left := marker + surface(zeroTheme.ink).Render(prefix+label)
-	right := ""
-	if tag := strings.TrimSpace(item.Provider); tag != "" {
-		right = surface(zeroTheme.faintest).Render(tag)
-	}
-	// Right-align the provider slug so each row reads "<model> … <provider>".
-	// Drop it when the row is too narrow to keep a clear gap from the model
-	// name (mirrors the generic picker's gap math at pickerOverlay).
-	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
-	if right == "" || gap < 2 {
-		return fillPaletteLine(left, width, surface)
-	}
-	line := left + surface(zeroTheme.ink).Render(strings.Repeat(" ", gap)) + right
-	return fitStyledLine(line, width)
+	// The provider is shown as a section header above each group, so rows no longer
+	// repeat it as a right-aligned tag (matches a grouped provider+model list).
+	return fillPaletteLine(left, width, surface)
 }
 
 func modelPickerItemDetail(item pickerItem) string {


### PR DESCRIPTION
## Summary

Stops provider API keys from being stored in plaintext, and makes `/model` reflect what each connected provider actually serves.

Two themes:

### 1. Encrypted credential storage
Previously a pasted API key was written in cleartext to `config.json` (`apiKey`). Now:
- **`internal/securefile`** — AES-256-GCM encryption-at-rest (fail-closed, atomic write, cross-process lock; key in a `0600` sidecar).
- **`internal/credstore`** — provider API-key store. Backend resolves **keyring-first** (OS credential store) → **encrypted-file** fallback; plaintext only via an explicit `ZERO_CRED_STORAGE=file` opt-out.
- **Keys leave `config.json`:** the wizard / CLI setup write the key straight into the store and persist only an `apiKeyStored` marker. Any existing inline plaintext key is **migrated to the store on launch** (fail-soft; the cleartext is stripped only after the store write succeeds, so a key is never stranded).
- **Load on use:** `buildProvider` and *every* model/provider switch reload the credential (stored key → env var → OAuth bearer), so a stored-key provider always authenticates — including after switching models mid-session.
- **`zero auth logout <provider>`** now removes the stored API key + marker (not just the OAuth token).

### 2. Provider-aware `/model` and `/provider`
- `/model` lists **every authenticated provider** (filtered to those with a usable credential — key / stored / env / OAuth / local), **grouped per provider** under section headers.
- Each provider's models are **live-discovered** (its real served models) instead of a static catalog; **local providers show only the models actually pulled** (no fake entries).
- Selecting a model from a different provider **switches provider + model together**.
- `/provider` offers **keep / replace / remove** when the selected provider already has a stored key.

## Behavior / compatibility
- Backward compatible: existing inline keys keep working and are migrated transparently on first interactive launch.
- Headless `exec` is unchanged (no migration, no interactive prompts).
- Keychain access prompts can be avoided with `ZERO_CRED_STORAGE=encrypted-file`.

## Test plan
- `go build ./...`, `go vet ./...`, `go test ./... -race`, lint — all green (72 packages).
- New unit tests: securefile round-trip / tamper / wrong-key; credstore backends + auto-resolution + migration + marker; `/model` provider grouping + live-discovery refresh + fallback; `/provider` keep/replace/remove.
- Manually verified: a stored key authenticates after a cross-provider model switch; `/model` shows real served models per provider; un-connected providers are hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encrypted credential storage for provider API keys, including fail-soft migration from existing plaintext keys and automatic use of stored keys during interactive runs.
  * Enhanced the model picker to list models grouped by saved providers, refresh live models per provider, and support switching provider+model together.
  * Added a provider “manage key” step (keep, replace, remove) for providers with stored keys.
* **Bug Fixes**
  * Logout now clears both OAuth credentials and stored provider API keys, with updated “no stored credential” messaging.
  * Credential indicators now correctly reflect stored-key availability even when the inline key field is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->