### PR TITLE
feat: require manual approval before npm publish + drop release-as pin

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -112,6 +112,12 @@ jobs:
     needs: package
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
+    # Manual approval gate: this environment carries a required-reviewer rule
+    # (Settings -> Environments -> npm-publish), so the job pauses until a
+    # maintainer approves it in the Actions UI before anything reaches npm.
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/@gitlawb/zero
     permissions:
       contents: read
       id-token: write # OIDC token exchange for npm trusted publishing + provenance

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,7 @@
   "bootstrap-sha": "02f0c0929bec65f5fc41bdcab3eb518d2b0b329a",
   "packages": {
     ".": {
-      "package-name": "@gitlawb/zero",
-      "release-as": "0.1.0"
+      "package-name": "@gitlawb/zero"
     }
   }
 }


### PR DESCRIPTION
## Summary

Two post-launch hardening changes to the release pipeline, now that v0.1.0 has shipped to npm:

- **Manual approval gate before npm publish.** The `publish-npm` job in `release-artifacts.yml` now targets a `npm-publish` deployment environment. With a required-reviewer rule on that environment, every release pauses after the GitHub Release and platform artifacts are published, and nothing reaches the npm registry until a maintainer approves the job in the Actions UI. The environment also carries the package URL so the approval prompt links straight to npmjs.com.
- **Remove the `release-as: 0.1.0` pin** from `release-please-config.json`. It existed only to force the version of the first release; now that v0.1.0 is tagged and published, leaving it in place would stamp every future release as 0.1.0. Versions are computed from conventional commits from here on.

**Post-merge setup (one-time):** GitHub auto-creates a referenced environment *without* protection rules, so the gate is only real once configured — Settings → Environments → `npm-publish` → add Required reviewers. Optionally set `npm-publish` as the environment in the npmjs.com trusted-publisher config to bind OIDC publishing exclusively to approved runs (names must match exactly).

## Linked issue

Fixes #

## Checklist

- [ ] The linked issue already has the `issue-approved` label.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] `gofmt` clean.
- [ ] Tests added/updated for the change (and run under `-race` where relevant). — N/A: no Go code changed; workflow YAML and config JSON re-validated by parsing.
- [ ] UI changes include screenshots or a short recording where possible. — N/A: CI/config only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manual approval step for NPM publishing on tagged releases, helping control when package releases go live.
  * Updated release configuration to rely on the package’s standard release settings instead of a fixed version override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->