### PR TITLE
fix(openai): forward reasoning effort to the Codex Responses API

### DIFF
--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -71,13 +71,21 @@ const (
 
 // responsesRequest is the wire shape POSTed to {baseURL}/responses.
 type responsesRequest struct {
-	Model           string          `json:"model"`
-	Instructions    string          `json:"instructions"`
-	Input           []inputItem     `json:"input"`
-	Stream          bool            `json:"stream"`
-	Store           bool            `json:"store"`
-	MaxOutputTokens int             `json:"max_output_tokens,omitempty"`
-	Tools           []responsesTool `json:"tools,omitempty"`
+	Model           string              `json:"model"`
+	Instructions    string              `json:"instructions"`
+	Input           []inputItem         `json:"input"`
+	Stream          bool                `json:"stream"`
+	Store           bool                `json:"store"`
+	MaxOutputTokens int                 `json:"max_output_tokens,omitempty"`
+	Tools           []responsesTool     `json:"tools,omitempty"`
+	Reasoning       *responsesReasoning `json:"reasoning,omitempty"`
+}
+
+// responsesReasoning carries the reasoning controls for the Responses API. The
+// chat-completions `reasoning_effort` field is nested under `reasoning.effort`
+// here; omitted entirely when the caller requests no (or an unsupported) effort.
+type responsesReasoning struct {
+	Effort string `json:"effort,omitempty"`
 }
 
 // inputItem is one element of the Responses `input` array. The Type field
@@ -241,6 +249,14 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 			Description: tool.Description,
 			Parameters:  tool.Parameters,
 		})
+	}
+	// Codex / o-series reasoning models take the effort tier nested under
+	// `reasoning` on the Responses API (the chat-completions `reasoning_effort`
+	// moved here). Reuse the chat normalizer so only API-accepted values are sent
+	// and an empty or unsupported effort simply omits the field — without this the
+	// caller's chosen effort was silently dropped for every Codex model.
+	if effort := openAIReasoningEffort(request.ReasoningEffort); effort != "" {
+		req.Reasoning = &responsesReasoning{Effort: effort}
 	}
 	return req, nil
 }

--- a/internal/providers/openai/codex_test.go
+++ b/internal/providers/openai/codex_test.go
@@ -454,6 +454,67 @@ func TestCodexProviderSendsResponsesRequestShape(t *testing.T) {
 	}
 }
 
+func TestCodexProviderForwardsReasoningEffort(t *testing.T) {
+	// A reasoning effort must reach the Responses backend nested under
+	// `reasoning.effort` (where the chat-completions `reasoning_effort` moved).
+	// Without this the user's chosen effort is silently dropped for Codex models.
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk-test", BaseURL: srv.URL, Model: "gpt-5-codex"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages:        []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+		ReasoningEffort: "high",
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+
+	reasoning, ok := rec.body["reasoning"].(map[string]any)
+	if !ok {
+		t.Fatalf("body.reasoning = %#v, want an object carrying the effort", rec.body["reasoning"])
+	}
+	if reasoning["effort"] != "high" {
+		t.Fatalf("body.reasoning.effort = %#v, want high", reasoning["effort"])
+	}
+}
+
+func TestCodexProviderOmitsReasoningWhenUnset(t *testing.T) {
+	// No effort (and unsupported values) must omit the `reasoning` field entirely
+	// rather than send an empty object, which the backend would reject.
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk-test", BaseURL: srv.URL, Model: "gpt-5-codex"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages:        []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+		ReasoningEffort: "", // auto
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+
+	if _, ok := rec.body["reasoning"]; ok {
+		t.Fatalf("body.reasoning must be omitted when no effort is requested, got %#v", rec.body["reasoning"])
+	}
+}
+
 func TestCodexProviderRetriesHeadersAfter401(t *testing.T) {
 	var hits atomic.Int32
 	var rec1, rec2 codexRequest


### PR DESCRIPTION
## What

The Codex provider speaks the **Responses API**, where the reasoning effort is nested under `reasoning.effort` (the chat-completions `reasoning_effort` field moved there). `buildResponsesRequest` built the payload with **no reasoning field at all**, so a user's chosen `--reasoning-effort` / `/effort` was **silently dropped for every Codex model** — the request always ran at the model's default, with no signal to the user.

## Change

- Add a `reasoning` object (`{ "effort": "..." }`) to `responsesRequest`, `omitempty`.
- Populate it in `buildResponsesRequest` from `request.ReasoningEffort`, reusing the chat path's `openAIReasoningEffort` normalizer so only API-accepted values (`minimal/low/medium/high`) are sent, and an empty or unsupported effort **omits the field entirely** (no empty object, no 400).

Self-contained to the Codex adapter; no behavior change for any non-Codex path.

## Test

- `TestCodexProviderForwardsReasoningEffort` — asserts `reasoning.effort` reaches the request body. Verified it **fails on pre-fix code** (`body.reasoning = <nil>`) and passes after.
- `TestCodexProviderOmitsReasoningWhenUnset` — asserts the field is omitted for auto/empty effort.

`go build ./...`, `go vet`, `gofmt -l` (clean), full `internal/providers/openai` suite green.

Part of the phased reasoning-effort correctness series (independent of #335).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Responses API requests now correctly include reasoning effort when it’s set, and leave it out when not provided.
  * This prevents empty reasoning fields from being sent in request payloads.

* **Tests**
  * Added coverage for request payload handling with and without reasoning effort enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->