### PR TITLE
fix(oauth): make xAI / Hugging Face OAuth actually launch from the wizard

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -283,6 +283,9 @@ func newAuthManager(deps appDeps, out io.Writer) (*oauth.Manager, error) {
 		// carries no token material. A real browser launch is intentionally not
 		// performed (the sandbox/headless contexts make printing the safer default).
 		OpenBrowser: func(string) error { return nil },
+		// `zero auth login <preset>` (e.g. xai) should resolve the baked-in preset
+		// without the operator exporting ZERO_OAUTH_ALLOW_PRESETS first.
+		AllowPresets: true,
 	})
 }
 

--- a/internal/cli/oauth_provider.go
+++ b/internal/cli/oauth_provider.go
@@ -43,6 +43,9 @@ func oauthResolverForProfile(profile config.ProviderProfile) providerio.TokenRes
 	manager, err := oauth.NewManager(oauth.ManagerOptions{
 		Store:      store,
 		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		// Refreshing a token the user logged into (possibly a preset provider like
+		// xAI) re-resolves that provider's OAuth config, which needs the preset.
+		AllowPresets: true,
 	})
 	if err != nil {
 		return nil

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -44,10 +44,17 @@ type Manager struct {
 
 // ManagerOptions configures a Manager.
 type ManagerOptions struct {
-	Store         *Store
-	Registry      *Registry
-	HTTPClient    *http.Client
-	Env           map[string]string
+	Store      *Store
+	Registry   *Registry
+	HTTPClient *http.Client
+	Env        map[string]string
+	// AllowPresets opts this manager into the baked-in OAuth presets without the
+	// operator exporting ZERO_OAUTH_ALLOW_PRESETS — used by the interactive wizard
+	// and CLI login (and the runtime token refresh) for a provider the user chose
+	// to sign into, whose preset client identity is public (e.g. xAI). It layers the
+	// flag onto Env (or the process environment when Env is nil), preserving any
+	// ZERO_OAUTH_<NAME>_* overrides. Leave false for hermetic tests.
+	AllowPresets  bool
 	Now           func() time.Time
 	RefreshBuffer time.Duration
 	Out           io.Writer
@@ -83,9 +90,13 @@ func NewManager(opts ManagerOptions) (*Manager, error) {
 	if open == nil {
 		open = func(string) error { return nil }
 	}
+	env := opts.Env
+	if opts.AllowPresets {
+		env = envWithPresetsAllowed(env)
+	}
 	return &Manager{
 		store: opts.Store, registry: registry, client: client,
-		env: opts.Env, now: now, buffer: buffer, out: out, openBrowser: open,
+		env: env, now: now, buffer: buffer, out: out, openBrowser: open,
 	}, nil
 }
 

--- a/internal/oauth/manager_test.go
+++ b/internal/oauth/manager_test.go
@@ -52,6 +52,30 @@ func managerFor(t *testing.T, env map[string]string, openBrowser func(string) er
 	return m
 }
 
+// AllowPresets layers the opt-in onto the manager's env so a login/refresh for a
+// preset provider resolves; without it (and no Env) the env stays nil so callers
+// and tests remain hermetic.
+func TestNewManagerAllowPresetsForcesOptIn(t *testing.T) {
+	store, err := NewStore(StoreOptions{FilePath: filepath.Join(t.TempDir(), "tok.json")})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	m, err := NewManager(ManagerOptions{Store: store, AllowPresets: true})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if m.env["ZERO_OAUTH_ALLOW_PRESETS"] != "1" {
+		t.Fatalf("AllowPresets should force the opt-in; got env[%q]=%q", "ZERO_OAUTH_ALLOW_PRESETS", m.env["ZERO_OAUTH_ALLOW_PRESETS"])
+	}
+	m2, err := NewManager(ManagerOptions{Store: store})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if m2.env != nil {
+		t.Fatalf("env should stay nil without AllowPresets, got %v", m2.env)
+	}
+}
+
 func TestManagerLoginLoopback(t *testing.T) {
 	fp := newFakeProvider(t, `{"access_token":"at","refresh_token":"rt","token_type":"Bearer","expires_in":3600}`)
 	env := map[string]string{

--- a/internal/oauth/presets.go
+++ b/internal/oauth/presets.go
@@ -1,6 +1,33 @@
 package oauth
 
-import "strings"
+import (
+	"os"
+	"strings"
+)
+
+// envWithPresetsAllowed returns an env map that opts into the baked-in presets
+// (as if ZERO_OAUTH_ALLOW_PRESETS=1 were exported) so an interactive wizard/CLI
+// login for a well-known public client (e.g. xAI) can use the preset without the
+// operator setting the flag themselves. It copies base — or snapshots the process
+// environment when base is nil — because envValue treats a non-nil map as hermetic
+// (a missing key does NOT fall back to os.Getenv), so a partial map would silently
+// drop the operator's ZERO_OAUTH_<NAME>_* overrides. The flag is then forced on.
+func envWithPresetsAllowed(base map[string]string) map[string]string {
+	env := make(map[string]string, len(base)+1)
+	if base == nil {
+		for _, kv := range os.Environ() {
+			if eq := strings.IndexByte(kv, '='); eq > 0 {
+				env[kv[:eq]] = kv[eq+1:]
+			}
+		}
+	} else {
+		for k, v := range base {
+			env[k] = v
+		}
+	}
+	env["ZERO_OAUTH_ALLOW_PRESETS"] = "1"
+	return env
+}
 
 // providerPreset is a baked-in default OAuth configuration for a well-known
 // provider. Every field is overridable per provider via ZERO_OAUTH_<NAME>_*

--- a/internal/oauth/presets_test.go
+++ b/internal/oauth/presets_test.go
@@ -46,6 +46,46 @@ func TestResolveConfigUsesXAIPreset(t *testing.T) {
 	}
 }
 
+// envWithPresetsAllowed lets a caller (the wizard / CLI login / runtime refresh)
+// opt into the preset without exporting ZERO_OAUTH_ALLOW_PRESETS: an otherwise-inert
+// xAI config now resolves from the baked-in preset.
+func TestEnvWithPresetsAllowedEnablesPreset(t *testing.T) {
+	r := NewRegistry()
+	// Baseline: a hermetic empty map keeps the preset inert.
+	if _, _, err := r.ResolveConfig("xai", map[string]string{}); err == nil {
+		t.Fatal("xai should not resolve without the opt-in")
+	}
+	// The helper forces the opt-in so the preset resolves.
+	cfg, _, err := r.ResolveConfig("xai", envWithPresetsAllowed(map[string]string{}))
+	if err != nil {
+		t.Fatalf("envWithPresetsAllowed should enable the xai preset: %v", err)
+	}
+	if cfg.ClientID != "b1a00492-073a-47ea-816f-4c329264a828" {
+		t.Fatalf("client_id = %q", cfg.ClientID)
+	}
+}
+
+// The helper copies the base map (never mutating it) and keeps ZERO_OAUTH_<NAME>_*
+// overrides — critical because envValue treats a non-nil map as hermetic, so a
+// partial map would silently drop them.
+func TestEnvWithPresetsAllowedPreservesOverrides(t *testing.T) {
+	base := map[string]string{"ZERO_OAUTH_XAI_CLIENT_ID": "custom-id"}
+	env := envWithPresetsAllowed(base)
+	if env["ZERO_OAUTH_ALLOW_PRESETS"] != "1" {
+		t.Fatalf("opt-in flag not set: %v", env)
+	}
+	if _, mutated := base["ZERO_OAUTH_ALLOW_PRESETS"]; mutated {
+		t.Fatal("envWithPresetsAllowed mutated the caller's base map")
+	}
+	cfg, _, err := NewRegistry().ResolveConfig("xai", env)
+	if err != nil {
+		t.Fatalf("ResolveConfig with override env: %v", err)
+	}
+	if cfg.ClientID != "custom-id" {
+		t.Fatalf("override dropped through the helper: client_id = %q", cfg.ClientID)
+	}
+}
+
 func TestResolveConfigEnvOverridesPreset(t *testing.T) {
 	r := NewRegistry()
 	env := map[string]string{

--- a/internal/tui/oauth_device.go
+++ b/internal/tui/oauth_device.go
@@ -44,6 +44,9 @@ func oauthDevicePrepare(name string) (oauth.DeviceAuth, oauth.Config, error) {
 		Store:       store,
 		HTTPClient:  &http.Client{Timeout: 60 * time.Second},
 		OpenBrowser: browser.OpenURL,
+		// Device-flow providers (e.g. Hugging Face) rely on the baked-in preset for
+		// their endpoints; opt in so the device code can be requested.
+		AllowPresets: true,
 	})
 	if err != nil {
 		return oauth.DeviceAuth{}, oauth.Config{}, err
@@ -62,8 +65,9 @@ func oauthDeviceComplete(name string, cfg oauth.Config, auth oauth.DeviceAuth) e
 		return err
 	}
 	manager, err := oauth.NewManager(oauth.ManagerOptions{
-		Store:      store,
-		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+		Store:        store,
+		HTTPClient:   &http.Client{Timeout: 60 * time.Second},
+		AllowPresets: true, // preset config is needed to poll/exchange the device token
 	})
 	if err != nil {
 		return err
@@ -84,8 +88,9 @@ func oauthStoredToken(ctx context.Context, providerID string) string {
 		return ""
 	}
 	manager, err := oauth.NewManager(oauth.ManagerOptions{
-		Store:      store,
-		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		Store:        store,
+		HTTPClient:   &http.Client{Timeout: 30 * time.Second},
+		AllowPresets: true, // refreshing a preset-provider token re-resolves its config
 	})
 	if err != nil {
 		return ""

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -166,6 +166,10 @@ func runProviderTokenLogin(name string) error {
 		Store:       store,
 		HTTPClient:  &http.Client{Timeout: 60 * time.Second},
 		OpenBrowser: browser.OpenURL,
+		// The user explicitly chose to sign in with this provider's OAuth, so opt
+		// into its baked-in preset (e.g. xAI's public client_id); without this the
+		// config never resolves and the browser never opens.
+		AllowPresets: true,
 	})
 	if err != nil {
 		return err
@@ -1229,7 +1233,27 @@ func (wizard *providerWizardState) renderProviderStep(width int) []string {
 	for offset, provider := range wizard.providers[start : start+maxVisible] {
 		lines = append(lines, wizard.renderSelectableProvider(width, start+offset, provider))
 	}
+	// A failed OAuth attempt leaves the wizard on this list (it does not advance),
+	// so the error must render here or the click looks like a silent no-op. The
+	// credential step renders its own copy for the ctrl+o path.
+	if wizard.oauthMode && wizard.oauthErr != "" {
+		lines = append(lines, "", zeroTheme.red.Render("OAuth login failed: "+wizard.oauthErr))
+		if hint := providerWizardOAuthErrHint(wizard.currentProvider()); hint != "" {
+			lines = append(lines, zeroTheme.faint.Render(hint))
+		}
+	}
 	return lines
+}
+
+// providerWizardOAuthErrHint returns a provider-specific next step for a failed
+// OAuth login. Hugging Face ships no public client_id (unlike xAI), so a login
+// can only work once the operator registers an app and supplies its client_id.
+func providerWizardOAuthErrHint(provider providercatalog.Descriptor) string {
+	if strings.EqualFold(provider.ID, "huggingface") {
+		return "Hugging Face needs your own app: create one at " +
+			"https://huggingface.co/settings/applications/new, then set ZERO_OAUTH_HUGGINGFACE_CLIENT_ID."
+	}
+	return ""
 }
 
 func (wizard *providerWizardState) renderSelectableProvider(width int, index int, provider providercatalog.Descriptor) string {

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -125,6 +125,36 @@ func TestProviderWizardDeviceCodeMsgShowsCodeAndPolls(t *testing.T) {
 	}
 }
 
+// A failed OAuth attempt leaves the wizard on the provider list; the error must be
+// rendered there (not just on the credential step) so a click isn't a silent
+// no-op, and Hugging Face gets an actionable client_id hint.
+func TestProviderStepSurfacesOAuthError(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	wizard := m.providerWizard
+	wizard.oauthMode = true
+	wizard.providers = providerWizardOAuthDescriptors()
+	found := false
+	for i, p := range wizard.providers {
+		if strings.EqualFold(p.ID, "huggingface") {
+			wizard.selectedProvider = i
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("huggingface should be an OAuth-capable provider")
+	}
+	wizard.oauthErr = `oauth: provider "huggingface" is not configured; set ZERO_OAUTH_HUGGINGFACE_CLIENT_ID`
+
+	view := strings.Join(wizard.renderProviderStep(72), "\n")
+	if !strings.Contains(view, "OAuth login failed") {
+		t.Fatalf("provider step should surface the OAuth error:\n%s", view)
+	}
+	if !strings.Contains(view, "huggingface.co/settings/applications/new") {
+		t.Fatalf("Hugging Face hint should point at app registration:\n%s", view)
+	}
+}
+
 func TestProviderWizardDeviceErrorSurfaced(t *testing.T) {
 	m := mouseTestModel()
 	m.providerWizard = m.newProviderWizard()


### PR DESCRIPTION
## Summary

The provider-setup wizard listed "Sign in with OAuth" for **xAI** and **Hugging Face**, but clicking them did nothing.

**Root cause:** the wizard's OAuth login managers (`runProviderTokenLogin`, the device-flow managers) were built without an `Env`, so `oauth.ResolveConfig` read the preset opt-in `ZERO_OAUTH_ALLOW_PRESETS` as unset and **errored before any browser launch**. The error was stored in `wizard.oauthErr` but `renderProviderStep` never rendered it, so the failure was invisible. ChatGPT worked only because its login path force-enables presets via a full-env snapshot.

## Fix

**A — make it launch (`ManagerOptions.AllowPresets`):** a new option that layers the preset opt-in onto the manager's env — snapshotting the process environment so `ZERO_OAUTH_<NAME>_*` overrides survive `envValue`'s hermetic-map rule — without the operator exporting the flag. Set on every *user-initiated* OAuth manager:
- wizard loopback login + device-code prepare/complete,
- post-login token refresh (model discovery),
- the runtime resolver that authenticates model calls (so the token keeps refreshing after login),
- `zero auth login <provider>`.

This fixes **xAI end to end** — it ships a public `client_id`, so the browser now opens (`rundll32` on Windows).

**B — no more silent no-op:** render `wizard.oauthErr` on the OAuth provider list, with a **Hugging Face** hint pointing at app registration + `ZERO_OAUTH_HUGGINGFACE_CLIENT_ID`. HF ships no public `client_id` by design, so it still needs that one env var — but the wizard now *tells you that* instead of doing nothing.

## Security

The `ZERO_OAUTH_ALLOW_PRESETS` gate keeps third-party OAuth client identities out of the *default* credential path. `AllowPresets` only forces it on where the user has **explicitly chosen** to sign into that provider (or the runtime is refreshing a token they already obtained), so the gate still applies to every other path. Non-preset providers are unaffected — their env config still resolves and there is no preset to consult.

## Testing

- `oauth`: `AllowPresets` enables an otherwise-inert xAI preset and preserves `ZERO_OAUTH_<NAME>_*` overrides; the manager forces the opt-in only when set (stays hermetic otherwise).
- `tui`: a failed OAuth attempt renders "OAuth login failed" + the HF registration hint on the provider list.
- `go build ./...`, `go vet`, `gofmt` clean; full `oauth` + `tui` suites and the CLI auth tests pass.

## Notes for users

- **xAI**: works out of the box now (requires a SuperGrok / X Premium+ subscription; pay-as-you-go users should use a console API key).
- **Hugging Face**: register an app at https://huggingface.co/settings/applications/new and set `ZERO_OAUTH_HUGGINGFACE_CLIENT_ID`. HF uses the device-code flow, so it shows a code + URL to enter rather than auto-opening a browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth sign-in now works more smoothly with built-in provider presets during login, device-code flows, and token refresh.
  * Provider setup now shows clearer OAuth error messages directly in the selection flow.

* **Bug Fixes**
  * Removed the need to manually enable preset-based OAuth logins for supported providers.
  * Added provider-specific guidance for failed sign-ins, including setup help for Hugging Face.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->