### PR TITLE
fix(tools): require permission before web_search requests

### DIFF
--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -37,6 +37,35 @@ func (provider *mockProvider) StreamCompletion(ctx context.Context, request zero
 	return ch, nil
 }
 
+type recordingWebSearchTool struct {
+	calls []map[string]any
+}
+
+func (tool *recordingWebSearchTool) Name() string        { return "web_search" }
+func (tool *recordingWebSearchTool) Description() string { return "test web search tool" }
+func (tool *recordingWebSearchTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"query": {Type: "string"},
+		},
+		Required:             []string{"query"},
+		AdditionalProperties: false,
+	}
+}
+func (tool *recordingWebSearchTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectNetwork,
+		Permission:      tools.PermissionPrompt,
+		Reason:          "Performs a web search over the network.",
+		AdvertiseInAuto: true,
+	}
+}
+func (tool *recordingWebSearchTool) Run(_ context.Context, args map[string]any) tools.Result {
+	tool.calls = append(tool.calls, cloneArgs(args))
+	return tools.Result{Status: tools.StatusOK, Output: "1. T — https://x.test"}
+}
+
 type sandboxDeniedRetryTool struct {
 	calls []map[string]any
 }
@@ -865,7 +894,7 @@ func TestRunRejectsLocalWebFetchBeforePermissionRequest(t *testing.T) {
 	}
 }
 
