### PR TITLE
feat(tui): compact one-line /model switch confirmation

### DIFF
--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -459,22 +459,27 @@ func (m model) handleModelCommand(args string) (model, string) {
 			effortLine = "effort: " + string(effective)
 		}
 	}
+	// Compact one-line summary — "<model> · <provider>[ · effort …][ · saved]" —
+	// instead of a multi-line model/provider/api/effort/saved block.
+	summary := target.modelID + " · " + displayValue(nextProfile.Name, string(metadata.ProviderKind))
+	effort := strings.TrimSpace(strings.TrimPrefix(effortLine, "effort: "))
+	if resetEffort {
+		summary += " · effort auto (reset)"
+	} else if effort != "" && effort != "auto" {
+		summary += " · effort " + effort
+	}
+	if persisted {
+		summary += " · saved"
+	} else if persistErr != nil {
+		// Keep the failure reason (e.g. an unwritable config path) so persistence
+		// problems stay debuggable from the status line.
+		summary += " · not saved (" + persistErr.Error() + ")"
+	}
 	lines := []string{"Model"}
 	if target.notice != "" {
 		lines = append(lines, target.notice)
 	}
-	lines = append(lines,
-		"Switched model.",
-		"model: "+target.modelID,
-		"provider: "+displayValue(nextProfile.Name, string(metadata.ProviderKind)),
-		"api model: "+metadata.APIModel,
-		effortLine,
-	)
-	if persisted {
-		lines = append(lines, "saved: user config")
-	} else if persistErr != nil {
-		lines = append(lines, "saved: no ("+persistErr.Error()+")")
-	}
+	lines = append(lines, summary)
 	return m, strings.Join(lines, "\n")
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -548,7 +548,7 @@ func TestModelCommandSwitchesSessionModel(t *testing.T) {
 	if rebuilt.Model != "gpt-4.1-mini" {
 		t.Fatalf("expected provider rebuild with selected model, got %#v", rebuilt)
 	}
-	for _, want := range []string{"Switched model", "model: gpt-4.1-mini", "api model: gpt-4.1-mini"} {
+	for _, want := range []string{"Model", "gpt-4.1-mini · openai"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected model transcript to contain %q, got %#v", want, next.transcript)
 		}
@@ -601,7 +601,7 @@ func TestModelCommandPersistsSelectedModelToUserConfig(t *testing.T) {
 	if got := persisted.Provider.Model; got != "gpt-4.1-mini" {
 		t.Fatalf("persisted provider model = %q, want gpt-4.1-mini", got)
 	}
-	if !transcriptContains(next.transcript, "saved: user config") {
+	if !transcriptContains(next.transcript, "· saved") {
 		t.Fatalf("expected model transcript to mention saved user config, got %#v", next.transcript)
 	}
 }

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -494,7 +494,7 @@ func TestModelPickerAppliesActiveProviderCatalogModelID(t *testing.T) {
 	if next.modelName != "openai/gpt-4.1" {
 		t.Fatalf("active model = %q, want raw OpenRouter model ID", next.modelName)
 	}
-	if !transcriptContains(next.transcript, "model: openai/gpt-4.1") {
+	if !transcriptContains(next.transcript, "openai/gpt-4.1 ·") {
 		t.Fatalf("expected model switch status, got %#v", next.transcript)
 	}
 }

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -870,7 +870,7 @@ func TestModelSwitchClearsUnsupportedEffortPreference(t *testing.T) {
 	if next.reasoningEffort != "" {
 		t.Fatalf("expected unsupported effort preference to reset, got %q", next.reasoningEffort)
 	}
-	if !transcriptContains(next.transcript, "effort: auto (unsupported preference reset)") {
+	if !transcriptContains(next.transcript, "effort auto (reset)") {
 		t.Fatalf("expected model switch transcript to mention effort reset, got %#v", next.transcript)
 	}
 }
@@ -903,7 +903,7 @@ func TestModelSwitchRedirectsDeprecatedModelWithNotice(t *testing.T) {
 	if !transcriptContains(next.transcript, "deprecated") {
 		t.Fatalf("expected deprecation notice in transcript, got %#v", next.transcript)
 	}
-	if !transcriptContains(next.transcript, "model: gpt-4.1") {
+	if !transcriptContains(next.transcript, "gpt-4.1 · openai") {
 		t.Fatalf("expected switch to canonical fallback id, got %#v", next.transcript)
 	}
 }


### PR DESCRIPTION
## Summary

The `/model` switch confirmation printed a 6–7 line block, which felt heavy for a routine action. This collapses it to a single summary line.

**Before**
```
Model
Switched model.
model: deepseek-v4-pro
provider: ollama-cloud
api model: deepseek-v4-pro
effort: auto
saved: user config
```

**After**
```
Model
deepseek-v4-pro · ollama-cloud · saved
```

## Details
- Format: `<model> · <provider>[ · effort <x>][ · saved]`.
- Effort is shown only when it isn't `auto` (or `effort auto (reset)` when an unsupported carry-over preference was dropped) — no noise otherwise.
- A deprecation/redirect notice (e.g. "gpt-4-turbo is deprecated; using gpt-4.1 instead") still renders as its own line when relevant.
- The cross-provider switch confirmation was already compact (`Switched to X · Y`) and is unchanged.

## Test plan
- Updated the five tests that asserted the old multi-line format.
- `go build`, `go vet ./...`, `go test ./... -race` (72 pkg), lint — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Simplified the model-switch confirmation into a cleaner one-line summary under the existing “Model” heading.
  * The message now concisely shows the selected model, provider, effort status (including “auto (reset)” when applicable), and whether the selection was saved.
  * Reduced extra detail from the previous multi-line confirmation while preserving any related notice.
* **Tests**
  * Updated transcript-based tests to match the new one-line model-switch wording and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->