### PR TITLE
fix(gemini): strip unsupported JSON Schema fields from tool declarations

### DIFF
--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -342,12 +342,77 @@ func (provider *Provider) geminiRequest(request zeroruntime.CompletionRequest) (
 			declarations = append(declarations, geminiFunctionDeclaration{
 				Name:        tool.Name,
 				Description: tool.Description,
-				Parameters:  tool.Parameters,
+				Parameters:  sanitizeGeminiSchema(tool.Parameters),
 			})
 		}
 		mapped.Tools = []geminiToolGroup{{FunctionDeclarations: declarations}}
 	}
 	return mapped, nil
+}
+
+// geminiSchemaFields is the subset of JSON Schema keywords Google's
+// functionDeclarations[].parameters accepts (the Generative AI Schema type).
+// Anything outside it — most notably OpenAI's `additionalProperties`, which Zero
+// emits on every tool's parameters and which Gemini 400s on ("Unknown name
+// \"additionalProperties\" … Cannot find field") — must be dropped before the
+// request goes out. Kept as an allowlist rather than a denylist so a schema
+// keyword Zero (or an MCP server) adds later can't silently leak an unsupported
+// field into the Gemini payload.
+var geminiSchemaFields = map[string]bool{
+	"type": true, "format": true, "title": true, "description": true,
+	"nullable": true, "enum": true, "items": true, "properties": true,
+	"required": true, "anyOf": true, "propertyOrdering": true, "default": true,
+	"minimum": true, "maximum": true, "minItems": true, "maxItems": true,
+	"minLength": true, "maxLength": true, "minProperties": true,
+	"maxProperties": true, "pattern": true, "example": true,
+}
+
+// sanitizeGeminiSchema returns a copy of a JSON-Schema map keeping only the
+// keywords Gemini supports (geminiSchemaFields), recursing through the nested
+// schemas under `properties`, `items`, and `anyOf`. Returns nil for a nil input
+// so a parameterless tool stays parameterless.
+func sanitizeGeminiSchema(schema map[string]any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	out := make(map[string]any, len(schema))
+	for key, value := range schema {
+		if !geminiSchemaFields[key] {
+			continue
+		}
+		switch key {
+		case "properties":
+			if props, ok := value.(map[string]any); ok {
+				cleaned := make(map[string]any, len(props))
+				for name, sub := range props {
+					if subMap, ok := sub.(map[string]any); ok {
+						cleaned[name] = sanitizeGeminiSchema(subMap)
+					} else {
+						cleaned[name] = sub
+					}
+				}
+				value = cleaned
+			}
+		case "items":
+			if subMap, ok := value.(map[string]any); ok {
+				value = sanitizeGeminiSchema(subMap)
+			}
+		case "anyOf":
+			if variants, ok := value.([]any); ok {
+				cleaned := make([]any, len(variants))
+				for i, variant := range variants {
+					if subMap, ok := variant.(map[string]any); ok {
+						cleaned[i] = sanitizeGeminiSchema(subMap)
+					} else {
+						cleaned[i] = variant
+					}
+				}
+				value = cleaned
+			}
+		}
+		out[key] = value
+	}
+	return out
 }
 
 func mapMessages(messages []zeroruntime.Message) (*geminiContent, []geminiContent, error) {

--- a/internal/providers/gemini/provider_test.go
+++ b/internal/providers/gemini/provider_test.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -503,4 +504,130 @@ func eventsOfType(events []zeroruntime.StreamEvent, eventType zeroruntime.Stream
 		}
 	}
 	return matching
