### PR TITLE
Document source-build sandbox helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ If you are testing before the first public release, build from source:
 go build -o zero ./cmd/zero
 ```
 
+On Linux, build the sandbox helper too if you want native sandboxing:
+
+```bash
+go build -o zero-linux-sandbox ./cmd/zero-linux-sandbox
+go build -o zero-seccomp ./cmd/zero-seccomp   # optional compatibility wrapper
+```
+
+Put `zero` and `zero-linux-sandbox` in the same directory on `PATH`
+(`~/.local/bin` is a good default). macOS does not need an extra helper binary.
+Windows source builds can use the main `zero.exe` as their sandbox helper; release
+archives still ship standalone Windows helper executables.
+
 More install details: [docs/INSTALL.md](docs/INSTALL.md).
 
 ## First Run

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -108,6 +108,36 @@ go build -o zero ./cmd/zero
 
 Source builds require Go 1.25+.
 
+### Sandbox Helpers For Source Builds
+
+Release archives include the platform sandbox helpers. If you build directly
+from source, build the helpers you need:
+
+Linux:
+
+```bash
+go build -o zero ./cmd/zero
+go build -o zero-linux-sandbox ./cmd/zero-linux-sandbox
+go build -o zero-seccomp ./cmd/zero-seccomp
+```
+
+Put `zero` and `zero-linux-sandbox` in the same directory on `PATH`, for example
+`~/.local/bin`. `zero-seccomp` is kept as a compatibility wrapper; the sandbox
+helper applies the Unix-socket filter itself when that sandbox option is enabled.
+Linux native sandboxing also requires Bubblewrap to be installed.
+
+macOS uses the system sandbox and does not need an extra helper binary.
+
+Windows source builds can use the main `zero.exe` as the command runner and setup
+helper through Zero's built-in self-dispatch path. If you want a release-style
+layout anyway, build the standalone helper executables next to `zero.exe`:
+
+```powershell
+go build -o zero.exe ./cmd/zero
+go build -o zero-windows-command-runner.exe ./cmd/zero-windows-command-runner
+go build -o zero-windows-sandbox-setup.exe ./cmd/zero-windows-sandbox-setup
+```
+
 ## Release Archive Format
 
 Release archives are named:


### PR DESCRIPTION
## Summary
- document the Linux sandbox helper binaries needed for source builds
- clarify macOS does not need an extra helper binary
- document Windows self-dispatch and optional release-style helper executables

## Tests
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded install instructions for source builds with platform-specific sandbox helper guidance.
  * Added Linux build and PATH setup steps for required helper binaries.
  * Clarified macOS and Windows source-build behavior, including optional Windows helper executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->