### PR TITLE
revert(tui): restore the original bright-lime accent color

### DIFF
--- a/internal/tui/streaming_fade_test.go
+++ b/internal/tui/streaming_fade_test.go
@@ -32,9 +32,9 @@ func TestStreamingFadePaletteMonotonic(t *testing.T) {
 	// so per-bucket comparisons are byte-stable. The endpoint byte
 	// values are the contract — the hex strings are not.
 	fresh := rgbaOf(t, palette[0])
-	// Sanity: palette[0] must equal the accent endpoint (#759523).
-	if fresh.R != 0x75 || fresh.G != 0x95 || fresh.B != 0x23 {
-		t.Errorf("palette[0] RGBA = %v, want {R:0x75, G:0x95, B:0x23} (accent)", fresh)
+	// Sanity: palette[0] must equal the accent endpoint (#caff3f).
+	if fresh.R != 0xca || fresh.G != 0xff || fresh.B != 0x3f {
+		t.Errorf("palette[0] RGBA = %v, want {R:0xca, G:0xff, B:0x3f} (accent)", fresh)
 	}
 	last := rgbaOf(t, palette[streamingFadeSteps-1])
 	if last == fresh {

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -129,23 +129,15 @@ type palette struct {
 // lime accent. bg (#070708) is the terminal's own canvas — deliberately never
 // painted — so no token references it.
 var darkPalette = palette{
-	panel:    "#0e0e10",
-	promptBg: "#262626",
-	line:     "#242429",
-	line2:    "#414147",
-	ink:      "#ececee",
-	muted:    "#9a9aa2", // secondary text — lifted so it clearly out-ranks faint
-	faint:    "#8a8a92", // hints/metadata — nudged up to separate from faintest
-	faintest: "#7c7c82", // line numbers/separators — pinned at the WCAG-AA floor on the dark panel
-	// Brand lime, softened from the original #caff3f (L 62%, S 100% — fully
-	// saturated, which read as glaring/neon everywhere it filled a block or
-	// bold-text surface: the composer prompt glyph, the permission popup's
-	// focused-option badge, the text-selection highlight). Two prior passes
-	// (#ade619 at L50/S80, #8db620 at L42/S70) were each confirmed too subtle
-	// in turn; settled at L 36%/S 62% — a darker, more olive lime. Contrast
-	// vs both black (onAccent) and the near-black panel stays comfortably
-	// above WCAG AA (~6.1:1 and ~5.6:1) with real margin to spare.
-	accent:    "#759523",
+	panel:     "#0e0e10",
+	promptBg:  "#262626",
+	line:      "#242429",
+	line2:     "#414147",
+	ink:       "#ececee",
+	muted:     "#9a9aa2", // secondary text — lifted so it clearly out-ranks faint
+	faint:     "#8a8a92", // hints/metadata — nudged up to separate from faintest
+	faintest:  "#7c7c82", // line numbers/separators — pinned at the WCAG-AA floor on the dark panel
+	accent:    "#caff3f",
 	green:     "#5dd1a4",
 	red:       "#ff7a7a",
 	amber:     "#ffc25c",


### PR DESCRIPTION
Reverts the `accent` palette token back to the original bright lime (`#caff3f`), undoing the brightness-reduction work merged in #350 (three rounds: `#ade619` → `#8db620` → `#759523`).

Only the single `accent` token changes. Everything else from #350 is untouched:
- the hover-highlight color (a separate `amber` token)
- the subchat mouse-selection fix
- drag-to-edge auto-scroll
- the `dragging`-flag fix from the #350 review round

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./internal/tui/` green, incl. the streaming-fade test's pinned RGB assertion restored to the original bytes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the dark theme’s accent color to a brighter lime shade for better visual consistency.
  * Updated the related palette check so the theme test matches the current accent color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->