+}
+
+// TestSanitizeGeminiSchemaStripsUnsupportedFields: the sanitizer keeps only
+// Gemini-supported keywords and recurses into properties/items/anyOf, so no
+// OpenAI-ism (additionalProperties, $schema, patternProperties) survives at any
+// depth while legitimate fields (type/description/enum/required/default) stay.
+func TestSanitizeGeminiSchemaStripsUnsupportedFields(t *testing.T) {
+	in := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"$schema":              "https://json-schema.org/draft/2020-12/schema",
+		"required":             []string{"path"},
+		"properties": map[string]any{
+			"path": map[string]any{
+				"type":        "string",
+				"description": "a path",
+				"default":     ".",
+			},
+			"nested": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false, // must be stripped at depth too
+				"properties": map[string]any{
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string", "additionalProperties": true},
+					},
+				},
+			},
+		},
+	}
+	out := sanitizeGeminiSchema(in)
+
+	assertNoAdditionalProps(t, out, "root")
+	if out["additionalProperties"] != nil {
+		t.Fatal("top-level additionalProperties must be stripped")
+	}
+	if out["$schema"] != nil {
+		t.Fatal("$schema must be stripped")
+	}
+	// Legitimate fields survive.
+	if out["type"] != "object" {
+		t.Fatalf("type should survive, got %v", out["type"])
+	}
+	props := out["properties"].(map[string]any)
+	pathProp := props["path"].(map[string]any)
+	if pathProp["description"] != "a path" || pathProp["default"] != "." {
+		t.Fatalf("legitimate property fields must survive: %#v", pathProp)
+	}
+	// nil input stays nil (parameterless tool).
+	if sanitizeGeminiSchema(nil) != nil {
+		t.Fatal("nil schema should map to nil")
+	}
+}
+
+// assertNoAdditionalProps fails if additionalProperties appears anywhere in the
+// (recursively walked) schema.
+func assertNoAdditionalProps(t *testing.T, node any, path string) {
+	t.Helper()
+	switch v := node.(type) {
+	case map[string]any:
+		if _, ok := v["additionalProperties"]; ok {
+			t.Fatalf("additionalProperties leaked at %s", path)
+		}
+		for k, sub := range v {
+			assertNoAdditionalProps(t, sub, path+"."+k)
+		}
+	case []any:
+		for i, sub := range v {
+			assertNoAdditionalProps(t, sub, fmt.Sprintf("%s[%d]", path, i))
+		}
+	}
+}
+
+// TestGeminiRequestOmitsAdditionalPropertiesInToolSchema: end-to-end, the tool
+// parameters Zero emits (schemaToRuntimeMap always writes additionalProperties)
+// must not reach Gemini — otherwise every functionDeclaration is 400-rejected
+// ("Unknown name additionalProperties"), which broke all tool-using exec calls
+// against Google (issue #373).
+func TestGeminiRequestOmitsAdditionalPropertiesInToolSchema(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `{"usageMetadata":{"promptTokenCount":1}}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{APIKey: "k", BaseURL: server.URL + "/", Model: "models/gemini-2.5-flash"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+		Tools: []zeroruntime.ToolDefinition{{
+			Name:        "grep",
+			Description: "search",
+			Parameters: map[string]any{ // exactly what schemaToRuntimeMap produces
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []string{"pattern"},
+				"properties": map[string]any{
+					"pattern": map[string]any{"type": "string", "description": "regex"},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	tools := gotBody["tools"].([]any)
+	decls := tools[0].(map[string]any)["functionDeclarations"].([]any)
+	params := decls[0].(map[string]any)["parameters"].(map[string]any)
+	if _, ok := params["additionalProperties"]; ok {
+		t.Fatalf("additionalProperties must not be sent to Gemini: %#v", params)
+	}
+	// The tool is still usable: its real schema survived.
+	if params["type"] != "object" {
+		t.Fatalf("tool parameters type should survive, got %v", params["type"])
+	}
+	props := params["properties"].(map[string]any)
+	if _, ok := props["pattern"]; !ok {
+		t.Fatalf("tool property must survive sanitization: %#v", props)
+	}
 }


### PR DESCRIPTION
## Problem

Fixes #373. Every `zero exec` against the Google/Gemini provider fails as soon as tools are advertised (i.e. essentially all agentic use). Zero serializes tool parameter schemas in OpenAI's JSON Schema dialect — `schemaToRuntimeMap` writes `additionalProperties` on every tool unconditionally — and Google's `functionDeclarations` schema doesn't recognize that keyword:

```
Invalid JSON payload received. Unknown name "additionalProperties"
at "tools[0].function_declarations[N].parameters": Cannot find field
```

The request is 400-rejected for every declaration, so the call never reaches the model. Reported against v0.1.0 with `gemini-2.5-pro`.

## Root cause

- `internal/agent/loop.go` — `schemaToRuntimeMap` always emits `"additionalProperties"` into a tool's runtime parameter map.
- `internal/providers/gemini/provider.go` — the mapper passed `tool.Parameters` **verbatim** into `functionDeclarations[].parameters`.

## Fix

Sanitize tool parameters **in the Gemini mapper only** — `additionalProperties: false` is valid and wanted for OpenAI strict mode and harmless for Anthropic, so this must not be stripped globally.

- `sanitizeGeminiSchema` keeps only the keywords Google's Schema type supports (`type`, `description`, `enum`, `properties`, `required`, `items`, `anyOf`, `default`, `nullable`, `format`, and the min/max/length constraints) via an **allowlist**, so any future OpenAI-ism or MCP-supplied field can't silently leak into a Gemini payload.
- Recurses through `properties`, `items`, and `anyOf`, so nested schemas are cleaned at every depth — not just the top level.
- `nil` parameters stay `nil` (parameterless tools unaffected).

## Tests

- Unit test on `sanitizeGeminiSchema`: nested stripping, legitimate fields (`type`/`description`/`enum`/`required`/`default`) preserved, `nil`-safe.
- End-to-end test asserting the real outgoing request body's `functionDeclarations[].parameters` carry no `additionalProperties` while the actual schema survives.
- Red-green: bypassing the sanitizer reproduces the exact reported payload and fails the E2E.

Full suite `go test ./...` passes (73/73 packages); change is isolated to the Gemini provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini tool calls to send cleaner JSON schemas, reducing compatibility issues with unsupported schema fields.
  * Preserved supported parameter details while removing invalid extras from tool definitions.
* **Tests**
  * Added coverage for schema sanitization across nested fields and end-to-end Gemini request payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->