### PR TITLE
fix(tui): require a second Esc press to cancel a running turn

### DIFF
--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -56,6 +56,13 @@ func pasteFromClipboardCmd() tea.Cmd {
 // spec prompt, the MCP manager, an open picker, the detailed transcript) swallow
 // the paste; empty content is a no-op.
 func (m model) routePaste(content string) (tea.Model, tea.Cmd) {
+	// A paste is a deliberate action, same as a keypress or click — it means
+	// the user moved on to something else, so it disarms a stale Esc
+	// cancel-confirmation. tea.PasteMsg/clipboardReadMsg aren't
+	// tea.KeyPressMsg, so they don't go through that generic keypress hook;
+	// do it once here, before any early return, so both the bracketed-paste
+	// and right-click-paste paths are covered uniformly.
+	m = m.disarmCancelConfirmation()
 	if content == "" {
 		// Empty text clipboard — the user may have pasted a screenshot.
 		// Probe the OS clipboard for image content asynchronously.

--- a/internal/tui/flush_test.go
+++ b/internal/tui/flush_test.go
@@ -122,6 +122,8 @@ func TestEscCancellationLeavesVisibleMarker(t *testing.T) {
 
 	updated, _ := m.Update(testKey(tea.KeyEsc))
 	next := updated.(model)
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
 	if !transcriptContains(next.transcript, "Run cancelled.") {
 		t.Fatalf("expected visible cancellation marker, got %#v", next.transcript)
 	}

--- a/internal/tui/keybinding_help.go
+++ b/internal/tui/keybinding_help.go
@@ -31,7 +31,7 @@ var keybindingGroups = []keybindingGroup{
 		bindings: []keybinding{
 			{"Enter", "send the message"},
 			{"Alt+Enter", "insert a newline (multi-line compose)"},
-			{"Esc", "cancel the run / dismiss a popup / clear the input"},
+			{"Esc (×2)", "cancel the run / dismiss a popup / clear the input"},
 			{"Ctrl+C", "cancel the run, then quit"},
 			{"?", "show this help (on an empty input)"},
 		},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -40,6 +40,15 @@ const chatWheelScrollLines = 5
 const ctrlCExitConfirmDuration = 3 * time.Second
 const ctrlCExitConfirmText = "Press Ctrl+C again to exit"
 
+// escCancelConfirmDuration/escCancelConfirmText guard Esc cancelling a running
+// turn, mirroring ctrlCExitConfirmDuration/ctrlCExitConfirmText's pattern (same
+// window, same amber footer treatment) so the two "stop it" keybinds feel
+// consistent. Without this, a single stray Esc — e.g. meant to dismiss a
+// suggestion overlay that had already closed — silently threw away an
+// in-progress run with no chance to reconsider.
+const escCancelConfirmDuration = 3 * time.Second
+const escCancelConfirmText = "Press Esc again to cancel"
+
 // dragEdgeScrollInterval/dragEdgeScrollStep drive the smooth-glide auto-scroll
 // while a drag holds past the transcript edge (see edgeScrollDelta). A small step
 // on a short, steady cadence reads as a smooth continuous scroll; the wheel-scroll
@@ -296,6 +305,14 @@ type model struct {
 	copyStatusSeq     int
 	exitConfirmActive bool
 	exitConfirmSeq    int
+	// cancelConfirmActive/cancelConfirmSeq mirror exitConfirmActive/exitConfirmSeq
+	// (same seq-gated tea.Tick pattern) but guard a DIFFERENT action: Esc
+	// cancelling a running turn. The two are deliberately separate state (not a
+	// shared flag) since they're different actions with different consequences
+	// (quit the app vs. cancel the current run) that are armed by different
+	// keys — Ctrl+C and Esc respectively.
+	cancelConfirmActive bool
+	cancelConfirmSeq    int
 	// edgeScrollDelta drives the smooth-glide auto-scroll while a drag holds past
 	// the transcript's top/bottom edge: 0 when idle, else the signed per-tick step
 	// (matches transcriptEdgeScrollDelta's sign convention). A self-scheduling
@@ -355,6 +372,12 @@ type agentTextMsg struct {
 }
 
 type exitConfirmExpiredMsg struct {
+	seq int
+}
+
+// cancelConfirmExpiredMsg mirrors exitConfirmExpiredMsg for the Esc
+// cancel-a-run confirmation (see cancelConfirmActive).
+type cancelConfirmExpiredMsg struct {
 	seq int
 }
 
@@ -849,6 +872,14 @@ func (m model) disarmExitConfirmation() model {
 	return m
 }
 
+func (m model) disarmCancelConfirmation() model {
+	if m.cancelConfirmActive {
+		m.cancelConfirmActive = false
+		m.cancelConfirmSeq++
+	}
+	return m
+}
+
 // Update routes every message through updateModel, then advances the flush
 // frontier for inline rendering. Alt-screen runs keep rows in the managed view
 // instead of printing into terminal scrollback (see flush.go).
@@ -925,6 +956,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case exitConfirmExpiredMsg:
 		if msg.seq == m.exitConfirmSeq {
 			m.exitConfirmActive = false
+		}
+		return m, nil
+	case cancelConfirmExpiredMsg:
+		if msg.seq == m.cancelConfirmSeq {
+			m.cancelConfirmActive = false
 		}
 		return m, nil
 	case dragEdgeScrollTickMsg:
@@ -1059,7 +1095,17 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clearComposer()
 			m.clearSuggestions()
 			if m.pending {
-				m.cancelRun()
+				if m.cancelConfirmActive {
+					m = m.disarmCancelConfirmation()
+					m.cancelRun()
+					return m, nil
+				}
+				m.cancelConfirmActive = true
+				m.cancelConfirmSeq++
+				seq := m.cancelConfirmSeq
+				return m, tea.Tick(escCancelConfirmDuration, func(time.Time) tea.Msg {
+					return cancelConfirmExpiredMsg{seq: seq}
+				})
 			}
 			return m, nil
 		case keyIs(msg, tea.KeyEnter):
@@ -1610,6 +1656,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.clearStreamingToolCall() // active run finished — drop any lingering "writing" block
 		m.pending = false
+		m = m.disarmCancelConfirmation() // the run finished on its own — nothing left to confirm cancelling
 		// Fully reset the fade state at stream end. The next render
 		// emits the final row in solid ink (no settling animation), and
 		// the pending streamingFadeTickMsg that lands after this point
@@ -3807,7 +3854,8 @@ func (m *model) cancelRun() {
 	m.pending = false
 	m.runCancel = nil
 	m.activeRunID = 0
-	m.plan.frozenAt = m.now() // freeze the plan clock while idle (no run in flight)
+	m.cancelConfirmActive = false // whatever path got here, there's nothing left to confirm cancelling
+	m.plan.frozenAt = m.now()     // freeze the plan clock while idle (no run in flight)
 	m.pendingPermission = nil
 	m.pendingAskUser = nil
 	// The interim block renders streamingText live; a cancelled run's partial

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1108,13 +1108,16 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.hasQueuedMessage() {
 				return m.clearQueuedMessage(), nil
 			}
-			m.clearComposer()
 			m.clearSuggestions()
 			if m.pending {
 				if wasConfirmingCancel {
+					m.clearComposer()
 					m.cancelRun()
 					return m, nil
 				}
+				// First Esc only arms the confirmation — preserve whatever
+				// draft the user has typed, since nothing has actually been
+				// cancelled yet and they may not press Esc again.
 				m.cancelConfirmActive = true
 				m.cancelConfirmSeq++
 				seq := m.cancelConfirmSeq
@@ -1122,6 +1125,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return cancelConfirmExpiredMsg{seq: seq}
 				})
 			}
+			m.clearComposer()
 			return m, nil
 		case keyIs(msg, tea.KeyEnter):
 			if m.transcriptDetailed {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1010,6 +1010,13 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !keyCtrl(msg, 'c') {
 			m = m.disarmExitConfirmation()
 		}
+		// Mirrors the exit-confirmation reset above: any key that isn't itself
+		// the confirming Esc means the user moved on to something else, so a
+		// later, unrelated Esc must arm a fresh confirmation rather than
+		// silently cancel off a stale press from seconds ago.
+		if !keyIs(msg, tea.KeyEsc) {
+			m = m.disarmCancelConfirmation()
+		}
 		// The `?` help overlay is modal: `?`, Esc, q, or Enter close it; every
 		// other key is swallowed so nothing types into the hidden composer.
 		if m.helpOverlay {
@@ -1032,6 +1039,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m.appendSystemNotice("Mouse interaction re-enabled."), nil
 		case keyIs(msg, tea.KeyEsc):
+			// Esc is heavily overloaded below (subchat exit, MCP cancel, ask-user,
+			// permission deny, wizard/picker/suggestions dismiss, ...) before ever
+			// reaching the run-cancel fallback. Capture whether this press really
+			// is the confirming second Esc BEFORE any of those branches can fire,
+			// then disarm unconditionally: an Esc that gets consumed by one of
+			// them wasn't a confirm, so it must not leave cancelConfirmActive
+			// armed for some later, unrelated Esc to silently act on.
+			wasConfirmingCancel := m.pending && m.cancelConfirmActive
+			m = m.disarmCancelConfirmation()
 			// Subchat view exits on Esc (returns to main chat).
 			if m.subchat.active {
 				m.chatScrollOffset = m.subchat.exit()
@@ -1095,8 +1111,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clearComposer()
 			m.clearSuggestions()
 			if m.pending {
-				if m.cancelConfirmActive {
-					m = m.disarmCancelConfirmation()
+				if wasConfirmingCancel {
 					m.cancelRun()
 					return m, nil
 				}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1152,6 +1152,71 @@ func TestEscRequiresSecondPressToCancelPendingRun(t *testing.T) {
 	}
 }
 
+// TestEscArmingCancelConfirmationPreservesComposerDraft: the first Esc only
+// arms the confirmation — nothing has actually been cancelled yet, so it
+// must not destroy a draft the user is still typing. Only the confirming
+// second Esc (the one that actually cancels the run) clears the composer.
+func TestEscArmingCancelConfirmationPreservesComposerDraft(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 1
+	m.runCancel = func() {}
+	m.input.SetValue("draft prompt")
+
+	updated, _ := m.Update(testKey(tea.KeyEsc))
+	next := updated.(model)
+
+	if !next.cancelConfirmActive {
+		t.Fatal("first Esc should arm cancel confirmation")
+	}
+	if next.composerValue() != "draft prompt" {
+		t.Fatalf("first Esc should preserve the draft, got %q", next.composerValue())
+	}
+
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
+
+	if next.pending {
+		t.Fatal("second Esc should cancel the pending run")
+	}
+	if next.composerValue() != "" {
+		t.Fatalf("the confirming second Esc should clear the draft, got %q", next.composerValue())
+	}
+}
+
+// TestPasteDisarmsCancelConfirmation: a paste isn't a keypress, so it never
+// went through the generic "any non-Esc key disarms it" hook. Pasting is a
+// deliberate action just like typing or clicking — it must disarm a stale
+// confirmation too, or a later, unrelated Esc could silently cancel the run.
+func TestPasteDisarmsCancelConfirmation(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	cancelled := false
+	m.pending = true
+	m.activeRunID = 1
+	m.runCancel = func() { cancelled = true }
+
+	updated, _ := m.Update(testKey(tea.KeyEsc))
+	next := updated.(model)
+	if !next.cancelConfirmActive {
+		t.Fatal("first Esc should arm cancel confirmation")
+	}
+
+	updated, _ = next.Update(testPaste("pasted text"))
+	next = updated.(model)
+	if next.cancelConfirmActive {
+		t.Fatal("a paste should disarm the stale cancel confirmation")
+	}
+
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
+	if cancelled {
+		t.Fatal("Esc after a paste should re-arm, not immediately cancel")
+	}
+	if !next.cancelConfirmActive {
+		t.Fatal("Esc after a paste should arm a fresh confirmation")
+	}
+}
+
 func TestEscCancelConfirmationExpires(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.pending = true

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1108,24 +1108,73 @@ func TestPromptSubmitDoesNotStartAnotherRunWhilePending(t *testing.T) {
 	}
 }
 
-func TestEscCancelsPendingRun(t *testing.T) {
+func TestEscRequiresSecondPressToCancelPendingRun(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	cancelled := false
 	m.pending = true
 	m.activeRunID = 1
 	m.runCancel = func() { cancelled = true }
 
-	updated, _ := m.Update(testKey(tea.KeyEsc))
+	updated, cmd := m.Update(testKey(tea.KeyEsc))
 	next := updated.(model)
 
+	if cancelled {
+		t.Fatal("first Esc should not cancel the pending run")
+	}
+	if !next.pending {
+		t.Fatal("first Esc should leave the run pending")
+	}
+	if !next.cancelConfirmActive {
+		t.Fatal("first Esc should arm cancel confirmation")
+	}
+	if cmd == nil {
+		t.Fatal("first Esc should schedule confirmation expiry")
+	}
+	status := plainRender(t, next.statusLine(80))
+	if !strings.Contains(status, escCancelConfirmText) {
+		t.Fatalf("status line = %q, want cancel confirmation", status)
+	}
+
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
+
 	if !cancelled {
-		t.Fatal("expected Esc to cancel pending run")
+		t.Fatal("second Esc should cancel pending run")
 	}
 	if next.pending {
-		t.Fatal("expected Esc to clear pending state")
+		t.Fatal("expected second Esc to clear pending state")
 	}
 	if next.activeRunID != 0 || next.runCancel != nil {
 		t.Fatalf("expected active run state to clear, got id=%d cancel=%v", next.activeRunID, next.runCancel)
+	}
+	if next.cancelConfirmActive {
+		t.Fatal("cancelling should clear cancel confirmation")
+	}
+}
+
+func TestEscCancelConfirmationExpires(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 1
+	m.runCancel = func() {}
+
+	updated, _ := m.Update(testKey(tea.KeyEsc))
+	next := updated.(model)
+	seq := next.cancelConfirmSeq
+
+	updated, _ = next.Update(cancelConfirmExpiredMsg{seq: seq - 1})
+	next = updated.(model)
+	if !next.cancelConfirmActive {
+		t.Fatal("stale expiry should not clear active cancel confirmation")
+	}
+
+	updated, _ = next.Update(cancelConfirmExpiredMsg{seq: seq})
+	next = updated.(model)
+	if next.cancelConfirmActive {
+		t.Fatal("matching expiry should clear cancel confirmation")
+	}
+	if !next.pending {
+		t.Fatal("expiring the confirmation should not cancel the run")
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1178,6 +1178,88 @@ func TestEscCancelConfirmationExpires(t *testing.T) {
 	}
 }
 
+// TestEscCancelConfirmationDisarmsOnInterveningKey mirrors
+// TestCtrlCExitConfirmationDisarmsOnInterveningKey: an intervening key other
+// than Esc (typing, Ctrl+O, etc.) means the user moved on to something else,
+// so a later, unrelated Esc must arm a fresh confirmation instead of
+// silently cancelling off a stale press from seconds ago.
+func TestEscCancelConfirmationDisarmsOnInterveningKey(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	cancelled := false
+	m.pending = true
+	m.activeRunID = 1
+	m.runCancel = func() { cancelled = true }
+
+	updated, _ := m.Update(testKey(tea.KeyEsc))
+	next := updated.(model)
+	if !next.cancelConfirmActive {
+		t.Fatal("first Esc should arm cancel confirmation")
+	}
+	seq := next.cancelConfirmSeq
+
+	updated, _ = next.Update(testKey('h'))
+	next = updated.(model)
+	if next.cancelConfirmActive {
+		t.Fatal("an intervening non-Esc key should disarm cancel confirmation")
+	}
+	if next.cancelConfirmSeq == seq {
+		t.Fatal("disarming should advance the sequence so a stale expiry tick is ignored")
+	}
+
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
+	if cancelled {
+		t.Fatal("Esc after an intervening key should re-arm, not cancel")
+	}
+	if !next.cancelConfirmActive {
+		t.Fatal("Esc after an intervening key should arm a fresh confirmation")
+	}
+}
+
+// TestEscCancelConfirmationDisarmsWhenStolenByAskUser: a mid-turn ask_user
+// prompt lands between the two Esc presses. The user's second Esc denies the
+// questionnaire (an earlier branch in the Esc handler), not a confirm, so it
+// must not leave cancelConfirmActive armed for a later, unrelated Esc to
+// silently cancel the run.
+func TestEscCancelConfirmationDisarmsWhenStolenByAskUser(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	cancelled := false
+	m.pending = true
+	m.activeRunID = 1
+	m.runCancel = func() { cancelled = true }
+
+	updated, _ := m.Update(testKey(tea.KeyEsc))
+	next := updated.(model)
+	if !next.cancelConfirmActive {
+		t.Fatal("first Esc should arm cancel confirmation")
+	}
+
+	request := agent.AskUserRequest{Questions: []agent.AskUserQuestion{{Question: "name?"}}}
+	next.pendingAskUser = &pendingAskUserPrompt{
+		request: request,
+		answer:  func([]string) {},
+		states:  newAskUserStates(request.Questions),
+	}
+
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
+	if cancelled {
+		t.Fatal("an Esc consumed by the ask-user prompt must not cancel the run")
+	}
+	if next.cancelConfirmActive {
+		t.Fatal("an Esc consumed by the ask-user prompt must disarm the stale cancel confirmation")
+	}
+
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
+	if cancelled {
+		t.Fatal("the next Esc should arm a fresh confirmation, not immediately cancel")
+	}
+	if !next.cancelConfirmActive {
+		t.Fatal("the next Esc should arm a fresh confirmation")
+	}
+}
+
 func TestAgentResponseCompletesStuckPlan(t *testing.T) {
 	runningPlan := func() planPanelState {
 		var s planPanelState

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -40,6 +40,15 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	if m.providerWizard != nil && m.providerWizard.oauthPending {
 		return m, nil
 	}
+	// A click is a deliberate action, same as a keypress — it means the user
+	// moved on to something else, so it disarms a stale Esc cancel-confirmation
+	// rather than leaving it armed for some later, unrelated Esc to act on.
+	// Scoped to actual clicks (not hover/motion/wheel), since motion events fire
+	// continuously while the mouse merely sits over the terminal and would
+	// otherwise defeat the confirmation window on every render tick.
+	if mouseLeftPress(msg) || mouseRightPress(msg) {
+		m = m.disarmCancelConfirmation()
+	}
 	// A right-click pastes the clipboard straight into the focused field — no
 	// menu. pasteFromClipboardCmd reads the clipboard off the Update goroutine; the
 	// clipboardReadMsg result is routed by routePaste to wherever input is focused

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -36,7 +36,7 @@ func pickerBusyText(name string) string {
 			Title: "Busy",
 			Lines: []string{"Can't change " + label + " while a run is in progress."},
 		}},
-		Hints: []string{"press Esc to cancel the run, then try again"},
+		Hints: []string{"press Esc twice to cancel the run, then try again"},
 	})
 }
 

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -777,6 +777,8 @@ func TestEscCancelRecordsSessionError(t *testing.T) {
 
 	updated, _ = next.Update(testKey(tea.KeyEsc))
 	next = updated.(model)
+	updated, _ = next.Update(testKey(tea.KeyEsc))
+	next = updated.(model)
 
 	list, err := store.List()
 	if err != nil {
@@ -836,7 +838,10 @@ func TestCancelledRunFlushesCheckpointSessionEvents(t *testing.T) {
 		next = updated.(model)
 		if _, ok := runtimeMsg.(permissionRequestMsg); ok {
 			// Cancel mid-run via Esc while the permission prompt is pending: this
-			// unblocks the goroutine through ctx cancellation.
+			// unblocks the goroutine through ctx cancellation. Esc now requires a
+			// second press within the confirmation window to actually cancel.
+			updated, _ = next.Update(testKey(tea.KeyEsc))
+			next = updated.(model)
 			updated, _ = next.Update(testKey(tea.KeyEsc))
 			next = updated.(model)
 			cancelled = true

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -201,6 +201,9 @@ func (m model) statusLine(width int) string {
 		if m.exitConfirmActive {
 			return fitStyledLine(prefix+zeroTheme.amber.Render("●")+" "+zeroTheme.amber.Render(ctrlCExitConfirmText), width)
 		}
+		if m.cancelConfirmActive {
+			return fitStyledLine(prefix+zeroTheme.amber.Render("●")+" "+zeroTheme.amber.Render(escCancelConfirmText), width)
+		}
 		return fitStyledLine(left, width)
 	}
 
@@ -210,6 +213,8 @@ func (m model) statusLine(width int) string {
 	}
 	if m.exitConfirmActive {
 		left = prefix + zeroTheme.amber.Render("●") + " " + zeroTheme.amber.Render(ctrlCExitConfirmText)
+	} else if m.cancelConfirmActive {
+		left = prefix + zeroTheme.amber.Render("●") + " " + zeroTheme.amber.Render(escCancelConfirmText)
 	} else if summary := m.backgroundTerminalSummary(); summary != "" {
 		left += separator + zeroTheme.muted.Render(summary)
 	}


### PR DESCRIPTION
## Summary
- A single stray Esc during an active run cancelled it instantly with no chance to reconsider. Esc now requires a second press within 3s to cancel, mirroring the existing Ctrl+C double-press exit confirmation — but as fully independent state (`cancelConfirmActive`/`cancelConfirmSeq`), since Ctrl+C guards app-exit and Esc guards run-cancellation, two different actions with different consequences.
- First Esc arms a 3s window and shows `Press Esc again to cancel` in the footer; a second Esc within the window cancels the run; letting it expire, or the run finishing on its own, disarms without cancelling.
- Ran an adversarial pre-push review that found the initial confirmation gate had no "anything else disarms it" safety net (unlike the Ctrl+C version), so a stale confirmation could be silently tripped by an unrelated later Esc, an intervening key, or a mouse click. Fixed by disarming on any non-Esc key, any mouse click, and by restructuring the Esc handler so an earlier branch (ask-user, permission, subchat, wizard, picker, suggestions, queued-message, detailed-transcript) consuming the Esc also clears stale confirmation state.
- Updated two now-stale help strings (`?` overlay, `pickerBusyText()` hint) that still described single-press behavior.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/tui/ -count=1` (including new `TestEscRequiresSecondPressToCancelPendingRun`, `TestEscCancelConfirmationExpires`, `TestEscCancelConfirmationDisarmsOnInterveningKey`, `TestEscCancelConfirmationDisarmsWhenStolenByAskUser`)
- [x] `go test ./... -race -count=1` (full repo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-step Esc confirmation for canceling an in-progress run (press Esc twice to cancel).
  * Updated the on-screen help and status/busy prompts to reflect the new two-step Esc behavior.
* **Bug Fixes**
  * Prevented stale Esc cancel confirmations from triggering after unrelated key presses, mouse clicks, paste actions, or run completion.
  * Improved Esc behavior during prompts so cancellation occurs only when the second Esc is pressed within the allowed window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->