### PR TITLE
fix(modelregistry): one source of truth for a model's reasoning efforts

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -1014,14 +1014,6 @@ func modelContextWindow(registry modelregistry.Registry, modelID string) int {
 	return entry.ContextLimits.ContextWindow
 }
 
-// reasoningEffortNotice resolves the requested --reasoning-effort against the
-// selected model's supported efforts via EffectiveReasoningEffort and returns a
-// short advisory when the requested value is unsupported (and was coerced to the
-// model default).
-//
-// NOTE: the effective effort is not yet forwarded to the provider request — the
-// zeroruntime.CompletionRequest / provider wire schemas carry no effort field.
-// Full provider-request propagation is deferred (see slice-3 report).
 // forwardedReasoningEffort returns the effort to send on the provider request.
 // It mirrors reasoningEffortNotice: a known model that does not support reasoning
 // yields "" (matching the "ignoring" advisory, so the request never carries an
@@ -1044,6 +1036,10 @@ func forwardedReasoningEffort(registry modelregistry.Registry, modelID string, r
 	return string(effective)
 }
 
+// reasoningEffortNotice resolves the requested --reasoning-effort against the
+// selected model's supported efforts via EffectiveReasoningEffort and returns a
+// short advisory when the requested value is unsupported (and was coerced to the
+// model default).
 func reasoningEffortNotice(registry modelregistry.Registry, modelID string, requested string) string {
 	trimmed := strings.TrimSpace(modelID)
 	if trimmed == "" {

--- a/internal/modelregistry/catalog.go
+++ b/internal/modelregistry/catalog.go
@@ -172,13 +172,12 @@ func (registry Registry) SupportsCapability(pattern string, capability ModelCapa
 }
 
 func (registry Registry) ReasoningEfforts(pattern string) []ReasoningEffort {
-	if model, ok := registry.Get(pattern); ok && len(model.ReasoningEfforts) > 0 {
-		return append([]ReasoningEffort{}, model.ReasoningEfforts...)
+	if model, ok := registry.Get(pattern); ok {
+		return append([]ReasoningEffort{}, effectiveReasoningEfforts(model)...)
 	}
-	// Fallback for reasoning-model families that aren't enumerated in the curated
-	// catalog — e.g. the GPT-5 / Codex / o-series variants served via the ChatGPT
-	// proxy or custom OpenAI-compatible endpoints. Without this, /effort shows no
-	// controls for those models even though they support reasoning_effort.
+	// Unknown model not in the curated catalog — e.g. a GPT-5 / Codex / o-series
+	// variant served via the ChatGPT proxy or a custom OpenAI-compatible endpoint.
+	// Infer from the name so /effort still shows controls for it.
 	return reasoningEffortsForModelName(pattern)
 }
 

--- a/internal/modelregistry/resolve.go
+++ b/internal/modelregistry/resolve.go
@@ -47,10 +47,13 @@ func (registry Registry) ResolveWithFallback(input string) (ModelEntry, string, 
 
 // EffectiveReasoningEffort returns the effort to use for a model: the requested
 // value if the model supports it, otherwise the model's default (or first
-// supported, or none).
+// supported, or none). It resolves the supported set through
+// effectiveReasoningEfforts so it sees the same name-based fallback the /effort
+// picker uses — the two must never disagree about which tiers a model supports.
 func EffectiveReasoningEffort(model ModelEntry, requested ReasoningEffort) ReasoningEffort {
+	efforts := effectiveReasoningEfforts(model)
 	if requested != "" {
-		for _, effort := range model.ReasoningEfforts {
+		for _, effort := range efforts {
 			if effort == requested {
 				return requested
 			}
@@ -59,8 +62,23 @@ func EffectiveReasoningEffort(model ModelEntry, requested ReasoningEffort) Reaso
 	if model.DefaultReasoningEffort != "" {
 		return model.DefaultReasoningEffort
 	}
-	if len(model.ReasoningEfforts) > 0 {
-		return model.ReasoningEfforts[0]
+	if len(efforts) > 0 {
+		return efforts[0]
 	}
 	return ReasoningEffortNone
+}
+
+// effectiveReasoningEfforts returns a model's supported reasoning efforts, falling
+// back to name-based inference (reasoningEffortsForModelName) when the catalog
+// entry enumerates none. Both the /effort picker (Registry.ReasoningEfforts) and
+// the run-time resolver (EffectiveReasoningEffort) read efforts through this
+// single helper, so the picker can never advertise a tier the resolver drops.
+func effectiveReasoningEfforts(model ModelEntry) []ReasoningEffort {
+	if len(model.ReasoningEfforts) > 0 {
+		return model.ReasoningEfforts
+	}
+	if efforts := reasoningEffortsForModelName(model.ID); len(efforts) > 0 {
+		return efforts
+	}
+	return reasoningEffortsForModelName(model.APIModel)
 }

--- a/internal/modelregistry/resolve_test.go
+++ b/internal/modelregistry/resolve_test.go
@@ -79,3 +79,43 @@ func TestEffectiveReasoningEffort(t *testing.T) {
 		t.Errorf("empty effort should use default low, got %q", got)
 	}
 }
+
+// TestEffectiveReasoningEffortUsesNameFallback pins that the run-time resolver
+// honors the same name-based fallback the /effort picker uses. A model that the
+// catalog enumerates with no efforts but whose name is a known reasoning family
+// (e.g. a GPT-5 variant served via a proxy) must have its requested effort
+// honored — not silently coerced to "none" while the picker advertises controls.
+func TestEffectiveReasoningEffortUsesNameFallback(t *testing.T) {
+	// Registered model, no explicit efforts, GPT-5 api model -> fallback infers
+	// {minimal, low, medium, high}.
+	gpt5 := ModelEntry{ID: "gpt-5-proxy", APIModel: "gpt-5", Provider: ProviderOpenAI}
+	if got := EffectiveReasoningEffort(gpt5, ReasoningEffortHigh); got != ReasoningEffortHigh {
+		t.Errorf("supported (via name fallback) effort = %q; want high", got)
+	}
+	if got := EffectiveReasoningEffort(gpt5, ReasoningEffortMinimal); got != ReasoningEffortMinimal {
+		t.Errorf("minimal (via name fallback) = %q; want minimal", got)
+	}
+	// xhigh is outside the inferred set and there is no declared default, so it
+	// coerces to the first inferred tier rather than to "none".
+	if got := EffectiveReasoningEffort(gpt5, ReasoningEffortXHigh); got != ReasoningEffortMinimal {
+		t.Errorf("unsupported effort on a fallback model = %q; want minimal (first inferred)", got)
+	}
+
+	// Non-reasoning model: name matches nothing, stays "none".
+	gpt4o := ModelEntry{ID: "gpt-4o", APIModel: "gpt-4o", Provider: ProviderOpenAI}
+	if got := EffectiveReasoningEffort(gpt4o, ReasoningEffortHigh); got != ReasoningEffortNone {
+		t.Errorf("non-reasoning model = %q; want none", got)
+	}
+
+	// The picker and the resolver must agree on the supported set for the same id.
+	reg := resolveTestRegistry(t)
+	picker := reg.ReasoningEfforts("gpt-5") // unknown -> name fallback
+	if len(picker) == 0 {
+		t.Fatal("picker should advertise efforts for a gpt-5 name")
+	}
+	for _, tier := range picker {
+		if got := EffectiveReasoningEffort(gpt5, tier); got != tier {
+			t.Errorf("picker advertises %q but resolver returns %q", tier, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

`/effort` (the TUI picker) and the run-time effort resolver used two different answers for "which reasoning tiers does this model support":

- `Registry.ReasoningEfforts` (picker source) falls back to name-based inference when the catalog enumerates no efforts, so it shows controls for GPT-5 / Codex / o-series variants served via a proxy or a custom OpenAI-compatible endpoint.
- `EffectiveReasoningEffort` (the clamp the CLI/run path uses) read `model.ReasoningEfforts` **directly** and never saw that fallback — so it coerced the same request to `none`.

Result: the picker advertises a tier the resolver silently drops. It's latent in the curated catalog today (only `gpt-4.1`/`gpt-4o` are enumerated, and their names match no fallback) but wrong by construction, and it activates the moment a reasoning model is reached via a proxy or added with empty efforts.

## Change

- Add a single `effectiveReasoningEfforts(model)` helper that applies the name-based fallback when the catalog lists none.
- Route **both** `EffectiveReasoningEffort` and `Registry.ReasoningEfforts` through it, so the picker and the resolver can never disagree.
- Remove the orphaned, stale `NOTE` above `forwardedReasoningEffort` that claimed effort "is not yet forwarded" (it is), and move the `reasoningEffortNotice` doc back onto its own function.

No behavior change for the curated catalog; this only makes the two paths agree for name-fallback models.

## Test

`TestEffectiveReasoningEffortUsesNameFallback` pins that a model the catalog enumerates with no efforts but whose name is a known reasoning family has its requested effort honored, that non-reasoning models still resolve to `none`, and that every tier the picker advertises is one the resolver returns. Verified it **fails on pre-fix code** (picker advertises `minimal/low/medium/high`, resolver returned `none`) and passes after.

`go build ./...`, `go vet`, `gofmt -l` (clean), and the `modelregistry` / `cli` / `tui` effort suites all green.

First of a phased series fixing per-provider reasoning-effort detection/representation; this is the lowest-risk correctness step (no new types, no provider changes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning-effort selection so supported tiers are now detected more consistently for catalog and name-based models.
  * Requests for unsupported tiers now fall back more predictably, and models without reasoning support remain on none.
  * Aligned effort resolution behavior across model lookup and execution paths for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->