### PR TITLE
Polish TUI transcript rendering

### DIFF
--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -137,18 +139,22 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 
 		if allowHighlight && looksLikeBareCodeLine(line) {
 			code := []string{}
-			for index < len(raw) {
-				next := raw[index]
+			probe := index
+			for probe < len(raw) {
+				next := raw[probe]
 				nextTrimmed := strings.TrimSpace(next)
-				if nextTrimmed == "" || markdownStartsBlock(raw, index) || !looksLikeBareCodeLine(next) {
+				if nextTrimmed == "" || markdownStartsBlock(raw, probe) || !looksLikeBareCodeLine(next) {
 					break
 				}
 				code = append(code, strings.ReplaceAll(next, "\t", "    "))
-				index++
+				probe++
 			}
-			if highlighted, ok := highlightCodeAuto(code, "", tableMeasure); ok {
-				lines = append(lines, highlighted...)
-				continue
+			if looksLikeBareCodeBlock(code) {
+				if highlighted, ok := highlightCodeAuto(code, "", tableMeasure); ok {
+					lines = append(lines, highlighted...)
+					index = probe
+					continue
+				}
 			}
 		}
 
@@ -171,7 +177,20 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 }
 
 func renderStreamingAssistantMarkdownText(text string, proseMeasure int, tableMeasure int) []string {
-	return renderAssistantMarkdownText(streamingMarkdownStablePrefix(text), proseMeasure, tableMeasure, true)
+	stablePrefix := streamingMarkdownStablePrefix(text)
+	if defaultRenderCache == nil {
+		return renderAssistantMarkdownText(stablePrefix, proseMeasure, tableMeasure, true)
+	}
+	key := streamingMarkdownRenderCacheKey(stablePrefix, proseMeasure, tableMeasure)
+	rendered := defaultRenderCache.render(key, true, func() string {
+		return strings.Join(renderAssistantMarkdownText(stablePrefix, proseMeasure, tableMeasure, true), "\n")
+	})
+	return viewLines(rendered)
+}
+
+func streamingMarkdownRenderCacheKey(text string, proseMeasure int, tableMeasure int) string {
+	sum := sha256.Sum256([]byte(text))
+	return fmt.Sprintf("stream-md-v1:%d:%d:%x", proseMeasure, tableMeasure, sum)
 }
 
 func streamingMarkdownStablePrefix(text string) string {
@@ -419,16 +438,54 @@ func looksLikeBareCodeLine(line string) bool {
 func looksLikeBareCodeBlock(lines []string) bool {
 	nonBlank := 0
 	codeLike := 0
+	strongSignals := 0
 	for _, line := range lines {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
 		nonBlank++
-		if looksLikeBareCodeLine(line) || isIndentedCodeContinuation(line) {
+		if isIndentedCodeContinuation(line) {
 			codeLike++
+			strongSignals++
+			continue
+		}
+		if looksLikeBareCodeLine(line) {
+			codeLike++
+			if looksLikeStrongBareCodeLine(line) {
+				strongSignals++
+			}
 		}
 	}
-	return nonBlank >= 2 && codeLike == nonBlank
+	return nonBlank >= 2 && codeLike == nonBlank && strongSignals > 0
+}
+
+func looksLikeStrongBareCodeLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	switch {
+	case strings.HasPrefix(trimmed, "from ") && strings.Contains(trimmed, " import "):
+		return true
+	case strings.HasPrefix(trimmed, "import ") && !strings.Contains(trimmed, " from "):
+		return true
+	case strings.HasPrefix(trimmed, "def ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "class ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "print("):
+		return true
+	case isSimpleFunctionCall(trimmed):
+		return true
+	case strings.HasPrefix(trimmed, "package "):
+		return true
+	case strings.HasPrefix(trimmed, "func ") && strings.Contains(trimmed, "{"):
+		return true
+	case strings.HasPrefix(trimmed, "const "), strings.HasPrefix(trimmed, "let "), strings.HasPrefix(trimmed, "var "):
+		return true
+	case strings.HasPrefix(trimmed, "function ") && strings.Contains(trimmed, "{"):
+		return true
+	case strings.HasPrefix(trimmed, "<!DOCTYPE "), strings.HasPrefix(trimmed, "<html"), strings.HasPrefix(trimmed, "<div"), strings.HasPrefix(trimmed, "<span"):
+		return true
+	}
+	return false
 }
 
 func isIndentedCodeContinuation(line string) bool {

--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -44,6 +44,11 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 	if len(raw) == 0 {
 		return []string{""}
 	}
+	if allowHighlight && looksLikeBareCodeBlock(raw) {
+		if highlighted, ok := highlightCodeAuto(raw, "", tableMeasure); ok {
+			return trimMarkdownDisplayBlankEdges(highlighted)
+		}
+	}
 
 	lines := []string{}
 	// blankBefore inserts one separator blank line before a block (heading or
@@ -82,11 +87,8 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 				code = append(code, strings.ReplaceAll(raw[index], "\t", "    "))
 				index++
 			}
-			// Highlighting tokenises the whole block, so it is confined to
-			// committed/cached rows (allowHighlight); the live streaming block
-			// renders plain so the per-frame render loop never re-lexes.
 			if allowHighlight {
-				if highlighted, ok := highlightCode(code, lang, tableMeasure); ok {
+				if highlighted, ok := highlightCodeAuto(code, lang, tableMeasure); ok {
 					lines = append(lines, highlighted...)
 					continue
 				}
@@ -104,6 +106,13 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 				index++
 			}
 			lines = append(lines, renderMarkdownTable(tableRows, alignments, tableMeasure)...)
+			continue
+		}
+
+		if isMarkdownHorizontalRule(trimmed) {
+			blankBefore()
+			lines = append(lines, renderMarkdownHorizontalRule(proseMeasure))
+			index++
 			continue
 		}
 
@@ -126,6 +135,23 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 			continue
 		}
 
+		if allowHighlight && looksLikeBareCodeLine(line) {
+			code := []string{}
+			for index < len(raw) {
+				next := raw[index]
+				nextTrimmed := strings.TrimSpace(next)
+				if nextTrimmed == "" || markdownStartsBlock(raw, index) || !looksLikeBareCodeLine(next) {
+					break
+				}
+				code = append(code, strings.ReplaceAll(next, "\t", "    "))
+				index++
+			}
+			if highlighted, ok := highlightCodeAuto(code, "", tableMeasure); ok {
+				lines = append(lines, highlighted...)
+				continue
+			}
+		}
+
 		blankBefore()
 		paragraph := []string{strings.TrimSpace(line)}
 		index++
@@ -144,6 +170,45 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 	return trimMarkdownDisplayBlankEdges(lines)
 }
 
+func renderStreamingAssistantMarkdownText(text string, proseMeasure int, tableMeasure int) []string {
+	return renderAssistantMarkdownText(streamingMarkdownStablePrefix(text), proseMeasure, tableMeasure, true)
+}
+
+func streamingMarkdownStablePrefix(text string) string {
+	text = strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", "\n"), "\r", "\n")
+	offset := 0
+	openFenceStart := -1
+	openFence := ""
+	for offset <= len(text) {
+		lineStart := offset
+		next := strings.IndexByte(text[offset:], '\n')
+		line := ""
+		if next < 0 {
+			line = text[offset:]
+			offset = len(text) + 1
+		} else {
+			line = text[offset : offset+next]
+			offset += next + 1
+		}
+		if fence, ok := markdownFenceMarker(strings.TrimSpace(line)); ok {
+			if openFence == "" {
+				openFence = fence
+				openFenceStart = lineStart
+			} else if fence == openFence {
+				openFence = ""
+				openFenceStart = -1
+			}
+		}
+		if next < 0 {
+			break
+		}
+	}
+	if openFenceStart >= 0 {
+		return strings.TrimRight(text[:openFenceStart], "\n")
+	}
+	return text
+}
+
 func renderAssistantMarkdownPlainText(text string, proseMeasure int, tableMeasure int) []string {
 	lines := renderAssistantMarkdownText(text, proseMeasure, tableMeasure, false)
 	for index := range lines {
@@ -158,6 +223,10 @@ func stripMarkdownRenderControls(text string) string {
 }
 
 func styleAssistantMarkdownLine(line string, base lipgloss.Style) string {
+	if hasExternalANSIStyle(line) {
+		return line
+	}
+
 	var builder strings.Builder
 	style := markdownDisplayNormal
 	var run strings.Builder
@@ -222,6 +291,26 @@ func styleAssistantMarkdownLine(line string, base lipgloss.Style) string {
 	return builder.String()
 }
 
+func hasExternalANSIStyle(line string) bool {
+	for index := 0; index < len(line); {
+		if line[index] != '\x1b' {
+			index++
+			continue
+		}
+		end := ansiSequenceEnd(line, index)
+		if end <= index {
+			index++
+			continue
+		}
+		seq := line[index:end]
+		if seq != markdownBoldStart && seq != markdownBoldEnd {
+			return true
+		}
+		index = end
+	}
+	return false
+}
+
 func markdownDisplayStyleForRune(r rune, current markdownDisplayStyle) markdownDisplayStyle {
 	switch r {
 	case '│', '─', '┼', '╭', '╮', '╰', '╯', '├', '┤', '┬', '┴':
@@ -245,10 +334,126 @@ func markdownStartsBlock(lines []string, index int) bool {
 	if _, ok := markdownFenceMarker(trimmed); ok {
 		return true
 	}
-	if markdownHeadingText(trimmed) != "" || isMarkdownListLine(trimmed) || strings.HasPrefix(trimmed, ">") {
+	if markdownHeadingText(trimmed) != "" || isMarkdownHorizontalRule(trimmed) || isMarkdownListLine(trimmed) || strings.HasPrefix(trimmed, ">") {
 		return true
 	}
 	return index+1 < len(lines) && isMarkdownTableHeader(lines[index], lines[index+1])
+}
+
+func isMarkdownHorizontalRule(trimmed string) bool {
+	if trimmed == "" {
+		return false
+	}
+	marker := rune(0)
+	count := 0
+	for _, r := range trimmed {
+		if r == ' ' || r == '\t' {
+			continue
+		}
+		if r != '-' && r != '_' && r != '*' {
+			return false
+		}
+		if marker == 0 {
+			marker = r
+		} else if marker != r {
+			return false
+		}
+		count++
+	}
+	return count >= 3
+}
+
+func renderMarkdownHorizontalRule(measure int) string {
+	width := clampInt(measure, 16, 96)
+	return strings.Repeat("─", width)
+}
+
+func looksLikeBareCodeLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(trimmed, "from ") && strings.Contains(trimmed, " import "):
+		return true
+	case strings.HasPrefix(trimmed, "import ") && !strings.Contains(trimmed, " from "):
+		return true
+	case strings.HasPrefix(trimmed, "def ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "class ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "if ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "elif ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case trimmed == "else:" || trimmed == "try:" || trimmed == "finally:":
+		return true
+	case strings.HasPrefix(trimmed, "for ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "while ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "with ") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "except") && strings.HasSuffix(trimmed, ":"):
+		return true
+	case strings.HasPrefix(trimmed, "return "):
+		return true
+	case strings.HasPrefix(trimmed, "print("):
+		return true
+	case isSimpleFunctionCall(trimmed):
+		return true
+	case strings.HasPrefix(trimmed, "package "):
+		return true
+	case strings.HasPrefix(trimmed, "func ") && strings.Contains(trimmed, "{"):
+		return true
+	case strings.HasPrefix(trimmed, "const "), strings.HasPrefix(trimmed, "let "), strings.HasPrefix(trimmed, "var "):
+		return true
+	case strings.HasPrefix(trimmed, "function ") && strings.Contains(trimmed, "{"):
+		return true
+	case strings.HasPrefix(trimmed, "<!DOCTYPE "), strings.HasPrefix(trimmed, "<html"), strings.HasPrefix(trimmed, "<div"), strings.HasPrefix(trimmed, "<span"):
+		return true
+	}
+	return false
+}
+
+func looksLikeBareCodeBlock(lines []string) bool {
+	nonBlank := 0
+	codeLike := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		nonBlank++
+		if looksLikeBareCodeLine(line) || isIndentedCodeContinuation(line) {
+			codeLike++
+		}
+	}
+	return nonBlank >= 2 && codeLike == nonBlank
+}
+
+func isIndentedCodeContinuation(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return trimmed != "" && (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t"))
+}
+
+func isSimpleFunctionCall(trimmed string) bool {
+	open := strings.Index(trimmed, "(")
+	return open > 0 &&
+		strings.HasSuffix(trimmed, ")") &&
+		isIdentifierText(trimmed[:open])
+}
+
+func isIdentifierText(text string) bool {
+	if text == "" {
+		return false
+	}
+	for index, r := range text {
+		if r == '_' || unicode.IsLetter(r) || (index > 0 && unicode.IsDigit(r)) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func markdownFenceMarker(trimmed string) (string, bool) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2453,17 +2453,13 @@ func (m model) interimBlock(width int) string {
 		}
 		return strings.Join(blocks, "\n")
 	}
-	// Live streaming block: render plain (no chroma) so the per-frame render loop
-	// never re-tokenises the growing code block. Highlighting happens once the row
-	// commits (renderAssistantRow, cached).
-	lines := renderAssistantMarkdownText(text, assistantMeasure(width), width, false)
+	// Live streaming block: prose streams normally, but an open fenced code block
+	// is buffered until its closing fence arrives so the code appears as one
+	// highlighted block instead of recoloring token-by-token.
+	lines := renderStreamingAssistantMarkdownText(text, assistantMeasure(width), width)
 	for index, line := range lines {
-		// styleStreamingLine applies the fade palette when fadeActive is
-		// true and lineAges is populated; otherwise it falls through to
-		// the same base-ink render styleAssistantMarkdownLine would have
-		// applied. This means test fixtures that pre-populate
-		// m.streamingText without going through the agentTextMsg
-		// branch keep rendering identically to before.
+		// styleStreamingLine fades plain prose but leaves already-highlighted
+		// markdown/code lines alone, so live colors match the committed row.
 		lines[index] = m.styleStreamingLine(line, index, len(lines))
 	}
 	lines = m.appendStreamingCursor(lines, width)
@@ -3090,6 +3086,17 @@ func startsTurn(kind rowKind) bool {
 // (summary line + injected spacing) and must not be double-spaced.
 func isToolCardKind(kind rowKind) bool {
 	return kind == rowToolCall || kind == rowToolResult
+}
+
+func needsSeparatorBeforeToolCard(previous rowKind, current rowKind) bool {
+	if !isToolCardKind(current) {
+		return false
+	}
+	return isToolCardKind(previous) || previous == rowAssistant || previous == rowUser
+}
+
+func shouldRuleBeforeTurn(previous rowKind, current rowKind) bool {
+	return current == rowAssistant && isToolCardKind(previous)
 }
 
 func (m model) handlePermissionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1297,7 +1297,10 @@ func TestAgentResponsePreservesToolResultMetadata(t *testing.T) {
 	if row.tool != "apply_patch" || row.status != tools.StatusError || row.detail != diff {
 		t.Fatalf("tool result metadata was not preserved: %#v", row)
 	}
-	assertContains(t, next.renderRow(row, 80, buildRowContext(next.transcript)), "@@ -1 +1 @@")
+	rendered := next.renderRow(row, 80, buildRowContext(next.transcript))
+	assertContains(t, rendered, "old")
+	assertContains(t, rendered, "new")
+	assertNotContains(t, rendered, "@@")
 }
 
 func TestAgentResponsePreservesPermissionMetadata(t *testing.T) {
@@ -1549,7 +1552,7 @@ func TestAgentEventRenderingMappingCoversRuntimeContract(t *testing.T) {
 				tool:   "read_file",
 				detail: "README.md",
 			},
-			wants: []string{"read_file", "README.md"},
+			wants: []string{"Read", "README.md"},
 		},
 		zeroruntime.AgentEventToolResult: {
 			row: transcriptRow{
@@ -1565,7 +1568,7 @@ func TestAgentEventRenderingMappingCoversRuntimeContract(t *testing.T) {
 					"+new",
 				}, "\n"),
 			},
-			wants: []string{"apply_patch", "@@ -1 +1 @@"},
+			wants: []string{"Patched", "file.txt", "old", "new"},
 		},
 		zeroruntime.AgentEventPlanUpdate: {
 			row:   transcriptRow{kind: rowSystem, text: "Plan updated\n- inspect: completed"},
@@ -1926,11 +1929,9 @@ func TestSelectionHighlightUsesGutterShiftedCoordinate(t *testing.T) {
 }
 
 // TestTranscriptSelectionPaintsHighlightOnceNotTwice guards the "two highlights"
-// bug: assistant/user/reasoning rows used to self-paint the selection in the
-// UNSHIFTED coordinate AND finalizeTranscriptBodyRow re-painted it in the
-// gutter-shifted coordinate, so a single selection lit up in two places (the
-// real one plus a copy shifted right by the reading gutter). The highlight must
-// land exactly once.
+// bug: assistant/user/reasoning rows used to self-paint the selection and
+// finalizeTranscriptBodyRow re-painted it, so a single selection lit up twice.
+// The highlight must land exactly once.
 func TestTranscriptSelectionPaintsHighlightOnceNotTwice(t *testing.T) {
 	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
 	m.width, m.height = 160, 30
@@ -1939,9 +1940,6 @@ func TestTranscriptSelectionPaintsHighlightOnceNotTwice(t *testing.T) {
 		kind: rowAssistant, text: "alpha beta gamma delta epsilon zeta", final: true,
 	})
 	width := m.chatColumnWidth()
-	if transcriptGutter(width) <= 0 {
-		t.Fatalf("need a positive reading gutter at width %d", width)
-	}
 
 	findRow := func(mm model) (transcriptBodyItem, bool) {
 		for _, it := range mm.transcriptBodyItems(width, "") {
@@ -1967,8 +1965,8 @@ func TestTranscriptSelectionPaintsHighlightOnceNotTwice(t *testing.T) {
 		t.Fatalf("expected a selectable text line of width >= 5, got %+v", line)
 	}
 
-	// Select the first 5 columns of that line (in the gutter-shifted coordinate the
-	// mouse hands to anchor/cursor).
+	// Select the first 5 columns of that line in the same coordinate system mouse
+	// selection uses.
 	m.transcriptSelection = transcriptSelectionState{
 		active: true,
 		anchor: transcriptSelectionPoint{bodyY: line.bodyY, x: line.textStart},
@@ -2016,20 +2014,127 @@ func TestReasoningAfterToolCardGetsBlankSeparator(t *testing.T) {
 	}
 }
 
+func TestAssistantNarrationBeforeToolCardGetsBlankSeparator(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.width, m.height = 120, 40
+	m.altScreen = true
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowUser, text: "run it"},
+		transcriptRow{kind: rowAssistant, text: "I'll inspect the existing file, then run it."},
+		transcriptRow{kind: rowToolResult, id: "t1", tool: "read_file", status: tools.StatusOK, detail: "File: time_test.py\n\n  1 | print('x')"},
+	)
+	items := m.transcriptBodyItems(m.chatColumnWidth(), "")
+	toolIdx := -1
+	for i := range items {
+		if items[i].rowIndex >= 0 && items[i].rowIndex < len(m.transcript) &&
+			m.transcript[items[i].rowIndex].kind == rowToolResult {
+			toolIdx = i
+		}
+	}
+	if toolIdx <= 0 {
+		t.Fatal("tool item not found in the body")
+	}
+	if items[toolIdx-1].kind != transcriptBodyItemSeparator {
+		t.Fatalf("expected a blank separator between assistant narration and first tool card, got kind %v", items[toolIdx-1].kind)
+	}
+}
+
+func TestUserPromptBeforeToolCardGetsBlankSeparator(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.width, m.height = 120, 40
+	m.altScreen = true
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowUser, text: "create the landing page"},
+		transcriptRow{kind: rowToolResult, id: "t1", tool: "write_file", status: tools.StatusOK, detail: "--- /dev/null\n+++ b/index.html\n@@ -0,0 +1,1 @@\n+<!DOCTYPE html>"},
+	)
+	items := m.transcriptBodyItems(m.chatColumnWidth(), "")
+	toolIdx := -1
+	for i := range items {
+		if items[i].rowIndex >= 0 && items[i].rowIndex < len(m.transcript) &&
+			m.transcript[items[i].rowIndex].kind == rowToolResult {
+			toolIdx = i
+		}
+	}
+	if toolIdx <= 0 {
+		t.Fatal("tool item not found in the body")
+	}
+	if items[toolIdx-1].kind != transcriptBodyItemSeparator {
+		t.Fatalf("expected a blank separator between user prompt and first tool card, got kind %v", items[toolIdx-1].kind)
+	}
+}
+
+func TestAssistantAfterToolCardGetsRuleSeparator(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.width, m.height = 120, 40
+	m.altScreen = true
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowUser, text: "run it"},
+		transcriptRow{kind: rowAssistant, text: "I'll run it first."},
+		transcriptRow{kind: rowToolResult, id: "t1", tool: "bash", status: tools.StatusOK, detail: "stdout:\nok\nexit_code: 0"},
+		transcriptRow{kind: rowAssistant, text: "Done.", final: true},
+	)
+	items := m.transcriptBodyItems(m.chatColumnWidth(), "")
+	finalIdx := -1
+	for i := range items {
+		if items[i].rowIndex >= 0 && items[i].rowIndex < len(m.transcript) &&
+			m.transcript[items[i].rowIndex].kind == rowAssistant &&
+			m.transcript[items[i].rowIndex].final {
+			finalIdx = i
+		}
+	}
+	if finalIdx <= 0 {
+		t.Fatal("final assistant item not found in the body")
+	}
+	if items[finalIdx-1].kind != transcriptBodyItemRule {
+		t.Fatalf("expected a rule separator before assistant prose after tool output, got kind %v", items[finalIdx-1].kind)
+	}
+
+	body, _ := m.transcriptBody(m.chatColumnWidth(), "")
+	got := plainRender(t, body)
+	if !strings.Contains(got, "──") || !strings.Contains(got, "Done.") {
+		t.Fatalf("expected visible rule before final answer, got:\n%s", got)
+	}
+}
+
+func TestStreamingAssistantAfterToolCardGetsRuleSeparator(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.width, m.height = 120, 40
+	m.altScreen = true
+	m.pending = true
+	m.streamingText = "Done."
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowUser, text: "run it"},
+		transcriptRow{kind: rowAssistant, text: "I'll run it first."},
+		transcriptRow{kind: rowToolResult, id: "t1", tool: "bash", status: tools.StatusOK, detail: "stdout:\nok\nexit_code: 0"},
+	)
+	items := m.transcriptBodyItems(m.chatColumnWidth(), "")
+	pendingIdx := -1
+	for i := range items {
+		if items[i].kind == transcriptBodyItemPendingInterim {
+			pendingIdx = i
+		}
+	}
+	if pendingIdx <= 0 {
+		t.Fatal("pending interim item not found in the body")
+	}
+	if items[pendingIdx-1].kind != transcriptBodyItemRule {
+		t.Fatalf("expected a live rule separator before streaming assistant text after tool output, got kind %v", items[pendingIdx-1].kind)
+	}
+}
+
 func TestTranscriptReadingColumnHelpers(t *testing.T) {
-	// Wide terminal: a scaled side margin on each side, and the content fills the
-	// rest (column minus both margins) instead of stopping at a fixed cap.
-	if g := transcriptGutter(160); g != 8 {
-		t.Fatalf("wide gutter = %d, want 8", g)
+	// Wide terminal: no body gutter, full content width.
+	if g := transcriptGutter(160); g != 0 {
+		t.Fatalf("wide gutter = %d, want 0", g)
 	}
-	if cw := transcriptContentWidth(160); cw != 160-2*8 {
-		t.Fatalf("wide contentWidth = %d, want %d (column minus both margins)", cw, 160-2*8)
+	if cw := transcriptContentWidth(160); cw != 160 {
+		t.Fatalf("wide contentWidth = %d, want full 160", cw)
 	}
-	// Very wide terminal: the margin is clamped so it never grows unbounded.
-	if g := transcriptGutter(400); g != 12 {
-		t.Fatalf("very wide gutter = %d, want clamp ceiling 12", g)
+	// Very wide terminal: still no gutter, so code/tool blocks use the width.
+	if g := transcriptGutter(400); g != 0 {
+		t.Fatalf("very wide gutter = %d, want 0", g)
 	}
-	// Tiny terminal: no margins, full width so prose never collapses.
+	// Tiny terminal: full width so prose never collapses.
 	if g := transcriptGutter(40); g != 0 {
 		t.Fatalf("tiny gutter = %d, want 0", g)
 	}
@@ -2038,7 +2143,7 @@ func TestTranscriptReadingColumnHelpers(t *testing.T) {
 	}
 }
 
-func TestTranscriptBodyRowsUseReadingColumnAndAlignSelection(t *testing.T) {
+func TestTranscriptBodyRowsUseFullWidthAndAlignSelection(t *testing.T) {
 	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
 	m.width, m.height = 160, 30
 	m.altScreen = true
@@ -2048,8 +2153,8 @@ func TestTranscriptBodyRowsUseReadingColumnAndAlignSelection(t *testing.T) {
 
 	width := m.chatColumnWidth()
 	gutter := transcriptGutter(width)
-	if gutter <= 0 {
-		t.Fatalf("expected a gutter at width %d", width)
+	if gutter != 0 {
+		t.Fatalf("expected no body gutter at width %d, got %d", width, gutter)
 	}
 
 	items := m.transcriptBodyItems(width, "")
@@ -2064,24 +2169,21 @@ func TestTranscriptBodyRowsUseReadingColumnAndAlignSelection(t *testing.T) {
 	}
 	rendered := row.render(0)
 
-	maxLine := transcriptContentWidth(width) + gutter // content plus the left indent
-	wroteIndented := false
+	maxLine := transcriptContentWidth(width) + gutter // content plus any left indent
+	sawContent := false
 	for _, line := range rendered.lines {
 		if w := lipgloss.Width(line); w > maxLine {
-			t.Fatalf("body line width %d exceeds reading column %d: %q", w, maxLine, line)
+			t.Fatalf("body line width %d exceeds chat column %d: %q", w, maxLine, line)
 		}
 		if strings.TrimSpace(line) != "" {
-			if !strings.HasPrefix(line, strings.Repeat(" ", gutter)) {
-				t.Fatalf("non-blank body line is not gutter-indented: %q", line)
-			}
-			wroteIndented = true
+			sawContent = true
 		}
 	}
-	if !wroteIndented {
-		t.Fatal("expected at least one indented content line")
+	if !sawContent {
+		t.Fatal("expected at least one content line")
 	}
-	// Selection alignment: text-carrying selectable lines start at/after the gutter
-	// so click-to-select and the highlight track the indented glyphs.
+	// Selection alignment: text-carrying selectable lines should never start before
+	// the rendered text coordinate.
 	for _, sl := range rendered.selectable {
 		if sl.text != "" && sl.textStart < gutter {
 			t.Fatalf("selectable textStart %d < gutter %d — selection would misalign", sl.textStart, gutter)

--- a/internal/tui/render_cache.go
+++ b/internal/tui/render_cache.go
@@ -150,6 +150,7 @@ func (m model) renderRowCacheKey(row transcriptRow, width int, rc rowContext, op
 	appendRenderCacheField(&b, strconv.Itoa(width))
 	appendRenderCacheField(&b, strconv.FormatBool(flush))
 	appendRenderCacheField(&b, strconv.Itoa(opts.bodyCap))
+	appendRenderCacheField(&b, strconv.FormatBool(opts.expanded))
 	appendRenderCacheField(&b, opts.cwd)
 	appendRenderCacheField(&b, strconv.Itoa(int(row.kind)))
 	appendRenderCacheField(&b, row.id)

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -128,8 +128,8 @@ func isHiddenPlumbingTool(name string) bool {
 
 // skip reports whether a row renders nothing itself: a tool call whose result
 // arrived collapses into the result's card; a permission prompt that has been
-// decided collapses into its decision line; an unprompted allow is already
-// surfaced as the card's [auto] tag.
+// decided collapses away; allow rows are audit events and the tool card speaks
+// for the approved action.
 func (rc rowContext) skip(row transcriptRow) bool {
 	switch row.kind {
 	case rowToolCall:
@@ -154,7 +154,7 @@ func (rc rowContext) skip(row transcriptRow) bool {
 		case agent.PermissionActionPrompt:
 			return rc.decided[key]
 		case agent.PermissionActionAllow:
-			return rc.auto[key]
+			return true
 		}
 	}
 	return false
@@ -518,12 +518,6 @@ func renderUserRow(row transcriptRow, width int) string {
 
 const userPromptPrefix = "▌  "
 
-// narrationPrefix is the 2-col gutter on the agent's interim narration: a "●"
-// bullet on the first line marks each story beat; continuation lines indent to
-// match. Width 2 (● is single-width + a space), so wrapping to assistantMeasure-2
-// keeps every composed line within the chat column.
-const narrationPrefix = "● "
-
 func userPromptContentWidth(width int) int {
 	if width <= 0 {
 		return 0
@@ -547,19 +541,13 @@ func renderAssistantRow(row transcriptRow, width int) string {
 	tableMeasure := width
 	if !row.final {
 		// Interim prose is the agent's connective narration ("Now the stylesheet.").
-		// Render it bright (ink) and mark each block with a leading "●" so the build
-		// reads as a clear story. Wrap to a 2-col-narrower measure so the bullet /
-		// indent never pushes a line past the chat width; fitStyledLine backstops it.
-		gutter := lipgloss.Width(narrationPrefix)
-		narr := renderAssistantMarkdownText(row.text, maxInt(16, assistantMeasure(width)-gutter), tableMeasure, true)
+		// Render it as plain prose so the transcript doesn't grow a separate
+		// activity rail beside the tool rows.
+		narr := renderAssistantMarkdownText(row.text, assistantMeasure(width), tableMeasure, true)
 		out := make([]string, 0, len(narr))
-		for index, line := range narr {
+		for _, line := range narr {
 			styled := styleAssistantMarkdownLine(line, zeroTheme.ink)
-			prefix := "  "
-			if index == 0 {
-				prefix = zeroTheme.accent.Render("●") + " "
-			}
-			out = append(out, fitStyledLine(prefix+styled, width))
+			out = append(out, fitStyledLine(styled, width))
 		}
 		return strings.Join(out, "\n")
 	}
@@ -1025,6 +1013,7 @@ func renderPermissionRow(row transcriptRow, width int) string {
 	if name == "" {
 		name = row.tool
 	}
+	displayName := permissionToolDisplayName(name)
 	dot := zeroTheme.faintest.Render(" · ")
 
 	switch event.Action {
@@ -1041,18 +1030,18 @@ func renderPermissionRow(row transcriptRow, width int) string {
 			event.Grant != nil || event.GrantMatched {
 			label = "always"
 		}
-		line := zeroTheme.green.Render(label) + dot + zeroTheme.green.Render(name)
+		line := zeroTheme.green.Render(label) + dot + zeroTheme.green.Render(displayName)
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
 			line += dot + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
 		}
 		return fitStyledLine(line, width)
 	case agent.PermissionActionDeny:
-		line := zeroTheme.red.Render("denied") + dot + zeroTheme.red.Render(name)
+		line := zeroTheme.red.Render("denied") + dot + zeroTheme.red.Render(displayName)
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
 			line += dot + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
 		}
 		if reason := permissionDisplayReason(event.Reason); reason != "" {
-			line += zeroTheme.faint.Render(" — " + truncateRunes(reason, maxInt(16, width-lipgloss.Width(name)-16)))
+			line += zeroTheme.faint.Render(" — " + truncateRunes(reason, maxInt(16, width-lipgloss.Width(displayName)-16)))
 		}
 		out := fitStyledLine(line, width)
 		if detail := strings.TrimSpace(row.detail); detail != "" {
@@ -1060,12 +1049,12 @@ func renderPermissionRow(row transcriptRow, width int) string {
 		}
 		return out
 	case agent.PermissionActionCancel:
-		line := zeroTheme.red.Render("cancelled") + dot + zeroTheme.red.Render(name)
+		line := zeroTheme.red.Render("cancelled") + dot + zeroTheme.red.Render(displayName)
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
 			line += dot + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
 		}
 		if reason := permissionDisplayReason(event.Reason); reason != "" {
-			line += zeroTheme.faint.Render(" — " + truncateRunes(reason, maxInt(16, width-lipgloss.Width(name)-16)))
+			line += zeroTheme.faint.Render(" — " + truncateRunes(reason, maxInt(16, width-lipgloss.Width(displayName)-16)))
 		}
 		out := fitStyledLine(line, width)
 		if detail := strings.TrimSpace(row.detail); detail != "" {
@@ -1073,7 +1062,7 @@ func renderPermissionRow(row transcriptRow, width int) string {
 		}
 		return out
 	default:
-		line := zeroTheme.amber.Render("permission") + "  " + zeroTheme.ink.Render(name) + "  " + zeroTheme.amber.Render("prompt")
+		line := zeroTheme.amber.Render("permission") + "  " + zeroTheme.ink.Render(displayName) + "  " + zeroTheme.amber.Render("prompt")
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
 			line += "  " + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
 		}
@@ -1390,29 +1379,35 @@ func (m model) renderRunningToolCard(row transcriptRow, width int, rc rowContext
 	}
 	// Running cards keep the normal name color; the accent spinner glyph at the
 	// front already marks them live (and orphaned dead cards must not look active).
-	head := toolCardHead(toolRowName(row), hint, arg, "", zeroTheme.ink, rc.auto[rcKey(row.runID, row.id)], width, opts)
+	head := toolCardHead(toolRowName(row), hint, arg, "", "", "", true, zeroTheme.ink, rc.auto[rcKey(row.runID, row.id)], width, opts)
 	return toolCard(head, glyph, nil, "", zeroTheme.cardRun, width)
 }
 
 func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts cardRenderOptions) string {
 	name := toolRowName(row)
 	failed := row.status == tools.StatusError
-	glyph := zeroTheme.green.Render("✓")
+	glyph := zeroTheme.green.Render("•")
 	nameStyle := zeroTheme.green
 	borderStyle := zeroTheme.line
 	if failed {
-		glyph = zeroTheme.red.Render("✗")
+		glyph = zeroTheme.red.Render("•")
 		nameStyle = zeroTheme.red
 		borderStyle = zeroTheme.cardErr
 	}
 	key := rcKey(row.runID, row.id)
+	headTarget := rc.hints[key]
+	headArg := rc.args[key]
+	if !failed && isExploreTool(name) {
+		headTarget = ""
+		headArg = ""
+	}
 	// A successful call whose only output is a one-line confirmation ("Created
 	// examples/calc.go (45 bytes).", "Successfully created directory …") restates
-	// what the head already shows (action + target + ✓), so drop the body and let
+	// what the head already shows (action + target + status dot), so drop the body and let
 	// the card collapse to a single line — matching the reference agents' density.
 	// Only for clean OK results: errors and anything multi-line keep their body.
 	if !failed && opts.bodyCap > 0 && !toolCardAlwaysExpands(name) && looksLikeRedundantConfirmation(row.detail) {
-		head := toolCardHead(name, rc.hints[key], rc.args[key], "", nameStyle, rc.auto[key], width, opts)
+		head := toolCardHead(name, headTarget, headArg, "", row.detail, row.text, false, nameStyle, rc.auto[key], width, opts)
 		return toolCard(head, glyph, nil, "", borderStyle, width)
 	}
 	// Collapse long, noisy output (web-search/MCP/read dumps) by default so the
@@ -1421,15 +1416,15 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 	// scrollback clean. Skipped for: the uncapped detailed view (opts.bodyCap==0),
 	// diff tools whose body must stay reviewable, and short output.
 	collapsedFooter := ""
-	if opts.bodyCap > 0 && !toolCardAlwaysExpands(name) {
+	if opts.bodyCap > 0 && !toolCardAlwaysExpands(name) && !(!failed && (isExploreTool(name) || isLocalControlTool(name))) {
 		collapsedFooter = collapsedToolFooter(row.detail)
 	}
 	if collapsedFooter != "" && !row.expanded {
-		head := toolCardHead(name, rc.hints[key], rc.args[key], "", nameStyle, rc.auto[key], width, opts)
+		head := toolCardHead(name, headTarget, headArg, "", row.detail, row.text, false, nameStyle, rc.auto[key], width, opts)
 		return toolCard(head, glyph, nil, collapsedFooter, borderStyle, width)
 	}
-	body := toolCardBody(name, rc.hints[key], row.detail, width, opts)
-	head := toolCardHead(name, rc.hints[key], rc.args[key], body.headTag, nameStyle, rc.auto[key], width, opts)
+	body := toolCardBody(name, rc.hints[key], rc.args[key], row.detail, width, opts, failed)
+	head := toolCardHead(name, headTarget, headArg, body.headTag, row.detail, row.text, false, nameStyle, rc.auto[key], width, opts)
 	footer := body.footer
 	if collapsedFooter != "" && row.expanded && footer == "" {
 		footer = "▾ collapse"
@@ -1490,11 +1485,77 @@ func toolRowName(row transcriptRow) string {
 	return strings.TrimPrefix(name, "tool result: ")
 }
 
-// toolDisplayName is the human-facing label for a tool card head. MCP tools are
-// exposed as "mcp_<server>_<tool>", which is noise in the UI — show a clean
-// "<tool>" (e.g. mcp_exa_web_search_exa → "web search"); the search query/target
-// is shown beside it. Built-in tool names are left as-is.
+func isExploreTool(name string) bool {
+	switch name {
+	case "read_file", "read_minified_file", "list_directory", "grep", "glob":
+		return true
+	}
+	return false
+}
+
+func isLocalControlTool(name string) bool {
+	switch name {
+	case "browser_install", "browser_launch", "browser_connect", "browser_open", "browser_snapshot",
+		"browser_click", "browser_type", "browser_press", "browser_action",
+		"desktop_windows", "desktop_snapshot", "desktop_action",
+		"terminal_session", "capture_artifact":
+		return true
+	}
+	return false
+}
+
+// toolDisplayName is the human-facing label for a tool card head. Core tools use
+// action-oriented labels, and MCP tools are cleaned from "mcp_<server>_<tool>"
+// to "<tool>" (e.g. mcp_exa_web_search_exa → "web search").
 func toolDisplayName(name string) string {
+	switch name {
+	case "write_file":
+		return "Create"
+	case "edit_file":
+		return "Edit"
+	case "apply_patch":
+		return "Patch"
+	case "read_file", "read_minified_file":
+		return "Read"
+	case "list_directory":
+		return "List"
+	case "grep":
+		return "Search"
+	case "glob":
+		return "Find"
+	case "bash", "exec_command":
+		return "Run"
+	case "write_stdin":
+		return "Send input"
+	case "browser_install":
+		return "Install browser"
+	case "browser_launch":
+		return "Launch browser"
+	case "browser_connect":
+		return "Connect browser"
+	case "browser_open":
+		return "Open browser"
+	case "browser_snapshot":
+		return "Browser snapshot"
+	case "browser_click":
+		return "Click"
+	case "browser_type":
+		return "Type"
+	case "browser_press":
+		return "Press key"
+	case "browser_action":
+		return "Browser action"
+	case "desktop_windows":
+		return "Desktop windows"
+	case "desktop_snapshot":
+		return "Desktop snapshot"
+	case "desktop_action":
+		return "Desktop action"
+	case "terminal_session":
+		return "Terminal session"
+	case "capture_artifact":
+		return "Capture"
+	}
 	if !strings.HasPrefix(name, "mcp_") {
 		return name
 	}
@@ -1513,16 +1574,170 @@ func toolDisplayName(name string) string {
 	return strings.ReplaceAll(rest, "_", " ")
 }
 
-// toolCardHead composes the card head: tool name, middle-truncated target
-// (hyperlinked when it names a file), the faintest arg column, optional extra
-// tag, and the auto marker. The status glyph is NOT included here — toolCard
-// right-aligns it on the rule line so it sits at the card's right edge instead
-// of trailing the head text.
-func toolCardHead(name string, target string, arg string, headTag string, nameStyle lipgloss.Style, auto bool, width int, opts cardRenderOptions) string {
-	// Color the tool name by state (accent running / green done / red failed) so
-	// the head row reads at a glance, reinforcing the leading status glyph.
-	head := nameStyle.Bold(true).Render(toolDisplayName(name))
-	if target = strings.TrimSpace(target); target != "" {
+func toolCardActionLabel(name string, detail string, running bool) string {
+	if running {
+		switch name {
+		case "write_file":
+			return "Adding"
+		case "edit_file":
+			return "Editing"
+		case "apply_patch":
+			return "Patching"
+		case "read_file", "read_minified_file":
+			return "Reading"
+		case "list_directory":
+			return "Listing"
+		case "grep":
+			return "Searching"
+		case "glob":
+			return "Finding"
+		case "bash", "exec_command":
+			return "Running"
+		case "write_stdin":
+			return "Sending input"
+		case "browser_install":
+			return "Installing"
+		case "browser_launch":
+			return "Launching"
+		case "browser_connect":
+			return "Connecting"
+		case "browser_open":
+			return "Opening"
+		case "browser_snapshot", "desktop_snapshot", "capture_artifact":
+			return "Capturing"
+		case "browser_click":
+			return "Clicking"
+		case "browser_type":
+			return "Typing"
+		case "browser_press":
+			return "Pressing"
+		case "browser_action", "desktop_action":
+			return "Interacting"
+		case "desktop_windows":
+			return "Listing"
+		case "terminal_session":
+			return "Running"
+		default:
+			return toolDisplayName(name)
+		}
+	}
+	switch name {
+	case "read_file", "read_minified_file", "list_directory", "grep", "glob":
+		return "Explored"
+	case "write_file":
+		meta := diffCardMetadata(detail)
+		trimmed := strings.TrimSpace(detail)
+		switch {
+		case strings.Contains(trimmed, "Overwrote "):
+			return "Updated"
+		case strings.Contains(trimmed, "Created "):
+			return "Added"
+		case meta.adds > 0 && meta.dels == 0:
+			return "Added"
+		case meta.adds > 0 || meta.dels > 0:
+			return "Updated"
+		default:
+			return "Create"
+		}
+	case "edit_file":
+		if strings.TrimSpace(detail) != "" {
+			return "Edited"
+		}
+		return "Edit"
+	case "apply_patch":
+		if strings.TrimSpace(detail) != "" {
+			return "Patched"
+		}
+		return "Patch"
+	case "bash", "exec_command":
+		return "Ran"
+	case "write_stdin":
+		return "Sent input"
+	case "browser_install":
+		return "Installed"
+	case "browser_launch":
+		return "Launched"
+	case "browser_connect":
+		return "Connected"
+	case "browser_open":
+		return "Opened"
+	case "browser_snapshot":
+		return "Captured"
+	case "browser_click":
+		return "Clicked"
+	case "browser_type":
+		return "Typed"
+	case "browser_press":
+		return "Pressed"
+	case "browser_action":
+		return "Ran action"
+	case "desktop_windows":
+		return "Listed"
+	case "desktop_snapshot":
+		return "Captured"
+	case "desktop_action":
+		return "Ran desktop action"
+	case "terminal_session":
+		return "Ran"
+	case "capture_artifact":
+		return "Captured"
+	default:
+		return toolDisplayName(name)
+	}
+}
+
+func toolCardHeadTarget(name string, target string, detail string) string {
+	target = strings.TrimSpace(target)
+	if target != "" {
+		return target
+	}
+	if name == "write_file" || name == "edit_file" || name == "apply_patch" || looksLikeDiff(detail) {
+		if meta := diffCardMetadata(detail); meta.path != "" {
+			return meta.path
+		}
+	}
+	if target := localControlHeadTarget(name, detail); target != "" {
+		return target
+	}
+	return ""
+}
+
+func localControlHeadTarget(name string, detail string) string {
+	switch name {
+	case "browser_snapshot":
+		return "snapshot"
+	case "desktop_windows":
+		return "windows"
+	case "desktop_snapshot":
+		return "desktop"
+	case "browser_install":
+		return "runtime"
+	case "capture_artifact":
+		return artifactCapturedPath(detail)
+	default:
+		return ""
+	}
+}
+
+func permissionToolDisplayName(name string) string {
+	if isLocalControlTool(name) {
+		return toolDisplayName(name)
+	}
+	return name
+}
+
+// toolCardHead composes the card head: user-facing action label,
+// middle-truncated target (hyperlinked when it names a file), the faintest arg
+// column, optional extra tag, and the auto marker. The status glyph is added by
+// toolCard so it leads the head text.
+func toolCardHead(name string, target string, arg string, headTag string, detail string, actionDetail string, running bool, nameStyle lipgloss.Style, auto bool, width int, opts cardRenderOptions) string {
+	// Color the action label by state (accent running / green done / red failed)
+	// so the head row reads at a glance, reinforcing the leading status glyph.
+	if actionDetail == "" {
+		actionDetail = detail
+	}
+	head := nameStyle.Bold(true).Render(toolCardActionLabel(name, actionDetail, running))
+	if target = singleLineToolHeadText(toolCardHeadTarget(name, target, detail)); target != "" {
 		// Show a shortened, workspace-relative path, but keep the hyperlink
 		// pointing at the original absolute path so the file still opens.
 		shown := target
@@ -1536,42 +1751,46 @@ func toolCardHead(name string, target string, arg string, headTag string, nameSt
 		head += " " + styled
 	}
 	// The arg column is the first thing the width tiers drop (below 100 cols).
-	if arg = strings.TrimSpace(arg); arg != "" && widthTier(width) == tierFull {
+	if arg = singleLineToolHeadText(arg); arg != "" && widthTier(width) == tierFull {
 		head += "  " + zeroTheme.toolArg.Render(truncateRunes(arg, maxInt(12, width/3)))
 	}
 	if headTag != "" {
-		head += "  " + zeroTheme.faint.Render(headTag)
+		if strings.Contains(headTag, "\x1b") {
+			head += "  " + headTag
+		} else {
+			head += "  " + zeroTheme.faint.Render(headTag)
+		}
 	}
 	_ = auto // the permission mode is shown in the composer divider; a per-card [auto] badge is redundant noise
 	return head
 }
 
-// toolCard draws a left-rule card: a status-tinted "│ " rail down the left
-// edge, the head (with the status glyph right-aligned to the card edge) on the
-// first line, body lines below, and an optional footer line — no top, right, or
-// bottom borders. This matches the lighter inline style of specialist cards
-// (renderLeftRuleCard) and comparable terminal agents, instead of the
-// older full rounded box. Every emitted line is exactly `width` cells, and the
-// inner content budget stays width-4, so the diff/read/bash body renderers
-// (which assume width-4) need no change. On the tiny tier the rail goes away
-// (bare lines) so content keeps every column — and so a tiny card carries no
-// leading "│", matching TestTinyToolCardDropsSideBorders.
-func toolCard(head string, glyph string, body []string, footer string, borderStyle lipgloss.Style, width int) string {
-	tiny := widthTier(width) == tierTiny
+func singleLineToolHeadText(text string) string {
+	text = strings.TrimSpace(strings.ReplaceAll(text, "\r\n", "\n"))
+	if text == "" {
+		return ""
+	}
+	parts := []string{}
+	for _, line := range strings.Split(strings.ReplaceAll(text, "\r", "\n"), "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// toolCard draws a compact tool block: the status glyph leads the head row,
+// body lines follow directly below, and an optional footer closes the block. No
+// rail or box border is drawn, so the transcript does not carry a distracting
+// vertical activity line.
+func toolCard(head string, glyph string, body []string, footer string, _ lipgloss.Style, width int) string {
 	if width < 24 {
 		width = 24
 	}
-	rail := borderStyle.Render("│ ")
-	railWidth := 2
-	innerWidth := width - 4 // "│ " (2) + content + 2 trailing cells where the old right border sat
-	if tiny {
-		rail = ""
-		railWidth = 0
-		innerWidth = width
-	}
+	innerWidth := width
 
-	// Head line: rail + LEADING status glyph + head. Leading the row with the
-	// glyph (✓ done / ✗ failed / spinner running) puts state in the first cell the
+	// Head line: LEADING status glyph + head. Leading the row with the
+	// glyph (status dot / spinner running) puts state in the first cell the
 	// eye lands on, instead of right-aligning it to the far card edge. The glyph
 	// (and the space after it) is reserved out of the head's width budget so a long
 	// head truncates cleanly; the row is right-padded to the full card width.
@@ -1582,46 +1801,37 @@ func toolCard(head string, glyph string, body []string, footer string, borderSty
 		leading = glyph + " "
 		leadingWidth = glyphWidth + 1
 	}
-	headBudget := maxInt(1, width-railWidth-leadingWidth)
+	headBudget := maxInt(1, width-leadingWidth)
 	head = fitStyledLine(head, headBudget)
-	headPad := maxInt(0, width-railWidth-leadingWidth-lipgloss.Width(head))
-	headLine := rail + leading + head + strings.Repeat(" ", headPad)
+	headPad := maxInt(0, width-leadingWidth-lipgloss.Width(head))
+	headLine := leading + head + strings.Repeat(" ", headPad)
 
 	lines := make([]string, 0, len(body)+2)
 	lines = append(lines, headLine)
 	for _, line := range body {
 		fitted := fitStyledLine(line, innerWidth)
-		if tiny {
-			lines = append(lines, fitted)
-			continue
-		}
-		// Fill to the full card width (not just innerWidth) with plain spaces so
-		// the row spans the same cells as before; the trailing region falls
-		// through to the bare terminal background (no panel band).
-		pad := strings.Repeat(" ", maxInt(0, width-railWidth-lipgloss.Width(fitted)))
-		lines = append(lines, rail+fitted+pad)
+		pad := strings.Repeat(" ", maxInt(0, width-lipgloss.Width(fitted)))
+		lines = append(lines, fitted+pad)
 	}
 
 	if strings.TrimSpace(footer) != "" {
-		fittedFooter := fitStyledLine(footer, width-railWidth)
-		if tiny {
-			lines = append(lines, fittedFooter)
-		} else {
-			pad := strings.Repeat(" ", maxInt(0, width-railWidth-lipgloss.Width(fittedFooter)))
-			lines = append(lines, rail+fittedFooter+pad)
-		}
+		fittedFooter := fitStyledLine(footer, width)
+		pad := strings.Repeat(" ", maxInt(0, width-lipgloss.Width(fittedFooter)))
+		lines = append(lines, fittedFooter+pad)
 	}
 	return strings.Join(lines, "\n")
 }
 
 // toolCardBody delegates result-shape selection to the tool body registry.
-func toolCardBody(name string, hint string, detail string, width int, opts cardRenderOptions) cardBody {
+func toolCardBody(name string, hint string, arg string, detail string, width int, opts cardRenderOptions, failed bool) cardBody {
 	return defaultToolBodyRegistry.render(toolBodyRequest{
 		name:   name,
 		hint:   hint,
+		arg:    arg,
 		detail: detail,
 		width:  width,
 		opts:   opts,
+		failed: failed,
 	})
 }
 
@@ -1649,43 +1859,56 @@ func genericCardBody(detail string, opts cardRenderOptions) cardBody {
 // header so the gutter can show real line numbers.
 var hunkHeaderPattern = regexp.MustCompile(`^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
 
-func diffCardBody(detail string, width int, opts cardRenderOptions) cardBody {
-	rawLines := strings.Split(detail, "\n")
+type diffMetadata struct {
+	path    string
+	newFile bool
+	adds    int
+	dels    int
+}
 
-	path := ""
-	newFile := false
-	adds, dels := 0, 0
-	for _, line := range rawLines {
+func diffCardMetadata(detail string) diffMetadata {
+	meta := diffMetadata{}
+	for _, line := range strings.Split(detail, "\n") {
 		switch {
 		case strings.HasPrefix(line, "+++ "):
-			path = strings.TrimPrefix(strings.TrimSpace(strings.TrimPrefix(line, "+++ ")), "b/")
+			meta.path = strings.TrimPrefix(strings.TrimSpace(strings.TrimPrefix(line, "+++ ")), "b/")
 		case strings.HasPrefix(line, "--- "):
 			if strings.TrimSpace(strings.TrimPrefix(line, "--- ")) == "/dev/null" {
-				newFile = true
+				meta.newFile = true
 			}
 		case strings.HasPrefix(line, "+"):
-			adds++
+			meta.adds++
 		case strings.HasPrefix(line, "-"):
-			dels++
+			meta.dels++
 		}
 	}
+	return meta
+}
 
-	innerWidth := width - 4
-	// The edited file's path is a clickable OSC 8 link, so the edited place in
-	// history opens straight from the terminal.
-	headLeft := hyperlink(fileURL(opts.cwd, path),
-		zeroTheme.ink.Render(middleTruncate(path, maxInt(16, innerWidth/2))))
-	if newFile {
-		headLeft += "  " + zeroTheme.addSign.Render(" NEW FILE ")
+func diffHeadTag(meta diffMetadata) string {
+	return diffCountTag(meta.adds, meta.dels)
+}
+
+func diffCountTag(adds int, dels int) string {
+	if adds == 0 && dels == 0 {
+		return ""
 	}
-	counts := []string{}
-	if adds > 0 {
-		counts = append(counts, zeroTheme.diffAdd.Render(fmt.Sprintf("+%d", adds)))
-	}
-	if dels > 0 {
-		counts = append(counts, zeroTheme.diffDel.Render(fmt.Sprintf("−%d", dels)))
-	}
-	lines := []string{joinHeaderLine(headLeft, strings.Join(counts, " "), innerWidth)}
+	return zeroTheme.faint.Render("(") +
+		zeroTheme.diffAdd.Render(fmt.Sprintf("+%d", adds)) +
+		zeroTheme.faint.Render(" ") +
+		zeroTheme.diffDel.Render(fmt.Sprintf("-%d", dels)) +
+		zeroTheme.faint.Render(")")
+}
+
+func (meta diffMetadata) addOnly() bool {
+	return meta.adds > 0 && meta.dels == 0
+}
+
+func diffCardBody(detail string, width int, opts cardRenderOptions) cardBody {
+	rawLines := strings.Split(detail, "\n")
+	meta := diffCardMetadata(detail)
+	innerWidth := width
+	lines := []string{}
 
 	// The line-number gutter drops below 80 cols (the 60–79 tier). With it,
 	// gutter(4) + sign(3) + textBudget == innerWidth; without, sign(3) + text.
@@ -1695,20 +1918,24 @@ func diffCardBody(detail string, width int, opts cardRenderOptions) cardBody {
 		gutterWidth = 4
 	}
 	textBudget := maxInt(8, innerWidth-3-gutterWidth)
+	highlightedAdds := highlightedAddedDiffLines(rawLines, meta, textBudget)
+	highlightAddIndex := 0
 	oldLine, newLine := 0, 0
 	inHunk := false
 	for i := 0; i < len(rawLines); i++ {
 		line := rawLines[i]
 		switch {
 		case strings.HasPrefix(line, "+++ "), strings.HasPrefix(line, "--- "):
-			// Path already in the body head row.
+			// Path and counts live in the tool head row.
 		case strings.HasPrefix(line, "@@"):
 			if match := hunkHeaderPattern.FindStringSubmatch(line); match != nil {
 				oldLine, _ = strconv.Atoi(match[1])
 				newLine, _ = strconv.Atoi(match[2])
 				inHunk = true
 			}
-			lines = append(lines, zeroTheme.diffMeta.Render(truncateRunes(line, innerWidth)))
+			// The raw hunk header is implementation metadata. Use it for line
+			// numbers, but keep the visible diff focused on file content.
+			continue
 		case !inHunk, strings.HasPrefix(line, `\`):
 			// Preamble ("diff --git", "index …", a stray "stdout:") and the
 			// "\ No newline at end of file" marker are not content lines: no
@@ -1716,7 +1943,12 @@ func diffCardBody(detail string, width int, opts cardRenderOptions) cardBody {
 			lines = append(lines, zeroTheme.diffMeta.Render(truncateRunes(line, innerWidth)))
 		case strings.HasPrefix(line, "+"):
 			text := truncateRunes(strings.TrimPrefix(line, "+"), textBudget)
-			lines = append(lines, diffBodyLine(newLine, "+", text, true, textBudget, gutter))
+			if len(highlightedAdds) == meta.adds && highlightAddIndex < len(highlightedAdds) {
+				lines = append(lines, diffBodyStyledLine(newLine, "+", highlightedAdds[highlightAddIndex], true, textBudget, gutter))
+				highlightAddIndex++
+			} else {
+				lines = append(lines, diffBodyLine(newLine, "+", text, true, textBudget, gutter))
+			}
 			newLine++
 		case strings.HasPrefix(line, "-"):
 			// Isolated 1:1 replacement (one "-" immediately followed by one "+"):
@@ -1747,7 +1979,27 @@ func diffCardBody(detail string, width int, opts cardRenderOptions) cardBody {
 			newLine++
 		}
 	}
-	return cardBody{lines: capCardLines(lines, opts.bodyCap)}
+	return cardBody{lines: capCardLines(lines, opts.bodyCap), headTag: diffHeadTag(meta)}
+}
+
+func highlightedAddedDiffLines(rawLines []string, meta diffMetadata, textBudget int) []string {
+	if !meta.addOnly() || meta.path == "" {
+		return nil
+	}
+	content := make([]string, 0, meta.adds)
+	for _, line := range rawLines {
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+			content = append(content, strings.TrimPrefix(line, "+"))
+		}
+	}
+	if len(content) == 0 {
+		return nil
+	}
+	highlighted, ok := highlightCodeForPath(content, meta.path, textBudget, zeroTheme.addLine.GetBackground())
+	if !ok || len(highlighted) != len(content) {
+		return nil
+	}
+	return highlighted
 }
 
 // diffBodyLine paints one changed row: optional gutter number, sign column,
@@ -1770,6 +2022,21 @@ func diffBodyLine(number int, sign string, text string, added bool, textBudget i
 		return numCol + zeroTheme.addSign.Render(" "+sign+" ") + zeroTheme.addLine.Render(text)
 	}
 	return numCol + zeroTheme.delSign.Render(" "+sign+" ") + zeroTheme.delLine.Render(text)
+}
+
+func diffBodyStyledLine(number int, sign string, styledText string, added bool, textBudget int, gutter bool) string {
+	lineStyle, signStyle, numStyle := zeroTheme.delLine, zeroTheme.delSign, zeroTheme.delLineNum
+	if added {
+		lineStyle, signStyle, numStyle = zeroTheme.addLine, zeroTheme.addSign, zeroTheme.addLineNum
+	}
+	if pad := textBudget - lipgloss.Width(styledText); pad > 0 {
+		styledText += lineStyle.Render(strings.Repeat(" ", pad))
+	}
+	numCol := ""
+	if gutter {
+		numCol = numStyle.Render(fmt.Sprintf("%4d", number))
+	}
+	return numCol + signStyle.Render(" "+sign+" ") + styledText
 }
 
 func isDiffAddContent(s string) bool {
@@ -1859,51 +2126,155 @@ func diffBodyLineSpanned(number int, sign string, text []rune, added bool, spanS
 	return numCol + signStyle.Render(" "+sign+" ") + body
 }
 
-// readNumberedLinePattern matches read_file's body rows, which the tool emits
-// as "<right-aligned N> | <text>" (see internal/tools/read_file.go).
-var readNumberedLinePattern = regexp.MustCompile(`^\s*(\d+) \| (.*)$`)
+func exploreCardBody(name string, hint string, arg string, detail string, width int, opts cardRenderOptions, failed bool) cardBody {
+	if failed {
+		return genericCardBody(detail, opts)
+	}
+	return cardBody{lines: []string{exploreCardLine(name, hint, arg, detail, width, opts, "└")}}
+}
 
-func readCardBody(detail string, width int, opts cardRenderOptions) cardBody {
-	// The number gutter drops with the diff gutter below 80 cols.
-	gutter := widthTier(width) >= tierMedium
-	raw := strings.Split(detail, "\n")
-	lines := make([]string, 0, len(raw))
-	first, last := 0, 0
-	for _, line := range raw {
-		if strings.HasPrefix(line, "File: ") || strings.TrimSpace(line) == "" {
+func exploreCardLine(name string, hint string, arg string, detail string, width int, opts cardRenderOptions, marker string) string {
+	if marker == "" {
+		marker = "└"
+	}
+	action := exploreChildAction(name)
+	target := exploreTarget(name, hint, arg, detail)
+	line := zeroTheme.faint.Render("  "+marker+" ") + zeroTheme.green.Render(action)
+	if target != "" {
+		shown := target
+		if looksLikePath(target) {
+			shown = displayPath(opts.cwd, target)
+		}
+		styled := zeroTheme.toolTarget.Render(middleTruncate(shown, maxInt(8, width-lipgloss.Width(action)-6)))
+		if looksLikePath(target) {
+			styled = hyperlink(fileURL(opts.cwd, target), styled)
+		}
+		line += " " + styled
+	}
+	return line
+}
+
+func exploreChildAction(name string) string {
+	switch name {
+	case "read_file", "read_minified_file":
+		return "Read"
+	case "list_directory":
+		return "List"
+	case "grep":
+		return "Search"
+	case "glob":
+		return "Find"
+	default:
+		return toolDisplayName(name)
+	}
+}
+
+func exploreTarget(name string, hint string, arg string, detail string) string {
+	switch name {
+	case "read_file", "read_minified_file":
+		if target := strings.TrimSpace(hint); target != "" {
+			return target
+		}
+		return readDetailPath(detail)
+	case "grep":
+		if target := strings.TrimSpace(arg); target != "" {
+			return target
+		}
+		return strings.TrimSpace(hint)
+	case "glob":
+		if target := strings.TrimSpace(arg); target != "" {
+			return target
+		}
+		return strings.TrimSpace(hint)
+	case "list_directory":
+		return strings.TrimSpace(hint)
+	default:
+		return strings.TrimSpace(hint)
+	}
+}
+
+func readDetailPath(detail string) string {
+	for _, line := range strings.Split(detail, "\n") {
+		if strings.HasPrefix(line, "File: ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "File: "))
+		}
+	}
+	return ""
+}
+
+func localControlCardBody(name string, hint string, detail string, width int, opts cardRenderOptions, failed bool) cardBody {
+	if failed {
+		return genericCardBody(detail, opts)
+	}
+	switch name {
+	case "browser_snapshot", "desktop_windows", "desktop_snapshot", "capture_artifact":
+		return cardBody{}
+	case "browser_open":
+		if summary := browserOpenSummary(detail, hint); summary != "" {
+			return cardBody{lines: []string{localControlChildLine(summary, width)}}
+		}
+		return cardBody{}
+	default:
+		if summary := firstLocalControlSummaryLine(detail); summary != "" {
+			return cardBody{lines: []string{localControlChildLine(summary, width)}}
+		}
+		return cardBody{}
+	}
+}
+
+func localControlChildLine(text string, width int) string {
+	prefix := "  └ "
+	budget := maxInt(8, width-lipgloss.Width(prefix))
+	return zeroTheme.faint.Render(prefix) + zeroTheme.muted.Render(truncateRunes(text, budget))
+}
+
+func browserOpenSummary(detail string, target string) string {
+	target = strings.TrimRight(strings.TrimSpace(target), "/")
+	for _, line := range strings.Split(detail, "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "✓"))
+		if line == "" {
 			continue
 		}
-		if match := readNumberedLinePattern.FindStringSubmatch(line); match != nil {
-			number, _ := strconv.Atoi(match[1])
-			if first == 0 {
-				first = number
-			}
-			last = number
-			row := zeroTheme.muted.Render(match[2])
-			if gutter {
-				row = zeroTheme.faintest.Render(fmt.Sprintf("%4s", match[1])) + " " + row
-			}
-			lines = append(lines, row)
+		normalized := strings.TrimRight(line, "/")
+		if target != "" && normalized == target {
 			continue
 		}
-		lines = append(lines, zeroTheme.muted.Render(line))
+		if strings.HasPrefix(line, "http://") || strings.HasPrefix(line, "https://") {
+			continue
+		}
+		return line
 	}
-	headTag := ""
-	if first > 0 && last >= first {
-		headTag = fmt.Sprintf("L%d–L%d", first, last)
+	return ""
+}
+
+func firstLocalControlSummaryLine(detail string) string {
+	for _, line := range strings.Split(detail, "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "✓"))
+		switch {
+		case line == "":
+			continue
+		case strings.HasPrefix(line, "Artifact captured:"):
+			continue
+		default:
+			return line
+		}
 	}
-	return cardBody{lines: capCardLines(lines, opts.bodyCap), headTag: headTag}
+	return ""
+}
+
+func artifactCapturedPath(detail string) string {
+	for _, line := range strings.Split(detail, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Artifact captured:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "Artifact captured:"))
+		}
+	}
+	return ""
 }
 
 func bashCardBody(command string, detail string, width int, opts cardRenderOptions) cardBody {
-	innerWidth := width - 4
-	lines := []string{}
-	if command = strings.TrimSpace(command); command != "" {
-		lines = append(lines, zeroTheme.bashPrompt.Render("❯ ")+zeroTheme.ink.Render(truncateRunes(command, maxInt(8, innerWidth-2))))
-		lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", maxInt(1, innerWidth))))
-	}
-
 	footer := ""
+	output := []commandOutputLine{}
 	section := "stdout"
 	for _, line := range strings.Split(detail, "\n") {
 		switch {
@@ -1913,9 +2284,7 @@ func bashCardBody(command string, detail string, width int, opts cardRenderOptio
 			section = "stderr"
 		case strings.HasPrefix(line, "exit_code: "):
 			code := strings.TrimPrefix(line, "exit_code: ")
-			if code == "0" {
-				footer = zeroTheme.green.Render("exit 0")
-			} else {
+			if code != "0" {
 				footer = zeroTheme.red.Render("exit " + code)
 			}
 		default:
@@ -1923,21 +2292,16 @@ func bashCardBody(command string, detail string, width int, opts cardRenderOptio
 			if section == "stderr" {
 				style = zeroTheme.delText
 			}
-			lines = append(lines, "  "+style.Render(line))
+			output = append(output, commandOutputLine{text: line, style: style})
 		}
 	}
+	lines := renderCommandOutputLines(output, width, opts)
 	return cardBody{lines: capCardLines(lines, opts.bodyCap), footer: footer}
 }
 
 func execCommandCardBody(command string, detail string, width int, opts cardRenderOptions) cardBody {
-	innerWidth := width - 4
-	lines := []string{}
-	if command = strings.TrimSpace(command); command != "" {
-		lines = append(lines, zeroTheme.bashPrompt.Render("❯ ")+zeroTheme.ink.Render(truncateRunes(command, maxInt(8, innerWidth-2))))
-		lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", maxInt(1, innerWidth))))
-	}
-
 	footer := ""
+	output := []commandOutputLine{}
 	section := ""
 	interrupted := false
 	for _, line := range strings.Split(detail, "\n") {
@@ -1950,7 +2314,7 @@ func execCommandCardBody(command string, detail string, width int, opts cardRend
 		case strings.HasPrefix(line, "exit_code: "):
 			code := strings.TrimPrefix(line, "exit_code: ")
 			if code == "0" {
-				footer = zeroTheme.green.Render("exit 0")
+				// Successful completion is already visible from the green status dot.
 			} else if interrupted {
 				footer = zeroTheme.green.Render("interrupted")
 			} else {
@@ -1965,10 +2329,46 @@ func execCommandCardBody(command string, detail string, width int, opts cardRend
 			if section == "" && strings.HasPrefix(line, "Command is still running.") {
 				style = zeroTheme.faint
 			}
-			lines = append(lines, "  "+style.Render(line))
+			output = append(output, commandOutputLine{text: line, style: style})
 		}
 	}
+	lines := renderCommandOutputLines(output, width, opts)
 	return cardBody{lines: capCardLines(lines, opts.bodyCap), footer: footer}
+}
+
+type commandOutputLine struct {
+	text  string
+	style lipgloss.Style
+}
+
+func renderCommandOutputLines(output []commandOutputLine, width int, opts cardRenderOptions) []string {
+	output = trimTrailingEmptyCommandOutput(output)
+	if len(output) == 0 {
+		return nil
+	}
+
+	if len(output) == 1 {
+		prefix := "  └ "
+		budget := maxInt(8, width-lipgloss.Width(prefix))
+		text := truncateRunes(output[0].text, budget)
+		return capCardLines([]string{zeroTheme.faint.Render(prefix) + output[0].style.Render(text)}, opts.bodyCap)
+	}
+
+	lines := make([]string, 0, len(output))
+	prefix := "  │ "
+	budget := maxInt(8, width-lipgloss.Width(prefix))
+	for _, item := range output {
+		text := truncateRunes(item.text, budget)
+		lines = append(lines, zeroTheme.faint.Render(prefix)+item.style.Render(text))
+	}
+	return capCardLines(lines, opts.bodyCap)
+}
+
+func trimTrailingEmptyCommandOutput(output []commandOutputLine) []commandOutputLine {
+	for len(output) > 0 && strings.TrimSpace(output[len(output)-1].text) == "" {
+		output = output[:len(output)-1]
+	}
+	return output
 }
 
 // renderSessionsCards draws the /resume list as stacked cards: id (accent) +
@@ -2004,7 +2404,7 @@ func renderSessionsCards(payload string, width int) string {
 var grepMatchPattern = regexp.MustCompile(`^(.+?:\d+):\s?(.*)$`)
 
 func grepCardBody(detail string, width int, opts cardRenderOptions) cardBody {
-	innerWidth := width - 4
+	innerWidth := width
 	raw := strings.Split(detail, "\n")
 	lines := make([]string, 0, len(raw))
 	matches := 0

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -128,8 +128,8 @@ func isHiddenPlumbingTool(name string) bool {
 
 // skip reports whether a row renders nothing itself: a tool call whose result
 // arrived collapses into the result's card; a permission prompt that has been
-// decided collapses away; allow rows are audit events and the tool card speaks
-// for the approved action.
+// decided collapses away; silent auto-approvals collapse, while manual approval
+// decisions remain as audit rows.
 func (rc rowContext) skip(row transcriptRow) bool {
 	switch row.kind {
 	case rowToolCall:
@@ -154,7 +154,7 @@ func (rc rowContext) skip(row transcriptRow) bool {
 		case agent.PermissionActionPrompt:
 			return rc.decided[key]
 		case agent.PermissionActionAllow:
-			return true
+			return rc.auto[key]
 		}
 	}
 	return false
@@ -164,8 +164,9 @@ func (rc rowContext) skip(row transcriptRow) bool {
 // (small for the live region, generous for the permanent scrollback flush) and
 // the workspace root used to absolutize paths for OSC 8 file hyperlinks.
 type cardRenderOptions struct {
-	bodyCap int
-	cwd     string
+	bodyCap  int
+	cwd      string
+	expanded bool
 }
 
 // flushCardBodyMaxLines is the body cap for cards flushed to scrollback. The
@@ -1423,7 +1424,9 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 		head := toolCardHead(name, headTarget, headArg, "", row.detail, row.text, false, nameStyle, rc.auto[key], width, opts)
 		return toolCard(head, glyph, nil, collapsedFooter, borderStyle, width)
 	}
-	body := toolCardBody(name, rc.hints[key], rc.args[key], row.detail, width, opts, failed)
+	bodyOpts := opts
+	bodyOpts.expanded = row.expanded
+	body := toolCardBody(name, rc.hints[key], rc.args[key], row.detail, width, bodyOpts, failed)
 	head := toolCardHead(name, headTarget, headArg, body.headTag, row.detail, row.text, false, nameStyle, rc.auto[key], width, opts)
 	footer := body.footer
 	if collapsedFooter != "" && row.expanded && footer == "" {
@@ -1988,7 +1991,7 @@ func highlightedAddedDiffLines(rawLines []string, meta diffMetadata, textBudget 
 	}
 	content := make([]string, 0, meta.adds)
 	for _, line := range rawLines {
-		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++ ") {
 			content = append(content, strings.TrimPrefix(line, "+"))
 		}
 	}
@@ -2040,10 +2043,10 @@ func diffBodyStyledLine(number int, sign string, styledText string, added bool, 
 }
 
 func isDiffAddContent(s string) bool {
-	return strings.HasPrefix(s, "+") && !strings.HasPrefix(s, "+++")
+	return strings.HasPrefix(s, "+") && !strings.HasPrefix(s, "+++ ")
 }
 func isDiffDelContent(s string) bool {
-	return strings.HasPrefix(s, "-") && !strings.HasPrefix(s, "---")
+	return strings.HasPrefix(s, "-") && !strings.HasPrefix(s, "--- ")
 }
 
 // isIsolatedReplacement reports whether rawLines[i] (already a deleted content
@@ -2130,7 +2133,30 @@ func exploreCardBody(name string, hint string, arg string, detail string, width 
 	if failed {
 		return genericCardBody(detail, opts)
 	}
-	return cardBody{lines: []string{exploreCardLine(name, hint, arg, detail, width, opts, "└")}}
+	summary := exploreCardLine(name, hint, arg, detail, width, opts, "└")
+	if !opts.expanded && opts.bodyCap > 0 {
+		footer := ""
+		if strings.TrimSpace(detail) != "" {
+			footer = zeroTheme.faint.Render("▸ details")
+		}
+		return cardBody{lines: []string{summary}, footer: footer}
+	}
+	body := exploreDetailCardBody(name, detail, width, opts)
+	lines := append([]string{summary}, body.lines...)
+	footer := body.footer
+	if opts.expanded && opts.bodyCap > 0 && footer == "" {
+		footer = zeroTheme.faint.Render("▾ collapse")
+	}
+	return cardBody{lines: lines, footer: footer}
+}
+
+func exploreDetailCardBody(name string, detail string, width int, opts cardRenderOptions) cardBody {
+	switch name {
+	case "grep":
+		return grepCardBody(detail, width, opts)
+	default:
+		return genericCardBody(detail, opts)
+	}
 }
 
 func exploreCardLine(name string, hint string, arg string, detail string, width int, opts cardRenderOptions, marker string) string {
@@ -2235,7 +2261,7 @@ func localControlCardBody(name string, hint string, detail string, width int, op
 func localControlChildLine(text string, width int) string {
 	prefix := "  └ "
 	budget := maxInt(8, width-lipgloss.Width(prefix))
-	return zeroTheme.faint.Render(prefix) + zeroTheme.muted.Render(truncateRunes(text, budget))
+	return zeroTheme.faint.Render(prefix) + zeroTheme.muted.Render(truncateDisplayWidth(text, budget))
 }
 
 func browserOpenSummary(detail string, target string) string {
@@ -2360,7 +2386,7 @@ func renderCommandOutputLines(output []commandOutputLine, width int, opts cardRe
 	if len(output) == 1 {
 		prefix := "  └ "
 		budget := maxInt(8, width-lipgloss.Width(prefix))
-		text := truncateRunes(output[0].text, budget)
+		text := truncateDisplayWidth(output[0].text, budget)
 		return capCardLines([]string{zeroTheme.faint.Render(prefix) + output[0].style.Render(text)}, opts.bodyCap)
 	}
 
@@ -2368,7 +2394,7 @@ func renderCommandOutputLines(output []commandOutputLine, width int, opts cardRe
 	prefix := "  │ "
 	budget := maxInt(8, width-lipgloss.Width(prefix))
 	for _, item := range output {
-		text := truncateRunes(item.text, budget)
+		text := truncateDisplayWidth(item.text, budget)
 		lines = append(lines, zeroTheme.faint.Render(prefix)+item.style.Render(text))
 	}
 	return capCardLines(lines, opts.bodyCap)
@@ -2379,6 +2405,20 @@ func trimTrailingEmptyCommandOutput(output []commandOutputLine) []commandOutputL
 		output = output[:len(output)-1]
 	}
 	return output
+}
+
+func truncateDisplayWidth(text string, budget int) string {
+	if budget <= 0 {
+		return ""
+	}
+	if lipgloss.Width(text) <= budget {
+		return text
+	}
+	if budget <= 1 {
+		return "…"
+	}
+	head, _ := splitAtWidth(text, budget-1)
+	return head + "…"
 }
 
 // renderSessionsCards draws the /resume list as stacked cards: id (accent) +
@@ -2427,7 +2467,7 @@ func grepCardBody(detail string, width int, opts cardRenderOptions) cardBody {
 				location = hyperlink(fileURL(opts.cwd, path), location)
 			}
 			budget := maxInt(8, innerWidth-lipgloss.Width(match[1])-2)
-			lines = append(lines, location+"  "+zeroTheme.muted.Render(truncateRunes(match[2], budget)))
+			lines = append(lines, location+"  "+zeroTheme.muted.Render(truncateDisplayWidth(match[2], budget)))
 			continue
 		}
 		lines = append(lines, zeroTheme.muted.Render(line))

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -2142,11 +2142,12 @@ func exploreCardLine(name string, hint string, arg string, detail string, width 
 	line := zeroTheme.faint.Render("  "+marker+" ") + zeroTheme.green.Render(action)
 	if target != "" {
 		shown := target
-		if looksLikePath(target) {
+		isPath := exploreTargetLooksLikePath(name, target)
+		if isPath {
 			shown = displayPath(opts.cwd, target)
 		}
 		styled := zeroTheme.toolTarget.Render(middleTruncate(shown, maxInt(8, width-lipgloss.Width(action)-6)))
-		if looksLikePath(target) {
+		if isPath {
 			styled = hyperlink(fileURL(opts.cwd, target), styled)
 		}
 		line += " " + styled
@@ -2166,6 +2167,15 @@ func exploreChildAction(name string) string {
 		return "Find"
 	default:
 		return toolDisplayName(name)
+	}
+}
+
+func exploreTargetLooksLikePath(name string, target string) bool {
+	switch name {
+	case "read_file", "read_minified_file", "list_directory":
+		return looksLikePath(target)
+	default:
+		return false
 	}
 }
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -47,15 +47,8 @@ func TestStyleAssistantMarkdownLinePassesAnsiVerbatim(t *testing.T) {
 	in := "\x1b[31mtoken\x1b[0m" // an already-colored code token
 	out := styleAssistantMarkdownLine(in, lipgloss.NewStyle().Bold(true))
 
-	// With the fix the input escape leads the output verbatim. Without it, the
-	// whole line is re-wrapped so the output would START with base's own "\x1b[1m"
-	// and the input escape would be nested inside it.
-	if !strings.HasPrefix(out, "\x1b[31m") {
-		t.Fatalf("already-styled input was re-wrapped instead of passed verbatim: %q", out)
-	}
-	// The input's reset must also survive, not be re-encoded as runes.
-	if !strings.Contains(out, "\x1b[0m") {
-		t.Fatalf("input reset escape not preserved: %q", out)
+	if out != in {
+		t.Fatalf("already-styled input must pass through verbatim:\nin:  %q\nout: %q", in, out)
 	}
 }
 
@@ -323,6 +316,40 @@ func TestMarkdownInlineKeepsCodingLiterals(t *testing.T) {
 		if got != want {
 			t.Fatalf("inline markdown for %q = %q, want %q", input, got, want)
 		}
+	}
+}
+
+func TestMarkdownHorizontalRulesRenderAsDividers(t *testing.T) {
+	lines := renderAssistantMarkdownText(strings.Join([]string{
+		"Before",
+		"---",
+		"After",
+		"***",
+		"Done",
+	}, "\n"), 40, 40, true)
+	got := plainRender(t, strings.Join(lines, "\n"))
+	if strings.Contains(got, "\n---\n") || strings.Contains(got, "\n***\n") {
+		t.Fatalf("horizontal rules should not leak raw markdown markers:\n%s", got)
+	}
+	if strings.Count(got, strings.Repeat("─", 40)) != 2 {
+		t.Fatalf("horizontal rules should render as divider lines, got:\n%s", got)
+	}
+}
+
+func TestMarkdownHorizontalRulesDoNotEatListsOrDiffHeaders(t *testing.T) {
+	lines := renderAssistantMarkdownText(strings.Join([]string{
+		"- item",
+		"--- a/file.go",
+		"+++ b/file.go",
+	}, "\n"), 60, 60, false)
+	got := plainRender(t, strings.Join(lines, "\n"))
+	for _, want := range []string{"- item", "--- a/file.go", "+++ b/file.go"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown rule parser should leave %q alone, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, strings.Repeat("─", 16)) {
+		t.Fatalf("list/diff-looking text should not render as a divider:\n%s", got)
 	}
 }
 
@@ -734,44 +761,38 @@ func TestDoneLineOnlyOnLongTurns(t *testing.T) {
 	}
 }
 
-func TestInterimAssistantRowRendersAsBulletedProse(t *testing.T) {
+func TestInterimAssistantRowRendersAsPlainProse(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{kind: rowAssistant, text: "No provider configured."}
 	got := plainRender(t, m.renderRow(row, 96, buildRowContext(nil)))
-	if strings.Contains(got, "│") {
-		t.Fatalf("non-final assistant row = %q, must not carry a card rail", got)
-	}
-	// Narration carries a leading "●" bullet so each story beat stands out.
-	if !strings.Contains(got, "●") {
-		t.Fatalf("non-final assistant row should carry the narration bullet, got %q", got)
+	if strings.Contains(got, "│") || strings.Contains(got, "●") {
+		t.Fatalf("non-final assistant row = %q, must not carry activity chrome", got)
 	}
 	if !strings.Contains(got, "No provider configured.") {
 		t.Fatalf("non-final assistant row should carry the body text, got %q", got)
 	}
 }
 
-// TestNarrationBulletSelectionGeometry locks the bullet's column math: the
-// narration block wraps 2 cols narrower, every selectable meta starts at the
-// gutter (so copy/selection stays aligned and copied text is gutter-free), no
-// line overflows the width, and the final answer keeps no bullet / textStart 0.
-func TestNarrationBulletSelectionGeometry(t *testing.T) {
+// TestNarrationSelectionGeometry locks narration column math: interim prose and
+// final answers both start at textStart 0, no line overflows the width, and copy
+// metadata stays free of display-only chrome.
+func TestNarrationSelectionGeometry(t *testing.T) {
 	m := limeTestModel()
-	gutter := lipgloss.Width(narrationPrefix)
 	narr := transcriptRow{kind: rowAssistant, text: "Now the stylesheet. " + strings.Repeat("word ", 60)}
 	rendered, metas := m.renderSelectableAssistantRow(0, narr, 90, 0)
 
-	if !strings.Contains(plainRender(t, rendered), "●") {
-		t.Fatalf("narration display should carry the bullet:\n%s", rendered)
+	if strings.Contains(plainRender(t, rendered), "●") {
+		t.Fatalf("narration display should not carry the old bullet:\n%s", rendered)
 	}
 	if len(metas) < 2 {
 		t.Fatalf("expected the long narration to wrap to multiple lines, got %d", len(metas))
 	}
 	for i, meta := range metas {
-		if meta.textStart != gutter {
-			t.Errorf("meta %d textStart = %d, want %d (gutter)", i, meta.textStart, gutter)
+		if meta.textStart != 0 {
+			t.Errorf("meta %d textStart = %d, want 0", i, meta.textStart)
 		}
 		if strings.Contains(meta.text, "●") {
-			t.Errorf("meta %d copy text should be gutter-free, got %q", i, meta.text)
+			t.Errorf("meta %d copy text should be chrome-free, got %q", i, meta.text)
 		}
 	}
 	for _, line := range strings.Split(rendered, "\n") {
@@ -820,13 +841,11 @@ func TestRunningToolCardShowsHeadAndSpinnerSlot(t *testing.T) {
 	m.pending = true
 	row := transcriptRow{kind: rowToolCall, id: "call_1", tool: "grep", detail: "internal/cli"}
 	got := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
-	if !strings.Contains(got, "grep") || !strings.Contains(got, "internal/cli") {
-		t.Fatalf("running card = %q, want tool name and target in head", got)
+	if !strings.Contains(got, "Searching") || !strings.Contains(got, "internal/cli") {
+		t.Fatalf("running card = %q, want action label and target in head", got)
 	}
-	// Tool cards render as a left-rule card (status-tinted "│ " rail, no box),
-	// matching specialist cards and the reference TUIs.
-	if !strings.HasPrefix(got, "│ ") {
-		t.Fatalf("running card = %q, want a left-rule card", got)
+	if strings.HasPrefix(got, "│ ") || strings.Contains(got, "\n│ ") {
+		t.Fatalf("running card = %q, must not carry the old left rail", got)
 	}
 	if strings.ContainsAny(got, "╭╮╰╯") {
 		t.Fatalf("running card = %q, must not carry box-border corners", got)
@@ -850,19 +869,31 @@ func TestResolvedToolCallCollapsesIntoResultCard(t *testing.T) {
 func TestDiffCardBodyRendersCountsNumbersAndCap(t *testing.T) {
 	m := limeTestModel()
 	diff := strings.Join([]string{
-		"--- /dev/null",
-		"+++ b/internal/cli/root.go",
+		"--- internal/cli/root.go",
+		"+++ internal/cli/root.go",
 		"@@ -0,0 +1,3 @@",
 		"+package cli",
 		"+",
 		"+var Version = \"dev\"",
 	}, "\n")
-	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "edit_file", status: tools.StatusOK, detail: diff}
-	got := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
-	for _, want := range []string{"internal/cli/root.go", "NEW FILE", "+3", "package cli", "   1"} {
+	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "write_file", status: tools.StatusOK, detail: diff}
+	styled := m.renderRow(row, 80, buildRowContext(nil))
+	for _, want := range []string{zeroTheme.diffAdd.Render("+3"), zeroTheme.diffDel.Render("-0")} {
+		if !strings.Contains(styled, want) {
+			t.Fatalf("diff card count tag should color additions/deletions, missing styled %q in:\n%s", want, styled)
+		}
+	}
+	got := plainRender(t, styled)
+	for _, want := range []string{"Added", "internal/cli/root.go", "(+3 -0)", "package cli", "   1"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("diff card = %q, missing %q", got, want)
 		}
+	}
+	if strings.Contains(got, "write_file") || strings.Contains(got, "NEW FILE") {
+		t.Fatalf("diff card = %q, must not expose raw tool name or duplicate new-file tag", got)
+	}
+	if strings.Contains(got, "@@") {
+		t.Fatalf("diff card should hide raw hunk metadata, got %q", got)
 	}
 
 	// The 16-line cap keeps long diffs bounded.
@@ -877,17 +908,46 @@ func TestDiffCardBodyRendersCountsNumbersAndCap(t *testing.T) {
 	}
 }
 
-func TestReadCardBodyShowsGutterAndRange(t *testing.T) {
+func TestEditedDiffCardHidesHunkHeader(t *testing.T) {
+	m := limeTestModel()
+	diff := strings.Join([]string{
+		"--- a/time_test.py",
+		"+++ b/time_test.py",
+		"@@ -1,3 +1,3 @@",
+		" from datetime import datetime",
+		"",
+		"-print(datetime.now().strftime(\"%Y-%m-%d %H:%M:%S\"))",
+		"+print(f\"Current system time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\")",
+	}, "\n")
+	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "edit_file", status: tools.StatusOK, detail: diff}
+	got := plainRender(t, m.renderRow(row, 96, buildRowContext(nil)))
+	for _, want := range []string{"Edited", "time_test.py", "(+1 -1)", "from datetime import datetime", "   3 −", "   3 +"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("edited diff card = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "@@") {
+		t.Fatalf("edited diff card should hide raw hunk metadata, got %q", got)
+	}
+}
+
+func TestReadCardBodyShowsExploredSummary(t *testing.T) {
 	m := limeTestModel()
 	// Mirrors the real read_file output shape: "<right-aligned N> | <text>".
 	detail := "File: internal/agent/loop.go\n\n  12 | func Run() {\n  13 | }\n"
 	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "read_file", status: tools.StatusOK, detail: detail}
 	rc := buildRowContext([]transcriptRow{{kind: rowToolCall, id: "call_1", tool: "read_file", detail: "internal/agent/loop.go"}})
 	got := plainRender(t, m.renderRow(row, 80, rc))
-	for _, want := range []string{"read_file", "internal/agent/loop.go", "L12–L13", "func Run() {"} {
+	for _, want := range []string{"Explored", "└ Read", "internal/agent/loop.go"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("read card = %q, missing %q", got, want)
 		}
+	}
+	if strings.Contains(got, "L12") || strings.Contains(got, "func Run()") || strings.Contains(got, "  12 ") {
+		t.Fatalf("read card = %q, must not dump read_file body into the transcript", got)
+	}
+	if strings.Contains(got, "read_file") {
+		t.Fatalf("read card = %q, must not expose raw tool name", got)
 	}
 }
 
@@ -897,13 +957,45 @@ func TestBashCardBodyShowsCommandOutputAndExit(t *testing.T) {
 	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "bash", status: tools.StatusError, detail: detail}
 	rc := buildRowContext([]transcriptRow{{kind: rowToolCall, id: "call_1", tool: "bash", detail: "go build ./..."}})
 	got := plainRender(t, m.renderRow(row, 80, rc))
-	for _, want := range []string{"❯ go build ./...", "ok build", "warning: slow", "exit 1"} {
+	for _, want := range []string{"Ran", "go build ./...", "ok build", "warning: slow", "exit 1"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("bash card = %q, missing %q", got, want)
 		}
 	}
-	if strings.Contains(got, "stdout:") || strings.Contains(got, "exit_code:") {
+	if strings.Contains(got, "❯") || strings.Contains(got, "stdout:") || strings.Contains(got, "exit_code:") {
 		t.Fatalf("bash card = %q, must restyle section markers", got)
+	}
+	if strings.Contains(got, "├ ok build") || strings.Contains(got, "└ warning: slow") {
+		t.Fatalf("multi-line command output should render as a simple output block, got:\n%s", got)
+	}
+	if !strings.Contains(got, "│ ok build") || !strings.Contains(got, "│ warning: slow") {
+		t.Fatalf("multi-line command output should stay grouped under the command, got:\n%s", got)
+	}
+}
+
+func TestBashCardBodyKeepsSingleLineOutputCompact(t *testing.T) {
+	m := limeTestModel()
+	detail := "stdout:\nJS syntax: OK\nexit_code: 0"
+	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "bash", status: tools.StatusOK, detail: detail}
+	rc := buildRowContext([]transcriptRow{{kind: rowToolCall, id: "call_1", tool: "bash", detail: `node -e "console.log('ok')"`}})
+	got := plainRender(t, m.renderRow(row, 80, rc))
+	if !strings.Contains(got, "└ JS syntax: OK") {
+		t.Fatalf("single-line command output should keep compact child marker, got:\n%s", got)
+	}
+}
+
+func TestToolCardHeadCollapsesMultilineCommand(t *testing.T) {
+	m := limeTestModel()
+	command := "node -e \"\nconst fs = require('fs')\nconsole.log('ok')\n\""
+	detail := "stdout:\nJS syntax: OK\nexit_code: 0"
+	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "bash", status: tools.StatusOK, detail: detail}
+	rc := buildRowContext([]transcriptRow{{kind: rowToolCall, id: "call_1", tool: "bash", detail: command}})
+	got := plainRender(t, m.renderRow(row, 120, rc))
+	if strings.Contains(got, "\nconst fs") || strings.Contains(got, "\n\"") {
+		t.Fatalf("multi-line command should not break the card header, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Ran node -e") || !strings.Contains(got, "const fs = require") {
+		t.Fatalf("multi-line command summary should stay visible on one line, got:\n%s", got)
 	}
 }
 
@@ -913,18 +1005,24 @@ func TestExecCommandCardBodyShowsSessionAndExit(t *testing.T) {
 	running := transcriptRow{kind: rowToolResult, id: "call_1", tool: "exec_command", status: tools.StatusOK, detail: runningDetail}
 	rc := buildRowContext([]transcriptRow{{kind: rowToolCall, id: "call_1", tool: "exec_command", detail: "python3 -m http.server 8000"}})
 	got := plainRender(t, m.renderRow(running, 90, rc))
-	for _, want := range []string{"❯ python3 -m http.server 8000", "Serving HTTP", "session 1000"} {
+	for _, want := range []string{"Ran", "python3 -m http.server 8000", "Serving HTTP", "session 1000"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("exec_command card = %q, missing %q", got, want)
 		}
 	}
-	if strings.Contains(got, "Use write_stdin") || strings.Contains(got, "session_id:") {
+	if strings.Contains(got, "❯") || strings.Contains(got, "Use write_stdin") || strings.Contains(got, "session_id:") {
 		t.Fatalf("exec_command card = %q, must restyle session markers", got)
 	}
 
 	exited := transcriptRow{kind: rowToolResult, id: "call_2", tool: "write_stdin", status: tools.StatusOK, detail: "output:\ndone\nexit_code: 0"}
 	got = plainRender(t, m.renderRow(exited, 90, buildRowContext(nil)))
-	for _, want := range []string{"done", "exit 0"} {
+	if !strings.Contains(got, "done") {
+		t.Fatalf("write_stdin card = %q, missing output", got)
+	}
+	if strings.Contains(got, "exit 0") {
+		t.Fatalf("write_stdin card = %q, must not show successful exit", got)
+	}
+	for _, want := range []string{"done"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("write_stdin card = %q, missing %q", got, want)
 		}
@@ -937,6 +1035,61 @@ func TestExecCommandCardBodyShowsSessionAndExit(t *testing.T) {
 	}
 }
 
+func TestLocalControlCardsUseFriendlyCompactLabels(t *testing.T) {
+	m := limeTestModel()
+
+	open := transcriptRow{kind: rowToolResult, id: "call_1", tool: "browser_open", status: tools.StatusOK, detail: "✓ ZERO - terminal agent\nhttp://localhost:8080/"}
+	openRC := buildRowContext([]transcriptRow{{kind: rowToolCall, id: "call_1", tool: "browser_open", detail: "http://localhost:8080"}})
+	got := plainRender(t, m.renderRow(open, 100, openRC))
+	for _, want := range []string{"Opened", "http://localhost:8080", "ZERO - terminal agent"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("browser_open card missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "browser_open") || strings.Contains(got, "http://localhost:8080/\n") {
+		t.Fatalf("browser_open card should not expose raw tool names or repeat the URL body:\n%s", got)
+	}
+
+	snapshotDetail := strings.Repeat("button \"Item\"\n", 31)
+	snapshot := transcriptRow{kind: rowToolResult, id: "call_2", tool: "browser_snapshot", status: tools.StatusOK, detail: snapshotDetail}
+	got = plainRender(t, m.renderRow(snapshot, 100, buildRowContext(nil)))
+	for _, want := range []string{"Captured", "snapshot"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("browser_snapshot card missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "browser_snapshot") || strings.Contains(got, "click to expand") || strings.Contains(got, "button \"Item\"") {
+		t.Fatalf("browser_snapshot card should stay compact and friendly:\n%s", got)
+	}
+
+	artifact := transcriptRow{kind: rowToolResult, id: "call_3", tool: "capture_artifact", status: tools.StatusOK, detail: "Artifact captured: /tmp/zero-artifacts/page.png\n\nhelper wrote screenshot"}
+	got = plainRender(t, m.renderRow(artifact, 100, buildRowContext(nil)))
+	for _, want := range []string{"Captured", "page.png"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("capture_artifact card missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "capture_artifact") || strings.Contains(got, "Artifact captured:") || strings.Contains(got, "helper wrote screenshot") {
+		t.Fatalf("capture_artifact card should summarize the artifact instead of dumping helper output:\n%s", got)
+	}
+}
+
+func TestPermissionRowsUseFriendlyLocalControlLabels(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{kind: rowPermission, id: "call_1", permission: &agent.PermissionEvent{
+		ToolCallID: "call_1",
+		ToolName:   "browser_open",
+		Action:     agent.PermissionActionPrompt,
+	}}
+	got := plainRender(t, m.renderRow(row, 100, buildRowContext(nil)))
+	if !strings.Contains(got, "Open browser") {
+		t.Fatalf("permission row should use local-control display name:\n%s", got)
+	}
+	if strings.Contains(got, "browser_open") {
+		t.Fatalf("permission row should not expose raw local-control tool name:\n%s", got)
+	}
+}
+
 func TestToolCallSummaryDescribesExecSessions(t *testing.T) {
 	cases := []struct {
 		event streamjson.Event
@@ -945,6 +1098,10 @@ func TestToolCallSummaryDescribesExecSessions(t *testing.T) {
 		{
 			event: streamjson.Event{Name: "exec_command", Args: map[string]any{"cmd": "python3 -m http.server 8000"}},
 			want:  "python3 -m http.server 8000",
+		},
+		{
+			event: streamjson.Event{Name: "exec_command", Args: map[string]any{"cmd": "node -e \"\nconsole.log('ok')\n\""}},
+			want:  `node -e " console.log('ok') "`,
 		},
 		{
 			event: streamjson.Event{Name: "write_stdin", Args: map[string]any{"session_id": 1000}},
@@ -966,15 +1123,19 @@ func TestToolCallSummaryDescribesExecSessions(t *testing.T) {
 	}
 }
 
-func TestGrepCardBodyShowsLocationsAndMatchCount(t *testing.T) {
+func TestGrepCardBodyShowsExploredSummary(t *testing.T) {
 	m := limeTestModel()
 	detail := "internal/cli/root.go:41: fs := flag.NewFlagSet\ninternal/cli/app.go:12: flag.Parse()"
 	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "grep", status: tools.StatusOK, detail: detail}
-	got := plainRender(t, m.renderRow(row, 90, buildRowContext(nil)))
-	for _, want := range []string{"internal/cli/root.go:41", "2 matches"} {
+	rc := buildRowContext([]transcriptRow{{kind: rowToolCall, id: "call_1", tool: "grep", detail: "internal/cli", arg: "flag"}})
+	got := plainRender(t, m.renderRow(row, 90, rc))
+	for _, want := range []string{"Explored", "└ Search", "flag"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("grep card = %q, missing %q", got, want)
 		}
+	}
+	if strings.Contains(got, "internal/cli/root.go:41") || strings.Contains(got, "2 matches") {
+		t.Fatalf("grep card = %q, must not expose raw search matches", got)
 	}
 }
 
@@ -1326,7 +1487,7 @@ func TestToolCardLinesAllSameWidth(t *testing.T) {
 	}
 }
 
-func TestToolResultCardRendersAsLeftRule(t *testing.T) {
+func TestToolResultCardRendersInlineWithoutRail(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{
 		kind:   rowToolResult,
@@ -1337,19 +1498,18 @@ func TestToolResultCardRendersAsLeftRule(t *testing.T) {
 	}
 	card := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
 	lines := strings.Split(card, "\n")
-	// Every line carries the left rail; none carries a box corner or a right
-	// border — the unified left-rule card shape (matches specialist cards).
+	// No line carries the old left rail or box borders.
 	for i, line := range lines {
-		if !strings.HasPrefix(line, "│ ") {
-			t.Fatalf("line %d = %q, want left-rule prefix", i, line)
+		if strings.HasPrefix(line, "│ ") {
+			t.Fatalf("line %d = %q, must not carry left-rule prefix", i, line)
 		}
 		if strings.ContainsAny(line, "╭╮╰╯") || strings.HasSuffix(line, "│") {
 			t.Fatalf("line %d = %q, must not carry box borders", i, line)
 		}
 	}
-	// The status glyph sits on the head line (first line), right-aligned.
-	if !strings.Contains(lines[0], "✓") {
-		t.Fatalf("head line = %q, want the status glyph on the rule line", lines[0])
+	// The status glyph still sits on the head line.
+	if !strings.Contains(lines[0], "•") {
+		t.Fatalf("head line = %q, want the status glyph on the head line", lines[0])
 	}
 }
 
@@ -1421,8 +1581,13 @@ func TestGrepCardHeadShowsTargetAndPatternColumns(t *testing.T) {
 	}
 	rc := buildRowContext(rows)
 	got := plainRender(t, m.renderRow(rows[1], 110, rc))
-	if !strings.Contains(got, "internal/cli") || !strings.Contains(got, `flag\.|RegisterFlag`) {
-		t.Fatalf("grep card head = %q, want separate target and pattern columns", got)
+	for _, want := range []string{"Explored", "└ Search", `flag\.|RegisterFlag`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("grep card = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "internal/cli/root.go:41") {
+		t.Fatalf("grep card = %q, must not dump search matches", got)
 	}
 }
 
@@ -1464,8 +1629,8 @@ func TestPermissionPromptCollapsesAfterDecision(t *testing.T) {
 	if !rc.skip(prompt) {
 		t.Fatal("a decided prompt row must collapse away")
 	}
-	if got := plainRender(t, m.renderRow(allowed, 80, rc)); !strings.Contains(got, "allowed once · bash") {
-		t.Fatalf("manual allow = %q, want allowed once · bash", got)
+	if !rc.skip(allowed) {
+		t.Fatal("manual allow rows should collapse; the tool card shows the approved action")
 	}
 
 	session := transcriptRow{kind: rowPermission, id: "call_session", permission: &agent.PermissionEvent{
@@ -1475,8 +1640,8 @@ func TestPermissionPromptCollapsesAfterDecision(t *testing.T) {
 		{kind: rowPermission, id: "call_session", permission: &agent.PermissionEvent{ToolCallID: "call_session", ToolName: "bash", Action: agent.PermissionActionPrompt}},
 		session,
 	})
-	if got := plainRender(t, m.renderRow(session, 80, rcSession)); !strings.Contains(got, "allowed for session · bash") {
-		t.Fatalf("session allow = %q, want allowed for session · bash", got)
+	if !rcSession.skip(session) {
+		t.Fatal("session allow rows should collapse; the durable decision is still recorded")
 	}
 
 	grant := &agent.PermissionEvent{ToolCallID: "call_2", ToolName: "bash", Action: agent.PermissionActionAllow}
@@ -1486,8 +1651,8 @@ func TestPermissionPromptCollapsesAfterDecision(t *testing.T) {
 		ToolCallID: "call_2", ToolName: "bash", Action: agent.PermissionActionPrompt,
 	}}
 	rcTwo := buildRowContext([]transcriptRow{promptTwo, always})
-	if got := plainRender(t, m.renderRow(always, 80, rcTwo)); !strings.Contains(got, "always · bash") {
-		t.Fatalf("always allow = %q, want always · bash", got)
+	if !rcTwo.skip(always) {
+		t.Fatal("always allow rows should collapse; the saved grant is still recorded")
 	}
 
 	denied := transcriptRow{kind: rowPermission, id: "call_3", permission: &agent.PermissionEvent{
@@ -1504,7 +1669,7 @@ func TestUnpromptedAllowRowsCollapseIntoAutoTag(t *testing.T) {
 	}}
 	rc := buildRowContext([]transcriptRow{allow})
 	if !rc.skip(allow) {
-		t.Fatal("an unprompted (auto) allow row must collapse — the tool card carries [auto]")
+		t.Fatal("an unprompted (auto) allow row must collapse")
 	}
 }
 
@@ -1632,8 +1797,8 @@ func TestPermissionCollapseIsRunScoped(t *testing.T) {
 	if !rcSame.skip(sameRunPrompt) {
 		t.Fatal("a same-run decided prompt must collapse")
 	}
-	if rcSame.skip(sameRunAllow) {
-		t.Fatal("the same-run manual decision line must render")
+	if !rcSame.skip(sameRunAllow) {
+		t.Fatal("the same-run manual decision line must collapse")
 	}
 }
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -1589,6 +1589,9 @@ func TestGrepCardHeadShowsTargetAndPatternColumns(t *testing.T) {
 	if strings.Contains(got, "internal/cli/root.go:41") {
 		t.Fatalf("grep card = %q, must not dump search matches", got)
 	}
+	if exploreTargetLooksLikePath("grep", `flag\.|RegisterFlag`) {
+		t.Fatal("grep regex arguments must not be treated as paths")
+	}
 }
 
 // --- Stage 3: interactive surfaces ------------------------------------------

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -874,7 +874,7 @@ func TestDiffCardBodyRendersCountsNumbersAndCap(t *testing.T) {
 		"@@ -0,0 +1,3 @@",
 		"+package cli",
 		"+",
-		"+var Version = \"dev\"",
+		"+++var Version = \"dev\"",
 	}, "\n")
 	row := transcriptRow{kind: rowToolResult, id: "call_1", tool: "write_file", status: tools.StatusOK, detail: diff}
 	styled := m.renderRow(row, 80, buildRowContext(nil))
@@ -884,7 +884,7 @@ func TestDiffCardBodyRendersCountsNumbersAndCap(t *testing.T) {
 		}
 	}
 	got := plainRender(t, styled)
-	for _, want := range []string{"Added", "internal/cli/root.go", "(+3 -0)", "package cli", "   1"} {
+	for _, want := range []string{"Added", "internal/cli/root.go", "(+3 -0)", "package cli", "++var Version = \"dev\"", "   1"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("diff card = %q, missing %q", got, want)
 		}
@@ -943,11 +943,22 @@ func TestReadCardBodyShowsExploredSummary(t *testing.T) {
 			t.Fatalf("read card = %q, missing %q", got, want)
 		}
 	}
+	if !strings.Contains(got, "▸ details") {
+		t.Fatalf("read card = %q, missing expand affordance", got)
+	}
 	if strings.Contains(got, "L12") || strings.Contains(got, "func Run()") || strings.Contains(got, "  12 ") {
 		t.Fatalf("read card = %q, must not dump read_file body into the transcript", got)
 	}
 	if strings.Contains(got, "read_file") {
 		t.Fatalf("read card = %q, must not expose raw tool name", got)
+	}
+
+	row.expanded = true
+	expanded := plainRender(t, m.renderRow(row, 80, rc))
+	for _, want := range []string{"Explored", "└ Read", "internal/agent/loop.go", "func Run()", "13 |"} {
+		if !strings.Contains(expanded, want) {
+			t.Fatalf("expanded read card = %q, missing %q", expanded, want)
+		}
 	}
 }
 
@@ -1632,8 +1643,11 @@ func TestPermissionPromptCollapsesAfterDecision(t *testing.T) {
 	if !rc.skip(prompt) {
 		t.Fatal("a decided prompt row must collapse away")
 	}
-	if !rc.skip(allowed) {
-		t.Fatal("manual allow rows should collapse; the tool card shows the approved action")
+	if rc.skip(allowed) {
+		t.Fatal("manual allow rows should remain as audit lines")
+	}
+	if got := plainRender(t, m.renderRow(allowed, 80, rc)); !strings.Contains(got, "allowed once · bash") {
+		t.Fatalf("manual allow = %q, want allowed once · bash", got)
 	}
 
 	session := transcriptRow{kind: rowPermission, id: "call_session", permission: &agent.PermissionEvent{
@@ -1643,8 +1657,11 @@ func TestPermissionPromptCollapsesAfterDecision(t *testing.T) {
 		{kind: rowPermission, id: "call_session", permission: &agent.PermissionEvent{ToolCallID: "call_session", ToolName: "bash", Action: agent.PermissionActionPrompt}},
 		session,
 	})
-	if !rcSession.skip(session) {
-		t.Fatal("session allow rows should collapse; the durable decision is still recorded")
+	if rcSession.skip(session) {
+		t.Fatal("session allow rows should remain as audit lines")
+	}
+	if got := plainRender(t, m.renderRow(session, 80, rcSession)); !strings.Contains(got, "allowed for session · bash") {
+		t.Fatalf("session allow = %q, want allowed for session · bash", got)
 	}
 
 	grant := &agent.PermissionEvent{ToolCallID: "call_2", ToolName: "bash", Action: agent.PermissionActionAllow}
@@ -1654,8 +1671,11 @@ func TestPermissionPromptCollapsesAfterDecision(t *testing.T) {
 		ToolCallID: "call_2", ToolName: "bash", Action: agent.PermissionActionPrompt,
 	}}
 	rcTwo := buildRowContext([]transcriptRow{promptTwo, always})
-	if !rcTwo.skip(always) {
-		t.Fatal("always allow rows should collapse; the saved grant is still recorded")
+	if rcTwo.skip(always) {
+		t.Fatal("always allow rows should remain as audit lines")
+	}
+	if got := plainRender(t, m.renderRow(always, 80, rcTwo)); !strings.Contains(got, "always · bash") {
+		t.Fatalf("always allow = %q, want always · bash", got)
 	}
 
 	denied := transcriptRow{kind: rowPermission, id: "call_3", permission: &agent.PermissionEvent{
@@ -1789,7 +1809,8 @@ func TestPermissionCollapseIsRunScoped(t *testing.T) {
 		t.Fatal("run 2's unprompted allow should fold into its tool card's [auto] tag")
 	}
 
-	// Same-run prompt+decision still collapses as before.
+	// Same-run prompt+decision collapses the prompt but keeps the manual decision
+	// as an audit line.
 	sameRunPrompt := transcriptRow{kind: rowPermission, id: "gemini_tool_1", runID: 3, permission: &agent.PermissionEvent{
 		ToolCallID: "gemini_tool_1", ToolName: "bash", Action: agent.PermissionActionPrompt,
 	}}
@@ -1800,8 +1821,8 @@ func TestPermissionCollapseIsRunScoped(t *testing.T) {
 	if !rcSame.skip(sameRunPrompt) {
 		t.Fatal("a same-run decided prompt must collapse")
 	}
-	if !rcSame.skip(sameRunAllow) {
-		t.Fatal("the same-run manual decision line must collapse")
+	if rcSame.skip(sameRunAllow) {
+		t.Fatal("the same-run manual decision line must render")
 	}
 }
 

--- a/internal/tui/scannable_results_test.go
+++ b/internal/tui/scannable_results_test.go
@@ -5,16 +5,15 @@ import (
 	"testing"
 )
 
-// The status glyph must LEAD the tool-card head row (✓/✗/spinner in the first
-// cell after the rail), not be right-aligned to the far edge — so state reads at
-// a glance. Guards the "easier-to-scan results" change.
+// The status glyph must LEAD the tool-card head row (dot/spinner first), not be
+// right-aligned to the far edge — so state reads at a glance.
 func TestToolCardGlyphLeadsHeadRow(t *testing.T) {
 	head := zeroTheme.toolName.Render("bash")
-	glyph := zeroTheme.green.Render("✓")
+	glyph := zeroTheme.green.Render("•")
 	out := toolCard(head, glyph, nil, "", zeroTheme.line, 60)
 	first := strings.SplitN(out, "\n", 2)[0]
 
-	glyphIdx := strings.Index(first, "✓")
+	glyphIdx := strings.Index(first, "•")
 	nameIdx := strings.Index(first, "bash")
 	if glyphIdx < 0 {
 		t.Fatalf("head row missing status glyph: %q", first)

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -113,30 +113,16 @@ func (m model) chatColumnWidth() int {
 	return chatWidth(m.width)
 }
 
-// transcriptGutterMinColumn is the column width below which the body uses the
-// full width (no side margins). Narrow columns (e.g. the chat column in the
-// two-column layout) have no space to waste, so they stay flush; the breathing
-// room is only for wide terminals where text would otherwise leave a big void.
-const transcriptGutterMinColumn = 98
-
-// transcriptGutter is the side margin applied to transcript body rows so the
-// reading column floats off both edges instead of running flush. It scales gently
-// with the column (a wider terminal earns a little more breathing room), is
-// applied on the left as an indent, and is mirrored on the right by
-// transcriptContentWidth. Zero on terminals too narrow to spare it.
+// transcriptGutter is the left indent applied to transcript body rows. Keep this
+// at zero so content starts at the chat edge and tool/code blocks can use the
+// full available width.
 func transcriptGutter(columnWidth int) int {
-	if columnWidth <= transcriptGutterMinColumn {
-		return 0
-	}
-	return clamp(columnWidth/20, 4, 12)
+	return 0
 }
 
-// transcriptContentWidth is the wrap width for transcript body rows: the column
-// minus a margin on each side, so the chat fills most of a wide terminal with a
-// little breathing room rather than stopping at a fixed reading cap. Degrades to
-// the full column on tiny terminals so prose never collapses to the wrap floor.
+// transcriptContentWidth is the wrap width for transcript body rows.
 func transcriptContentWidth(columnWidth int) int {
-	cw := columnWidth - 2*transcriptGutter(columnWidth)
+	cw := columnWidth - transcriptGutter(columnWidth)
 	if cw < 24 {
 		return columnWidth
 	}

--- a/internal/tui/specialist_card.go
+++ b/internal/tui/specialist_card.go
@@ -406,10 +406,10 @@ func toolCallSummary(event streamjson.Event) string {
 		}
 	case "bash", "exec_command":
 		if cmd, ok := args["command"].(string); ok {
-			return truncateRunes(cmd, 40)
+			return truncateRunes(singleLineToolHeadText(cmd), 40)
 		}
 		if cmd, ok := args["cmd"].(string); ok {
-			return truncateRunes(cmd, 40)
+			return truncateRunes(singleLineToolHeadText(cmd), 40)
 		}
 	case "write_stdin":
 		sessionID := toolCallIntArg(args, "session_id")

--- a/internal/tui/streaming_decoder.go
+++ b/internal/tui/streaming_decoder.go
@@ -17,6 +17,7 @@ type streamingDecoder struct {
 
 	rawLen   int    // total raw arg bytes seen (for the "receiving N KB" indicator)
 	head     []byte // raw args before the content value; dropped once content starts
+	pathScan []byte // bounded post-content args used only to recover a late path
 	path     string
 	pathDone bool
 
@@ -32,7 +33,7 @@ type streamingDecoder struct {
 
 func newStreamingDecoder() *streamingDecoder {
 	return &streamingDecoder{
-		pathKeys:    []string{"path", "file_path", "filename"},
+		pathKeys:    []string{"path", "file", "file_path", "filepath", "filename"},
 		contentKeys: []string{"content", "new_string", "new_str", "new_text", "new", "replacement", "patch", "input"},
 		tailCap:     streamingTailLines,
 	}
@@ -42,27 +43,54 @@ func newStreamingDecoder() *streamingDecoder {
 func (d *streamingDecoder) feed(fragment string) {
 	d.rawLen += len(fragment)
 	if d.closed {
+		d.scanPathFragment(fragment)
 		return
 	}
 	if d.inContent {
-		d.consume(fragment)
+		if remainder := d.consume(fragment); remainder != "" {
+			d.scanPathFragment(remainder)
+		}
 		return
 	}
 	d.head = append(d.head, fragment...)
 	if !d.pathDone {
 		// Best effort: the path completes quickly (it precedes the content), and a
 		// partial value just updates until it's whole.
-		d.path = streamingFilePath(string(d.head))
+		d.setPathFrom(string(d.head))
 	}
 	start := d.contentValueStart()
 	if start < 0 {
 		return // content value hasn't begun yet
 	}
-	d.pathDone = true
 	d.inContent = true
 	rest := string(d.head[start:])
 	d.head = nil
-	d.consume(rest)
+	if remainder := d.consume(rest); remainder != "" {
+		d.scanPathFragment(remainder)
+	}
+}
+
+func (d *streamingDecoder) setPathFrom(args string) {
+	if d.pathDone {
+		return
+	}
+	if v := streamingFilePath(args); v != "" {
+		d.path = v
+		d.pathDone = true
+	}
+}
+
+const maxStreamingPathScanBytes = 8192
+
+func (d *streamingDecoder) scanPathFragment(fragment string) {
+	if d.pathDone || fragment == "" {
+		return
+	}
+	d.pathScan = append(d.pathScan, fragment...)
+	if len(d.pathScan) > maxStreamingPathScanBytes {
+		d.pathScan = d.pathScan[len(d.pathScan)-maxStreamingPathScanBytes:]
+	}
+	d.setPathFrom(string(d.pathScan))
 }
 
 // contentValueStart returns the index in head just past the opening quote of the
@@ -78,9 +106,9 @@ func (d *streamingDecoder) contentValueStart() int {
 	return best
 }
 
-// consume decodes content bytes, splitting on decoded newlines into tail lines and
-// stopping at the value's closing quote.
-func (d *streamingDecoder) consume(b string) {
+// consume decodes content bytes, splitting on decoded newlines into tail lines,
+// stopping at the value's closing quote, and returning any bytes after it.
+func (d *streamingDecoder) consume(b string) string {
 	for i := 0; i < len(b); i++ {
 		c := b[i]
 		if d.uSkip > 0 {
@@ -108,11 +136,12 @@ func (d *streamingDecoder) consume(b string) {
 			d.pendingEsc = true
 		case '"':
 			d.closed = true // closing quote of the content value
-			return
+			return b[i+1:]
 		default:
 			d.cur = append(d.cur, c)
 		}
 	}
+	return ""
 }
 
 func (d *streamingDecoder) newline() {

--- a/internal/tui/streaming_decoder_test.go
+++ b/internal/tui/streaming_decoder_test.go
@@ -31,6 +31,27 @@ func TestStreamingDecoderPathTailAndCount(t *testing.T) {
 	}
 }
 
+func TestStreamingDecoderPathAliases(t *testing.T) {
+	for _, key := range []string{"file", "file_path", "filepath", "filename"} {
+		d := newStreamingDecoder()
+		d.feed(`{"` + key + `":"time_test.py","content":"print(1)"}`)
+		if d.path != "time_test.py" {
+			t.Errorf("%s path = %q, want time_test.py", key, d.path)
+		}
+	}
+}
+
+func TestStreamingDecoderFindsPathAfterContent(t *testing.T) {
+	d := newStreamingDecoder()
+	feedChunks(d, `{"content":"from datetime import datetime\n`, `print(datetime.now())",`, `"path":"time_test.py"}`)
+	if d.path != "time_test.py" {
+		t.Fatalf("late path = %q, want time_test.py", d.path)
+	}
+	if got := d.lineTotal(); got != 2 {
+		t.Fatalf("lineTotal = %d, want 2", got)
+	}
+}
+
 func TestStreamingDecoderSplitEscape(t *testing.T) {
 	d := newStreamingDecoder()
 	// The \n and \t escapes are split across feed boundaries (backslash, then n/t).

--- a/internal/tui/streaming_fade.go
+++ b/internal/tui/streaming_fade.go
@@ -262,12 +262,14 @@ func (m *model) resetStreamingFade() {
 	m.lastStreamActivity = time.Time{}
 }
 
-// styleStreamingLine applies the fade palette to one visual line of the
-// streaming block. When fadeActive is false (or lineAges is nil because a
-// test fixture pre-populated streamingText), the line is styled with the
-// base ink color — the same look the streaming block had before the fade
-// feature shipped.
+// styleStreamingLine applies the fade palette to one visual line of prose in the
+// streaming block. Already-styled lines (markdown/code/table highlighting) are
+// returned unchanged so live colors match committed colors instead of snapping at
+// turn end.
 func (m model) styleStreamingLine(line string, visualIndex, visualCount int) string {
+	if strings.Contains(line, "\x1b") {
+		return line
+	}
 	if !m.fadeActive || m.lineAges == nil {
 		return zeroTheme.ink.Render(line)
 	}

--- a/internal/tui/streaming_fade_test.go
+++ b/internal/tui/streaming_fade_test.go
@@ -362,3 +362,13 @@ func TestStyleStreamingLineFallsBackWhenLineAgesNil(t *testing.T) {
 		t.Errorf("styleStreamingLine with nil lineAges = %q, want %q (base render)", out, want)
 	}
 }
+
+func TestStyleStreamingLinePreservesHighlightedLines(t *testing.T) {
+	m := model{}
+	m.fadeActive = true
+	m.lineAges = []time.Time{time.Now()}
+	line := zeroTheme.accent.Render("func") + " main()"
+	if out := m.styleStreamingLine(line, 0, 1); out != line {
+		t.Errorf("highlighted streaming line should be preserved, got %q want %q", out, line)
+	}
+}

--- a/internal/tui/streaming_tool_call.go
+++ b/internal/tui/streaming_tool_call.go
@@ -3,8 +3,6 @@ package tui
 import (
 	"fmt"
 	"strings"
-
-	"github.com/charmbracelet/x/ansi"
 )
 
 // streamingTailLines is how many trailing lines of a file's in-progress content
@@ -96,7 +94,7 @@ func skipJSONSpace(s string, i int) int {
 // streamingFilePath pulls the file path out of a streaming tool-call args buffer,
 // trying the argument names the file tools use. Used to seed the decoder's path.
 func streamingFilePath(args string) string {
-	for _, key := range []string{"path", "file_path", "filename"} {
+	for _, key := range []string{"path", "file", "file_path", "filepath", "filename"} {
 		if v, ok := decodeStreamingJSONString(args, key); ok && v != "" {
 			return v
 		}
@@ -104,64 +102,29 @@ func streamingFilePath(args string) string {
 	return ""
 }
 
-// streamingToolCallView renders the in-progress file-writing tool call — its path,
-// a live line count, and a tail of the streaming content — so a long write/edit
-// shows the code flowing in instead of a frozen spinner. It reads the decoder's
-// incrementally-maintained state (O(1) per render); returns "" when no
-// file-writing call is mid-stream.
+// streamingToolCallView renders the in-progress file-writing tool call: its path
+// and live line count. The code body is intentionally buffered until the result
+// card lands, so partial code does not recolor or shift while generating.
 func (m model) streamingToolCallView(width int) string {
 	if m.streamCallID == "" || !isFileWritingTool(m.streamCallName) || m.streamCallDecoder == nil {
 		return ""
 	}
 	d := m.streamCallDecoder
 
-	head := zeroTheme.accent.Render("✎ ") + zeroTheme.toolName.Render(m.streamCallName)
-	if d.path != "" {
-		head += " " + zeroTheme.toolTarget.Render(d.path)
-	}
+	headTag := ""
 	switch {
 	case d.hasContent():
-		head += zeroTheme.faint.Render(fmt.Sprintf("  ·  %d lines", d.lineTotal()))
+		if m.streamCallName == "write_file" {
+			headTag = diffCountTag(d.lineTotal(), 0)
+		} else {
+			headTag = fmt.Sprintf("%d lines", d.lineTotal())
+		}
 	case d.rawLen > 0:
 		// Args are streaming but the content field hasn't arrived yet — show a live
 		// byte count so it reads as progressing, never frozen.
-		head += zeroTheme.faint.Render(fmt.Sprintf("  ·  receiving %.1f KB", float64(d.rawLen)/1024))
+		headTag = fmt.Sprintf("receiving %.1f KB", float64(d.rawLen)/1024)
 	}
-	lines := []string{head}
-	if d.hasContent() {
-		bodyWidth := maxInt(8, width-4)
-		// write_file/edit_file content is brand-new, so every line is an addition;
-		// apply_patch carries a real ± diff. styleStreamingCodeLine colors added
-		// lines green, removed red, and everything else bright (not the old dim gray).
-		newContent := m.streamCallName == "write_file" || m.streamCallName == "edit_file"
-		for _, line := range d.tailLines() {
-			line = strings.ReplaceAll(line, "\t", "    ")
-			// Truncate by display WIDTH (ansi.Truncate), not rune count, so wide/CJK
-			// glyphs can't overrun bodyWidth and break the tail layout.
-			lines = append(lines, "  "+styleStreamingCodeLine(ansi.Truncate(line, bodyWidth, ""), newContent))
-		}
-	}
+	head := toolCardHead(m.streamCallName, d.path, "", headTag, "", "", true, zeroTheme.ink, false, width, cardRenderOptions{cwd: m.cwd})
+	lines := []string{zeroTheme.accent.Render(m.spinnerGlyph()) + " " + head}
 	return strings.Join(lines, "\n")
-}
-
-// styleStreamingCodeLine colors one line of the live code preview: explicit diff
-// additions (+) render green and removals (-) red; for a brand-new write_file/edit
-// every line is an addition (green); anything else renders in bright ink. This
-// replaces the old dim faintest gray the streamed code was nearly invisible in.
-func styleStreamingCodeLine(line string, newContent bool) string {
-	// A brand-new write_file/edit_file is NOT a diff: every line is added content,
-	// so color it all green and never treat a leading "-" (e.g. CSS "-webkit-…") as
-	// a removal. Only apply_patch (newContent=false) carries real ± diff markers.
-	if newContent {
-		return zeroTheme.green.Render(line)
-	}
-	trimmed := strings.TrimLeft(line, " ")
-	switch {
-	case strings.HasPrefix(trimmed, "+") && !strings.HasPrefix(trimmed, "+++"):
-		return zeroTheme.green.Render(line)
-	case strings.HasPrefix(trimmed, "-") && !strings.HasPrefix(trimmed, "---"):
-		return zeroTheme.red.Render(line)
-	default:
-		return zeroTheme.ink.Render(line)
-	}
 }

--- a/internal/tui/streaming_tool_call_test.go
+++ b/internal/tui/streaming_tool_call_test.go
@@ -62,11 +62,36 @@ func TestStreamingToolCallView(t *testing.T) {
 	if viewModel("bash", `{"command":"ls"}`).streamingToolCallView(80) != "" {
 		t.Error("non-file tool should render nothing")
 	}
-	// Active write_file → shows path, line count, and a content tail.
+	// Active write_file → shows path and live count, but buffers the code body
+	// until the final tool result lands.
 	out := viewModel("write_file", `{"path":"a/b.go","content":"package main\n\nfunc main() {}\n"}`).streamingToolCallView(80)
-	for _, want := range []string{"write_file", "a/b.go", "lines", "func main()"} {
+	for _, want := range []string{zeroTheme.diffAdd.Render("+3"), zeroTheme.diffDel.Render("-0")} {
 		if !strings.Contains(out, want) {
+			t.Errorf("live count tag should color additions/deletions, missing styled %q in:\n%s", want, out)
+		}
+	}
+	plain := plainRender(t, out)
+	for _, want := range []string{"Adding", "a/b.go", "(+3 -0)"} {
+		if !strings.Contains(plain, want) {
 			t.Errorf("view missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(plain, "package main") || strings.Contains(plain, "func main()") {
+		t.Errorf("live write preview should buffer code body until completion:\n%s", out)
+	}
+	if strings.Contains(out, "write_file") {
+		t.Errorf("live preview must not expose raw tool name:\n%s", out)
+	}
+}
+
+func TestStreamingToolCallViewShowsLatePath(t *testing.T) {
+	dec := newStreamingDecoder()
+	feedChunks(dec, `{"content":"from datetime import datetime\n`, `print(datetime.now())",`, `"path":"time_test.py"}`)
+	m := model{streamCallID: "1", streamCallName: "write_file", streamCallDecoder: dec}
+	out := plainRender(t, m.streamingToolCallView(80))
+	for _, want := range []string{"Adding", "time_test.py", "(+2 -0)"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("live write header = %q, missing %q", out, want)
 		}
 	}
 }
@@ -80,21 +105,5 @@ func TestStreamingViewShowsProgressBeforeContent(t *testing.T) {
 	}
 	if !strings.Contains(out, "KB") {
 		t.Errorf("should show a receiving byte count before content: %q", out)
-	}
-}
-
-func TestStyleStreamingNewContentNeverRed(t *testing.T) {
-	// L8: a brand-new file line beginning with "-" (e.g. CSS "-webkit-…") must NOT
-	// be colored as a diff removal. With newContent=true it renders green; the
-	// red/green diff branches apply only to apply_patch (newContent=false).
-	green := zeroTheme.green.Render("-webkit-box-shadow: none;")
-	got := styleStreamingCodeLine("-webkit-box-shadow: none;", true)
-	if got != green {
-		t.Errorf("new-file '-' line should render green, got %q want %q", got, green)
-	}
-	// And for a real patch (newContent=false) a '-' line IS a red removal.
-	red := zeroTheme.red.Render("-old line")
-	if got := styleStreamingCodeLine("-old line", false); got != red {
-		t.Errorf("patch '-' line should render red, got %q", got)
 	}
 }

--- a/internal/tui/syntax_highlight.go
+++ b/internal/tui/syntax_highlight.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"image/color"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -37,6 +39,25 @@ func cachedLexer(lang string) chroma.Lexer {
 	return lexer
 }
 
+func cachedLexerForPath(path string) chroma.Lexer {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	key := "path:" + strings.ToLower(filepath.Base(path))
+	lexerCacheMu.RLock()
+	lexer, ok := lexerCache[key]
+	lexerCacheMu.RUnlock()
+	if ok {
+		return lexer
+	}
+	lexer = lexers.Match(path)
+	lexerCacheMu.Lock()
+	lexerCache[key] = lexer
+	lexerCacheMu.Unlock()
+	return lexer
+}
+
 // tokenStyle maps a chroma token type onto Zero's existing, contrast-audited
 // palette rather than a chroma color scheme — so highlighted code stays on-brand
 // and degrades through the same lipgloss profile path as the rest of the UI
@@ -66,10 +87,73 @@ func tokenStyle(tt chroma.TokenType) lipgloss.Style {
 // unknown or missing language is never worse than today. Wrapping is done at the
 // token level so colors never split an ANSI escape.
 func highlightCode(code []string, lang string, measure int) ([]string, bool) {
+	return highlightCodeWithLexer(cachedLexer(lang), code, measure, nil)
+}
+
+func highlightCodeAuto(code []string, lang string, measure int) ([]string, bool) {
+	if strings.TrimSpace(lang) == "" {
+		lang = inferCodeLanguage(code)
+	}
+	return highlightCode(code, lang, measure)
+}
+
+func highlightCodeForPath(code []string, path string, measure int, bg color.Color) ([]string, bool) {
+	return highlightCodeWithLexer(cachedLexerForPath(path), code, measure, bg)
+}
+
+func inferCodeLanguage(code []string) string {
+	for _, line := range code {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "from ") && strings.Contains(trimmed, " import "):
+			return "python"
+		case strings.HasPrefix(trimmed, "import ") && !strings.Contains(trimmed, " from "):
+			return "python"
+		case strings.HasPrefix(trimmed, "def ") && strings.HasSuffix(trimmed, ":"):
+			return "python"
+		case strings.HasPrefix(trimmed, "class ") && strings.HasSuffix(trimmed, ":"):
+			return "python"
+		case strings.HasPrefix(trimmed, "if ") && strings.HasSuffix(trimmed, ":"):
+			return "python"
+		case strings.HasPrefix(trimmed, "elif ") && strings.HasSuffix(trimmed, ":"):
+			return "python"
+		case trimmed == "else:" || trimmed == "try:" || trimmed == "finally:":
+			return "python"
+		case strings.HasPrefix(trimmed, "for ") && strings.HasSuffix(trimmed, ":"):
+			return "python"
+		case strings.HasPrefix(trimmed, "while ") && strings.HasSuffix(trimmed, ":"):
+			return "python"
+		case strings.HasPrefix(trimmed, "with ") && strings.HasSuffix(trimmed, ":"):
+			return "python"
+		case strings.HasPrefix(trimmed, "except") && strings.HasSuffix(trimmed, ":"):
+			return "python"
+		case strings.HasPrefix(trimmed, "return "):
+			return "python"
+		case strings.HasPrefix(trimmed, "print("):
+			return "python"
+		case strings.HasPrefix(trimmed, "package "):
+			return "go"
+		case strings.HasPrefix(trimmed, "func ") && strings.Contains(trimmed, "{"):
+			return "go"
+		case strings.HasPrefix(trimmed, "const "), strings.HasPrefix(trimmed, "let "), strings.HasPrefix(trimmed, "var "):
+			return "javascript"
+		case strings.HasPrefix(trimmed, "function ") && strings.Contains(trimmed, "{"):
+			return "javascript"
+		case strings.HasPrefix(trimmed, "<!DOCTYPE "), strings.HasPrefix(trimmed, "<html"), strings.HasPrefix(trimmed, "<div"), strings.HasPrefix(trimmed, "<span"):
+			return "html"
+		}
+		break
+	}
+	return ""
+}
+
+func highlightCodeWithLexer(lexer chroma.Lexer, code []string, measure int, bg color.Color) ([]string, bool) {
 	if measure < 4 {
 		return nil, false
 	}
-	lexer := cachedLexer(lang)
 	if lexer == nil {
 		return nil, false
 	}
@@ -87,6 +171,9 @@ func highlightCode(code []string, lang string, measure int) ([]string, bool) {
 		curWidth = 0
 	}
 	emit := func(style lipgloss.Style, s string) {
+		if bg != nil {
+			style = style.Background(bg)
+		}
 		var chunk strings.Builder
 		flushChunk := func() {
 			if chunk.Len() > 0 {

--- a/internal/tui/syntax_highlight_test.go
+++ b/internal/tui/syntax_highlight_test.go
@@ -5,15 +5,90 @@ import (
 	"testing"
 )
 
-// The live streaming render path (allowHighlight=false) must render code
-// verbatim/plain — never tokenised — so the per-frame loop can't re-lex a
-// growing block. Profile-independent: the plain path applies no styling, so the
-// code appears as a contiguous substring (a highlighted block would not).
-func TestStreamingCodeRendersPlain(t *testing.T) {
-	md := "```go\nfunc main() {}\n```"
-	out := strings.Join(renderAssistantMarkdownText(md, 80, 80, false), "\n")
-	if !strings.Contains(out, "func main() {}") {
-		t.Fatalf("interim render must keep code verbatim (no chroma), got:\n%s", out)
+func TestStreamingCodeRendersHighlighted(t *testing.T) {
+	m := model{
+		streamingText: "```go\nfunc main() {}\n```",
+		pending:       true,
+	}
+	out := m.interimBlock(80)
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("live code should be highlighted before commit, got:\n%s", out)
+	}
+	if !strings.Contains(plainRender(t, out), "func main() {}") {
+		t.Fatalf("live code should keep the plain content, got:\n%s", out)
+	}
+}
+
+func TestFinalBarePythonCodeRendersHighlighted(t *testing.T) {
+	row := transcriptRow{
+		kind:  rowAssistant,
+		final: true,
+		text: strings.Join([]string{
+			"from datetime import datetime",
+			"",
+			"def print_current_time():",
+			"    print(datetime.now().strftime(\"%Y-%m-%d %H:%M:%S\"))",
+			"",
+			"if __name__ == \"__main__\":",
+			"    print_current_time()",
+		}, "\n"),
+	}
+	out := renderAssistantRow(row, 90)
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("final bare Python code should be syntax-highlighted, got:\n%s", out)
+	}
+	plain := plainRender(t, out)
+	if !strings.Contains(plain, "from datetime import datetime") ||
+		!strings.Contains(plain, "def print_current_time():") ||
+		!strings.Contains(plain, `if __name__ == "__main__":`) ||
+		!strings.Contains(plain, "print_current_time()") {
+		t.Fatalf("final bare Python code should keep content, got:\n%s", out)
+	}
+	for _, wantStyled := range []string{"from", "def", "if"} {
+		if !strings.Contains(out, zeroTheme.accent.Render(wantStyled)) {
+			t.Fatalf("final bare Python code should color keyword %q, got:\n%s", wantStyled, out)
+		}
+	}
+}
+
+func TestBareFencedCodeInfersLanguage(t *testing.T) {
+	out := strings.Join(renderAssistantMarkdownText("```\nfrom datetime import datetime\nprint(datetime.now())\n```", 90, 90, true), "\n")
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("bare fenced Python code should infer language and highlight, got:\n%s", out)
+	}
+}
+
+func TestPlainProseDoesNotTriggerBareCodeHighlight(t *testing.T) {
+	out := strings.Join(renderAssistantMarkdownText("from here we continue with the explanation", 90, 90, true), "\n")
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("plain prose should not be treated as bare code, got:\n%s", out)
+	}
+}
+
+func TestStreamingBuffersOpenFencedCodeBlock(t *testing.T) {
+	open := model{
+		streamingText: "Here is the script:\n```python\nfrom datetime import datetime\nprint(datetime.now())",
+		pending:       true,
+	}
+	openOut := plainRender(t, open.interimBlock(90))
+	if !strings.Contains(openOut, "Here is the script:") {
+		t.Fatalf("streaming prose before code should remain visible, got:\n%s", openOut)
+	}
+	if strings.Contains(openOut, "datetime") || strings.Contains(openOut, "print(") {
+		t.Fatalf("open fenced code should be buffered until the closing fence, got:\n%s", openOut)
+	}
+
+	closed := model{
+		streamingText: open.streamingText + "\n```",
+		pending:       true,
+	}
+	closedOut := closed.interimBlock(90)
+	closedPlain := plainRender(t, closedOut)
+	if !strings.Contains(closedPlain, "from datetime import datetime") || !strings.Contains(closedPlain, "print(datetime.now())") {
+		t.Fatalf("closed fenced code should appear as one block, got:\n%s", closedOut)
+	}
+	if !strings.Contains(closedOut, "\x1b[") {
+		t.Fatalf("closed streaming code should be highlighted, got:\n%s", closedOut)
 	}
 }
 

--- a/internal/tui/syntax_highlight_test.go
+++ b/internal/tui/syntax_highlight_test.go
@@ -65,6 +65,25 @@ func TestPlainProseDoesNotTriggerBareCodeHighlight(t *testing.T) {
 	}
 }
 
+func TestBareCodeHighlightRequiresBlockSignal(t *testing.T) {
+	out := strings.Join(renderAssistantMarkdownText("for these reasons:\nreturn later with a decision", 90, 90, true), "\n")
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("ordinary prose should not be highlighted as bare code, got:\n%s", out)
+	}
+}
+
+func TestStreamingMarkdownStablePrefixUsesRenderCache(t *testing.T) {
+	defaultRenderCache.clear()
+	text := "Here is the script:\n```go\nfunc main() {}\n```\nDone."
+	_ = renderStreamingAssistantMarkdownText(text, 90, 90)
+	before := defaultRenderCache.stats()
+	_ = renderStreamingAssistantMarkdownText(text, 90, 90)
+	after := defaultRenderCache.stats()
+	if after.Hits <= before.Hits {
+		t.Fatalf("streaming stable markdown should reuse highlighted cache, before=%+v after=%+v", before, after)
+	}
+}
+
 func TestStreamingBuffersOpenFencedCodeBlock(t *testing.T) {
 	open := model{
 		streamingText: "Here is the script:\n```python\nfrom datetime import datetime\nprint(datetime.now())",

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -40,7 +40,7 @@ type tuiTheme struct {
 
 	// Tool cards.
 	toolName   lipgloss.Style // head-row tool name, ink bold
-	toolTarget lipgloss.Style // head-row target path, muted
+	toolTarget lipgloss.Style // head-row target path, ink
 	toolArg    lipgloss.Style // one-line arg hint, faintest
 	cardRun    lipgloss.Style // card border while the call runs (accent-mixed)
 	cardErr    lipgloss.Style // card border after an error (red-mixed)
@@ -144,9 +144,9 @@ var darkPalette = palette{
 	blue:      "#7db4ff",
 	gitAdd:    "#7db87a",
 	gitDel:    "#b87a7a",
-	addBg:     "#15201d",
+	addBg:     "#18352c",
 	delBg:     "#241819",
-	addBgWord: "#26503d", // changed span within an added line — brighter green (sep 1.83 vs addBg, addInk 7.1:1)
+	addBgWord: "#2e654d", // changed span within an added line — brighter green (sep 1.83 vs addBg, addInk 7.1:1)
 	delBgWord: "#502d30", // changed span within a deleted line — brighter red (sep 1.44 vs delBg, delInk 7.7:1)
 	permBg:    "#1c1915",
 	selBg:     "#32401b", // selected row bg — brightened from #1d2114 so the highlighted row separates from the panel (sep 1.18→1.73) while ink label contrast stays ~9.4:1
@@ -217,7 +217,7 @@ func buildTheme(p palette) tuiTheme {
 		userPrompt: fg(p.accent).Bold(true),
 		sayText:    fg(p.muted),
 		toolName:   fg(p.ink).Bold(true),
-		toolTarget: fg(p.muted),
+		toolTarget: fg(p.ink),
 		toolArg:    fg(p.faintest),
 		cardRun:    fg(p.cardRun),
 		cardErr:    fg(p.cardErr),

--- a/internal/tui/tool_call_density_test.go
+++ b/internal/tui/tool_call_density_test.go
@@ -120,18 +120,29 @@ func TestRedundantConfirmationCollapsesSuccessBody(t *testing.T) {
 	}
 }
 
-func TestRealOutputKeepsBody(t *testing.T) {
+func TestExplorationOutputSummarizesBody(t *testing.T) {
 	m := limeTestModel()
-	row := transcriptRow{
+	rows := []transcriptRow{{
+		kind:   rowToolCall,
+		id:     "c2",
+		tool:   "grep",
+		detail: "internal/cli",
+		arg:    "flag.NewFlagSet",
+	}, {
 		kind:   rowToolResult,
 		id:     "c2",
 		tool:   "grep",
 		status: tools.StatusOK,
 		detail: "internal/cli/root.go:41: fs := flag.NewFlagSet",
+	}}
+	card := plainRender(t, m.renderRow(rows[1], 80, buildRowContext(rows)))
+	for _, want := range []string{"Explored", "Search", "flag.NewFlagSet"} {
+		if !strings.Contains(card, want) {
+			t.Fatalf("exploration card missing %q:\n%s", want, card)
+		}
 	}
-	card := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
-	if !strings.Contains(card, "flag.NewFlagSet") {
-		t.Fatalf("real grep output must NOT be suppressed, got:\n%s", card)
+	if strings.Contains(card, "internal/cli/root.go:41") {
+		t.Fatalf("exploration card must not dump raw grep output, got:\n%s", card)
 	}
 }
 
@@ -151,9 +162,7 @@ func TestErrorConfirmationKeepsBody(t *testing.T) {
 	}
 }
 
-// --- Fix 5: blank line between consecutive tool cards -------------------------
-
-func TestConsecutiveToolCardsAreBlankSeparated(t *testing.T) {
+func TestConsecutiveExplorationResultsGroup(t *testing.T) {
 	m := limeTestModel()
 	m.headerPrinted = true
 	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: "go"})
@@ -168,16 +177,11 @@ func TestConsecutiveToolCardsAreBlankSeparated(t *testing.T) {
 
 	body, _ := m.transcriptBody(96, "")
 	got := plainRender(t, body)
-	// Both cards must be present, and a blank line must sit between the end of the
-	// first card and the start of the second (the "wall" fix).
-	firstIdx := strings.Index(got, "internal/a.go")
-	secondIdx := strings.Index(got, "internal/b.go")
-	if firstIdx < 0 || secondIdx < 0 || secondIdx <= firstIdx {
-		t.Fatalf("both tool cards should render in order, got:\n%s", got)
+	if strings.Count(got, "Explored") != 1 {
+		t.Fatalf("adjacent exploration results should group into one card, got:\n%s", got)
 	}
-	between := got[firstIdx:secondIdx]
-	if !strings.Contains(between, "\n\n") {
-		t.Fatalf("expected a blank line between consecutive tool cards, got:\n%s", got)
+	if strings.Count(got, "Search") != 2 || !strings.Contains(got, "├ Search") || !strings.Contains(got, "└ Search") {
+		t.Fatalf("grouped exploration card should show both searches, got:\n%s", got)
 	}
 }
 

--- a/internal/tui/tool_display_test.go
+++ b/internal/tui/tool_display_test.go
@@ -12,7 +12,13 @@ func TestToolDisplayNameCleansMCPNames(t *testing.T) {
 		"mcp_exa_web_search_exa": "web search",
 		"mcp_exa_web_fetch_exa":  "web fetch",
 		"mcp_foo_bar":            "bar",
-		"edit_file":              "edit_file",  // built-in, unchanged
+		"write_file":             "Create",
+		"edit_file":              "Edit",
+		"read_file":              "Read",
+		"bash":                   "Run",
+		"browser_open":           "Open browser",
+		"browser_snapshot":       "Browser snapshot",
+		"capture_artifact":       "Capture",
 		"web_search":             "web_search", // built-in, unchanged
 	}
 	for in, want := range cases {

--- a/internal/tui/tool_render_registry.go
+++ b/internal/tui/tool_render_registry.go
@@ -8,9 +8,11 @@ import (
 type toolBodyRequest struct {
 	name   string
 	hint   string
+	arg    string
 	detail string
 	width  int
 	opts   cardRenderOptions
+	failed bool
 }
 
 type toolBodyRenderer interface {
@@ -40,9 +42,13 @@ func newDefaultToolBodyRegistry() *toolBodyRegistry {
 	// write_file's card-only Display.Preview is a synthesized all-additions diff
 	// (the new file's head), so render it through the same diff path.
 	registry.register("write_file", diffOrFallback)
-	registry.register("read_file", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
-		return readCardBody(req.detail, req.width, req.opts)
-	})})
+	exploreRenderer := diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return exploreCardBody(req.name, req.hint, req.arg, req.detail, req.width, req.opts, req.failed)
+	})}
+	registry.register("read_file", exploreRenderer)
+	registry.register("read_minified_file", exploreRenderer)
+	registry.register("list_directory", exploreRenderer)
+	registry.register("glob", exploreRenderer)
 	registry.register("bash", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
 		return bashCardBody(req.hint, req.detail, req.width, req.opts)
 	})})
@@ -52,9 +58,18 @@ func newDefaultToolBodyRegistry() *toolBodyRegistry {
 	registry.register("write_stdin", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
 		return execCommandCardBody("", req.detail, req.width, req.opts)
 	})})
-	registry.register("grep", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
-		return grepCardBody(req.detail, req.width, req.opts)
-	})})
+	registry.register("grep", exploreRenderer)
+	localControlRenderer := diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return localControlCardBody(req.name, req.hint, req.detail, req.width, req.opts, req.failed)
+	})}
+	for _, name := range []string{
+		"browser_install", "browser_launch", "browser_connect", "browser_open", "browser_snapshot",
+		"browser_click", "browser_type", "browser_press", "browser_action",
+		"desktop_windows", "desktop_snapshot", "desktop_action",
+		"terminal_session", "capture_artifact",
+	} {
+		registry.register(name, localControlRenderer)
+	}
 	// update_plan's full plan is already shown live by the sticky plan panel
 	// (renderPlanPanel); collapse its transcript card to a one-line summary so the
 	// plan isn't re-dumped into the transcript on every call.

--- a/internal/tui/tool_render_registry_test.go
+++ b/internal/tui/tool_render_registry_test.go
@@ -12,6 +12,7 @@ func TestDefaultToolBodyRegistrySelectsCoreRenderers(t *testing.T) {
 	tests := []struct {
 		name   string
 		hint   string
+		arg    string
 		detail string
 		want   []string
 	}{
@@ -24,7 +25,7 @@ func TestDefaultToolBodyRegistrySelectsCoreRenderers(t *testing.T) {
 				"-old",
 				"+new",
 			}, "\n"),
-			want: []string{"app.go", "-1", "+1", "new"},
+			want: []string{"(+1 -1)", "-1", "+1", "new"},
 		},
 		{
 			name: "apply_patch",
@@ -35,23 +36,25 @@ func TestDefaultToolBodyRegistrySelectsCoreRenderers(t *testing.T) {
 				"-old",
 				"+new",
 			}, "\n"),
-			want: []string{"app.go", "-1", "+1", "new"},
+			want: []string{"(+1 -1)", "-1", "+1", "new"},
 		},
 		{
 			name:   "read_file",
+			hint:   "README.md",
 			detail: "File: README.md\n\n  7 | # Zero",
-			want:   []string{"# Zero", "L7"},
+			want:   []string{"Read", "README.md"},
 		},
 		{
 			name:   "bash",
 			hint:   "go test ./internal/tui",
 			detail: "stdout:\nok\nexit_code: 0",
-			want:   []string{"go test ./internal/tui", "ok", "exit 0"},
+			want:   []string{"ok"},
 		},
 		{
 			name:   "grep",
+			arg:    "func render",
 			detail: "internal/tui/rendering.go:41: func render()",
-			want:   []string{"internal/tui/rendering.go:41", "1 matches"},
+			want:   []string{"Search", "func render"},
 		},
 		{
 			name:   "unknown_tool",
@@ -65,6 +68,7 @@ func TestDefaultToolBodyRegistrySelectsCoreRenderers(t *testing.T) {
 			body := registry.render(toolBodyRequest{
 				name:   tt.name,
 				hint:   tt.hint,
+				arg:    tt.arg,
 				detail: normalizeToolCardDetail(tt.detail),
 				width:  96,
 				opts:   opts,
@@ -74,6 +78,12 @@ func TestDefaultToolBodyRegistrySelectsCoreRenderers(t *testing.T) {
 				if !strings.Contains(got, want) {
 					t.Fatalf("%s body = %q, missing %q", tt.name, got, want)
 				}
+			}
+			if tt.name == "read_file" && strings.Contains(got, "# Zero") {
+				t.Fatalf("read_file body = %q, must not expose read contents", got)
+			}
+			if tt.name == "grep" && strings.Contains(got, "internal/tui/rendering.go:41") {
+				t.Fatalf("grep body = %q, must not expose raw search matches", got)
 			}
 		})
 	}
@@ -107,7 +117,7 @@ func TestToolBodyRegistryReplacementIsScopedToOneTool(t *testing.T) {
 	if strings.Contains(got, "replacement grep body") {
 		t.Fatalf("bash body = %q, must not use grep replacement", got)
 	}
-	if !strings.Contains(got, "go test ./internal/tui") || !strings.Contains(got, "exit 0") {
+	if !strings.Contains(got, "ok") || strings.Contains(got, "exit 0") {
 		t.Fatalf("bash body = %q, want original bash renderer", got)
 	}
 }

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -11,6 +11,8 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 type transcriptSelectionPoint struct {
@@ -59,6 +61,7 @@ const (
 	transcriptBodyItemTitle transcriptBodyItemKind = iota
 	transcriptBodyItemEmpty
 	transcriptBodyItemSeparator
+	transcriptBodyItemRule
 	transcriptBodyItemRow
 	transcriptBodyItemPendingPrompt
 	transcriptBodyItemPendingInterim
@@ -118,10 +121,11 @@ func (l transcriptBodyLayout) visibleLines(window transcriptViewportWindow) []st
 	return append([]string(nil), l.lines[start:end]...)
 }
 
-// padTranscriptBodyLines left-indents transcript body rows by gutter cells (the
-// reading-column margin). Horizontal only — it never changes the line count, so
-// the width-keyed height cache stays valid. Two-column mode right-pads the chat
-// block to the column width in joinColumns; single-column leaves the right blank.
+// padTranscriptBodyLines left-indents transcript body rows when a non-zero
+// gutter is configured. It is horizontal only — it never changes the line count,
+// so the width-keyed height cache stays valid. Two-column mode right-pads the
+// chat block to the column width in joinColumns; single-column leaves any
+// remaining cells blank.
 func padTranscriptBodyLines(lines []string, gutter int) []string {
 	if gutter <= 0 {
 		return lines
@@ -161,9 +165,9 @@ func (m model) finalizeTranscriptBodyRow(rendered string, selectable []transcrip
 
 func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptBodyItem {
 	items := []transcriptBodyItem{}
-	// Transcript ROWS render in a reading column: wrapped to contentWidth and
-	// indented by gutter, so wide terminals don't run text edge-to-edge. Block
-	// items (title bar, empty state, prompts) keep the full column width below.
+	// Transcript ROWS render at the full chat width; row/status glyphs provide
+	// structure without adding another body margin. Block items (title bar, empty
+	// state, prompts) keep the full column width below.
 	contentWidth := transcriptContentWidth(width)
 	gutter := transcriptGutter(width)
 
@@ -173,6 +177,8 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 		items = append(items, transcriptBlockBodyItem(transcriptBodyItemTitle, -1, m.titleBar(width)))
 	}
 
+	previousKind := rowWelcome
+	havePreviousKind := false
 	if m.transcriptEmpty() && !m.pending {
 		if emptyOverlay != "" {
 			items = append(items, transcriptBlockBodyItem(transcriptBodyItemEmpty, -1, m.emptyStateWithOverlay(width, emptyOverlay)))
@@ -182,7 +188,7 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 	} else {
 		rc := buildRowContext(m.transcript)
 		shownAny := false
-		previousKind, havePreviousKind := previousVisibleTranscriptKind(m.transcript, m.flushed, rc)
+		previousKind, havePreviousKind = previousVisibleTranscriptKind(m.transcript, m.flushed, rc)
 		specialistSummaryEmitted := false
 		for index := m.flushed; index < len(m.transcript); index++ {
 			row := m.transcript[index]
@@ -191,10 +197,54 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 			if row.kind == rowWelcome || rc.skip(row) {
 				continue
 			}
+			if isSuccessfulExploreResult(row) {
+				groupRows, groupIndices, nextIndex := collectExploreResultGroup(m.transcript, index, rc)
+				if len(groupRows) > 0 {
+					if (shownAny || m.flushedAny) && startsTurn(row.kind) {
+						items = append(items, transcriptBlankBodyItem())
+					}
+					if shownAny && havePreviousKind && needsSeparatorBeforeToolCard(previousKind, row.kind) {
+						items = append(items, transcriptBlankBodyItem())
+					}
+					firstRowIndex := groupIndices[0]
+					groupRowsCopy := append([]transcriptRow(nil), groupRows...)
+					groupIndicesCopy := append([]int(nil), groupIndices...)
+					block := m.renderExploreResultGroup(groupRowsCopy, contentWidth, rc)
+					items = append(items, transcriptBodyItem{
+						kind:              transcriptBodyItemRow,
+						rowIndex:          firstRowIndex,
+						heightCacheKey:    transcriptBlockBodyHeightCacheKey(transcriptBodyItemRow, block),
+						heightCacheStable: true,
+						render: func(startBodyY int) transcriptBodyRenderedItem {
+							rendered := m.renderExploreResultGroup(groupRowsCopy, contentWidth, rc)
+							selectable := make([]transcriptSelectableLine, 0, len(groupIndicesCopy)+1)
+							for offset, line := range viewLines(rendered) {
+								rowIndex := firstRowIndex
+								if offset > 0 && offset-1 < len(groupIndicesCopy) {
+									rowIndex = groupIndicesCopy[offset-1]
+								}
+								if meta, ok := selectableLineFromRenderedLine(rowIndex, startBodyY+offset, line, false); ok {
+									selectable = append(selectable, meta)
+								}
+							}
+							return m.finalizeTranscriptBodyRow(rendered, selectable, gutter, startBodyY)
+						},
+					})
+					shownAny = true
+					previousKind = row.kind
+					havePreviousKind = true
+					index = nextIndex - 1
+					continue
+				}
+			}
 			// Blank-line separation before turns, including between flushed
 			// history and the first live row.
 			if (shownAny || m.flushedAny) && startsTurn(row.kind) {
-				items = append(items, transcriptBlankBodyItem())
+				if havePreviousKind && shouldRuleBeforeTurn(previousKind, row.kind) {
+					items = append(items, transcriptRuleBodyItem(contentWidth, gutter))
+				} else {
+					items = append(items, transcriptBlankBodyItem())
+				}
 			}
 			if (shownAny || (m.flushedAny && havePreviousKind)) && previousKind == rowUser && row.kind == rowReasoning {
 				items = append(items, transcriptBlankBodyItem())
@@ -204,7 +254,7 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 			// would otherwise stack with no gap (the dense "wall" look). One blank
 			// line between them matches the reference agents. Turn-starters are
 			// separated above, so this only fires tool-card -> tool-card.
-			if shownAny && havePreviousKind && isToolCardKind(previousKind) && isToolCardKind(row.kind) {
+			if shownAny && havePreviousKind && needsSeparatorBeforeToolCard(previousKind, row.kind) {
 				items = append(items, transcriptBlankBodyItem())
 			}
 			// A "Thought for X" reasoning header opens the next think→act group, so
@@ -263,7 +313,12 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 	}
 
 	if m.pending {
-		items = append(items, transcriptBlankBodyItem())
+		pendingShowsAssistantText := m.pendingPermission == nil && m.pendingAskUser == nil && strings.TrimSpace(m.streamingText) != ""
+		if pendingShowsAssistantText && havePreviousKind && shouldRuleBeforeTurn(previousKind, rowAssistant) {
+			items = append(items, transcriptRuleBodyItem(contentWidth, gutter))
+		} else {
+			items = append(items, transcriptBlankBodyItem())
+		}
 		switch {
 		case m.pendingPermission != nil:
 			perm := m.pendingPermission
@@ -336,6 +391,61 @@ func transcriptBlankBodyItem() transcriptBodyItem {
 	}
 }
 
+func transcriptRuleBodyItem(width int, gutter int) transcriptBodyItem {
+	if width < 1 {
+		width = 1
+	}
+	return transcriptBodyItem{
+		kind:              transcriptBodyItemRule,
+		rowIndex:          -1,
+		heightCacheKey:    "transcript-body-height:v1:rule:" + strconv.Itoa(width) + ":" + strconv.Itoa(gutter),
+		heightCacheStable: true,
+		render: func(int) transcriptBodyRenderedItem {
+			rule := zeroTheme.line.Render(strings.Repeat("─", width))
+			return transcriptBodyRenderedItem{lines: padTranscriptBodyLines([]string{rule, ""}, gutter)}
+		},
+	}
+}
+
+func isSuccessfulExploreResult(row transcriptRow) bool {
+	return row.kind == rowToolResult && row.status != tools.StatusError && isExploreTool(toolRowName(row))
+}
+
+func collectExploreResultGroup(rows []transcriptRow, start int, rc rowContext) ([]transcriptRow, []int, int) {
+	groupRows := []transcriptRow{}
+	groupIndices := []int{}
+	for index := start; index < len(rows); index++ {
+		row := rows[index]
+		if row.kind == rowWelcome || rc.skip(row) {
+			continue
+		}
+		if !isSuccessfulExploreResult(row) {
+			return groupRows, groupIndices, index
+		}
+		groupRows = append(groupRows, row)
+		groupIndices = append(groupIndices, index)
+	}
+	return groupRows, groupIndices, len(rows)
+}
+
+func (m model) renderExploreResultGroup(rows []transcriptRow, width int, rc rowContext) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	opts := cardRenderOptions{bodyCap: cardBodyMaxLines, cwd: m.cwd}
+	body := make([]string, 0, len(rows))
+	for index, row := range rows {
+		marker := "├"
+		if index == len(rows)-1 {
+			marker = "└"
+		}
+		key := rcKey(row.runID, row.id)
+		body = append(body, exploreCardLine(toolRowName(row), rc.hints[key], rc.args[key], row.detail, width, opts, marker))
+	}
+	head := zeroTheme.green.Bold(true).Render("Explored")
+	return toolCard(head, zeroTheme.green.Render("•"), body, "", zeroTheme.line, width)
+}
+
 // transcriptBodyItemsFromRows builds body items from an arbitrary set of
 // transcript rows (used by the subchat drill-in view to render a child
 // session's events). It mirrors the main loop's logic but operates on the
@@ -357,7 +467,11 @@ func (m model) transcriptBodyItemsFromRows(rows []transcriptRow, width int) []tr
 			continue
 		}
 		if shownAny && startsTurn(row.kind) {
-			items = append(items, transcriptBlankBodyItem())
+			if havePreviousKind && shouldRuleBeforeTurn(previousKind, row.kind) {
+				items = append(items, transcriptRuleBodyItem(contentWidth, gutter))
+			} else {
+				items = append(items, transcriptBlankBodyItem())
+			}
 		}
 		if shownAny && havePreviousKind && previousKind == rowUser && row.kind == rowReasoning {
 			items = append(items, transcriptBlankBodyItem())
@@ -570,6 +684,13 @@ func selectableLineFromRenderedLine(rowIndex int, bodyY int, rendered string, bo
 			text = strings.TrimSuffix(text, " │")
 		}
 	}
+	for _, prefix := range []string{"  ├ ", "  └ ", "  │ "} {
+		if strings.HasPrefix(text, prefix) {
+			textStart += lipgloss.Width(prefix)
+			text = strings.TrimPrefix(text, prefix)
+			break
+		}
+	}
 	text = strings.TrimRight(text, " ")
 	if strings.TrimSpace(text) == "" {
 		return transcriptSelectableLine{}, false
@@ -706,16 +827,8 @@ func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width in
 
 func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
 	tableMeasure := width
-	// Interim narration carries a 2-col "● " gutter (see renderAssistantRow), so it
-	// wraps 2 cols narrower and its selectable columns start at textStart=gutter;
-	// the final answer keeps the full width and textStart=0.
-	gutter := lipgloss.Width(narrationPrefix)
 	measure := assistantMeasure(width)
 	textStart := 0
-	if !row.final {
-		measure = maxInt(16, assistantMeasure(width)-gutter)
-		textStart = gutter
-	}
 	// Committed/selectable row: highlight (the result is cached per row).
 	wrapped := renderAssistantMarkdownText(row.text, measure, tableMeasure, true)
 	selectable := make([]transcriptSelectableLine, 0, len(wrapped))

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -408,7 +408,7 @@ func transcriptRuleBodyItem(width int, gutter int) transcriptBodyItem {
 }
 
 func isSuccessfulExploreResult(row transcriptRow) bool {
-	return row.kind == rowToolResult && row.status != tools.StatusError && isExploreTool(toolRowName(row))
+	return row.kind == rowToolResult && !row.expanded && row.status != tools.StatusError && isExploreTool(toolRowName(row))
 }
 
 func collectExploreResultGroup(rows []transcriptRow, start int, rc rowContext) ([]transcriptRow, []int, int) {
@@ -443,7 +443,7 @@ func (m model) renderExploreResultGroup(rows []transcriptRow, width int, rc rowC
 		body = append(body, exploreCardLine(toolRowName(row), rc.hints[key], rc.args[key], row.detail, width, opts, marker))
 	}
 	head := zeroTheme.green.Bold(true).Render("Explored")
-	return toolCard(head, zeroTheme.green.Render("•"), body, "", zeroTheme.line, width)
+	return toolCard(head, zeroTheme.green.Render("•"), body, zeroTheme.faint.Render("▸ details"), zeroTheme.line, width)
 }
 
 // transcriptBodyItemsFromRows builds body items from an arbitrary set of

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -939,7 +939,7 @@ func firstArgValue(raw string, keys []string) string {
 	for _, key := range keys {
 		if value, ok := args[key]; ok {
 			if text, ok := value.(string); ok && strings.TrimSpace(text) != "" {
-				return strings.TrimSpace(text)
+				return singleLineToolHeadText(text)
 			}
 		}
 	}

--- a/internal/tui/width_tiers_test.go
+++ b/internal/tui/width_tiers_test.go
@@ -54,8 +54,8 @@ func TestWidthTierSegments(t *testing.T) {
 		}
 
 		rows := []transcriptRow{
-			{kind: rowToolCall, id: "c", tool: "grep", detail: "internal/cli", arg: "RegisterFlag"},
-			{kind: rowToolResult, id: "c", tool: "grep", status: tools.StatusOK, detail: "internal/cli/root.go:41: x"},
+			{kind: rowToolCall, id: "c", tool: "custom_tool", detail: "internal/cli", arg: "RegisterFlag"},
+			{kind: rowToolResult, id: "c", tool: "custom_tool", status: tools.StatusOK, detail: "ok"},
 		}
 		rc := buildRowContext(rows)
 		card := plainRender(t, m.renderRow(rows[1], tc.width, rc))

--- a/internal/tui/word_diff_test.go
+++ b/internal/tui/word_diff_test.go
@@ -59,8 +59,8 @@ func TestDiffBodyWordHighlightRenders(t *testing.T) {
 	d := "--- a/x\n+++ b/x\n@@ -1,1 +1,1 @@\n-timeout = 90\n+timeout = 300"
 	body := diffCardBody(d, 70, cardRenderOptions{bodyCap: 20})
 	joined := strings.Join(body.lines, "\n")
-	// addBgWord #26503d -> "38;80;61"; delBgWord #502d30 -> "80;45;48"
-	if !strings.Contains(joined, "38;80;61") || !strings.Contains(joined, "80;45;48") {
+	// addBgWord #2e654d -> "46;101;77"; delBgWord #502d30 -> "80;45;48"
+	if !strings.Contains(joined, "46;101;77") || !strings.Contains(joined, "80;45;48") {
 		t.Errorf("expected changed spans on the brighter word bg, got:\n%s", joined)
 	}
 }


### PR DESCRIPTION
## Summary
- tighten transcript spacing and remove distracting rails/gutters
- render tool activity with cleaner action labels and grouped exploration summaries
- improve markdown, code, diff, and command-output rendering in the transcript

## Tests
- env GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter markdown rendering: bare-code auto-highlighting, fenced-code highlighting, and horizontal-rule dividers now render correctly (including during streaming).
  * Live tool-card/prose layout improvements: clearer rule/separator behavior, friendlier labels, and more stable interim markdown.
  * Syntax highlighting can infer language and optionally use richer styling; streaming code buffers until fences close.
* **Bug Fixes**
  * Preserve pre-styled/ANSI output during streaming and fading.
  * Improve streamed tool views and late path detection; adjust diff/command/search display to reduce visual noise.
  * Update transcript wrapping, gutters, and selection alignment; refine rendering cache uniqueness.
* **Tests**
  * Expanded TUI, streaming, and rendering regression coverage for the updated UI contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->