### PR TITLE
test: widen timing margins on two Windows-flaky CI tests

### DIFF
--- a/internal/agenteval/benchmark_test.go
+++ b/internal/agenteval/benchmark_test.go
@@ -455,11 +455,15 @@ func TestHarnessTimeoutCancelsBlockedAgent(t *testing.T) {
 
 	// The timeout is longer than materialization of the small fixture even on
 	// slower Windows CI runners, so the agent is reached before it blocks until
-	// the deadline fires.
+	// the deadline fires. 10s wasn't generous enough in practice — it failed
+	// on an otherwise-unrelated PR merge (materialization alone consumed the
+	// full budget on a contended Windows runner, so the agent was never
+	// reached); widened for headroom, since the assertions below still bound
+	// worst-case test time via that same deadline, not this constant.
 	report := harness.Run(context.Background(), suitePath, suite, BenchmarkInput{
 		TaskID:   "document-stream-json-verify-events",
 		WorkRoot: t.TempDir(),
-		Timeout:  10 * time.Second,
+		Timeout:  30 * time.Second,
 	})
 
 	if !agentReached {

--- a/internal/specialist/output_tool_test.go
+++ b/internal/specialist/output_tool_test.go
@@ -124,10 +124,16 @@ func TestOutputToolBlocksUntilTaskCompletes(t *testing.T) {
 	tool := NewOutputTool(manager)
 	tool.PollInterval = time.Millisecond
 
+	// timeout is a ceiling, not a target: the test still returns as soon as the
+	// 5ms write lands (PollInterval keeps it responsive), it just tolerates a
+	// slow/contended CI runner without failing. A 100ms budget against a 5ms
+	// write only left 20x margin, which Windows CI runners (coarser default
+	// timer granularity, heavier scheduling contention than Linux/macOS) blew
+	// through and failed the test on an otherwise-unrelated PR merge.
 	result := tool.Run(context.Background(), map[string]any{
 		"task_id": "child_task",
 		"block":   true,
-		"timeout": 100,
+		"timeout": 2000,
 	})
 
 	if result.Status != tools.StatusOK || !strings.Contains(result.Output, "output:\nfinished") {


### PR DESCRIPTION
## Summary
Investigated two `windows-latest` smoke-test failures from today's merges. Both are pre-existing test-timing issues, unrelated to the content of the PRs whose merge-to-main runs they failed on (#349, #356 — neither touches `internal/specialist` or `internal/agenteval`).

- **`TestOutputToolBlocksUntilTaskCompletes`**: a 100ms poll timeout against a 5ms background write left only 20x margin — not enough headroom against Windows' coarser default timer granularity and heavier CI scheduling contention than Linux/macOS. Widened the timeout to 2000ms. This is a ceiling, not a target: `PollInterval` keeps the test fast in the success case (it still returns as soon as output lands), it just tolerates more jitter before failing.
- **`TestHarnessTimeoutCancelsBlockedAgent`**: confirmed there's no actual data race first (`harness.Agent.Run` is a direct synchronous call on the test's own goroutine, not a spawned goroutine racing the assertions). The failure was workspace materialization alone consuming the full 10s budget on a contended Windows runner, so the agent was never reached before the deadline fired. Widened to 30s. Unlike the other fix, this test's own design blocks for the full timeout to observe cancellation, so this directly costs ~20s more wall-clock time — inherent to what it's testing, not avoidable without restructuring the harness contract.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/specialist/ -count=1 -run TestOutputToolBlocksUntilTaskCompletes -v` (0.01s)
- [x] `go test ./internal/agenteval/ -count=1 -run TestHarnessTimeoutCancelsBlockedAgent -v` (30.03s, as expected)
- [x] `go test ./internal/specialist/ ./internal/agenteval/ -count=1` (full packages)
- [x] `go test ./... -race -count=1` (full repo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted automated test timing to better tolerate slower or contended CI environments.
  * Improved timeout handling in long-running test scenarios to reduce flaky failures and keep test runs more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->