### PR TITLE
fix: cut the content-stall dead-wait and auto-retry a mid-tool-call stall

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -210,27 +210,29 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			}
 		}
 
-		// Wrapped callbacks flag ANY output forwarded this turn, so a stall retry
-		// never re-streams on top of output the user already saw — even across the
-		// reactive-compaction retry below, which overwrites `collected`.
-		forwardedAnything := false
-		mark := func() { forwardedAnything = true }
-		// OnUsage is telemetry, not visible output, so it does NOT mark
-		// forwardedAnything: a provider that emits an early usage event (e.g. prompt
-		// tokens) then stalls with no content must still be safely retried. The gate
-		// only guards against re-streaming output the user actually SAW.
+		// forwardedVisibleText flags forwarded final PROSE (OnText) specifically —
+		// the only output whose re-stream on a stall retry would visibly DUPLICATE
+		// answer text the user already read. Transient working indicators
+		// (reasoning previews, tool-call "writing…" previews) are deliberately NOT
+		// counted: a turn that streamed only those then stalled — the common
+		// gpt-5.x / ollama "froze mid-write_file" case — is safe to re-issue, since
+		// the TUI resets the tool-call preview on the next tool-call-start and a
+		// stalled turn is never appended to `messages` (it returns on the error
+		// before the append), so the retry re-sends clean context with no
+		// conversation-state duplication.
+		forwardedVisibleText := false
 		forwardingOpts := zeroruntime.CollectOptions{OnUsage: options.OnUsage}
 		if options.OnText != nil {
-			forwardingOpts.OnText = func(s string) { mark(); options.OnText(s) }
+			forwardingOpts.OnText = func(s string) { forwardedVisibleText = true; options.OnText(s) }
 		}
 		if options.OnReasoning != nil {
-			forwardingOpts.OnReasoning = func(s string) { mark(); options.OnReasoning(s) }
+			forwardingOpts.OnReasoning = func(s string) { options.OnReasoning(s) }
 		}
 		if options.OnToolCallStart != nil {
-			forwardingOpts.OnToolCallStart = func(id, name string) { mark(); options.OnToolCallStart(id, name) }
+			forwardingOpts.OnToolCallStart = func(id, name string) { options.OnToolCallStart(id, name) }
 		}
 		if options.OnToolCallDelta != nil {
-			forwardingOpts.OnToolCallDelta = func(id, fragment string) { mark(); options.OnToolCallDelta(id, fragment) }
+			forwardingOpts.OnToolCallDelta = func(id, fragment string) { options.OnToolCallDelta(id, fragment) }
 		}
 		// recoverStreamError applies the same non-stall recovery the initial stream
 		// gets to ANY collected error — including one from a reissued (stall-retry)
@@ -284,15 +286,28 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			result.Messages = copyMessages(messages)
 			return result, ctx.Err()
 		}
-		// A stream idle/stall timeout with NO output forwarded yet this turn can be
-		// safely re-issued on a fresh connection — nothing was shown, so there's no
-		// duplication (this recovers the macOS stale-pooled-connection hang when it
-		// slips past the transport's response-header timeout). A turn that already
-		// streamed partial text/tool-calls is NOT retried (it would duplicate) and
-		// falls through to the error return below. Capped + exponential backoff.
+		// A stream idle/stall timeout is safely re-issued when the turn committed NO
+		// answer text — no forwarded visible prose (forwardedVisibleText) and no
+		// collected final text (collected.Text). This covers two cases:
+		//   1. Nothing streamed at all before the connection died (the original
+		//      macOS stale-pooled-connection hang past the response-header timeout).
+		//   2. The model streamed transient reasoning and began a tool call (e.g. a
+		//      large write_file) then froze mid-arguments — the common gpt-5.x /
+		//      ollama heartbeat-pause stall. That partial tool call is NEVER executed
+		//      (a turn with collected.Error returns before dispatch below) and NEVER
+		//      appended to `messages`, so a retry re-issues clean context; the only
+		//      re-render is transient previews, not duplicated answer text. This is
+		//      why the gate no longer excludes collected.ToolCalls: an incomplete
+		//      tool call from a timed-out stream is discard-and-retry, not output.
+		// A turn that forwarded real prose is NOT retried (it would duplicate visible
+		// answer text) and falls through to the error return below. Capped +
+		// exponential backoff, with a user-visible notice per attempt.
 		for attempt := 1; attempt <= maxStreamStallRetries &&
