### PR TITLE
fix(provider-wizard): allow multiple custom OpenAI-compatible providers

### DIFF
--- a/internal/cli/mcp_oauth_test.go
+++ b/internal/cli/mcp_oauth_test.go
@@ -144,7 +144,7 @@ func TestRunMCPOAuthLoginStoresTokens(t *testing.T) {
 	stdout := &syncBuffer{}
 	stderr := &syncBuffer{}
 	go func() {
-		deadline := time.Now().Add(3 * time.Second)
+		deadline := time.Now().Add(15 * time.Second)
 		for time.Now().Before(deadline) {
 			callbackURL := extractCallbackURL(stdout.String())
 			if callbackURL != "" {
@@ -164,8 +164,8 @@ func TestRunMCPOAuthLoginStoresTokens(t *testing.T) {
 	var exitCode int
 	select {
 	case exitCode = <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatalf("login did not complete within 10s; stderr=%s stdout=%s", stderr.String(), stdout.String())
+	case <-time.After(20 * time.Second):
+		t.Fatalf("login did not complete within 20s; stderr=%s stdout=%s", stderr.String(), stdout.String())
 	}
 	if exitCode != exitSuccess {
 		t.Fatalf("exitCode = %d stderr=%s stdout=%s", exitCode, stderr.String(), stdout.String())

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -942,7 +942,8 @@ func (m model) wizardProviderStoredKey(provider providercatalog.Descriptor) (str
 			continue
 		}
 		if strings.EqualFold(strings.TrimSpace(profile.Name), strings.TrimSpace(provider.Name)) ||
-			strings.EqualFold(strings.TrimSpace(profile.CatalogID), strings.TrimSpace(provider.ID)) ||
+			(!genericProviderCatalogID(provider.ID) &&
+				strings.EqualFold(strings.TrimSpace(profile.CatalogID), strings.TrimSpace(provider.ID))) ||
 			strings.EqualFold(strings.TrimSpace(profile.Name), strings.TrimSpace(provider.ID)) {
 			return profile.Name, true
 		}
@@ -963,7 +964,13 @@ func (m model) applyManageKeyChoice() (model, tea.Cmd) {
 	case 1: // Replace
 		wizard.apiKey = ""
 		wizard.err = ""
-		wizard.step = providerWizardStepCredential
+		wizard.baseURL = ""
+		wizard.profileName = ""
+		if providerWizardNeedsEndpoint(wizard.currentProvider()) {
+			wizard.step = providerWizardStepEndpoint
+		} else {
+			wizard.step = providerWizardStepCredential
+		}
 		return m, nil
 	case 2: // Remove
 		if strings.TrimSpace(m.userConfigPath) != "" {

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1174,6 +1174,10 @@ func TestProviderWizardManageKeyReplaceGeneric(t *testing.T) {
 		step:               providerWizardStepManageKey,
 		manageProviderName: "my-custom-openai",
 		manageKeyCursor:    1,
+		apiKey:             "stale-key",
+		baseURL:            "https://stale.example.com",
+		profileName:        "stale-profile",
+		err:                "stale error",
 		providers: []providercatalog.Descriptor{
 			{
 				ID:        "custom-openai-compatible",
@@ -1185,6 +1189,9 @@ func TestProviderWizardManageKeyReplaceGeneric(t *testing.T) {
 	next, _ := m.applyManageKeyChoice()
 	if next.providerWizard == nil || next.providerWizard.step != providerWizardStepEndpoint {
 		t.Fatalf("replace for generic provider should route to the endpoint step, got step: %v", next.providerWizard.step)
+	}
+	if next.providerWizard.apiKey != "" || next.providerWizard.baseURL != "" || next.providerWizard.profileName != "" || next.providerWizard.err != "" {
+		t.Fatal("replace should clear stale apiKey/baseURL/profileName/err before routing")
 	}
 }
 

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1167,6 +1167,27 @@ func TestProviderWizardManageKeyReplaceAndKeep(t *testing.T) {
 	}
 }
 
+func TestProviderWizardManageKeyReplaceGeneric(t *testing.T) {
+	m := newModel(context.Background(), Options{UserConfigPath: filepath.Join(t.TempDir(), "config.json")})
+
+	m.providerWizard = &providerWizardState{
+		step:               providerWizardStepManageKey,
+		manageProviderName: "my-custom-openai",
+		manageKeyCursor:    1,
+		providers: []providercatalog.Descriptor{
+			{
+				ID:        "custom-openai-compatible",
+				Transport: providercatalog.TransportOpenAICompatible,
+			},
+		},
+		selectedProvider: 0,
+	}
+	next, _ := m.applyManageKeyChoice()
+	if next.providerWizard == nil || next.providerWizard.step != providerWizardStepEndpoint {
+		t.Fatalf("replace for generic provider should route to the endpoint step, got step: %v", next.providerWizard.step)
+	}
+}
+
 func readProviderWizardConfigFixture(t *testing.T, path string) config.FileConfig {
 	t.Helper()
 


### PR DESCRIPTION
Fixes #375

**Problem:** \wizardProviderStoredKey\ matched saved providers by CatalogID. Since ALL custom OpenAI-compatible providers share CatalogID \custom-openai-compatible\, setting up one blocked configuring a second.

**Fix:**
1. Skip CatalogID matching for generic/custom providers (they all share the same ID)
2. When replacing a key for a generic provider, route through endpoint/name steps so the user enters a new base URL and name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saved provider matching to better handle generic/custom OpenAI-compatible provider IDs, reducing incorrect keep/replace/remove prompts.
  * Updated the “Replace” flow to clear stale connection details and route to the correct next step (endpoint when required; otherwise credentials).
* **Tests**
  * Increased OAuth callback polling/completion timeouts.
  * Added test coverage for generic OpenAI-compatible provider replace routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->