-func TestRunAdvertisesAllowedWebSearchInAutoMode(t *testing.T) {
+func TestRunAdvertisesPromptedWebSearchInAutoMode(t *testing.T) {
 	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
 	registry := tools.NewRegistry()
 	for _, tool := range tools.CoreNetworkTools() {
@@ -893,6 +922,52 @@ func TestRunAdvertisesAllowedWebSearchInAutoMode(t *testing.T) {
 	}
 	if len(provider.requests[0].Tools) != 1 || provider.requests[0].Tools[0].Name != "web_search" {
 		t.Fatalf("expected web_search to be advertised in auto mode, got %#v", provider.requests[0].Tools)
+	}
+}
+
+func TestRunRequestsPermissionBeforeWebSearchExecution(t *testing.T) {
+	search := &recordingWebSearchTool{}
+	registry := tools.NewRegistry()
+	registry.Register(search)
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "web_search"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"query":"private workspace detail"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+	var requests []PermissionRequest
+
+	result, err := Run(context.Background(), "search", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			requests = append(requests, request)
+			return PermissionDecision{Action: PermissionDecisionDeny, Reason: "network not approved"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("expected final answer after denied tool call, got %q", result.FinalAnswer)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected one permission request, got %#v", requests)
+	}
+	if requests[0].ToolName != "web_search" || requests[0].Permission != string(tools.PermissionPrompt) || requests[0].SideEffect != string(tools.SideEffectNetwork) {
+		t.Fatalf("unexpected permission request: %#v", requests[0])
+	}
+	if len(search.calls) != 0 {
+		t.Fatalf("web_search backend must not run when permission is denied, got calls %#v", search.calls)
 	}
 }
 

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -57,7 +57,7 @@ func (tool *recordingWebSearchTool) Safety() tools.Safety {
 	return tools.Safety{
 		SideEffect:      tools.SideEffectNetwork,
 		Permission:      tools.PermissionPrompt,
-		Reason:          "Performs a web search over the network.",
+		Reason:          "Sends model-provided search query text to the configured web search backend.",
 		AdvertiseInAuto: true,
 	}
 }

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -9,22 +9,25 @@ import (
 	"time"
 )
 
-// TestEvaluateExemptsNetworkToolsFromShellNetworkPolicy verifies that the
-// sandbox network policy gates sandboxed shell egress, not first-party
-// in-process web tools.
-func TestEvaluateExemptsNetworkToolsFromShellNetworkPolicy(t *testing.T) {
+// TestEvaluatePromptsForNetworkToolsButExemptsThemFromShellNetworkPolicy verifies
+// that first-party in-process network tools are governed by their permission
+// metadata, not by the sandboxed shell egress policy.
+func TestEvaluatePromptsForNetworkToolsButExemptsThemFromShellNetworkPolicy(t *testing.T) {
 	base := Policy{Mode: ModeEnforce, Network: NetworkDeny}
 
 	engine := NewEngine(EngineOptions{Policy: base})
 	d := engine.Evaluate(context.Background(), Request{
-		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionAllow,
+		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionPrompt,
 	})
-	if d.Action != ActionAllow || d.Block != nil {
-		t.Fatalf("web_search must be allowed by the sandbox gate, got %#v", d)
+	if d.Action != ActionPrompt || d.Block != nil {
+		t.Fatalf("web_search must prompt before permission is granted, got %#v", d)
+	}
+	if d.Reason == ReasonNetworkBlocked {
+		t.Fatalf("web_search prompt should come from tool permission, not shell network policy: %#v", d)
 	}
 
 	allowed := engine.Evaluate(context.Background(), Request{
-		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionAllow, PermissionGranted: true,
+		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionPrompt, PermissionGranted: true,
 	})
 	if allowed.Action != ActionAllow || allowed.Block != nil {
 		t.Fatalf("granted web_search must be allowed under deny, got %#v", allowed)

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -104,8 +104,8 @@ func TestCoreNetworkToolsExposeSafetyMetadata(t *testing.T) {
 	if property, ok := search.Parameters().Properties["query"]; !ok || property.Type != "string" {
 		t.Fatalf("web_search must expose a string query property, got %#v", search.Parameters().Properties["query"])
 	}
-	if safety := search.Safety(); safety.Permission != PermissionAllow || safety.AdvertiseInAuto {
-		t.Fatalf("web_search safety = %#v, want allow without prompt-advertise override", safety)
+	if safety := search.Safety(); safety.Permission != PermissionPrompt || !safety.AdvertiseInAuto {
+		t.Fatalf("web_search safety = %#v, want prompt and advertised in auto", safety)
 	}
 }
 

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -87,7 +87,7 @@ func newWebSearchToolWithBackend(backend searchBackend) Tool {
 			safety: Safety{
 				SideEffect:      SideEffectNetwork,
 				Permission:      PermissionPrompt,
-				Reason:          "Performs a web search over the network.",
+				Reason:          "Sends model-provided search query text to the configured web search backend.",
 				AdvertiseInAuto: true,
 			},
 		},

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -81,13 +81,14 @@ func newWebSearchToolWithBackend(backend searchBackend) Tool {
 				Required:             []string{"query"},
 				AdditionalProperties: false,
 			},
-			// Hosted search is a read-only discovery action. It remains marked as
-			// network for metadata, but sandbox network policy is the shell egress
-			// boundary; web_search keeps its own result-domain filtering safeguards.
+			// Hosted search sends model-provided query text to a configured network
+			// backend. Keep it visible in auto mode, but guard execution through the
+			// normal permission flow like web_fetch.
 			safety: Safety{
-				SideEffect: SideEffectNetwork,
-				Permission: PermissionAllow,
-				Reason:     "Performs a web search over the network.",
+				SideEffect:      SideEffectNetwork,
+				Permission:      PermissionPrompt,
+				Reason:          "Performs a web search over the network.",
+				AdvertiseInAuto: true,
 			},
 		},
 		backend: backend,
@@ -95,7 +96,8 @@ func newWebSearchToolWithBackend(backend searchBackend) Tool {
 }
 
 // RunWithSandbox follows the normal web_search path. The sandbox network policy
-// gates sandboxed shell egress, not this in-process hosted search tool.
+// gates sandboxed shell egress; this in-process hosted search tool is guarded by
+// the permission flow plus backend and result-domain safeguards.
 func (tool webSearchTool) RunWithSandbox(ctx context.Context, args map[string]any, engine *zeroSandbox.Engine) Result {
 	return tool.Run(ctx, args)
 }

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -116,17 +116,52 @@ func TestWebSearchRegisteredInCoreNetworkTools(t *testing.T) {
 	}
 }
 
-func TestWebSearchSafetyAllowsHostedSearchWithoutPrompt(t *testing.T) {
+func TestWebSearchSafetyPromptsForHostedSearchButAdvertisesInAuto(t *testing.T) {
 	tool := newWebSearchToolWithBackend(&fakeSearchBackend{})
 	safety := tool.Safety()
 	if safety.SideEffect != SideEffectNetwork {
 		t.Fatalf("side effect = %s, want network", safety.SideEffect)
 	}
-	if safety.Permission != PermissionAllow {
-		t.Fatalf("permission = %s, want allow", safety.Permission)
+	if safety.Permission != PermissionPrompt {
+		t.Fatalf("permission = %s, want prompt", safety.Permission)
 	}
-	if safety.AdvertiseInAuto {
-		t.Fatal("web_search should not need the prompt-tool auto advertisement override")
+	if !safety.AdvertiseInAuto {
+		t.Fatal("web_search should be advertised in auto mode while still requiring permission")
+	}
+}
+
+func TestWebSearchRegistryRequiresPermissionBeforeBackendCall(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{{Title: "T", URL: "https://x.test"}}}
+	registry := NewRegistry()
+	registry.Register(newWebSearchToolWithBackend(backend))
+
+	res := registry.Run(context.Background(), "web_search", map[string]any{"query": "private workspace detail"})
+
+	if res.Status != StatusError {
+		t.Fatalf("expected permission error, got %s: %s", res.Status, res.Output)
+	}
+	if !strings.Contains(res.Output, "Permission required for web_search") {
+		t.Fatalf("expected permission-required output, got %q", res.Output)
+	}
+	if backend.gotQuery != "" {
+		t.Fatalf("backend must not be called before permission, got query %q", backend.gotQuery)
+	}
+}
+
+func TestWebSearchRegistryRunsAfterPermissionGranted(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{{Title: "T", URL: "https://x.test"}}}
+	registry := NewRegistry()
+	registry.Register(newWebSearchToolWithBackend(backend))
+
+	res := registry.RunWithOptions(context.Background(), "web_search", map[string]any{"query": "go errors"}, RunOptions{
+		PermissionGranted: true,
+	})
+
+	if res.Status != StatusOK {
+		t.Fatalf("expected ok, got %s: %s", res.Status, res.Output)
+	}
+	if backend.gotQuery != "go errors" {
+		t.Fatalf("backend query = %q, want %q", backend.gotQuery, "go errors")
 	}
 }
 


### PR DESCRIPTION
Fixes #380

## Summary

- Gate the built-in `web_search` tool behind the normal permission flow before it sends queries to a configured backend.
- Keep `web_search` visible in auto mode with `AdvertiseInAuto: true`, matching the existing `web_fetch` pattern.
- Add coverage for registry, agent-loop, and sandbox behavior so denied permission prevents execution while approved calls still work.

## Why

`web_search` is marked as a network side-effecting tool, but it previously used `PermissionAllow`. That let hosted search run without a permission prompt even though queries may include prompt or workspace context.