-			isStreamTimeoutError(collected.Error) && !forwardedAnything &&
-			collected.Text == "" && len(collected.ToolCalls) == 0; attempt++ {
+			isStreamTimeoutError(collected.Error) && !forwardedVisibleText &&
+			collected.Text == ""; attempt++ {
+			if notify := stallRetryNoticeFor(options); notify != nil {
+				notify(attempt, maxStreamStallRetries)
+			}
 			if err := sleepWithContext(ctx, backoffFor(attempt)); err != nil {
 				result.Messages = copyMessages(messages)
 				return result, err

--- a/internal/agent/reconnect.go
+++ b/internal/agent/reconnect.go
@@ -40,6 +40,21 @@ func reconnectNoticeFor(options Options) reconnectNotifier {
 	}
 }
 
+// stallRetryNoticeFor builds a notifier for the loop's content-stall retry (a
+// stream that connected and produced only transient output, then went silent).
+// Distinct wording from reconnectNoticeFor's "connection lost" because the
+// connection was fine — the model stalled. Surfaced through OnReasoning, the
+// non-content channel, so it never folds into the answer text. Nil when there
+// is no reasoning sink (the retry still happens silently).
+func stallRetryNoticeFor(options Options) reconnectNotifier {
+	if options.OnReasoning == nil {
+		return nil
+	}
+	return func(attempt, max int) {
+		options.OnReasoning(fmt.Sprintf("\n[no output — model stalled; retrying %d/%d…]\n", attempt, max))
+	}
+}
+
 // streamWithReconnect issues request via provider.StreamCompletion and, on a
 // transient disconnect error, retries the connect up to maxStreamReconnects
 // times with exponential backoff. It returns the live stream on success, or the

--- a/internal/agent/stall_retry_test.go
+++ b/internal/agent/stall_retry_test.go
@@ -10,19 +10,25 @@ import (
 )
 
 // stallProvider connects successfully (HTTP 200) but the stream emits a stall/idle
-// timeout error for the first stallBefore calls, then succeeds with "done". When
-// partialText is set it emits that text BEFORE the stall, simulating a stall after
-// partial output (which must NOT be retried — re-issuing would duplicate it).
+// timeout error for the first stallBefore calls, then succeeds with "done". The
+// pre-stall emission simulates different partial-output shapes:
+//   - partialText: forwarded PROSE (StreamEventText) — must NOT be retried
+//     (re-issuing would duplicate visible answer text).
+//   - reasoningText: transient reasoning preview — IS retried.
+//   - partialToolCall: a tool call started (+ arg delta) but never ended, the
+//     "froze mid-write_file" case — IS retried (the incomplete call is never
+//     executed or committed).
 type stallProvider struct {
-	calls         int32
-	stallBefore   int32
-	partialText   string
-	reasoningText string
+	calls           int32
+	stallBefore     int32
+	partialText     string
+	reasoningText   string
+	partialToolCall string
 }
 
 func (p *stallProvider) StreamCompletion(_ context.Context, _ zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
 	n := atomic.AddInt32(&p.calls, 1)
-	ch := make(chan zeroruntime.StreamEvent, 3)
+	ch := make(chan zeroruntime.StreamEvent, 5)
 	if n <= p.stallBefore {
 		if p.partialText != "" {
 			ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: p.partialText}
@@ -30,9 +36,16 @@ func (p *stallProvider) StreamCompletion(_ context.Context, _ zeroruntime.Comple
 		if p.reasoningText != "" {
 			ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventReasoning, Content: p.reasoningText}
 		}
+		if p.partialToolCall != "" {
+			// A tool call that starts and streams a partial argument fragment but
+			// never gets StreamEventToolCallEnd, then the stream errors — exactly
+			// the gpt-5.x "began the big write_file then froze" shape.
+			ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "tc_1", ToolName: p.partialToolCall}
+			ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "tc_1", ArgumentsFragment: `{"path":"x.html","content":"<!doctype`}
+		}
 		ch <- zeroruntime.StreamEvent{
 			Type:  zeroruntime.StreamEventError,
-			Error: "provider stream error: no output for 10m (the model produced nothing)",
+			Error: "provider stream error: no output for 6m (the model produced nothing)",
 		}
 		close(ch)
 		return ch, nil
@@ -72,21 +85,54 @@ func TestRunDoesNotRetryStallAfterPartialOutput(t *testing.T) {
 	}
 }
 
-// A stall after only REASONING was forwarded (no text/tool-calls) must NOT be
-// retried: the user already saw the reasoning, so re-issuing with callbacks
-// re-enabled would duplicate it. collected.Text is empty here, so this exercises
-// the turn-level forwarded-output gate specifically, not the text check.
-func TestRunDoesNotRetryStallAfterForwardedReasoning(t *testing.T) {
+// A stall after only transient REASONING was forwarded (no prose text, no
+// completed tool call) IS retried: reasoning is a "thinking" preview, not
+// committed answer text, so re-streaming it on a clearly-signalled retry is
+// acceptable and recovers the common "reasoned then froze" stall. Only
+// forwarded final prose (OnText) blocks the retry (collected.Text is empty
+// here, so this exercises the transient-vs-prose gate specifically).
+func TestRunRetriesStallAfterOnlyReasoning(t *testing.T) {
 	p := &stallProvider{stallBefore: 1, reasoningText: "thinking hard"}
-	_, err := Run(context.Background(), "go", p, Options{
+	result, err := Run(context.Background(), "go", p, Options{
 		Registry:    tools.NewRegistry(),
 		OnReasoning: func(string) {},
 	})
-	if err == nil {
-		t.Fatal("a stall after forwarded reasoning must NOT be retried; want an error")
+	if err != nil {
+		t.Fatalf("a stall after only reasoning should retry to success, got %v", err)
 	}
-	if got := atomic.LoadInt32(&p.calls); got != 1 {
-		t.Fatalf("reasoning-then-stall must not retry, got %d calls", got)
+	if result.FinalAnswer != "done" {
+		t.Fatalf("final answer = %q, want %q", result.FinalAnswer, "done")
+	}
+	if got := atomic.LoadInt32(&p.calls); got != 2 {
+		t.Fatalf("want 2 calls (1 stall + 1 retry), got %d", got)
+	}
+}
+
+// A stall mid-way through an INCOMPLETE tool call (started + partial args, never
+// ended) IS retried — the exact gpt-5.x / ollama "began the big write_file then
+// froze" case. The incomplete call is never executed (a turn returns on the
+// stall error before dispatch) and never committed to history, so re-issuing is
+// safe and recovers to success. This is the primary scenario this change fixes.
+func TestRunRetriesStallAfterIncompleteToolCall(t *testing.T) {
+	starts := 0
+	p := &stallProvider{stallBefore: 1, reasoningText: "planning", partialToolCall: "write_file"}
+	result, err := Run(context.Background(), "go", p, Options{
+		Registry:        tools.NewRegistry(),
+		OnReasoning:     func(string) {},
+		OnToolCallStart: func(string, string) { starts++ },
+		OnToolCallDelta: func(string, string) {},
+	})
+	if err != nil {
+		t.Fatalf("a stall mid-incomplete-tool-call should retry to success, got %v", err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("final answer = %q, want %q", result.FinalAnswer, "done")
+	}
+	if got := atomic.LoadInt32(&p.calls); got != 2 {
+		t.Fatalf("want 2 calls (1 stall + 1 retry), got %d", got)
+	}
+	if starts != 1 {
+		t.Fatalf("the incomplete tool call should have been forwarded once before the stall, got %d starts", starts)
 	}
 }
 

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -68,7 +69,17 @@ func ContentStallTimeout(idleTimeout time.Duration) time.Duration {
 	if idleTimeout <= 0 {
 		return 0
 	}
-	return idleTimeout * 6 / 5
+	// 1.2× computed as idle + idle/5 (not idle*6/5), plus a clamp: a
+	// pathologically large ZERO_STREAM_IDLE_TIMEOUT could make idle*6 overflow
+	// int64 and wrap to a NEGATIVE duration, which would arm the content timer
+	// to fire immediately and abort every stream. Clamping to the max duration
+	// on overflow just means "effectively no content watchdog" — the sane
+	// result for an absurd idle timeout.
+	extra := idleTimeout / 5
+	if idleTimeout > math.MaxInt64-extra {
+		return math.MaxInt64
+	}
+	return idleTimeout + extra
 }
 
 // streamIdleTimeoutEnv is the global override for the stream idle timeout. It

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -26,9 +26,9 @@ var ErrStreamIdle = errors.New("idle timeout (upstream stopped sending data)")
 
 // ErrStreamStalled reports that a streaming upstream kept the connection alive
 // (SSE keep-alives reset the idle watchdog, so it never fired) but produced no
-// actual output for StreamContentStallFactor × the idle timeout. Without this an
-// upstream that heartbeats-but-stalls — observed on chatgpt/gpt-5.x and ollama
-// reasoning models — would hang the agent indefinitely.
+// actual output for ContentStallTimeout(idle). Without this an upstream that
+// heartbeats-but-stalls — observed on chatgpt/gpt-5.x and ollama reasoning
+// models — would hang the agent indefinitely.
 var ErrStreamStalled = errors.New("stream stalled (upstream kept the connection alive but produced no output)")
 
 // StreamTimeoutMessage returns the human-readable detail for a stream-timeout
@@ -39,7 +39,7 @@ var ErrStreamStalled = errors.New("stream stalled (upstream kept the connection 
 // stuck or very slow.
 func StreamTimeoutMessage(err error, idleTimeout time.Duration) string {
 	if errors.Is(err, ErrStreamStalled) {
-		return fmt.Sprintf("no output for %s (the model kept the connection alive but produced nothing — it may be stuck; try a faster model or lower reasoning effort)", idleTimeout*StreamContentStallFactor)
+		return fmt.Sprintf("no output for %s (the model kept the connection alive but produced nothing — it may be stuck; try a faster model or lower reasoning effort)", ContentStallTimeout(idleTimeout))
 	}
 	return fmt.Sprintf("idle timeout after %s (upstream stopped sending data)", idleTimeout)
 }
@@ -54,13 +54,22 @@ func StreamTimeoutMessage(err error, idleTimeout time.Duration) string {
 // Override globally with ZERO_STREAM_IDLE_TIMEOUT.
 const DefaultStreamIdleTimeout = 5 * time.Minute
 
-// StreamContentStallFactor bounds a heartbeat-but-no-output stream. Keep-alives
-// reset the idle watchdog (a heartbeating upstream is not "dead"), but if NO real
-// data line arrives for StreamContentStallFactor × the idle timeout, the stream is
-// treated as stalled and aborted (ErrStreamStalled). It is > 1 so a slow-but-
-// producing request — one that emits data between heartbeats — is never killed; the
-// content watchdog only catches a stream that heartbeats while producing nothing.
-const StreamContentStallFactor = 2
+// ContentStallTimeout bounds a heartbeat-but-no-output stream: keep-alives reset
+// the idle watchdog (a heartbeating upstream is not "dead"), but if NO real data
+// line arrives for this long the stream is aborted (ErrStreamStalled). Scaled
+// above idleTimeout (so a slow-but-producing request that emits data between
+// heartbeats is never killed — the watchdog only ever fires when NOTHING real
+// arrives), but only 1.2× rather than the old 2×: a genuine heartbeat-pause
+// stall on chatgpt/gpt-5.x rarely recovers, so a ~10-minute dead wait (at the 5m
+// idle default) was a terrible UX for a doomed turn. At the default idle this is
+// 6 minutes; it still scales with ZERO_STREAM_IDLE_TIMEOUT. A returned value <= 0
+// (idle watchdog disabled) leaves the content watchdog off too.
+func ContentStallTimeout(idleTimeout time.Duration) time.Duration {
+	if idleTimeout <= 0 {
+		return 0
+	}
+	return idleTimeout * 6 / 5
+}
 
 // streamIdleTimeoutEnv is the global override for the stream idle timeout. It
 // accepts a Go duration ("5m", "300s", "90s") or a bare number of seconds
@@ -302,7 +311,7 @@ func ScanSSEDataWithContext(
 		// Content watchdog: only real data lines reset it (keep-alives do not), so a
 		// stream that heartbeats without producing output is bounded instead of
 		// hanging forever.
-		contentTimeout := idleTimeout * StreamContentStallFactor
+		contentTimeout := ContentStallTimeout(idleTimeout)
 		content := time.NewTimer(contentTimeout)
 		defer content.Stop()
 		contentC = content.C

--- a/internal/providers/providerio/providerio_test.go
+++ b/internal/providers/providerio/providerio_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"runtime"
 	"strings"
@@ -201,6 +202,32 @@ func TestUpstreamUnreachable(t *testing.T) {
 				t.Errorf("missing reason %q in %q", testCase.wantReason, got)
 			}
 		})
+	}
+}
+
+// ContentStallTimeout is 1.2× the idle timeout, disabled (0) when idle is
+// disabled, and must never overflow to a negative duration for an absurdly
+// large idle timeout (which would arm the content timer to fire immediately
+// and abort every stream).
+func TestContentStallTimeout(t *testing.T) {
+	cases := []struct {
+		idle time.Duration
+		want time.Duration
+	}{
+		{5 * time.Minute, 6 * time.Minute},
+		{30 * time.Second, 36 * time.Second},
+		{100 * time.Millisecond, 120 * time.Millisecond},
+		{0, 0},
+		{-1, 0},
+	}
+	for _, c := range cases {
+		if got := ContentStallTimeout(c.idle); got != c.want {
+			t.Fatalf("ContentStallTimeout(%v) = %v, want %v", c.idle, got, c.want)
+		}
+	}
+	// Overflow guard: idle*6 would wrap negative; the clamp keeps it positive.
+	if got := ContentStallTimeout(math.MaxInt64); got <= 0 {
+		t.Fatalf("ContentStallTimeout(MaxInt64) = %v, must stay positive (no overflow wrap)", got)
 	}
 }
 

--- a/internal/providers/providerio/providerio_test.go
+++ b/internal/providers/providerio/providerio_test.go
@@ -206,9 +206,8 @@ func TestUpstreamUnreachable(t *testing.T) {
 
 // A heartbeating-but-output-less upstream must not hang forever: SSE keep-alives
 // feed the idle watchdog (so it never fires), but the content watchdog
-// (idleTimeout × StreamContentStallFactor) aborts with ErrStreamStalled when no
-// real data line arrives. This is the gpt-5.x / ollama "still generating forever"
-// hang.
+// (ContentStallTimeout(idle)) aborts with ErrStreamStalled when no real data
+// line arrives. This is the gpt-5.x / ollama "still generating forever" hang.
 func TestScanSSEDataWithContextAbortsOnContentStall(t *testing.T) {
 	pr, pw := io.Pipe()
 	defer func() { _ = pw.Close() }()
@@ -236,7 +235,8 @@ func TestScanSSEDataWithContextAbortsOnContentStall(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		// idle 100ms → content stall at 200ms. Keep-alives reset idle but not content.
+		// idle 100ms → content stall at 120ms (ContentStallTimeout = idle*1.2).
+		// Keep-alives reset idle but not content.
 		done <- ScanSSEDataWithContext(context.Background(), cancel, pr, 100*time.Millisecond, func(string) bool { return true })
 	}()
 
@@ -259,7 +259,7 @@ func TestScanSSEDataWithContextContentResetsOnData(t *testing.T) {
 	pr, pw := io.Pipe()
 
 	go func() {
-		// One data line every 30ms for ~300ms (well past the 200ms content window,
+		// One data line every 30ms for ~300ms (well past the 120ms content window,
 		// with comfortable slack under the 100ms idle timeout), so the content
 		// watchdog keeps resetting, then close cleanly.
 		for i := 0; i < 10; i++ {
@@ -291,16 +291,16 @@ func TestScanSSEDataWithContextContentResetsOnData(t *testing.T) {
 }
 
 // StreamTimeoutMessage must give a stalled stream a distinct, accurate detail —
-// it reports the content window (idle × factor) and must NOT claim the upstream
-// "stopped sending data" (keep-alives were still arriving).
+// it reports the content window (ContentStallTimeout) and must NOT claim the
+// upstream "stopped sending data" (keep-alives were still arriving).
 func TestStreamTimeoutMessage(t *testing.T) {
 	idle := 5 * time.Minute
 	if msg := StreamTimeoutMessage(ErrStreamIdle, idle); !strings.Contains(msg, "idle timeout after 5m") {
 		t.Fatalf("idle message = %q, want it to mention the 5m idle timeout", msg)
 	}
 	stalled := StreamTimeoutMessage(ErrStreamStalled, idle)
-	if !strings.Contains(stalled, "no output for 10m") {
-		t.Fatalf("stalled message = %q, want it to report the 10m content window", stalled)
+	if !strings.Contains(stalled, "no output for 6m") {
+		t.Fatalf("stalled message = %q, want it to report the 6m content window (idle 5m × 1.2)", stalled)
 	}
 	if strings.Contains(stalled, "stopped sending data") {
 		t.Fatalf("stalled message must not claim the upstream stopped sending data: %q", stalled)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2824,10 +2824,10 @@ const quietWorkingHint = 8 * time.Second
 // actually happening and when Zero will act on its own: a heartbeating-but-
 // silent stream (observed on chatgpt/gpt-5.x and ollama reasoning models,
 // see providerio.ErrStreamStalled) is bounded by the content-stall watchdog at
-// idleTimeout × providerio.StreamContentStallFactor, but until it fires this
-// exact same plain "still generating… Xs" text is indistinguishable from a
-// genuine hang — the ticking number was the only signal, and it looks
-// identical whether real (if slow) content is coming or nothing ever will.
+// providerio.ContentStallTimeout(idle), but until it fires this exact same
+// plain "still generating… Xs" text is indistinguishable from a genuine hang —
+// the ticking number was the only signal, and it looks identical whether real
+// (if slow) content is coming or nothing ever will.
 func (m model) quietGenerationHint() string {
 	if m.activeRunID == 0 {
 		return ""
@@ -2844,7 +2844,7 @@ func (m model) quietGenerationHint() string {
 		return ""
 	}
 	if idleTimeout := providerio.ResolveStreamIdleTimeout(0); idleTimeout > 0 && quiet >= idleTimeout/2 {
-		ceiling := idleTimeout * providerio.StreamContentStallFactor
+		ceiling := providerio.ContentStallTimeout(idleTimeout)
 		return fmt.Sprintf("still generating… %s — unusually quiet, Zero will auto-recover by ~%s if it doesn't resume", formatWorkingElapsed(quiet), formatWorkingElapsed(ceiling))
 	}
 	return "still generating… " + formatWorkingElapsed(quiet)

--- a/internal/tui/working_status_test.go
+++ b/internal/tui/working_status_test.go
@@ -135,14 +135,14 @@ func TestQuietGenerationHintEscalatesPastHalfIdleTimeout(t *testing.T) {
 	}
 
 	// Quiet for >= half the idle timeout -> escalates to name the watchdog and
-	// its ceiling (idleTimeout * providerio.StreamContentStallFactor = 1m00s here).
+	// its ceiling (providerio.ContentStallTimeout(30s) = 30s*1.2 = 36s here).
 	m.lastStreamActivity = base.Add(-15 * time.Second)
 	got = m.quietGenerationHint()
 	if !strings.Contains(got, "unusually quiet") || !strings.Contains(got, "auto-recover") {
 		t.Fatalf("past half the idle timeout: want an escalated cue naming the watchdog, got %q", got)
 	}
-	if !strings.Contains(got, "1m00s") {
-		t.Fatalf("escalated cue should name the content-stall ceiling (idleTimeout * StreamContentStallFactor = 1m00s), got %q", got)
+	if !strings.Contains(got, "36s") {
+		t.Fatalf("escalated cue should name the content-stall ceiling (ContentStallTimeout(30s) = 36s), got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Root-caused the chatgpt/gpt-5.5 (and ollama/minimax) "stuck" reports with a **live goroutine stack dump** during a headless reproduction: the cloud model backend sends `200 OK` + ~300 tokens, then stops sending SSE body bytes mid-generation of a large single tool-call output (a ~1000-line `write_file`). Every Zero goroutine was cleanly parked on the socket read — no channel-send block, no deadlock, no tool/sandbox hang. Confirmed on **two** backends across **two** transports (HTTP/2 Codex parser + HTTP/1.1 OpenAI parser), both blocked identically on the response-body `Read`. It's an upstream limitation, not a Zero bug or connection-pooling issue.

Zero already detected it, but two UX gaps made it feel like a hang. This PR closes both:

1. **Faster abort.** The content-stall watchdog fired at `idle × 2` = 10 minutes. A heartbeat/body-pause stall on these backends rarely recovers, so 10 minutes of a frozen counter was a terrible wait for a doomed turn. Replaced the `StreamContentStallFactor = 2` const with `ContentStallTimeout(idle) = idle × 1.2` (6 minutes at the default). It still only ever fires on a **true zero-output freeze** — any real data line resets it — so healthy slow-reasoning runs are unaffected. Scales with `ZERO_STREAM_IDLE_TIMEOUT`; returns 0 (disabled) when idle is disabled.

2. **Auto-retry the actual stall.** The existing stall-retry only fired when **nothing** had been forwarded — so the common case (model streamed transient reasoning + began the big `write_file`, then froze mid-arguments) was **not** retried, because the incomplete tool call is collected and transient output was forwarded. Relaxed the gate to retry when no visible **prose** was shown (`forwardedVisibleText`, marked only by `OnText`) and no final text was collected — dropping the `len(ToolCalls)==0` exclusion, since an incomplete tool call from a timed-out stream is never executed (the turn returns on the error before dispatch) and never appended to `messages`, so the retry re-sends clean context with no duplication. A visible `[no output — model stalled; retrying N/max]` notice fires per attempt. Forwarded prose still blocks the retry (it would duplicate answer text).

## Verification
- Full `-race` suite green.
- A 4-dimension root-cause audit + a 3-dimension adversarial review of this diff both passed with **no confirmed defects**.
- Reproduced the stall live (headless + `SIGQUIT` goroutine dump) on both chatgpt/gpt-5.5 and ollama/minimax-m3:cloud.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./... -race -count=1`
- [x] New tests: `TestRunRetriesStallAfterIncompleteToolCall` (the exact gpt-5.x case), `TestRunRetriesStallAfterOnlyReasoning`; preserved `TestRunDoesNotRetryStallAfterPartialOutput` (prose still blocks retry); updated content-stall timeout tests for the 1.2× factor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stall recovery so retries are triggered more reliably when the stream times out before any final answer text appears, including cases with only interim reasoning or an in-progress tool call.
  * Updated “no output” stall detection and messaging to use a consistent, clamped content-stall window and correct timeout wording.
  * Refined quiet-generation UI cues so the displayed recovery estimate matches the actual content-stall threshold, improving user confidence in retry timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->