### PR TITLE
fix(model): expose reasoning effort for GPT-5 / Codex / o-series

### DIFF
--- a/internal/modelregistry/catalog.go
+++ b/internal/modelregistry/catalog.go
@@ -1,6 +1,9 @@
 package modelregistry
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const DefaultModelID = "gpt-4.1"
 
@@ -169,11 +172,45 @@ func (registry Registry) SupportsCapability(pattern string, capability ModelCapa
 }
 
 func (registry Registry) ReasoningEfforts(pattern string) []ReasoningEffort {
-	model, ok := registry.Get(pattern)
-	if !ok {
+	if model, ok := registry.Get(pattern); ok && len(model.ReasoningEfforts) > 0 {
+		return append([]ReasoningEffort{}, model.ReasoningEfforts...)
+	}
+	// Fallback for reasoning-model families that aren't enumerated in the curated
+	// catalog — e.g. the GPT-5 / Codex / o-series variants served via the ChatGPT
+	// proxy or custom OpenAI-compatible endpoints. Without this, /effort shows no
+	// controls for those models even though they support reasoning_effort.
+	return reasoningEffortsForModelName(pattern)
+}
+
+// reasoningEffortsForModelName infers reasoning-effort controls from a model name
+// for known reasoning families not present in the catalog. It returns nil for
+// non-reasoning models (e.g. GPT-4.1 / GPT-4o), so /effort stays empty there.
+func reasoningEffortsForModelName(name string) []ReasoningEffort {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if i := strings.IndexByte(n, ':'); i >= 0 { // drop a "provider:" qualifier
+		n = n[i+1:]
+	}
+	switch {
+	case strings.HasPrefix(n, "gpt-5") || strings.HasPrefix(n, "gpt5"):
+		// GPT-5 / Codex (gpt-5.x) add a "minimal" tier below low.
+		return []ReasoningEffort{ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}
+	case strings.Contains(n, "codex") || isOSeriesModelName(n):
+		return []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}
+	default:
 		return nil
 	}
-	return append([]ReasoningEffort{}, model.ReasoningEfforts...)
+}
+
+// isOSeriesModelName reports whether name is an OpenAI o-series reasoning model
+// (o1/o3/o4, optionally with a -mini/-pro suffix), without matching unrelated
+// names that merely start with the same letters.
+func isOSeriesModelName(n string) bool {
+	for _, prefix := range []string{"o1", "o3", "o4"} {
+		if n == prefix || strings.HasPrefix(n, prefix+"-") || strings.HasPrefix(n, prefix+"mini") {
+			return true
+		}
+	}
+	return false
 }
 
 func (registry Registry) RequireProvider(pattern string, provider ProviderKind) (ModelEntry, error) {

--- a/internal/modelregistry/effort_fallback_test.go
+++ b/internal/modelregistry/effort_fallback_test.go
@@ -1,0 +1,34 @@
+package modelregistry
+
+import "testing"
+
+func TestReasoningEffortsFallbackForGPT5AndOSeries(t *testing.T) {
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		want []ReasoningEffort
+	}{
+		{"gpt-5", []ReasoningEffort{ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"gpt-5.5", []ReasoningEffort{ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"gpt-5.4-mini", []ReasoningEffort{ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"o3-mini", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"gpt-5.3-codex-spark", []ReasoningEffort{ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"gpt-4.1", nil}, // non-reasoning, registered: stays empty
+		{"gpt-4o-mini", nil},
+		{"ollama/llama3.1", nil},
+	}
+	for _, c := range cases {
+		got := reg.ReasoningEfforts(c.name)
+		if len(got) != len(c.want) {
+			t.Fatalf("%s: got %v, want %v", c.name, got, c.want)
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Fatalf("%s: got %v, want %v", c.name, got, c.want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`/effort` showed **no reasoning controls for ChatGPT (GPT-5)** even though GPT-5 supports `reasoning_effort`. This fixes that.

### Root cause
`/effort` lists `Registry.ReasoningEfforts(activeModel)`, which reads the efforts declared on the model's **curated registry entry**:
- **GPT-5 / `gpt-5.x` (Codex) and the o-series aren't in the registry at all** (the chatgpt-proxy default is `gpt-5`; the ChatGPT catalog serves `gpt-5.5`, `gpt-5.4`, …). `Registry.Get` misses → `ReasoningEfforts` returns `nil`.
- The OpenAI entries that *are* registered (`gpt-4.1`, `gpt-4o`, …) carry no efforts (and correctly so — they're not reasoning models).

So `/effort` reported *"Active model does not expose reasoning effort controls"* for GPT-5. The command itself works fine (it shows Low/Medium/High for Claude/Gemini).

### Fix
Add a **name-based fallback** in `Registry.ReasoningEfforts`: when a model isn't enumerated with efforts, infer them for known reasoning families:
- **GPT-5 / `gpt-5.x` Codex** → `minimal / low / medium / high`
- **o-series (`o1`/`o3`/`o4`, `*codex*`)** → `low / medium / high`

Non-reasoning models (GPT-4.1/4o, local/Ollama, etc.) return nil, so `/effort` still correctly hides controls where they don't apply. This covers all the proxy-served `gpt-5.x` variants without enumerating each in the catalog.

## Test plan
- New unit test `TestReasoningEffortsFallbackForGPT5AndOSeries`: gpt-5 / gpt-5.5 / gpt-5.4-mini / gpt-5.3-codex-spark / o3-mini → efforts; gpt-4.1 / gpt-4o-mini / ollama model → none.
- `go build`, `go vet ./...`, `go test ./... -race` (72 pkg), lint — all green.
- Manual: with ChatGPT (GPT-5) active, `/effort` now lists minimal/low/medium/high.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reasoning-effort options are now shown more reliably for supported models, even when a model isn’t explicitly listed.
  * Model names with provider prefixes are handled correctly, improving behavior for GPT-5-, Codex-, and OpenAI o-series variants.
  * Non-reasoning models continue to show no effort options, avoiding incorrect settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->