### PR TITLE
fix(swarm): constrain agent_type to the registered roster via a dynamic enum

### DIFF
--- a/internal/swarm/tools.go
+++ b/internal/swarm/tools.go
@@ -103,6 +103,25 @@ func errResult(format string, a ...any) tools.Result {
 	return tools.Result{Status: tools.StatusError, Output: "Error: " + fmt.Sprintf(format, a...)}
 }
 
+// agentTypeProperty builds the schema for an agent-type parameter, constraining it
+// to the roster's currently registered types (the built-ins plus any user-registered
+// agents) via an enum so a model can't spawn or hand off to an unknown type — the
+// schema teaches the valid set up front instead of the model learning it from a
+// failed call. Falls back to a free-form string if the roster is unavailable or
+// empty (so the tool never advertises an empty, un-satisfiable enum).
+func agentTypeProperty(sw *Swarm, description string) tools.PropertySchema {
+	prop := tools.PropertySchema{Type: "string", Description: description}
+	if sw == nil {
+		return prop
+	}
+	if registry := sw.Registry(); registry != nil {
+		if types := registry.AgentTypes(); len(types) > 0 {
+			prop.Enum = types
+		}
+	}
+	return prop
+}
+
 // ---- swarm_spawn -----------------------------------------------------------
 
 type spawnTool struct {
@@ -118,7 +137,7 @@ func (t *spawnTool) Parameters() tools.Schema {
 	return tools.Schema{
 		Type: "object",
 		Properties: map[string]tools.PropertySchema{
-			"agent_type": {Type: "string", Description: "Roster agent type to spawn (e.g. teammate, subagent)."},
+			"agent_type": agentTypeProperty(t.sw, "Roster agent type to spawn."),
 			"task":       {Type: "string", Description: "The focused task/briefing for the member."},
 			"team":       {Type: "string", Description: "Team to spawn into. Defaults to \"default\"."},
 		},
@@ -353,7 +372,7 @@ func (t *handoffTool) Parameters() tools.Schema {
 		Type: "object",
 		Properties: map[string]tools.PropertySchema{
 			"task_id":       {Type: "string", Description: "Task id to hand off."},
-			"to_agent_type": {Type: "string", Description: "Roster agent type to take over."},
+			"to_agent_type": agentTypeProperty(t.sw, "Roster agent type to take over."),
 			"note":          {Type: "string", Description: "Optional handoff note delivered to the new member's inbox."},
 			"team":          {Type: "string", Description: "Team the task belongs to. Defaults to \"default\"."},
 		},

--- a/internal/swarm/tools_test.go
+++ b/internal/swarm/tools_test.go
@@ -33,7 +33,11 @@ func TestSpawnAndHandoffAgentTypeEnumReflectsRoster(t *testing.T) {
 	}
 	spawnEnum = (&spawnTool{sw: sw}).Parameters().Properties["agent_type"].Enum
 	if !slices.Contains(spawnEnum, "researcher") {
-		t.Fatalf("custom agent type not reflected in enum: %v", spawnEnum)
+		t.Fatalf("custom agent type not reflected in spawn enum: %v", spawnEnum)
+	}
+	handoffEnum = (&handoffTool{sw: sw}).Parameters().Properties["to_agent_type"].Enum
+	if !slices.Contains(handoffEnum, "researcher") {
+		t.Fatalf("custom agent type not reflected in handoff enum: %v", handoffEnum)
 	}
 }
 

--- a/internal/swarm/tools_test.go
+++ b/internal/swarm/tools_test.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,42 @@ import (
 
 	"github.com/Gitlawb/zero/internal/tools"
 )
+
+func TestSpawnAndHandoffAgentTypeEnumReflectsRoster(t *testing.T) {
+	sw := newSwarmFor(t, newLauncher(okFor))
+	want := sw.Registry().AgentTypes() // sorted built-ins: subagent, teammate
+
+	spawnEnum := (&spawnTool{sw: sw}).Parameters().Properties["agent_type"].Enum
+	if !slices.Equal(spawnEnum, want) {
+		t.Fatalf("spawn agent_type enum = %v, want roster %v", spawnEnum, want)
+	}
+	if !slices.Contains(spawnEnum, "subagent") || !slices.Contains(spawnEnum, "teammate") {
+		t.Fatalf("enum missing built-in roster types: %v", spawnEnum)
+	}
+	handoffEnum := (&handoffTool{sw: sw}).Parameters().Properties["to_agent_type"].Enum
+	if !slices.Equal(handoffEnum, want) {
+		t.Fatalf("handoff to_agent_type enum = %v, want roster %v", handoffEnum, want)
+	}
+
+	// A user-registered custom type must extend the enum (not a hardcoded list).
+	if err := sw.Registry().Register(Definition{AgentType: "researcher"}); err != nil {
+		t.Fatalf("register custom agent: %v", err)
+	}
+	spawnEnum = (&spawnTool{sw: sw}).Parameters().Properties["agent_type"].Enum
+	if !slices.Contains(spawnEnum, "researcher") {
+		t.Fatalf("custom agent type not reflected in enum: %v", spawnEnum)
+	}
+}
+
+func TestAgentTypePropertyFallsBackWithoutRoster(t *testing.T) {
+	prop := agentTypeProperty(nil, "desc")
+	if prop.Type != "string" || prop.Description != "desc" {
+		t.Fatalf("unexpected property: %+v", prop)
+	}
+	if prop.Enum != nil {
+		t.Fatalf("nil swarm must not advertise an (empty) enum, got %v", prop.Enum)
+	}
+}
 
 func TestCollapseRuneSafeTruncation(t *testing.T) {
 	// 300 multi-byte runes: truncation must not split a rune (no invalid UTF-8).


### PR DESCRIPTION
## Summary

`swarm_spawn` (and `swarm_handoff`) described `agent_type` / `to_agent_type` as a free-form string with only an *"e.g. teammate, subagent"* hint in the description — no enum. So a model could pass an **unregistered type** (e.g. `"worker"`) and only find out it was invalid from the runtime error:

```
Error: swarm: unknown agent type; available agent types: subagent, teammate
```

That wastes tool calls (often several at once, fanning out a swarm) and hits weaker models hardest, since the valid set was never advertised in the schema.

## Fix
Set the parameter's `enum` **dynamically from the live roster** (`Registry.AgentTypes()`), via a shared `agentTypeProperty` helper used by both tools. The schema now advertises the valid set — the built-ins **plus any user-registered agents** — so an invalid type can't be sent in the first place.

- Dynamic, not hardcoded: custom agents registered via `Registry.Register` are reflected automatically.
- Falls back to a free-form string when the roster is unavailable/empty, so the tool never advertises an empty, un-satisfiable enum.
- The runtime `available agent types: …` error is kept as a backstop.

## Tests
- `TestSpawnAndHandoffAgentTypeEnumReflectsRoster`: both tools' enums equal the roster, include the built-ins, and pick up a newly-registered custom type.
- `TestAgentTypePropertyFallsBackWithoutRoster`: nil roster → no enum (no empty enum advertised).
- `go build`, `go vet ./...`, `go test ./... -race` (73 pkg), lint — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced swarm tool agent-type fields to show selectable options based on registered agent types when available, with free-form text fallback when not.
* **Tests**
  * Added unit tests to ensure agent-type option lists match the swarm registry (including custom types) and fall back to plain string behavior when no registry is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->