### PR TITLE
fix(tui): sub-agents inherit the parent's live provider after a /model switch

### DIFF
--- a/internal/config/active_provider_env_test.go
+++ b/internal/config/active_provider_env_test.go
@@ -7,16 +7,31 @@ import (
 
 // SetActiveProviderEnv must export the provider name so a child process (whose
 // resolution reads the inherited environment via the nil-map -> os.Getenv path in
-// applyEnv) resolves the SAME active provider. An empty name is a no-op.
+// applyEnv) resolves the SAME active provider. A blank name CLEARS it.
 func TestSetActiveProviderEnvRoundTrips(t *testing.T) {
 	t.Setenv(ActiveProviderEnv, "") // register cleanup; restores the original after
 
 	if err := os.Unsetenv(ActiveProviderEnv); err != nil {
 		t.Fatalf("unset: %v", err)
 	}
-	SetActiveProviderEnv("") // empty must not set anything
+	SetActiveProviderEnv("") // blank with nothing set stays unset
 	if got := os.Getenv(ActiveProviderEnv); got != "" {
 		t.Fatalf("empty name set the env to %q, want unset", got)
+	}
+
+	// Regression: switching from a named provider back to an unnamed/default profile
+	// must CLEAR a previously exported value, not leave it stale for children.
+	if err := os.Setenv(ActiveProviderEnv, "stale-provider"); err != nil {
+		t.Fatalf("seed stale: %v", err)
+	}
+	SetActiveProviderEnv("") // blank must unset the stale value
+	if got := os.Getenv(ActiveProviderEnv); got != "" {
+		t.Fatalf("blank name left stale env %q, want cleared", got)
+	}
+	cfgStale := &FileConfig{}
+	applyEnv(cfgStale, nil)
+	if cfgStale.ActiveProvider != "" {
+		t.Fatalf("applyEnv still resolved stale provider %q after clear", cfgStale.ActiveProvider)
 	}
 
 	SetActiveProviderEnv("ollama-cloud")

--- a/internal/config/active_provider_env_test.go
+++ b/internal/config/active_provider_env_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// SetActiveProviderEnv must export the provider name so a child process (whose
+// resolution reads the inherited environment via the nil-map -> os.Getenv path in
+// applyEnv) resolves the SAME active provider. An empty name is a no-op.
+func TestSetActiveProviderEnvRoundTrips(t *testing.T) {
+	t.Setenv(ActiveProviderEnv, "") // register cleanup; restores the original after
+
+	if err := os.Unsetenv(ActiveProviderEnv); err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	SetActiveProviderEnv("") // empty must not set anything
+	if got := os.Getenv(ActiveProviderEnv); got != "" {
+		t.Fatalf("empty name set the env to %q, want unset", got)
+	}
+
+	SetActiveProviderEnv("ollama-cloud")
+	if got := os.Getenv(ActiveProviderEnv); got != "ollama-cloud" {
+		t.Fatalf("env = %q, want ollama-cloud", got)
+	}
+
+	// applyEnv with a nil map is the exact path a child uses: it falls back to
+	// os.Getenv, so the inherited value selects the active provider.
+	cfg := &FileConfig{}
+	applyEnv(cfg, nil)
+	if cfg.ActiveProvider != "ollama-cloud" {
+		t.Fatalf("applyEnv ActiveProvider = %q, want ollama-cloud (inherited env not read)", cfg.ActiveProvider)
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -431,8 +431,23 @@ func mergeProfile(base ProviderProfile, next ProviderProfile) ProviderProfile {
 	return base
 }
 
+// ActiveProviderEnv selects the active provider profile by name (read in applyEnv).
+const ActiveProviderEnv = "ZERO_PROVIDER"
+
+// SetActiveProviderEnv exports the active provider name to the process environment
+// so a spawned child process (which inherits the environment) resolves the SAME
+// provider profile — and therefore the same credentials (env key / stored key /
+// OAuth) — as its parent. Without this a sub-agent re-resolves config.json's
+// default provider and can land on one whose credentials don't match the parent's
+// live selection, failing auth the instant it spawns. No-op for an empty name.
+func SetActiveProviderEnv(name string) {
+	if strings.TrimSpace(name) != "" {
+		_ = os.Setenv(ActiveProviderEnv, name)
+	}
+}
+
 func applyEnv(cfg *FileConfig, env map[string]string) {
-	activeProvider := strings.TrimSpace(envValue(env, "ZERO_PROVIDER"))
+	activeProvider := strings.TrimSpace(envValue(env, ActiveProviderEnv))
 	if activeProvider != "" {
 		cfg.ActiveProvider = activeProvider
 	}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -439,11 +439,16 @@ const ActiveProviderEnv = "ZERO_PROVIDER"
 // provider profile — and therefore the same credentials (env key / stored key /
 // OAuth) — as its parent. Without this a sub-agent re-resolves config.json's
 // default provider and can land on one whose credentials don't match the parent's
-// live selection, failing auth the instant it spawns. No-op for an empty name.
+// live selection, failing auth the instant it spawns. A blank name CLEARS the
+// variable: switching back to an unnamed/default profile must not keep exporting a
+// stale provider to children.
 func SetActiveProviderEnv(name string) {
-	if strings.TrimSpace(name) != "" {
-		_ = os.Setenv(ActiveProviderEnv, name)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		_ = os.Unsetenv(ActiveProviderEnv)
+		return
 	}
+	_ = os.Setenv(ActiveProviderEnv, name)
 }
 
 func applyEnv(cfg *FileConfig, env map[string]string) {

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -441,6 +441,8 @@ func (m model) handleModelCommand(args string) (model, string) {
 	m.providerProfile = nextProfile
 	m.provider = nextProvider
 	m.providerName = displayValue(nextProfile.Name, string(metadata.ProviderKind))
+	// Keep sub-agent child processes on the same provider we just switched to.
+	config.SetActiveProviderEnv(nextProfile.Name)
 	m.modelName = target.modelID
 	resetEffort := false
 	if m.reasoningEffort != "" && !reasoningEffortAllowed(target.reasoningEfforts, m.reasoningEffort) {
@@ -516,6 +518,8 @@ func (m model) switchProviderModel(providerName, modelID string) (model, string)
 	m.providerProfile = target
 	m.providerName = target.Name
 	m.modelName = target.Model
+	// Keep sub-agent child processes on the same provider we just switched to.
+	config.SetActiveProviderEnv(target.Name)
 	if strings.TrimSpace(m.userConfigPath) != "" {
 		_, _ = config.SetActiveProvider(m.userConfigPath, target.Name)
 		_, _ = config.SetProviderModel(m.userConfigPath, target.Name, target.Model)


### PR DESCRIPTION
## Summary

Swarm members and Task sub-agents fail authentication the instant they spawn — `exit 3`, `0 tool calls`, *"API key is missing or invalid … can't reach the provider"* — so the spawned agent appears in the AGENTS panel and **immediately disappears** (it errored out in ~3s, it didn't complete).

### Root cause
Sub-agents run as child `zero exec` processes that **re-resolve the provider from `config.json` themselves** — they're passed `--model` but **never the parent's provider**. After you switch provider/model in the TUI via **`/model`** (an in-memory change that doesn't rewrite `config.json`), the child still resolves `config.json`'s **stale `activeProvider`**, lands on a provider whose credentials don't match the live model, and 401s.

This is provider-credential-agnostic in the symptom but splits by method:
- **Env-var key** (`OPENAI_API_KEY`, …) — already worked (the child inherits the env).
- **Saved key (credstore/keychain)** and **OAuth login (`zero auth`)** — broke, because the child re-resolved the *wrong profile*.

### Fix
On a `/model` provider switch, export **`ZERO_PROVIDER`** (`config.SetActiveProviderEnv`) to the live provider name. Child processes inherit the environment, and config resolution **already** maps `ZERO_PROVIDER → activeProvider` — so the child resolves the **same profile and its credentials** (env key / stored key / OAuth), covering **all three auth methods**, for **both Task and swarm** (both spawn through the specialist executor).

Startup needs no export — the parent and child both read `config.json`'s default, so they already match; only an in-memory switch diverges. (Deliberately not exporting at startup also avoids a process-global `os.Setenv` on the launch path.)

## Test plan
- New `TestSetActiveProviderEnvRoundTrips`: the helper exports the name, is a no-op for empty, and `applyEnv` reads it back via the child's `nil-map → os.Getenv` path.
- `go build`, `go vet ./...`, `go test ./... -race` (73 pkg), lint — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switching providers or models now keeps any spawned/child processes aligned with the currently selected provider.
  * Provider selection via environment now behaves more reliably, including properly clearing the setting when no provider is selected.

* **Tests**
  * Added coverage to ensure the provider environment setting round-trips correctly and that inherited resolution matches the active provider.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->