### PR TITLE
security(config): project config should not override sandbox.network to allow

### DIFF
--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -225,7 +225,8 @@ func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
 	// WEAKEN (→ "allow"). A malicious repo must not be able to open network
 	// access for shell commands. Matches the AdditionalWriteRoots posture.
 	if network := strings.TrimSpace(src.Sandbox.Network); network != "" {
-		if sandbox.NetworkMode(network) == sandbox.NetworkDeny {
+		// Normalize: anything that isn't literally "allow" counts as deny.
+		if sandbox.NormalizeNetworkMode(sandbox.NetworkMode(network)) != sandbox.NetworkAllow {
 			dst.Sandbox.Network = network
 		}
 		// Silently ignore "allow" from project config — not an error, just

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -220,8 +220,16 @@ func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
 	// config: a cloned repo's .zero/config.json must not be able to grant
 	// itself write access outside the workspace. Global config and CLI flags
 	// are the only config sources for write roots.
+	//
+	// Sandbox.Network from project config may only TIGHTEN (→ "deny"), never
+	// WEAKEN (→ "allow"). A malicious repo must not be able to open network
+	// access for shell commands. Matches the AdditionalWriteRoots posture.
 	if network := strings.TrimSpace(src.Sandbox.Network); network != "" {
-		dst.Sandbox.Network = network
+		if sandbox.NetworkMode(network) == sandbox.NetworkDeny {
+			dst.Sandbox.Network = network
+		}
+		// Silently ignore "allow" from project config — not an error, just
+		// a privilege the project scope does not have.
 	}
 	if src.Sandbox.BlockUnixSockets {
 		dst.Sandbox.BlockUnixSockets = true

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1269,6 +1269,45 @@ func TestResolveSandboxBlockUnixSocketsFromFile(t *testing.T) {
 	}
 }
 
+func TestResolveSandboxNetworkProjectConfigCannotWeaken(t *testing.T) {
+	// 1. Project config tries to set network to "allow" (should be ignored).
+	userPath := writeConfig(t, `{}`)
+	projectPath := writeConfig(t, `{
+		"sandbox": {"network": "allow"}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env:               map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.Sandbox.Network == "allow" {
+		t.Fatal("resolved.Sandbox.Network = allow, want empty/deny to prevent project config from weakening sandbox")
+	}
+
+	// 2. User config sets network to "allow", project config sets it to "deny" (tightening is allowed).
+	userPath2 := writeConfig(t, `{
+		"sandbox": {"network": "allow"}
+	}`)
+	projectPath2 := writeConfig(t, `{
+		"sandbox": {"network": "deny"}
+	}`)
+	resolved2, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath2,
+		ProjectConfigPath: projectPath2,
+		Env:               map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved2.Sandbox.Network != "deny" {
+		t.Fatalf("resolved.Sandbox.Network = %q, want deny (project config allowed to tighten)", resolved2.Sandbox.Network)
+	}
+}
+
 func TestResolveNotifyValid(t *testing.T) {
 	path := writeConfig(t, `{"notify":{"mode":"both","focusMode":"always"}}`)
 	resolved, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}})


### PR DESCRIPTION
Closes #377

### Description
A repository's project-level `.zero/config.json` config can set `sandbox.network` to `"allow"`. This violates the sandbox boundary because a cloned repo should not be able to weaken sandbox network restrictions for shell commands. This is a security supply-chain risk.

### Solution
Prevented the project config merge from overriding `sandbox.network` to `"allow"`. Project config can only tighten network restrictions (e.g. to `"deny"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project-level sandbox network settings can no longer weaken security by switching the network mode to a less restrictive option (for example, a project “allow” won’t override when not tightening).
  * When a project config specifies a stricter sandbox network mode, it is now correctly applied during configuration resolution.
  * Added tests to verify correct sandbox network precedence between user and project configuration layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->