### PR TITLE
feat(tui): dim transcript backdrop behind overlays for visibility

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2261,6 +2261,12 @@ func overlayViewportLines(lines []string, overlay string, width int) []string {
 	if overlayWidth <= 0 {
 		return lines
 	}
+	// Scrim: dim the whole transcript backdrop so a floating overlay (slash-command
+	// palette, picker, wizard) clearly stands out instead of blending into the live
+	// chat behind it. Header and composer are rendered separately and stay bright.
+	for index := range lines {
+		lines[index] = scrimViewportLine(lines[index], width)
+	}
 	start := maxInt(0, (len(lines)-len(overlayLines))/2)
 	for offset, line := range overlayLines {
 		target := start + offset
@@ -2270,6 +2276,17 @@ func overlayViewportLines(lines []string, overlay string, width int) []string {
 		lines[target] = overlayViewportLine(lines[target], line, left, overlayWidth, width)
 	}
 	return lines
+}
+
+// scrimViewportLine dims one backdrop line: it strips the line's own colors and
+// re-renders the text faint, so the dimmed transcript recedes behind the overlay.
+// Blank lines are left untouched.
+func scrimViewportLine(line string, width int) string {
+	plain := ansi.Strip(line)
+	if strings.TrimSpace(plain) == "" {
+		return line
+	}
+	return zeroTheme.faint.Render(plain)
 }
 
 func normalizeOverlayBlock(lines []string, width int) (int, []string, int) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -13,6 +13,7 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
@@ -2314,5 +2315,62 @@ func TestModelNotifierFocusAndCompletion(t *testing.T) {
 	m.notifier.Notify(notify.Completion, "x")
 	if buf.Len() != 0 {
 		t.Fatalf("refocused should be silent, got %q", buf.String())
+	}
+}
+
+func TestScrimViewportLine(t *testing.T) {
+	// Blank lines are left untouched (no scrim).
+	if got := scrimViewportLine("   ", 10); got != "   " {
+		t.Fatalf("blank line should be untouched, got %q", got)
+	}
+	// Non-blank lines keep their text (only the styling is dimmed), so the backdrop
+	// stays readable behind the overlay.
+	got := scrimViewportLine("transcript content", 40)
+	if ansi.Strip(got) != "transcript content" {
+		t.Fatalf("scrim must preserve text, got %q", ansi.Strip(got))
+	}
+	// A pre-styled line must have its OWN styling stripped (so the dim wins), while
+	// the text content survives. This fails if scrim stops re-styling the backdrop.
+	styled := "\x1b[31mred backdrop\x1b[0m text"
+	scrimmed := scrimViewportLine(styled, 40)
+	if ansi.Strip(scrimmed) != "red backdrop text" {
+		t.Fatalf("scrim must preserve styled line's text, got %q", ansi.Strip(scrimmed))
+	}
+	if strings.Contains(scrimmed, "\x1b[31m") {
+		t.Fatalf("scrim must strip the line's original styling, got %q", scrimmed)
+	}
+}
+
+func TestOverlayViewportLinesCompositesAndPreservesBackdropText(t *testing.T) {
+	width := 40
+	lines := make([]string, 9)
+	for i := range lines {
+		lines[i] = "backdrop transcript row"
+	}
+	// Narrow, indented overlay so the composited rows keep backdrop in the margins.
+	overlay := "          ╭────╮\n          │ pn │\n          ╰────╯"
+	out := overlayViewportLines(append([]string{}, lines...), overlay, width)
+	joined := ansi.Strip(strings.Join(out, "\n"))
+	if !strings.Contains(joined, "pn") {
+		t.Fatalf("overlay panel should be composited, got:\n%s", joined)
+	}
+	// A non-overlaid row keeps its (dimmed) backdrop text.
+	if !strings.Contains(ansi.Strip(out[0]), "backdrop transcript row") {
+		t.Fatalf("non-overlaid backdrop should survive the scrim, got %q", ansi.Strip(out[0]))
+	}
+	// The compositing contract: the row carrying the panel must ALSO keep backdrop
+	// text outside the panel (left/right margins), not blank it out.
+	var panelRow string
+	for _, line := range out {
+		if strings.Contains(ansi.Strip(line), "pn") {
+			panelRow = ansi.Strip(line)
+			break
+		}
+	}
+	if panelRow == "" {
+		t.Fatal("expected a row containing the panel")
+	}
+	if !strings.Contains(panelRow, "backdrop") {
+		t.Fatalf("overlaid row should keep backdrop margin text alongside the panel, got %q", panelRow)
 	}
 }


### PR DESCRIPTION
## Summary

Slash-command/`@file` palettes (and the model/provider pickers and wizards) were composited directly over the live transcript with no visual separation, so the chat bled through around the box and the overlay was hard to read.

This adds a **modal scrim**: when an overlay is open, the transcript backdrop is dimmed (each line's colors are stripped and re-rendered faint) before the bright bordered overlay is drawn on top. The header/title bar and composer render separately and stay bright, so only the chat behind the palette recedes. Backdrop text is preserved (just dimmed), so context stays faintly readable.

Net effect: the palette clearly stands out as a floating card instead of blending into the chat.

## Scope
- `internal/tui/model.go` (+17): dim the backdrop in `overlayViewportLines` via a `scrimViewportLine` helper.
- `internal/tui/model_test.go` (+31): tests that the scrim preserves text + skips blank lines, and that the overlay still composites over a preserved backdrop.

## Test plan
- `go build`, `go vet ./...`, `go test ./... -race` (72 pkg), lint — all green.
- Manual: open `/` (command palette) or `@` (file palette) over a busy transcript — the chat behind dims and the palette is clearly legible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overlay views now dim the background transcript when menus, pickers, or wizards are open, making the active overlay stand out more clearly.
  * Existing text behind overlays is preserved and shown faintly instead of being visually disrupted.
  * Blank lines remain unchanged, keeping spacing intact in the transcript display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->