### PR TITLE
feat(providers): Add KiloCode and OpenCode Zen/Go provider support

### DIFF
--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -142,6 +142,9 @@ var descriptors = []Descriptor{
 	// endpoint. Local (no API key — the proxy authenticates); override the base URL
 	// for your proxy's port. See docs/oauth-subscriptions.md.
 	localOpenAI("chatgpt-proxy", "ChatGPT (local OAuth proxy)", "http://localhost:10531/v1", "gpt-5", "chatgpt"),
+	openAICompat("kilocode", "KiloCode", "https://api.kilo.ai/api/gateway", "anthropic/claude-sonnet-4.6", []string{"KILO_API_KEY"}, "kilo", "kilo gateway"),
+	openAICompat("opencode", "OpenCode Zen", "https://opencode.ai/zen/v1", "gpt-5.5", []string{"OPENCODE_API_KEY"}, "opencode zen"),
+	openAICompat("opencode-go", "OpenCode Go", "https://opencode.ai/zen/go/v1", "deepseek-v4-pro", []string{"OPENCODE_API_KEY"}, "opencode go"),
 	openAICompat("custom-openai-compatible", "Custom OpenAI-compatible", "https://example.invalid/v1", "custom-model", []string{"OPENAI_API_KEY"}, "custom openai compatible"),
 	anthropicCompat("custom-anthropic-compatible", "Custom Anthropic-compatible", "https://example.invalid/anthropic", "custom-model", []string{"ANTHROPIC_API_KEY"}, "custom anthropic compatible"),
 }

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -36,6 +36,9 @@ var expectedCatalogIDs = []string{
 	"zai",
 	"atomic-chat",
 	"chatgpt-proxy",
+	"kilocode",
+	"opencode",
+	"opencode-go",
 	"custom-openai-compatible",
 	"custom-anthropic-compatible",
 }
@@ -264,7 +267,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
 		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
-		TransportOpenAICompat:    {"gitlawb-opengateway", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
+		TransportOpenAICompat:    {"gitlawb-opengateway", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "atomic-chat", "chatgpt-proxy", "kilocode", "opencode", "opencode-go", "custom-openai-compatible"},
 	}
 
 	for transport, wantIDs := range cases {


### PR DESCRIPTION
Closes #383

Adds catalog entries for three new OpenAI-compatible providers:

1. **KiloCode (Kilo Gateway)** — unified OpenAI-compatible API at \https://api.kilo.ai/api/gateway\ with 500+ models
2. **OpenCode Zen** — curated model gateway at \https://opencode.ai/zen/v1\
3. **OpenCode Go** — subscription-based open model access at \https://opencode.ai/zen/go/v1\

All three use the existing \openAICompat()\ helper — no new transport types, runtime providers, or factory changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new OpenAI-compatible provider options: KiloCode, OpenCode Zen, and OpenCode Go.
  * Each new option includes its own connection details, default model, API key setup, and aliases.
* **Tests**
  * Updated catalog checks to include the new provider options and preserve the expected listing order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->