### PR TITLE
test(providers): isolate the OAuth store in the chatgpt Codex routing test

### DIFF
--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -264,6 +264,13 @@ func TestNewRejectsUnsupportedProviderKind(t *testing.T) {
 }
 
 func TestNewRoutesChatGPTCatalogToCodexProvider(t *testing.T) {
+	// Isolate the OAuth token store to an empty temp path so the factory reads no
+	// stored login — otherwise this test picks up the developer's real chatgpt
+	// OAuth token and the "want empty chatgpt-account-id" assertion fails locally
+	// (it still passes in CI, where no login is stored). Mirrors the isolation in
+	// TestNewRoutesChatGPTCatalogWithStoredAccountID.
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", t.TempDir()+"/tokens.json")
+
 	transport := &captureTransport{
 		responseBody: "data: [DONE]\n\n",
 	}


### PR DESCRIPTION
## Summary

`TestNewRoutesChatGPTCatalogToCodexProvider` asserts the `chatgpt-account-id` header is **empty when no OAuth login is stored**, but it never isolated the OAuth token store. The factory's store resolution honors `ZERO_OAUTH_TOKENS_PATH` → `XDG_CONFIG_HOME` → home dir (`internal/oauth/store.go:104-106`), so on a developer machine with a real chatgpt login the test read that login and failed:

```
factory_test.go: chatgpt-account-id = "13e7e3b7-…", want empty when no OAuth login is stored
```

It still passed in CI (no stored token), so this only bites local `go test ./...`.

## Fix
Set `ZERO_OAUTH_TOKENS_PATH` to an empty temp path at the top of the test, exactly as the sibling `TestNewRoutesChatGPTCatalogWithStoredAccountID` already does — so the factory reads no stored login and the assertion is deterministic regardless of the developer's credentials.

## Test plan
- `go test ./internal/providers/` — both chatgpt routing tests pass.
- `go test ./... -race` (73 pkg), `go vet`, lint — all green (this was the one previously-failing, environment-dependent test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation so local OAuth token data no longer affects route-mapping checks.
  * Made the relevant test more deterministic, reducing the chance of environment-specific failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->