### PR TITLE
fix(opengateway): correct gateway host, make it the recommended default

### DIFF
--- a/internal/cli/command_center.go
+++ b/internal/cli/command_center.go
@@ -277,6 +277,9 @@ func listProviderCatalogSummaries(options commandCenterOptions) ([]providerCatal
 		return nil, err
 	}
 	sort.SliceStable(summaries, func(i int, j int) bool {
+		if summaries[i].Recommended != summaries[j].Recommended {
+			return summaries[i].Recommended
+		}
 		return summaries[i].ID < summaries[j].ID
 	})
 	return summaries, nil
@@ -354,10 +357,17 @@ func formatProviderCatalogSummaries(providers []providerCatalogSummary) string {
 }
 
 func formatProviderCatalogLine(provider providerCatalogSummary) string {
+	name := formatProviderCatalogValue(provider.Name, "unknown")
+	prefix := "  id="
+	if provider.Recommended {
+		prefix = "  ★ id="
+		name += " (recommended)"
+	}
 	lines := []string{
-		fmt.Sprintf("  id=%s name=%s",
+		fmt.Sprintf("%s%s name=%s",
+			prefix,
 			formatProviderCatalogValue(provider.ID, "unknown"),
-			formatProviderCatalogValue(provider.Name, "unknown"),
+			name,
 		),
 		fmt.Sprintf("    transport=%s defaultModel=%s",
 			formatProviderCatalogValue(provider.Transport, "unknown"),

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -285,6 +285,7 @@ func setupProviderOptions() []tui.SetupProviderOption {
 			EnvVar:       setupProviderEnvVar(descriptor),
 			RequiresAuth: descriptor.RequiresAuth,
 			Local:        descriptor.Local,
+			Recommended:  descriptor.Recommended,
 		})
 	}
 	return options

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -58,6 +58,11 @@ type Descriptor struct {
 	// OAuthDeviceFlow reports that RFC 8628 device-code login is supported (for
 	// headless / SSH use) in addition to the browser flow.
 	OAuthDeviceFlow bool
+
+	// Recommended marks the provider that should be surfaced first and badged
+	// (★ … (recommended)) in every catalog-ordered list and picker. At most one
+	// descriptor should set this.
+	Recommended bool
 }
 
 func RuntimeSupported(descriptor Descriptor) bool {
@@ -82,6 +87,11 @@ func RuntimeUnsupportedReason(descriptor Descriptor) string {
 }
 
 var descriptors = []Descriptor{
+	// GitLawb OpenGateway — the recommended default. An OpenAI-compatible gateway
+	// that smart-routes by model id across upstream providers (xiaomi-mimo,
+	// minimax, qwen, google, nvidia, z-ai). Flat /v1/chat/completions with a
+	// Bearer ogw_live_… key; listed first and badged in every picker.
+	recommended(openAICompat("gitlawb-opengateway", "GitLawb OpenGateway", "https://opengateway.gitlawb.com/v1", "mimo-v2.5-pro", []string{"GITLAWB_OPENGATEWAY_API_KEY"}, "gitlawb opengateway", "opengateway")),
 	openAI("openai", "OpenAI", "https://api.openai.com/v1", "gpt-4.1", []string{"OPENAI_API_KEY"}),
 	anthropic("anthropic", "Anthropic", "https://api.anthropic.com", "claude-sonnet-4.5", []string{"ANTHROPIC_API_KEY"}),
 	google("google", "Google", "https://generativelanguage.googleapis.com", "gemini-2.5-pro", []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}, "gemini"),
@@ -124,7 +134,6 @@ var descriptors = []Descriptor{
 	openAICompat("xiaomi-mimo", "Xiaomi MiMo", "https://api.mimo.xiaomi.com/openai/v1", "mimo-vl", []string{"MIMO_API_KEY", "XIAOMI_API_KEY"}, "xiaomi mimo"),
 	openAICompat("bankr", "Bankr", "https://api.bankr.bot/v1", "bankr-large", []string{"BANKR_API_KEY"}),
 	openAICompat("zai", "Z.ai", "https://open.bigmodel.cn/api/paas/v4", "glm-4.5", []string{"ZAI_API_KEY", "ZHIPU_API_KEY"}),
-	openAICompat("gitlawb-opengateway", "GitLawb OpenGateway", "https://gateway.gitlawb.com/v1", "gpt-4.1", []string{"GITLAWB_OPENGATEWAY_API_KEY"}, "gitlawb opengateway"),
 	openAICompat("atomic-chat", "Atomic Chat", "https://api.atomic.chat/v1", "gpt-4.1", []string{"ATOMIC_CHAT_API_KEY"}),
 	// ChatGPT subscription via a local OAuth proxy. A ChatGPT (Plus/Pro) OAuth
 	// token only works against ChatGPT's own backend (which is Cloudflare-gated to
@@ -264,6 +273,13 @@ func google(id string, name string, baseURL string, model string, env []string, 
 		SupportedAPIFormats: []APIFormat{APIFormatGoogleGenerateContent},
 		Aliases:             aliases,
 	}
+}
+
+// recommended marks a descriptor as the recommended default so list/picker
+// surfaces sort it first and render the ★ … (recommended) badge.
+func recommended(descriptor Descriptor) Descriptor {
+	descriptor.Recommended = true
+	return descriptor
 }
 
 // oauthProvider marks a descriptor as OAuth-capable. mintsKey => the flow returns

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 var expectedCatalogIDs = []string{
+	"gitlawb-opengateway",
 	"openai",
 	"anthropic",
 	"google",
@@ -33,7 +34,6 @@ var expectedCatalogIDs = []string{
 	"xiaomi-mimo",
 	"bankr",
 	"zai",
-	"gitlawb-opengateway",
 	"atomic-chat",
 	"chatgpt-proxy",
 	"custom-openai-compatible",
@@ -58,6 +58,41 @@ func TestAllHasStableUniqueIDs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(IDs(), expectedCatalogIDs) {
 		t.Fatalf("IDs() = %#v, want %#v", IDs(), expectedCatalogIDs)
+	}
+}
+
+func TestRecommendedProviderIsFirstAndUnique(t *testing.T) {
+	descriptors := All()
+	if len(descriptors) == 0 {
+		t.Fatal("All() returned no descriptors")
+	}
+	if !descriptors[0].Recommended {
+		t.Fatalf("All()[0] = %q, want it to be the recommended provider", descriptors[0].ID)
+	}
+	if descriptors[0].ID != "gitlawb-opengateway" {
+		t.Fatalf("recommended provider = %q, want %q", descriptors[0].ID, "gitlawb-opengateway")
+	}
+	recommended := 0
+	for _, descriptor := range descriptors {
+		if descriptor.Recommended {
+			recommended++
+		}
+	}
+	if recommended != 1 {
+		t.Fatalf("recommended descriptor count = %d, want exactly 1", recommended)
+	}
+}
+
+func TestRecommendedProviderEndpoint(t *testing.T) {
+	descriptor, ok := Get("gitlawb-opengateway")
+	if !ok {
+		t.Fatal("gitlawb-opengateway not found in catalog")
+	}
+	if descriptor.DefaultBaseURL != "https://opengateway.gitlawb.com/v1" {
+		t.Fatalf("OpenGateway base URL = %q, want %q", descriptor.DefaultBaseURL, "https://opengateway.gitlawb.com/v1")
+	}
+	if descriptor.Transport != TransportOpenAICompatible {
+		t.Fatalf("OpenGateway transport = %q, want %q", descriptor.Transport, TransportOpenAICompatible)
 	}
 }
 
@@ -229,7 +264,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
 		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
-		TransportOpenAICompat:    {"ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
+		TransportOpenAICompat:    {"gitlawb-opengateway", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 
 	for transport, wantIDs := range cases {

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -326,6 +326,9 @@ func healthRequest(ctx context.Context, profile config.ProviderProfile, kind con
 		return nil, false, err
 	}
 	endpoint := baseURL + healthPath(kind)
+	if override, ok := overrideHealthEndpoint(profile, baseURL); ok {
+		endpoint = override
+	}
 	// Loopback is permitted only when the user's OWN configured base_url is loopback
 	// (a local provider like Ollama/LM Studio) — never for a redirect target. This is
 	// the flag returned to the caller so the dial path applies the same policy. (AUDIT-H1)
@@ -590,6 +593,22 @@ func blockedAddrReason(addr netip.Addr) string {
 		}
 	}
 	return ""
+}
+
+// overrideHealthEndpoint returns a provider-specific connectivity probe URL when
+// the default {baseURL}+/models path does not exist. GitLawb OpenGateway is a
+// smart-routing gateway whose flat /v1/models endpoint 404s by design ("Use
+// /v1/<provider>/<path>"), so probe its public /health endpoint at the host root
+// instead, which reports real reachability without a per-model call.
+func overrideHealthEndpoint(profile config.ProviderProfile, baseURL string) (string, bool) {
+	if profile.CatalogID != "gitlawb-opengateway" {
+		return "", false
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", false
+	}
+	return parsed.Scheme + "://" + parsed.Host + "/health", true
 }
 
 func healthPath(kind config.ProviderKind) string {

--- a/internal/providerhealth/providerhealth_additional_test.go
+++ b/internal/providerhealth/providerhealth_additional_test.go
@@ -170,3 +170,20 @@ func TestProbeConnectivityRedactsProviderErrorDetails(t *testing.T) {
 		t.Fatalf("custom header secret leaked in connectivity check: %s", rendered)
 	}
 }
+
+func TestOverrideHealthEndpointOpenGateway(t *testing.T) {
+	got, ok := overrideHealthEndpoint(config.ProviderProfile{CatalogID: "gitlawb-opengateway"}, "https://opengateway.gitlawb.com/v1")
+	if !ok {
+		t.Fatal("expected OpenGateway to override the health endpoint")
+	}
+	if got != "https://opengateway.gitlawb.com/health" {
+		t.Fatalf("OpenGateway health endpoint = %q, want host-root /health", got)
+	}
+
+	if _, ok := overrideHealthEndpoint(config.ProviderProfile{CatalogID: "openai"}, "https://api.openai.com/v1"); ok {
+		t.Fatal("non-OpenGateway providers must not override the health endpoint")
+	}
+	if _, ok := overrideHealthEndpoint(config.ProviderProfile{CatalogID: "gitlawb-opengateway"}, "::not a url"); ok {
+		t.Fatal("an unparseable base URL must not produce an override")
+	}
+}

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -129,10 +129,18 @@ var curatedModels = map[string][]Model{
 		{ID: "glm-4.6", Description: "latest general model"},
 		{ID: "glm-z1-air", Description: "reasoning model"},
 	},
+	// OpenGateway smart-routes by model id across its upstream providers
+	// (see /health: xiaomi-mimo, minimax, qwen, google, nvidia, z-ai). These are
+	// the curated coding defaults; the gateway accepts any model its upstreams
+	// expose, so users can also type an id the picker doesn't list.
 	"gitlawb-opengateway": {
-		{ID: "gpt-4.1", Description: "catalog default"},
-		{ID: "claude-sonnet-4.5", Description: "coding model"},
-		{ID: "gemini-2.5-pro", Description: "long-context model"},
+		{ID: "mimo-v2.5-pro", Description: "catalog default (Xiaomi MiMo)"},
+		{ID: "mimo-v2.5-pro-ultraspeed", Description: "fast model (Xiaomi MiMo)"},
+		{ID: "MiniMax-M3", Description: "MiniMax model"},
+		{ID: "qwen-plus", Description: "Qwen model"},
+		{ID: "gemini-2.5-pro", Description: "long-context model (Google)"},
+		{ID: "glm-4.6", Description: "Z.ai model"},
+		{ID: "nvidia/llama-3.1-nemotron-70b-instruct", Description: "NVIDIA NIM model"},
 	},
 	"atomic-chat": {
 		{ID: "gpt-4.1", Description: "catalog default"},

--- a/internal/providermodelcatalog/logic_test.go
+++ b/internal/providermodelcatalog/logic_test.go
@@ -54,7 +54,7 @@ func TestDefaultedOpenGatewayURL(t *testing.T) {
 	if got := defaultedOpenGatewayURL(providercatalog.Descriptor{DefaultBaseURL: "https://gw.example.com/v1"}, ""); got != "https://gw.example.com/zero/models.json" {
 		t.Fatalf("derived = %q", got)
 	}
-	if got := defaultedOpenGatewayURL(providercatalog.Descriptor{DefaultBaseURL: "::not a url"}, ""); got != "https://gateway.gitlawb.com/zero/models.json" {
+	if got := defaultedOpenGatewayURL(providercatalog.Descriptor{DefaultBaseURL: "::not a url"}, ""); got != "https://opengateway.gitlawb.com/zero/models.json" {
 		t.Fatalf("fallback = %q", got)
 	}
 }

--- a/internal/providermodelcatalog/remote.go
+++ b/internal/providermodelcatalog/remote.go
@@ -223,7 +223,7 @@ func defaultedOpenGatewayURL(provider providercatalog.Descriptor, override strin
 	}
 	parsed, err := url.Parse(provider.DefaultBaseURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "https://gateway.gitlawb.com/zero/models.json"
+		return "https://opengateway.gitlawb.com/zero/models.json"
 	}
 	return parsed.Scheme + "://" + parsed.Host + "/zero/models.json"
 }

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -1495,7 +1495,14 @@ func (m model) setupProviderLines(width int, height int) []string {
 			marker = "❯ "
 			style = zeroTheme.accent.Bold(true)
 		}
-		line := marker + style.Render(displayValue(option.Name, option.ID))
+		label := displayValue(option.Name, option.ID)
+		if option.Recommended {
+			label = "★ " + label
+		}
+		line := marker + style.Render(label)
+		if option.Recommended {
+			line += zeroTheme.faint.Render("  (recommended)")
+		}
 		lines = append(lines, padSetupLine(line, rowWidth))
 	}
 	// A failed OAuth login drops back here with oauthPending cleared, so the

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -99,6 +99,7 @@ type SetupProviderOption struct {
 	EnvVar       string
 	RequiresAuth bool
 	Local        bool
+	Recommended  bool
 }
 
 // SetupSelection is the user's setup choice.

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1240,11 +1240,24 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 		surface = zeroTheme.onSel
 		marker = surface(zeroTheme.accent).Render("❯ ")
 	}
-	left := marker + surface(zeroTheme.ink).Render(provider.Name)
-	if badge := providerWizardOAuthBadge(provider); badge != "" {
+	name := provider.Name
+	if provider.Recommended {
+		name = "★ " + name
+	}
+	left := marker + surface(zeroTheme.ink).Render(name)
+	if badge := providerWizardBadge(provider); badge != "" {
 		left += surface(zeroTheme.faint).Render("   " + badge)
 	}
 	return fitStyledLine(left, width)
+}
+
+// providerWizardBadge is the faint hint shown next to a provider row. The
+// recommended provider takes precedence over the OAuth hint.
+func providerWizardBadge(provider providercatalog.Descriptor) string {
+	if provider.Recommended {
+		return "(recommended)"
+	}
+	return providerWizardOAuthBadge(provider)
 }
 
 // providerWizardOAuthBadge is the faint mode hint shown next to OAuth providers.

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -53,7 +53,7 @@ func TestProviderCommandOpensOnboardingWizard(t *testing.T) {
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 	listView := plainRender(t, next.View())
-	for _, want := range []string{"Choose provider", "OpenAI", "Anthropic", "Google", "Groq", "OpenRouter", "Ollama"} {
+	for _, want := range []string{"Choose provider", "GitLawb OpenGateway", "OpenAI", "Anthropic", "Google", "OpenRouter", "Ollama"} {
 		assertContains(t, listView, want)
 	}
 }
@@ -172,8 +172,12 @@ func TestProviderWizardAdvancesProviderAPIKeyAndModelSteps(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m = openProviderWizardForTest(t, m)
 
+	// Index 0 is the recommended OpenGateway entry, so two downs land on anthropic
+	// (opengateway → openai → anthropic).
 	updated, _ := m.Update(testKey(tea.KeyDown))
 	next := updated.(model)
+	updated, _ = next.Update(testKey(tea.KeyDown))
+	next = updated.(model)
 	if got := next.providerWizard.currentProvider().ID; got != "anthropic" {
 		t.Fatalf("after down, selected provider = %q, want anthropic", got)
 	}
@@ -309,8 +313,15 @@ func TestProviderWizardRightAllowsExistingCredentialEnv(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m = openProviderWizardForTest(t, m)
 
-	updated, _ := m.Update(testKey(tea.KeyEnter))
+	// Move off the recommended OpenGateway entry (index 0) onto openai so the
+	// OPENAI_API_KEY env credential is the one in play.
+	updated, _ := m.Update(testKey(tea.KeyDown))
 	next := updated.(model)
+	if got := next.providerWizard.currentProvider().ID; got != "openai" {
+		t.Fatalf("after down, selected provider = %q, want openai", got)
+	}
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
 	if next.providerWizard.step != providerWizardStepCredential {
 		t.Fatalf("enter from provider step = %v, want credential", next.providerWizard.step)
 	}

--- a/internal/zerocommands/contracts.go
+++ b/internal/zerocommands/contracts.go
@@ -86,6 +86,7 @@ type ProviderCatalogSnapshot struct {
 	Local                    bool     `json:"local"`
 	RuntimeSupported         bool     `json:"runtimeSupported"`
 	RuntimeUnsupportedReason string   `json:"runtimeUnsupportedReason,omitempty"`
+	Recommended              bool     `json:"recommended,omitempty"`
 }
 
 type SessionSnapshot struct {
@@ -218,6 +219,9 @@ func ProviderCatalogSnapshots(options ProviderCatalogSnapshotOptions) ([]Provide
 		snapshots = append(snapshots, ProviderCatalogSnapshotFromDescriptor(descriptor))
 	}
 	sort.SliceStable(snapshots, func(i int, j int) bool {
+		if snapshots[i].Recommended != snapshots[j].Recommended {
+			return snapshots[i].Recommended
+		}
 		return snapshots[i].ID < snapshots[j].ID
 	})
 	return snapshots, nil
@@ -244,6 +248,7 @@ func ProviderCatalogSnapshotFromDescriptor(descriptor providercatalog.Descriptor
 		Local:                    descriptor.Local,
 		RuntimeSupported:         providercatalog.RuntimeSupported(descriptor),
 		RuntimeUnsupportedReason: providercatalog.RuntimeUnsupportedReason(descriptor),
+		Recommended:              descriptor.Recommended,
 	}
 }
 

--- a/internal/zerocommands/contracts_test.go
+++ b/internal/zerocommands/contracts_test.go
@@ -164,11 +164,16 @@ func TestProviderCatalogSnapshotsExposeStableDescriptors(t *testing.T) {
 	if len(snapshots) < 4 {
 		t.Fatalf("expected provider catalog descriptors, got %#v", snapshots)
 	}
+	if !snapshots[0].Recommended {
+		t.Fatalf("expected the recommended provider first, got %#v", snapshots[0])
+	}
 	for index, snapshot := range snapshots {
 		if snapshot.ID == "" || snapshot.Name == "" || snapshot.Transport == "" {
 			t.Fatalf("catalog snapshot missing identity fields: %#v", snapshot)
 		}
-		if index > 0 && snapshots[index-1].ID > snapshot.ID {
+		// The recommended provider is hoisted to the front; everything after it is
+		// sorted by id.
+		if index > 0 && !snapshots[index-1].Recommended && snapshots[index-1].ID > snapshot.ID {
 			t.Fatalf("provider catalog snapshots are not sorted by id: %#v", snapshots)
 		}
 	}


### PR DESCRIPTION
OpenGateway pointed at gateway.gitlawb.com, which does not resolve (NXDOMAIN), so every request failed with "no such host". The live gateway is opengateway.gitlawb.com — a flat OpenAI-compatible endpoint (/v1/chat/completions, Authorization: Bearer ogw_live_…) that smart-routes by model id across its upstreams (xiaomi-mimo, minimax, qwen, google, nvidia, z-ai).

- catalog: fix base URL to https://opengateway.gitlawb.com/v1, default model to mimo-v2.5-pro; add a Recommended descriptor field and hoist OpenGateway to the top of the catalog so it is the first/badged pick everywhere.
- models: replace the curated model list with the gateway's real upstream models; fix the stale model-discovery fallback host.
- providers catalog: sort recommended-first (CLI + snapshot) and render the ★ … (recommended) badge; same badge in the TUI /provider wizard and the setup onboarding list.
- providerhealth: OpenGateway's flat /v1/models 404s by design, so probe its public /health endpoint for connectivity instead of reporting a false fail.
- tests: update catalog order golden + transport/discovery expectations; add coverage for the recommended provider and the health-endpoint override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recommended providers are now highlighted in setup, provider lists, and catalog snapshots with a star and “recommended” label.
  * The recommended provider now appears first in provider listings and onboarding flows.
  * OpenGateway uses an updated default model set and a new fallback endpoint.

* **Bug Fixes**
  * Health checks for the OpenGateway provider now probe the correct `/health` endpoint.
  * Provider catalog ordering and display now better match the recommended provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->