### PR TITLE
fix(tui): title /model rows by model name, not the catalog description

### DIFF
--- a/internal/tui/model_picker_display_test.go
+++ b/internal/tui/model_picker_display_test.go
@@ -1,0 +1,57 @@
+package tui
+
+import "testing"
+
+// The model picker must title each row with the model NAME, not the models.dev
+// marketing description. Regression: Ollama Cloud models resolved full-sentence
+// descriptions from the remote catalog, so rows showed sentences and several
+// models sharing one description looked like exact duplicates (issue: /model
+// list rendered descriptions as titles).
+func TestModelPickerDisplayNamePrefersModelName(t *testing.T) {
+	sentence := "DeepSeek chat model for instruction following, coding, and analysis"
+	cases := []struct {
+		id          string
+		description string
+		want        string
+	}{
+		{"deepseek-v3.2", sentence, "Deepseek V3.2"},
+		{"deepseek-v3.2-thinking", sentence, "Deepseek V3.2 Thinking"},
+		{"glm-5.2", "GLM flagship model", "GLM 5.2"},
+		{"qwen3-coder:480b", "Qwen coding agent model for repository tasks", "Qwen3 Coder 480b"},
+		{"anthropic/claude-sonnet-4.6", "some blurb", "Claude Sonnet 4.6"},
+	}
+	for _, tc := range cases {
+		if got := modelPickerDisplayName(tc.id, tc.description); got != tc.want {
+			t.Errorf("modelPickerDisplayName(%q, %q) = %q, want %q", tc.id, tc.description, got, tc.want)
+		}
+	}
+}
+
+// Two distinct model ids that share the same catalog description must render as
+// distinct rows (the "duplicate-looking rows" symptom), never as the shared
+// sentence.
+func TestModelPickerDisplayNameDistinctForSharedDescription(t *testing.T) {
+	shared := "Mistral coding agent model for repository tasks and software engineering"
+	a := modelPickerDisplayName("codestral-2", shared)
+	b := modelPickerDisplayName("devstral-2", shared)
+	if a == b {
+		t.Fatalf("shared description collapsed rows to the same title: %q", a)
+	}
+	if a == shared || b == shared {
+		t.Fatalf("row title used the description sentence: a=%q b=%q", a, b)
+	}
+}
+
+// With no id to name the row, a non-generic description is still an acceptable
+// fallback; a generic placeholder (or nothing) falls back to "model".
+func TestModelPickerDisplayNameFallsBackToDescriptionOnlyWithoutID(t *testing.T) {
+	if got := modelPickerDisplayName("", "Friendly Name"); got != "Friendly Name" {
+		t.Fatalf("empty id should fall back to the description, got %q", got)
+	}
+	if got := modelPickerDisplayName("", "catalog default"); got != "model" {
+		t.Fatalf("generic description with no id should yield %q, got %q", "model", got)
+	}
+	if got := modelPickerDisplayName("", ""); got != "model" {
+		t.Fatalf("empty id and description should yield %q, got %q", "model", got)
+	}
+}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -452,11 +452,17 @@ func registryModelPickerMeta(entry modelregistry.ModelEntry) string {
 }
 
 func modelPickerDisplayName(id string, description string) string {
-	if description = strings.TrimSpace(description); description != "" && !providerWizardGenericModelDescription(description) {
-		return description
-	}
+	// The row title is the model NAME, not its marketing blurb. Catalog/discovery
+	// descriptions (from models.dev) are full sentences, and several models share
+	// the same one — using them as titles showed sentence-long rows that looked like
+	// exact duplicates and hid the actual id (which only survived in the meta line).
+	// Prefer the (prettified) id; fall back to a non-generic description only when
+	// there is no id to name the row.
 	id = strings.TrimSpace(id)
 	if id == "" {
+		if description = strings.TrimSpace(description); description != "" && !providerWizardGenericModelDescription(description) {
+			return description
+		}
 		return "model"
 	}
 	name := id


### PR DESCRIPTION
## Problem

The `/model` picker rendered rows with sentence-long titles and what looked like exact duplicates, hiding the real model id:

```
Ollama Cloud
  DeepSeek chat model for instruction following, coding, and analysis
> DeepSeek chat model for instruction following, coding, and analysis
  Fast DeepSeek model for efficient chat, coding help, and agent loops
  Mistral coding agent model for repository tasks and software engineer…
  Mistral coding agent model for repository tasks and software engineer…
```

## Root cause

`modelPickerDisplayName(id, description)` returned the **description** as the row title whenever it was non-empty and not a known-generic placeholder. Catalog/discovery descriptions come from **models.dev** as full sentences, and several models share the same sentence — so:

- titles became full sentences instead of `deepseek-v3.2` / `glm-5.2`,
- models sharing a description (e.g. `deepseek-v3.2` and `deepseek-v3.2-thinking`) looked like **duplicate rows**,
- the real id survived only in the meta line (`deepseek-v3.2 · 163K ctx · tools · reasoning`).

The `providerWizardGenericModelDescription` filter only catches placeholders and strings ending in `" model"`, so a sentence ending in `"analysis"` slipped through.

## Fix

Prefer the (prettified) model **id** as the row title; fall back to a non-generic description only when there is no id to name the row. Distinct ids that share a catalog description now render as distinct rows. No data is lost — the ctx/tools/reasoning spec is already in the row's meta line.

```
Ollama Cloud
  Deepseek V3.2
> Deepseek V3.2 Thinking
  Glm 4.6 Flash
  Codestral 2
  Devstral 2
```

## Tests

`internal/tui/model_picker_display_test.go`:
- titles come from the id, not a sentence description (incl. the exact Ollama Cloud scenario, provider-prefixed ids, and `:tag` ids);
- two distinct ids sharing one description render as distinct, non-sentence titles;
- with no id, a non-generic description is still an acceptable fallback (else `"model"`).

`go build ./...`, `go vet ./internal/tui/...`, `gofmt` clean; full `internal/tui` package passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model picker entries now show clearer, more consistent names based on the model ID when available.
  * Fixed cases where different models could appear under the same shared description.
  * Improved fallback behavior so empty or generic entries display a sensible default label.

* **Tests**
  * Added regression coverage for model picker display-name behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->