### PR TITLE
fix(config): create the right config file on first setup (macOS ~/.config) (#371)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -530,7 +530,15 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 
 	resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{})
 	if err != nil {
-		return writeAppError(stderr, err.Error(), 1)
+		// A resolve failure caused solely by a missing/unresolvable active provider
+		// is not fatal for the interactive TUI: drop into the setup wizard with an
+		// empty config so the user can onboard, instead of exiting with an error.
+		// Any other error (malformed JSON, directory conflict, etc.) is still fatal.
+		if !errors.Is(err, config.ErrNoActiveProvider) {
+			return writeAppError(stderr, err.Error(), 1)
+		}
+		resolved = config.ResolvedConfig{}
+		forceSetup = true
 	}
 	userConfigPath, err := deps.userConfigPath()
 	if err != nil {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -155,6 +156,80 @@ func TestRunNoArgsLaunchesSetupTUIWithNilProviderWhenNoProviderConfigured(t *tes
 	}
 	assertCoreRegistry(t, launchedOptions.Registry)
 	assertAgentOptions(t, launchedOptions, 12, agent.PermissionModeAsk)
+}
+
+func TestRunNoArgsEntersSetupWhenResolveReportsNoActiveProvider(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	setCLIUserConfigRoot(t)
+	userConfigPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	var launchedOptions tui.Options
+	launched := false
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, fmt.Errorf("%w: active provider %q not found", config.ErrNoActiveProvider, "ghost")
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			t.Fatal("newProvider should not be called without a resolved provider")
+			return nil, nil
+		},
+		userConfigPath: func() (string, error) {
+			return userConfigPath, nil
+		},
+		registerMCPTools: func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return noopMCPRuntime{}, nil
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			launched = true
+			launchedOptions = options
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (setup TUI launched), stderr=%q", exitCode, stderr.String())
+	}
+	if !launched {
+		t.Fatal("TUI was not launched; expected fallback into setup instead of a fatal error")
+	}
+	if !launchedOptions.Setup.Visible || !launchedOptions.Setup.Required {
+		t.Fatalf("Setup = %#v, want visible required setup", launchedOptions.Setup)
+	}
+	if launchedOptions.Provider != nil {
+		t.Fatalf("Provider = %#v, want nil for no-provider fallback", launchedOptions.Provider)
+	}
+}
+
+func TestRunNoArgsFailsWhenResolveErrorIsNotProviderRelated(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	setCLIUserConfigRoot(t)
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, fmt.Errorf("invalid config JSON")
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			t.Fatal("TUI must not launch on a non-provider resolve error")
+			return 0
+		},
+	})
+
+	if exitCode == 0 {
+		t.Fatal("exit code = 0, want non-zero for fatal config error")
+	}
+	if !strings.Contains(stderr.String(), "invalid config JSON") {
+		t.Fatalf("stderr = %q, want the underlying config error", stderr.String())
+	}
 }
 
 func TestRunNoArgsLaunchesTUIWithMCPState(t *testing.T) {

--- a/internal/cli/specialist_test.go
+++ b/internal/cli/specialist_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
 )
 
 func TestRunSpecialistListShowAndPath(t *testing.T) {
@@ -326,7 +328,7 @@ func setSpecialistConfigRoot(t *testing.T) string {
 	default:
 		t.Setenv("XDG_CONFIG_HOME", root)
 	}
-	configRoot, err := os.UserConfigDir()
+	configRoot, err := config.UserConfigDir()
 	if err != nil {
 		t.Fatalf("UserConfigDir() error = %v", err)
 	}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -33,11 +34,30 @@ func DefaultResolveOptions(workspaceRoot string) (ResolveOptions, error) {
 }
 
 func DefaultUserConfigPath() (string, error) {
-	userConfigDir, err := os.UserConfigDir()
+	userConfigDir, err := UserConfigDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve user config directory: %w", err)
 	}
 	return filepath.Join(userConfigDir, "zero", "config.json"), nil
+}
+
+// UserConfigDir returns the base directory Zero stores per-user config under.
+// It mirrors os.UserConfigDir everywhere except macOS: there Go defaults to
+// ~/Library/Application Support, but Zero deliberately uses ~/.config (XDG-style,
+// matching Linux and Claude Code) so a single config path works cross-platform.
+// $XDG_CONFIG_HOME still wins on macOS when set.
+func UserConfigDir() (string, error) {
+	if runtime.GOOS == "darwin" {
+		if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+			return xdg, nil
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return filepath.Join(home, ".config"), nil
+	}
+	return os.UserConfigDir()
 }
 
 func existingConfigFile(path string) (string, error) {

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -105,7 +105,7 @@ func setUserConfigRoot(t *testing.T) string {
 		t.Setenv("XDG_CONFIG_HOME", root)
 	}
 
-	configRoot, err := os.UserConfigDir()
+	configRoot, err := UserConfigDir()
 	if err != nil {
 		t.Fatalf("UserConfigDir() error = %v", err)
 	}
@@ -128,5 +128,23 @@ func mkdirAll(t *testing.T, path string) {
 
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Fatalf("create directory %s: %v", path, err)
+	}
+}
+
+func TestDefaultUserConfigPathUsesXDGConfigOnMacOS(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-specific config path behavior")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	path, err := DefaultUserConfigPath()
+	if err != nil {
+		t.Fatalf("DefaultUserConfigPath() error = %v", err)
+	}
+	want := filepath.Join(home, ".config", "zero", "config.json")
+	if path != want {
+		t.Fatalf("DefaultUserConfigPath() = %q, want %q", path, want)
 	}
 }

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -13,6 +14,11 @@ import (
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/sandbox"
 )
