### PR TITLE
feat: context-aware compaction + usage gauge for all models

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Gitlawb/zero/internal/lsp"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/notify"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -500,7 +502,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	defer lspShutdown()
 	result, err := agent.Run(runCtx, agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
-		ContextWindow:    modelregistry.AgentContextWindow(modelContextWindow(modelRegistry, resolved.Provider.Model)),
+		ContextWindow:    resolveAgentContextWindow(runCtx, modelRegistry, resolved.Provider),
 		DeferThreshold:   effectiveDeferThreshold,
 		Specialists:      specialistRuntime.specialistInfos(),
 		SessionID:        preparedSession.Session.SessionID,
@@ -1009,6 +1011,56 @@ func modelContextWindow(registry modelregistry.Registry, modelID string) int {
 	}
 	if entry, ok := registry.Resolve(trimmed); ok {
 		return entry.ContextLimits.ContextWindow
+	}
+	return 0
+}
+
+// resolveAgentContextWindow returns the context window used to enable/size agent
+// compaction: the exact registry value when catalogued, else a window learned from
+// live provider discovery (so an uncatalogued proxy/custom model gets its real
+// window instead of the generic fallback), else the positive FallbackContextWindow.
+// Discovery runs only on a registry miss (catalogued models pay no latency), is
+// bounded by a short timeout, and degrades to the fallback on any error — so a
+// headless run is never blocked or failed by it.
+func resolveAgentContextWindow(ctx context.Context, registry modelregistry.Registry, profile config.ProviderProfile) int {
+	if window := modelContextWindow(registry, profile.Model); window > 0 {
+		return window
+	}
+	if window := discoveredModelContextWindow(ctx, profile); window > 0 {
+		return window
+	}
+	return modelregistry.AgentContextWindow(0)
+}
+
+// discoveredModelContextWindow queries the provider's live model list for the
+// active model's context window. Returns 0 when the provider isn't catalogued, the
+// credential can't be resolved, discovery fails, or the model reports no window.
+func discoveredModelContextWindow(ctx context.Context, profile config.ProviderProfile) int {
+	descriptor, ok := providercatalog.Get(strings.TrimSpace(profile.CatalogID))
+	if !ok {
+		return 0
+	}
+	// Authenticate discovery with the resolved key (inline, then stored, then env).
+	authed := profile
+	if strings.TrimSpace(authed.APIKey) == "" {
+		if store, err := config.ProviderKeyStore(); err == nil {
+			authed = config.ApplyStoredAPIKey(authed, store)
+		}
+	}
+	if strings.TrimSpace(authed.APIKey) == "" && strings.TrimSpace(authed.APIKeyEnv) != "" {
+		authed.APIKey = strings.TrimSpace(os.Getenv(authed.APIKeyEnv))
+	}
+	dctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	models, err := providermodeldiscovery.DiscoverCatalog(dctx, descriptor, authed, providermodeldiscovery.Options{})
+	if err != nil {
+		return 0
+	}
+	target := strings.TrimSpace(profile.Model)
+	for _, model := range models {
+		if strings.EqualFold(strings.TrimSpace(model.ID), target) && model.ContextWindow > 0 {
+			return model.ContextWindow
+		}
 	}
 	return 0
 }

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -500,7 +500,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	defer lspShutdown()
 	result, err := agent.Run(runCtx, agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
-		ContextWindow:    modelContextWindow(modelRegistry, resolved.Provider.Model),
+		ContextWindow:    modelregistry.AgentContextWindow(modelContextWindow(modelRegistry, resolved.Provider.Model)),
 		DeferThreshold:   effectiveDeferThreshold,
 		Specialists:      specialistRuntime.specialistInfos(),
 		SessionID:        preparedSession.Session.SessionID,
@@ -998,20 +998,19 @@ func resolveSelectedModel(registry modelregistry.Registry, input string) (string
 	return entry.ID, notice
 }
 
-// modelContextWindow returns the resolved model's context window (max input
-// tokens) from the model registry, used to enable agent-loop compaction. An
-// unknown model (e.g. a custom openai-compatible name) returns 0, which leaves
-// compaction DISABLED — a safe default that never compacts unexpectedly.
+// modelContextWindow returns the resolved model's exact context window (max input
+// tokens) from the registry, or 0 when the model isn't catalogued. Compaction call
+// sites wrap this in modelregistry.AgentContextWindow to apply a positive fallback;
+// display/report sites use the raw value so an unknown model shows no denominator.
 func modelContextWindow(registry modelregistry.Registry, modelID string) int {
 	trimmed := strings.TrimSpace(modelID)
 	if trimmed == "" {
 		return 0
 	}
-	entry, ok := registry.Resolve(trimmed)
-	if !ok {
-		return 0
+	if entry, ok := registry.Resolve(trimmed); ok {
+		return entry.ContextLimits.ContextWindow
 	}
-	return entry.ContextLimits.ContextWindow
+	return 0
 }
 
 // reasoningEffortNotice resolves the requested --reasoning-effort against the

--- a/internal/cli/exec_spec.go
+++ b/internal/cli/exec_spec.go
@@ -98,7 +98,7 @@ func runExecSpecDraft(run execSpecDraftRun) int {
 	defer stopSignals()
 	result, err := agent.Run(runCtx, run.prompt, run.provider, agent.Options{
 		MaxTurns:        run.resolved.MaxTurns,
-		ContextWindow:   modelregistry.AgentContextWindow(modelContextWindow(run.modelRegistry, run.resolved.Provider.Model)),
+		ContextWindow:   resolveAgentContextWindow(runCtx, run.modelRegistry, run.resolved.Provider),
 		SessionID:       draftSession.SessionID,
 		SessionTitle:    run.sessionTitle,
 		ProviderName:    run.resolved.Provider.Name,

--- a/internal/cli/exec_spec.go
+++ b/internal/cli/exec_spec.go
@@ -98,7 +98,7 @@ func runExecSpecDraft(run execSpecDraftRun) int {
 	defer stopSignals()
 	result, err := agent.Run(runCtx, run.prompt, run.provider, agent.Options{
 		MaxTurns:        run.resolved.MaxTurns,
-		ContextWindow:   modelContextWindow(run.modelRegistry, run.resolved.Provider.Model),
+		ContextWindow:   modelregistry.AgentContextWindow(modelContextWindow(run.modelRegistry, run.resolved.Provider.Model)),
 		SessionID:       draftSession.SessionID,
 		SessionTitle:    run.sessionTitle,
 		ProviderName:    run.resolved.Provider.Name,

--- a/internal/modelregistry/catalog.go
+++ b/internal/modelregistry/catalog.go
@@ -4,6 +4,27 @@ import "fmt"
 
 const DefaultModelID = "gpt-4.1"
 
+// FallbackContextWindow is the assumed context window (max input tokens) for a
+// model that isn't in the curated registry and wasn't resolved from live provider
+// discovery — e.g. proxy/custom models like the GPT-5 Codex, xAI, or Ollama-cloud
+// variants. A positive value here is what enables agent-loop compaction (both the
+// proactive ~80% trigger and the reactive post-overflow recovery) for those models;
+// without it compaction stays disabled and long sessions overflow. It is only a
+// backstop: an exact window from the registry or live discovery always wins.
+const FallbackContextWindow = 200_000
+
+// AgentContextWindow turns a resolved context window into the value used to enable
+// agent-loop compaction: the resolved window when known, else FallbackContextWindow
+// so compaction is enabled even for uncatalogued models. Kept separate from the
+// raw resolver so display gauges still show nothing (not a guessed denominator)
+// when the real window is unknown.
+func AgentContextWindow(resolved int) int {
+	if resolved <= 0 {
+		return FallbackContextWindow
+	}
+	return resolved
+}
+
 const sourceLastVerified = "2026-06-04"
 
 const (

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -427,7 +427,7 @@ func (m model) handleModelCommand(args string) (model, string) {
 	if guarded, text, requested := m.requestCompactionBeforeModelSwitch(modelSwitchCompactionRequest{
 		TargetModel:         target.modelID,
 		TargetProvider:      string(metadata.ProviderKind),
-		TargetContextWindow: modelContextWindow(target.modelID),
+		TargetContextWindow: m.modelContextWindow(target.modelID),
 	}, "Model"); requested {
 		return guarded, text
 	}
@@ -655,7 +655,7 @@ func (m model) handleModeCommand(args string) (model, string) {
 	if guarded, text, requested := m.requestCompactionBeforeModelSwitch(modelSwitchCompactionRequest{
 		TargetModel:         entry.ID,
 		TargetProvider:      string(metadata.ProviderKind),
-		TargetContextWindow: modelContextWindow(entry.ID),
+		TargetContextWindow: m.modelContextWindow(entry.ID),
 	}, "Mode"); requested {
 		return guarded, text
 	}
@@ -710,7 +710,7 @@ func (m model) requestCompactionBeforeModelSwitch(request modelSwitchCompactionR
 	}
 	request.CurrentModel = m.modelName
 	request.CurrentProvider = m.providerName
-	request.CurrentContextWindow = modelContextWindow(m.modelName)
+	request.CurrentContextWindow = m.modelContextWindow(m.modelName)
 	request.EstimatedTokens = estimateTranscriptTokens(m.transcript)
 	request.SessionEventCount = len(m.sessionEvents)
 	request.CompactRequests = m.compactRequests

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -427,7 +427,7 @@ func (m model) handleModelCommand(args string) (model, string) {
 	if guarded, text, requested := m.requestCompactionBeforeModelSwitch(modelSwitchCompactionRequest{
 		TargetModel:         target.modelID,
 		TargetProvider:      string(metadata.ProviderKind),
-		TargetContextWindow: m.modelContextWindow(target.modelID),
+		TargetContextWindow: modelregistry.AgentContextWindow(m.modelContextWindow(target.modelID)),
 	}, "Model"); requested {
 		return guarded, text
 	}
@@ -655,7 +655,7 @@ func (m model) handleModeCommand(args string) (model, string) {
 	if guarded, text, requested := m.requestCompactionBeforeModelSwitch(modelSwitchCompactionRequest{
 		TargetModel:         entry.ID,
 		TargetProvider:      string(metadata.ProviderKind),
-		TargetContextWindow: m.modelContextWindow(entry.ID),
+		TargetContextWindow: modelregistry.AgentContextWindow(m.modelContextWindow(entry.ID)),
 	}, "Mode"); requested {
 		return guarded, text
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -727,6 +727,16 @@ func (m model) Init() tea.Cmd {
 	if m.themeMode == themeAuto {
 		cmds = append(cmds, tea.RequestBackgroundColor)
 	}
+	// Warm model discovery for the active provider in the background so the
+	// context-usage gauge (used / total tokens + % fill) knows the active model's
+	// window from launch — including proxy/custom models not in the curated
+	// registry. Async: never blocks startup; if discovery is unavailable the gauge
+	// just shows the used-token count until the window is otherwise learned.
+	if descriptor, ok := m.activeProviderDescriptor(); ok {
+		if cmd := m.modelPickerProviderDiscoveryCmd(descriptor, m.providerProfile); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
 	if m.prService != nil && m.runtimeMessageSink != nil {
 		service := m.prService
 		sink := m.runtimeMessageSink

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3778,9 +3778,11 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 		if m.captureRunImages != nil {
 			m.captureRunImages(images)
 		}
-		// Enable agent-loop compaction sized to the active model's context
-		// window. An unknown/custom model resolves to 0, leaving compaction off.
-		options.ContextWindow = modelContextWindow(m.modelName)
+		// Enable agent-loop compaction sized to the active model's context window.
+		// AgentContextWindow applies a positive fallback for unknown/custom models so
+		// compaction (proactive + reactive) is enabled for every model, not just
+		// catalogued ones.
+		options.ContextWindow = modelregistry.AgentContextWindow(m.modelContextWindow(m.modelName))
 
 		// Post-edit self-correction is on by default in the TUI but kept FAST: it
 		// runs LSP diagnostics over the changed files only — cheap, change-scoped,

--- a/internal/tui/model_catalog.go
+++ b/internal/tui/model_catalog.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 )
 
 func (m model) modelListText() string {
@@ -70,16 +71,32 @@ func (m model) modelContextWindow(modelName string) int {
 			return entry.ContextLimits.ContextWindow
 		}
 	}
-	// Live-discovered window for any provider that has surfaced this model.
+	// Live-discovered window, preferring the ACTIVE provider's models so a model ID
+	// shared across providers resolves to the provider actually in use; only then
+	// fall back to other providers that surfaced the same ID.
+	if descriptor, ok := m.activeProviderDescriptor(); ok {
+		if window := discoveredContextWindow(m.modelPickerLiveByProvider[descriptor.ID], trimmed); window > 0 {
+			return window
+		}
+	}
 	for _, models := range m.modelPickerLiveByProvider {
-		for _, dm := range models {
-			if strings.EqualFold(strings.TrimSpace(dm.ID), trimmed) && dm.ContextWindow > 0 {
-				return dm.ContextWindow
-			}
+		if window := discoveredContextWindow(models, trimmed); window > 0 {
+			return window
 		}
 	}
 	// Unknown: report 0 so display gauges show no denominator. Compaction enablement
 	// applies its own positive fallback via modelregistry.AgentContextWindow.
+	return 0
+}
+
+// discoveredContextWindow returns the context window of the model whose ID matches
+// name in a provider's live-discovered model list, or 0 when absent.
+func discoveredContextWindow(models []providermodeldiscovery.Model, name string) int {
+	for _, dm := range models {
+		if strings.EqualFold(strings.TrimSpace(dm.ID), name) && dm.ContextWindow > 0 {
+			return dm.ContextWindow
+		}
+	}
 	return 0
 }
 

--- a/internal/tui/model_catalog.go
+++ b/internal/tui/model_catalog.go
@@ -54,20 +54,33 @@ func (m model) modelListText() string {
 // modelContextWindow resolves the active model's context window (max input
 // tokens) from the model registry to size agent-loop compaction. An unknown or
 // custom model resolves to 0, leaving compaction DISABLED as a safe default.
-func modelContextWindow(modelName string) int {
+// modelContextWindow resolves a model's exact context window (max input tokens) for
+// the context gauges: the curated registry value, else a value learned from live
+// provider discovery (so proxy/custom models like GPT-5 Codex, xAI, or Ollama-cloud
+// get an accurate window once /model has discovered them), else 0 (unknown). The
+// agent-run compaction path wraps this in modelregistry.AgentContextWindow to apply
+// a positive fallback so compaction is enabled even for unknown models.
+func (m model) modelContextWindow(modelName string) int {
 	trimmed := strings.TrimSpace(modelName)
 	if trimmed == "" {
 		return 0
 	}
-	registry, err := modelregistry.DefaultRegistry()
-	if err != nil {
-		return 0
+	if registry, err := modelregistry.DefaultRegistry(); err == nil {
+		if entry, ok := registry.Resolve(trimmed); ok && entry.ContextLimits.ContextWindow > 0 {
+			return entry.ContextLimits.ContextWindow
+		}
 	}
-	entry, ok := registry.Resolve(trimmed)
-	if !ok {
-		return 0
+	// Live-discovered window for any provider that has surfaced this model.
+	for _, models := range m.modelPickerLiveByProvider {
+		for _, dm := range models {
+			if strings.EqualFold(strings.TrimSpace(dm.ID), trimmed) && dm.ContextWindow > 0 {
+				return dm.ContextWindow
+			}
+		}
 	}
-	return entry.ContextLimits.ContextWindow
+	// Unknown: report 0 so display gauges show no denominator. Compaction enablement
+	// applies its own positive fallback via modelregistry.AgentContextWindow.
+	return 0
 }
 
 func activeModelID(registry modelregistry.Registry, modelName string) string {

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -841,3 +841,30 @@ func TestEffortPickerAutoSelectionKeepsEffortUnset(t *testing.T) {
 		t.Fatalf("auto selection should clear reasoning effort, got %q", m.reasoningEffort)
 	}
 }
+
+func TestModelContextWindowResolution(t *testing.T) {
+	m := model{}
+	// Registered model → exact registry window.
+	if got := m.modelContextWindow("gpt-4.1"); got <= 0 || got == modelregistry.FallbackContextWindow {
+		t.Fatalf("registered model should resolve an exact window, got %d", got)
+	}
+	// Unknown model → 0 (display shows no denominator); compaction applies its own
+	// fallback via AgentContextWindow.
+	if got := m.modelContextWindow("totally-unknown-proxy-model"); got != 0 {
+		t.Fatalf("unknown model should resolve 0 for display, got %d", got)
+	}
+	if got := modelregistry.AgentContextWindow(m.modelContextWindow("totally-unknown-proxy-model")); got != modelregistry.FallbackContextWindow {
+		t.Fatalf("compaction window for unknown model should be %d, got %d", modelregistry.FallbackContextWindow, got)
+	}
+	// Live-discovered window wins for an unregistered model.
+	m.modelPickerLiveByProvider = map[string][]providermodeldiscovery.Model{
+		"xai": {{ID: "grok-4", ContextWindow: 256000}},
+	}
+	if got := m.modelContextWindow("grok-4"); got != 256000 {
+		t.Fatalf("discovered window should win for unregistered model, got %d", got)
+	}
+	// Empty name → 0 (no window).
+	if got := m.modelContextWindow(""); got != 0 {
+		t.Fatalf("empty model name should yield 0, got %d", got)
+	}
+}

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -844,9 +844,18 @@ func TestEffortPickerAutoSelectionKeepsEffortUnset(t *testing.T) {
 
 func TestModelContextWindowResolution(t *testing.T) {
 	m := model{}
-	// Registered model → exact registry window.
-	if got := m.modelContextWindow("gpt-4.1"); got <= 0 || got == modelregistry.FallbackContextWindow {
-		t.Fatalf("registered model should resolve an exact window, got %d", got)
+	// Registered model → the exact registry window (compare to the registry value so
+	// this doesn't break on a benign catalog update).
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("load default registry: %v", err)
+	}
+	entry, ok := registry.Resolve("gpt-4.1")
+	if !ok || entry.ContextLimits.ContextWindow <= 0 {
+		t.Fatalf("gpt-4.1 should resolve a positive window in the registry")
+	}
+	if got := m.modelContextWindow("gpt-4.1"); got != entry.ContextLimits.ContextWindow {
+		t.Fatalf("registered model window = %d, want %d", got, entry.ContextLimits.ContextWindow)
 	}
 	// Unknown model → 0 (display shows no denominator); compaction applies its own
 	// fallback via AgentContextWindow.

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -519,7 +519,7 @@ func (m model) compactRequest() CompactRequest {
 	return CompactRequest{
 		SessionID:             strings.TrimSpace(m.activeSession.SessionID),
 		ModelName:             strings.TrimSpace(m.modelName),
-		ContextWindow:         modelContextWindow(m.modelName),
+		ContextWindow:         m.modelContextWindow(m.modelName),
 		SessionEventCount:     len(m.sessionEvents),
 		EstimatedTokens:       estimateTranscriptTokens(m.transcript),
 		VisibleTranscriptRows: len(m.transcript),

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -263,8 +263,8 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 	if request.ModelName != "gpt-4.1" {
 		t.Fatalf("expected request model gpt-4.1, got %q", request.ModelName)
 	}
-	if request.ContextWindow != modelContextWindow("gpt-4.1") {
-		t.Fatalf("expected request context window %d, got %d", modelContextWindow("gpt-4.1"), request.ContextWindow)
+	if request.ContextWindow != next.modelContextWindow("gpt-4.1") {
+		t.Fatalf("expected request context window %d, got %d", next.modelContextWindow("gpt-4.1"), request.ContextWindow)
 	}
 	if request.EstimatedTokens <= 0 || request.VisibleTranscriptRows != len(m.transcript) {
 		t.Fatalf("expected request estimate and transcript count, got %#v", request)

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -837,7 +837,7 @@ func (m model) sidebarTokenText() string {
 	if used <= 0 {
 		return ""
 	}
-	if window := modelContextWindow(m.modelName); window > 0 {
+	if window := m.modelContextWindow(m.modelName); window > 0 {
 		return fmt.Sprintf("%s / %s tokens", humanCount(used), humanCount(window))
 	}
 	return humanCount(used) + " tokens"

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -67,7 +67,7 @@ func (m model) titleBar(width int) string {
 	}
 	model := m.titleModelSegment()
 	ctx := ""
-	if window := modelContextWindow(m.modelName); window > 0 {
+	if window := m.modelContextWindow(m.modelName); window > 0 {
 		ctx = zeroTheme.faint.Render(" · " + formatContextWindow(window))
 	}
 
@@ -348,7 +348,7 @@ func (m model) contextFillPercent() (pct, used, window int, style lipgloss.Style
 	}
 	summary := m.usageTracker.Summary()
 	used = m.latestUsageTokens(summary)
-	window = modelContextWindow(m.modelName)
+	window = m.modelContextWindow(m.modelName)
 	if used <= 0 || window <= 0 {
 		return 0, 0, 0, lipgloss.Style{}, false
 	}


### PR DESCRIPTION
## Summary

Makes ZERO's context-window awareness work for **every** model, not just the ones in the curated registry. Two related fixes:

### 1. Auto-compaction for all models
Auto-compaction is gated on the model's context window (`enabled = ContextWindow > 0`), which was resolved **only from the registry**. Unregistered models — GPT-5/Codex, xAI, Ollama-cloud, custom endpoints — resolved to `0`, so **both** the proactive (~80%) and the reactive post-overflow compaction were silently disabled and long sessions just overflowed.

- Context-window resolution now also consults **live-discovered** windows (accurate for proxy/custom models once discovery has run).
- New `modelregistry.AgentContextWindow` applies a positive `FallbackContextWindow` (200k) **only on the compaction-enable path** (TUI run + CLI `exec`/spec), so compaction is on for every model while **display gauges stay accurate-or-empty** (no guessed denominator). Exact windows (registry/discovered) always win.

### 2. Context-usage gauge for all models, from launch
The sidebar/status-line gauge (`used / total tokens` + a % fill) only rendered a total when the window was known. It now **warms model discovery for the active provider in `Init()`** (background, non-blocking), so the active model's window is learned at startup and the gauge shows `used / total` + fill % for every model — proxy/custom included. If a provider doesn't report a window, that model still shows just the used-token count (never a fake total).

## Test plan
- New unit tests: context-window resolution (registry / live-discovered / unknown→0) and `AgentContextWindow` fallback.
- `go build`, `go vet ./...`, `go test ./... -race` (72 pkg), lint — all green.
- Manual: on ollama-cloud / Grok / GPT-5, long sessions now compact instead of overflowing, and the sidebar shows `used / total` + % shortly after launch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved model context-window sizing, including live-discovered provider models.
  * Added a positive fallback so compaction can stay enabled for unknown/custom models.
  * Start a background warm-up to discover active provider models.
* **Bug Fixes**
  * Corrected and unified context-window calculations across the UI (sidebar token, title bar, status line) and for compaction requests and exec runs.
* **Tests**
  * Added coverage for context-window resolution (registered, unknown, empty, live-discovered).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->