+
+// ErrNoActiveProvider marks a resolve failure caused solely by a missing or
+// unresolvable active provider. The interactive TUI treats this as "needs
+// onboarding" (drop into the setup wizard) rather than a fatal config error.
+var ErrNoActiveProvider = errors.New("no active provider configured")
 
 // defaultMaxTurns is the per-run tool-turn budget when none is configured. 30 was
 // too low for real multi-step agentic work (agents ran out mid-task before reaching
@@ -750,7 +756,7 @@ func normalizeProvidersWithOptions(providers []ProviderProfile, activeName strin
 	}
 	if len(providers) == 0 {
 		if activeName != "" {
-			return nil, ProviderProfile{}, fmt.Errorf("active provider %q not found", activeName)
+			return nil, ProviderProfile{}, fmt.Errorf("%w: active provider %q not found", ErrNoActiveProvider, activeName)
 		}
 		return []ProviderProfile{}, ProviderProfile{}, nil
 	}
@@ -782,7 +788,7 @@ func normalizeProvidersWithOptions(providers []ProviderProfile, activeName strin
 	}
 
 	if !activeFound {
-		return nil, ProviderProfile{}, fmt.Errorf("active provider %q not found", activeName)
+		return nil, ProviderProfile{}, fmt.Errorf("%w: active provider %q not found", ErrNoActiveProvider, activeName)
 	}
 	if active.Model == "" {
 		return nil, ProviderProfile{}, providerError(active, "provider %s requires model", active.Name)

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -897,6 +898,9 @@ func TestResolveRejectsActiveProviderWithoutConfiguredProfiles(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `active provider "ghost" not found`) {
 		t.Fatalf("error = %q, want active provider missing message", err.Error())
+	}
+	if !errors.Is(err, ErrNoActiveProvider) {
+		t.Fatalf("error = %v, want errors.Is(err, ErrNoActiveProvider)", err)
 	}
 	if resolved.ActiveProvider != "" {
 		t.Fatalf("ActiveProvider = %q, want empty", resolved.ActiveProvider)

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 )
 
@@ -120,7 +121,7 @@ var knownToolNames = map[string]bool{
 }
 
 func DefaultPaths(workspaceRoot string) (Paths, error) {
-	userConfigDir, err := os.UserConfigDir()
+	userConfigDir, err := config.UserConfigDir()
 	if err != nil {
 		return Paths{}, fmt.Errorf("resolve user config directory: %w", err)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -635,7 +635,7 @@ func newModel(ctx context.Context, options Options) model {
 		}
 	}
 
-	userConfigDir, _ := os.UserConfigDir()
+	userConfigDir, _ := config.UserConfigDir()
 	loadedUserCommands := usercommands.Load(usercommands.DefaultPaths(cwd, userConfigDir))
 
 	registry := options.Registry


### PR DESCRIPTION
Fixes #371.

## Problem

On macOS, a fresh `go run cmd/zero setup` failed with `active provider "" not found`. Two root causes:

1. **Wrong config path on macOS.** `DefaultUserConfigPath` used Go's `os.UserConfigDir()`, which returns `~/Library/Application Support` on darwin — but users (and Claude Code) put config at `~/.config/zero/config.json`. The user config was never read, so `activeProvider` stayed empty.
2. **No fallback to setup.** When resolve failed because no active provider could be found, the interactive TUI exited fatally instead of dropping into the setup wizard.

## Changes

- **`~/.config` on macOS.** Add `config.UserConfigDir()`: on darwin it resolves to `~/.config` (honoring `XDG_CONFIG_HOME`), matching Linux and Claude Code. `DefaultUserConfigPath`, the TUI user-commands dir (`internal/tui/model.go`), and specialist manifests (`internal/specialist/manifest.go`) all route through it, so credential store / specialists / user commands land in the same tree.
- **Enter setup instead of crashing.** Add a `config.ErrNoActiveProvider` sentinel (the two "active provider not found" errors are now `%w`-wrapped, message unchanged). The interactive TUI (`internal/cli/app.go`) drops into the setup wizard when resolve fails *solely* due to a missing/unresolvable active provider. Other resolve errors (malformed JSON, directory conflicts) remain fatal.

The config directory is already auto-created on first write — every writer (`writeConfigFile`, credstore, oauth store) does `os.MkdirAll(dir, 0o700)` before writing.

## Testing

- `go build ./...`
- `go test ./internal/config/... ./internal/cli/... ./internal/tui/... ./internal/specialist/...`
- New tests: darwin `DefaultUserConfigPath` → `~/.config/zero/config.json`; `errors.Is(err, ErrNoActiveProvider)`; TUI enters setup on `ErrNoActiveProvider` and stays fatal on other errors.
- Pre-existing `TestLocalControl*` / `TestResolveLocalControl*` failures in `internal/config` are unrelated to this change (verified by diffing failures against `main`).

Manual: place config at `~/.config/zero/config.json` and run `zero` — starts normally; clear `activeProvider` / remove providers and run `zero` — enters the setup wizard instead of erroring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now opens the setup flow automatically when no active provider is available, instead of exiting with an error.
  * macOS users now get more consistent config path handling, including support for the standard XDG config location when available.

* **Bug Fixes**
  * Improved error handling so unrelated configuration issues still fail normally, with the error shown to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->