### PR TITLE
Feat/cli auth autodetect -- restore claude cli integration and auto cli detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Superpowers skill artifacts (brainstorm mockups, specs, plans) — local only
 .superpowers/
 docs/superpowers/
+/.gocache

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .superpowers/
 docs/superpowers/
 /.gocache
+/.claude
+/cascade
+/cascade

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,3 @@ docs/superpowers/
 /.gocache
 /.claude
 /cascade
-/cascade

--- a/cascade/00-task.txt
+++ b/cascade/00-task.txt
@@ -1,5 +1,0 @@
-Full code review of the zero repository (Go 1.25 terminal coding agent, ~134k LOC, 968 files under internal/ and cmd/).
-Goal: surface defects worth fixing — correctness bugs, data races, security issues (credential handling, command execution, sandbox escapes), resource leaks, error-handling gaps, API misuse.
-Priority packages: internal/agent, internal/providers, internal/tools, internal/sessions, internal/sandbox, internal/credstore, internal/oauth, internal/secrets, internal/config, internal/tui, cmd/zero.
-Exceptions only: report high-confidence findings a maintainer would act on, not style nits. Repo is clean on main; fixes will be applied to the working tree.
-Build/test: go build ./... ; go test ./<pkg>/ ; go vet ./...

--- a/cascade/00-task.txt
+++ b/cascade/00-task.txt
@@ -1,0 +1,5 @@
+Full code review of the zero repository (Go 1.25 terminal coding agent, ~134k LOC, 968 files under internal/ and cmd/).
+Goal: surface defects worth fixing — correctness bugs, data races, security issues (credential handling, command execution, sandbox escapes), resource leaks, error-handling gaps, API misuse.
+Priority packages: internal/agent, internal/providers, internal/tools, internal/sessions, internal/sandbox, internal/credstore, internal/oauth, internal/secrets, internal/config, internal/tui, cmd/zero.
+Exceptions only: report high-confidence findings a maintainer would act on, not style nits. Repo is clean on main; fixes will be applied to the working tree.
+Build/test: go build ./... ; go test ./<pkg>/ ; go vet ./...

--- a/cascade/10-findings.cf
+++ b/cascade/10-findings.cf
@@ -1,0 +1,2 @@
+HUMAN: Full review done — agent, tools, providers, sessions, sandbox, oauth, credstore, config, tui, cmd all clean; race+vet pass. Zero findings.
+DONE stage=F find=0 open=0 tok~=190

--- a/cascade/10-findings.cf
+++ b/cascade/10-findings.cf
@@ -1,2 +1,0 @@
-HUMAN: Full review done — agent, tools, providers, sessions, sandbox, oauth, credstore, config, tui, cmd all clean; race+vet pass. Zero findings.
-DONE stage=F find=0 open=0 tok~=190

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1000,6 +1000,34 @@ func TestRunRejectsToolCallsOutsideEnabledList(t *testing.T) {
 	}
 }
 
+// TestToolAllowedByFiltersOnlyBashBlocksDelegation locks the invariant the
+// TUI's /onlybash mode (and the modelregistry "onlybash" preset) relies on:
+// EnabledTools=[bash, skill] is a strict allowlist, so any tool not on it —
+// including "Task", the specialist/subagent delegation tool — is rejected.
+// Onlybash therefore can't spawn a child that escapes the restricted surface;
+// there is no child to propagate the filter to in the first place.
+func TestToolAllowedByFiltersOnlyBashBlocksDelegation(t *testing.T) {
+	onlyBashEnabled := []string{"bash", "skill"}
+	onlyBashDisabled := []string{tools.ToolSearchToolName}
+
+	if ToolAllowedByFilters("Task", onlyBashEnabled, onlyBashDisabled) {
+		t.Fatal("Task should not be allowed under onlybash's EnabledTools allowlist")
+	}
+	if !ToolAllowedByFilters("bash", onlyBashEnabled, onlyBashDisabled) {
+		t.Fatal("bash should be allowed under onlybash")
+	}
+	if !ToolAllowedByFilters("skill", onlyBashEnabled, onlyBashDisabled) {
+		t.Fatal("skill should be allowed under onlybash")
+	}
+	// tool_search is exempted from allowlist rejection (executeToolCall), so the
+	// filter check alone would let it through; the explicit DisabledTools entry
+	// is what actually blocks it. ToolAllowedByFilters reflects that: it denies
+	// tool_search here purely via the DisabledTools branch.
+	if ToolAllowedByFilters(tools.ToolSearchToolName, onlyBashEnabled, onlyBashDisabled) {
+		t.Fatal("tool_search should be denied by onlybash's DisabledTools")
+	}
+}
+
 func TestRunExecutesToolCallThroughRegistry(t *testing.T) {
 	root := t.TempDir()
 	writeAgentTestFile(t, filepath.Join(root, "notes.txt"), "alpha\nbeta\n")

--- a/internal/agentcli/agentcli.go
+++ b/internal/agentcli/agentcli.go
@@ -1,0 +1,379 @@
+// Package agentcli is the single source of truth for detecting installed
+// third-party agent-harness CLIs (Claude Code, Codex, Gemini CLI, ...), probing
+// whether each is logged in, and — where the harness's local credential store is
+// understood — extracting those credentials for reuse by zero's own providers.
+// The onboarding wizard, the provider factory, and the specialist harness
+// launcher all build on this API, so the catalog below is deliberately encoded
+// as data (one line per harness) rather than scattered logic: these third-party
+// CLIs change their binary names, cred-file locations, and CLI flags over time,
+// and a correction should be a one-line edit here rather than a hunt across
+// packages.
+//
+// Login probing is heuristic, not authoritative: a hit means "this harness has
+// a local credential store with something in it," not "the stored token is
+// still valid." Callers that need certainty must still make a real request and
+// handle auth failure.
+package agentcli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// LoginState reports what Detect could establish about a harness's login
+// status from local, non-interactive probes.
+type LoginState int
+
+const (
+	// LoginUnknown means the harness has no known credential-file or keychain
+	// probe (e.g. it is purely API-key driven via environment variables), so
+	// binary presence is all Detect can report.
+	LoginUnknown LoginState = iota
+	// LoggedOut means the harness has at least one probe, but none of them
+	// found a stored credential.
+	LoggedOut
+	// LoggedIn means at least one probe (a credential file or keychain entry)
+	// was found.
+	LoggedIn
+)
+
+// Harness describes one known agent CLI: how to find its binary, how to guess
+// whether it is logged in, and how to invoke it non-interactively for a single
+// prompt.
+type Harness struct {
+	// ID is the stable slug used everywhere else in zero to refer to this
+	// harness ("claude", "codex", ...). Never change an existing ID; downstream
+	// config/state references it by value.
+	ID string
+	// DisplayName is the human-readable name shown in UI ("Claude Code").
+	DisplayName string
+	// Binaries are executable names tried with LookPath, in order. The first
+	// one found on PATH wins.
+	Binaries []string
+	// Vendor is the upstream company slug ("anthropic", "openai", "google",
+	// "alibaba"), or "" for harnesses that are provider-agnostic.
+	Vendor string
+	// CatalogID is the zero providercatalog id whose provider can run directly
+	// on this CLI's extracted credentials, or "" when the harness's credentials
+	// are not reusable that way (either extraction is unsupported, or the
+	// harness has no single backing provider).
+	CatalogID string
+	// CredFiles are $HOME-relative paths whose existence implies a stored
+	// login. Checked in order; any hit is enough.
+	CredFiles []string
+	// KeychainService is the macOS keychain generic-password service name that
+	// holds this harness's credentials, or "" when it does not use the
+	// keychain.
+	KeychainService string
+	// PrintArgs returns the argv (excluding the binary itself) for a one-shot,
+	// non-interactive run of prompt. Never nil for a cataloged harness.
+	PrintArgs func(prompt string) []string
+	// Stream names the stdout format PrintArgs's invocation produces:
+	// "claude-stream-json", "codex-json", "gemini-json", or "text".
+	Stream string
+	// LoginHint is the command to suggest when the harness is installed but not
+	// logged in ("codex login"). Empty when the harness has no known dedicated
+	// login subcommand — LoginCommand falls back to the bare binary name, which
+	// is always a safe suggestion (every one of these CLIs walks the user
+	// through login on first interactive run).
+	LoginHint string
+}
+
+// LoginCommand returns the command to suggest a user run to authenticate this
+// harness: LoginHint when known, otherwise the first binary name.
+func (h Harness) LoginCommand() string {
+	if hint := strings.TrimSpace(h.LoginHint); hint != "" {
+		return hint
+	}
+	if len(h.Binaries) > 0 {
+		return h.Binaries[0]
+	}
+	return h.ID
+}
+
+// Detection is one probed harness: where its binary resolved to, and what
+// Detect could infer about its login state.
+type Detection struct {
+	Harness Harness
+	Path    string // resolved binary path
+	Login   LoginState
+}
+
+// Deps are the side-effecting operations Detect/ExtractCredentials perform,
+// injectable so tests never touch a real PATH, filesystem, or keychain. Any nil
+// field falls back to the real implementation.
+type Deps struct {
+	// LookPath resolves a binary name on PATH; nil -> exec.LookPath.
+	LookPath func(string) (string, error)
+	// Home is the directory CredFiles are resolved relative to; "" ->
+	// os.UserHomeDir().
+	Home string
+	// ReadFile reads a file's contents; nil -> os.ReadFile.
+	ReadFile func(string) ([]byte, error)
+	// Keychain reads a macOS generic password by service name; nil -> the real
+	// implementation via `/usr/bin/security find-generic-password -s <svc> -w`,
+	// and even that real default is only wired up on darwin. An explicitly
+	// injected Keychain always wins regardless of GOOS, so tests can exercise
+	// keychain-backed harnesses portably.
+	Keychain func(service string) ([]byte, error)
+}
+
+var catalog = []Harness{
+	{
+		ID:              "claude",
+		DisplayName:     "Claude Code",
+		Binaries:        []string{"claude"},
+		Vendor:          "anthropic",
+		CatalogID:       "anthropic",
+		CredFiles:       []string{".claude/.credentials.json"},
+		KeychainService: "Claude Code-credentials",
+		PrintArgs: func(prompt string) []string {
+			return []string{"-p", prompt, "--output-format", "stream-json", "--verbose"}
+		},
+		Stream: "claude-stream-json",
+	},
+	{
+		ID:          "codex",
+		DisplayName: "OpenAI Codex CLI",
+		Binaries:    []string{"codex"},
+		Vendor:      "openai",
+		CatalogID:   "chatgpt",
+		CredFiles:   []string{".codex/auth.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"exec", "--json", prompt}
+		},
+		Stream:    "codex-json",
+		LoginHint: "codex login",
+	},
+	{
+		ID:          "gemini",
+		DisplayName: "Gemini CLI",
+		Binaries:    []string{"gemini"},
+		Vendor:      "google",
+		CredFiles:   []string{".gemini/oauth_creds.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"-p", prompt}
+		},
+		Stream: "text",
+	},
+	{
+		ID:          "qwen",
+		DisplayName: "Qwen Code",
+		Binaries:    []string{"qwen"},
+		Vendor:      "alibaba",
+		CredFiles:   []string{".qwen/oauth_creds.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"-p", prompt}
+		},
+		Stream: "text",
+	},
+	{
+		ID:          "opencode",
+		DisplayName: "OpenCode",
+		Binaries:    []string{"opencode"},
+		CredFiles:   []string{".local/share/opencode/auth.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"run", prompt}
+		},
+		Stream: "text",
+	},
+	{
+		ID:          "aider",
+		DisplayName: "Aider",
+		Binaries:    []string{"aider"},
+		// No CredFiles: aider is driven purely by API-key environment variables,
+		// so there is nothing local to probe. Detect reports LoginUnknown.
+		PrintArgs: func(prompt string) []string {
+			return []string{"--message", prompt, "--yes-always", "--no-auto-commits"}
+		},
+		Stream: "text",
+	},
+	{
+		ID:          "goose",
+		DisplayName: "Goose",
+		Binaries:    []string{"goose"},
+		CredFiles:   []string{".config/goose/config.yaml"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"run", "-t", prompt}
+		},
+		Stream: "text",
+	},
+	{
+		ID:          "amp",
+		DisplayName: "Amp",
+		Binaries:    []string{"amp"},
+		CredFiles:   []string{".config/amp/settings.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"-x", prompt}
+		},
+		Stream: "text",
+	},
+	{
+		ID:          "crush",
+		DisplayName: "Crush",
+		Binaries:    []string{"crush"},
+		CredFiles:   []string{".config/crush/crush.json", ".local/share/crush/crush.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"run", "-q", prompt}
+		},
+		Stream: "text",
+	},
+	{
+		ID:          "cursor-agent",
+		DisplayName: "Cursor Agent",
+		Binaries:    []string{"cursor-agent"},
+		CredFiles:   []string{".cursor/cli-config.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"-p", prompt, "--output-format", "stream-json"}
+		},
+		Stream: "claude-stream-json",
+	},
+	{
+		ID:          "copilot",
+		DisplayName: "GitHub Copilot CLI",
+		Binaries:    []string{"copilot"},
+		CredFiles:   []string{".copilot/config.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"-p", prompt}
+		},
+		Stream: "text",
+	},
+	{
+		ID:          "droid",
+		DisplayName: "Factory Droid",
+		Binaries:    []string{"droid"},
+		CredFiles:   []string{".factory/auth.json"},
+		PrintArgs: func(prompt string) []string {
+			return []string{"exec", prompt}
+		},
+		Stream: "text",
+	},
+}
+
+// Harnesses returns the known-CLI catalog, in stable declaration order. It is a
+// copy: callers may not mutate zero's catalog through the returned slice.
+func Harnesses() []Harness {
+	out := make([]Harness, len(catalog))
+	for i, h := range catalog {
+		out[i] = cloneHarness(h)
+	}
+	return out
+}
+
+// Lookup returns the harness registered under id.
+func Lookup(id string) (Harness, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(id))
+	for _, h := range catalog {
+		if h.ID == normalized {
+			return cloneHarness(h), true
+		}
+	}
+	return Harness{}, false
+}
+
+func cloneHarness(h Harness) Harness {
+	h.Binaries = append([]string{}, h.Binaries...)
+	h.CredFiles = append([]string{}, h.CredFiles...)
+	return h
+}
+
+// Detect scans PATH for every known harness and probes login state for each
+// one found. Harnesses whose binary is not on PATH are omitted entirely — a
+// Detection always names a CLI that is actually installed.
+func Detect(deps Deps) []Detection {
+	deps = resolveDeps(deps)
+	out := make([]Detection, 0, len(catalog))
+	for _, h := range catalog {
+		path, found := lookupBinary(h, deps)
+		if !found {
+			continue
+		}
+		out = append(out, Detection{Harness: cloneHarness(h), Path: path, Login: probeLogin(h, deps)})
+	}
+	return out
+}
+
+// DetectOne probes a single harness by id. It reports false when id is not in
+// the catalog or its binary is not on PATH.
+func DetectOne(id string, deps Deps) (Detection, bool) {
+	h, ok := Lookup(id)
+	if !ok {
+		return Detection{}, false
+	}
+	deps = resolveDeps(deps)
+	path, found := lookupBinary(h, deps)
+	if !found {
+		return Detection{}, false
+	}
+	return Detection{Harness: h, Path: path, Login: probeLogin(h, deps)}, true
+}
+
+func lookupBinary(h Harness, deps Deps) (string, bool) {
+	for _, name := range h.Binaries {
+		if path, err := deps.LookPath(name); err == nil {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+// probeLogin applies the heuristic described in the package doc: LoggedIn if
+// any CredFile exists under Home or the keychain probe returns data, LoggedOut
+// if the harness has probes but none hit, LoginUnknown if it has none.
+func probeLogin(h Harness, deps Deps) LoginState {
+	hasKeychainProbe := h.KeychainService != "" && deps.Keychain != nil
+	if len(h.CredFiles) == 0 && !hasKeychainProbe {
+		return LoginUnknown
+	}
+	for _, rel := range h.CredFiles {
+		if _, err := deps.ReadFile(homeJoin(deps.Home, rel)); err == nil {
+			return LoggedIn
+		}
+	}
+	if hasKeychainProbe {
+		if data, err := deps.Keychain(h.KeychainService); err == nil && len(data) > 0 {
+			return LoggedIn
+		}
+	}
+	return LoggedOut
+}
+
+func resolveDeps(deps Deps) Deps {
+	if deps.LookPath == nil {
+		deps.LookPath = exec.LookPath
+	}
+	if deps.Home == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			deps.Home = home
+		}
+	}
+	if deps.ReadFile == nil {
+		deps.ReadFile = os.ReadFile
+	}
+	if deps.Keychain == nil && runtime.GOOS == "darwin" {
+		deps.Keychain = readKeychain
+	}
+	return deps
+}
+
+func homeJoin(home, rel string) string {
+	if home == "" {
+		return rel
+	}
+	return home + string(os.PathSeparator) + rel
+}
+
+// readKeychain is the real Deps.Keychain implementation, wired up only on
+// darwin (see resolveDeps): it shells out to the `security` CLI rather than
+// linking a CGo/keychain-access library, keeping this package stdlib-only.
+func readKeychain(service string) ([]byte, error) {
+	out, err := exec.Command("/usr/bin/security", "find-generic-password", "-s", service, "-w").Output()
+	if err != nil {
+		return nil, fmt.Errorf("agentcli: keychain lookup for %q: %w", service, err)
+	}
+	return bytes.TrimRight(out, "\n"), nil
+}

--- a/internal/agentcli/agentcli.go
+++ b/internal/agentcli/agentcli.go
@@ -17,12 +17,20 @@ package agentcli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 )
+
+// keychainTimeout bounds the `security` shell-out in readKeychain. Without it
+// a stalled keychain (locked/prompting) blocks Detect indefinitely — and
+// agentclicreds.go re-probes credentials on every outbound provider request,
+// so an unbounded hang here would freeze real requests, not just TUI startup.
+const keychainTimeout = 5 * time.Second
 
 // LoginState reports what Detect could establish about a harness's login
 // status from local, non-interactive probes.
@@ -371,7 +379,9 @@ func homeJoin(home, rel string) string {
 // darwin (see resolveDeps): it shells out to the `security` CLI rather than
 // linking a CGo/keychain-access library, keeping this package stdlib-only.
 func readKeychain(service string) ([]byte, error) {
-	out, err := exec.Command("/usr/bin/security", "find-generic-password", "-s", service, "-w").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), keychainTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "/usr/bin/security", "find-generic-password", "-s", service, "-w").Output()
 	if err != nil {
 		return nil, fmt.Errorf("agentcli: keychain lookup for %q: %w", service, err)
 	}

--- a/internal/agentcli/agentcli_test.go
+++ b/internal/agentcli/agentcli_test.go
@@ -1,0 +1,299 @@
+package agentcli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// --- catalog sanity ----------------------------------------------------
+
+func TestCatalogHasUniqueIDs(t *testing.T) {
+	seen := map[string]bool{}
+	for _, h := range Harnesses() {
+		if seen[h.ID] {
+			t.Fatalf("duplicate harness ID %q", h.ID)
+		}
+		seen[h.ID] = true
+	}
+}
+
+func TestCatalogEveryHarnessHasABinary(t *testing.T) {
+	for _, h := range Harnesses() {
+		if len(h.Binaries) == 0 {
+			t.Fatalf("harness %q has no Binaries", h.ID)
+		}
+		for _, bin := range h.Binaries {
+			if strings.TrimSpace(bin) == "" {
+				t.Fatalf("harness %q has a blank binary name", h.ID)
+			}
+		}
+	}
+}
+
+func TestLookupRoundTrip(t *testing.T) {
+	for _, h := range Harnesses() {
+		got, ok := Lookup(h.ID)
+		if !ok {
+			t.Fatalf("Lookup(%q) not found", h.ID)
+		}
+		if got.ID != h.ID || got.DisplayName != h.DisplayName {
+			t.Fatalf("Lookup(%q) = %+v, want %+v", h.ID, got, h)
+		}
+	}
+	if _, ok := Lookup("does-not-exist"); ok {
+		t.Fatal("Lookup of unknown id should report false")
+	}
+}
+
+func TestHarnessesReturnsIndependentCopy(t *testing.T) {
+	first := Harnesses()
+	first[0].Binaries[0] = "mutated"
+	first[0].ID = "mutated"
+	second := Harnesses()
+	if second[0].ID == "mutated" || second[0].Binaries[0] == "mutated" {
+		t.Fatal("Harnesses() must return a copy; mutation leaked into the catalog")
+	}
+}
+
+func TestCatalogPrintArgsEmbedsPrompt(t *testing.T) {
+	const prompt = "unique-prompt-token-xyz"
+	for _, h := range Harnesses() {
+		if h.PrintArgs == nil {
+			t.Fatalf("harness %q has nil PrintArgs", h.ID)
+		}
+		args := h.PrintArgs(prompt)
+		found := false
+		for _, a := range args {
+			if strings.Contains(a, prompt) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("harness %q PrintArgs(%q) = %v, want an arg containing the prompt", h.ID, prompt, args)
+		}
+	}
+}
+
+// --- Detect --------------------------------------------------------------
+
+// fakeLookPath resolves only the given binary names, mapping each to
+// "/fake/bin/<name>".
+func fakeLookPath(found ...string) func(string) (string, error) {
+	set := map[string]bool{}
+	for _, f := range found {
+		set[f] = true
+	}
+	return func(name string) (string, error) {
+		if set[name] {
+			return "/fake/bin/" + name, nil
+		}
+		return "", errors.New("not found")
+	}
+}
+
+func TestDetectOmitsHarnessesNotOnPath(t *testing.T) {
+	deps := Deps{
+		LookPath: fakeLookPath("claude"),
+		Home:     "/home/u",
+		ReadFile: func(string) ([]byte, error) { return nil, errors.New("no such file") },
+		// claude declares KeychainService; inject a stub so this test can't fall
+		// through to the real darwin `security` default and shell out to this
+		// machine's actual Claude Code keychain entry.
+		Keychain: func(string) ([]byte, error) { return nil, errors.New("not found") },
+	}
+	detections := Detect(deps)
+	if len(detections) != 1 {
+		t.Fatalf("Detect() = %d detections, want 1 (only claude on PATH): %+v", len(detections), detections)
+	}
+	if detections[0].Harness.ID != "claude" {
+		t.Fatalf("Detect()[0].Harness.ID = %q, want claude", detections[0].Harness.ID)
+	}
+	if detections[0].Path != "/fake/bin/claude" {
+		t.Fatalf("Detect()[0].Path = %q, want /fake/bin/claude", detections[0].Path)
+	}
+}
+
+func TestDetectLoginStates(t *testing.T) {
+	tests := []struct {
+		name     string
+		harness  string
+		readFile func(string) ([]byte, error)
+		keychain func(string) ([]byte, error)
+		want     LoginState
+	}{
+		{
+			name:    "aider has no probes at all -> unknown",
+			harness: "aider",
+			readFile: func(string) ([]byte, error) {
+				return nil, errors.New("no such file")
+			},
+			want: LoginUnknown,
+		},
+		{
+			name:    "codex cred file present -> logged in",
+			harness: "codex",
+			readFile: func(path string) ([]byte, error) {
+				if strings.HasSuffix(path, ".codex/auth.json") {
+					return []byte(`{}`), nil
+				}
+				return nil, errors.New("no such file")
+			},
+			want: LoggedIn,
+		},
+		{
+			name:    "codex cred file absent -> logged out",
+			harness: "codex",
+			readFile: func(string) ([]byte, error) {
+				return nil, errors.New("no such file")
+			},
+			want: LoggedOut,
+		},
+		{
+			name:    "claude keychain hit -> logged in even without cred file",
+			harness: "claude",
+			readFile: func(string) ([]byte, error) {
+				return nil, errors.New("no such file")
+			},
+			keychain: func(service string) ([]byte, error) {
+				if service == "Claude Code-credentials" {
+					return []byte("secret"), nil
+				}
+				return nil, errors.New("not found")
+			},
+			want: LoggedIn,
+		},
+		{
+			name:    "claude no cred file, no keychain hit -> logged out",
+			harness: "claude",
+			readFile: func(string) ([]byte, error) {
+				return nil, errors.New("no such file")
+			},
+			keychain: func(string) ([]byte, error) {
+				return nil, errors.New("not found")
+			},
+			want: LoggedOut,
+		},
+		{
+			name:    "crush checks the second CredFile entry too",
+			harness: "crush",
+			readFile: func(path string) ([]byte, error) {
+				if strings.HasSuffix(path, ".local/share/crush/crush.json") {
+					return []byte(`{}`), nil
+				}
+				return nil, errors.New("no such file")
+			},
+			want: LoggedIn,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, ok := Lookup(tt.harness)
+			if !ok {
+				t.Fatalf("Lookup(%q) failed", tt.harness)
+			}
+			deps := Deps{
+				LookPath: fakeLookPath(h.Binaries[0]),
+				Home:     "/home/u",
+				ReadFile: tt.readFile,
+				Keychain: tt.keychain,
+			}
+			detections := Detect(deps)
+			if len(detections) != 1 {
+				t.Fatalf("Detect() = %d detections, want 1: %+v", len(detections), detections)
+			}
+			if detections[0].Login != tt.want {
+				t.Fatalf("Login = %v, want %v", detections[0].Login, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectHomeRelativeResolution(t *testing.T) {
+	var seenPath string
+	deps := Deps{
+		LookPath: fakeLookPath("codex"),
+		Home:     "/custom/home",
+		ReadFile: func(path string) ([]byte, error) {
+			seenPath = path
+			return nil, errors.New("no such file")
+		},
+	}
+	Detect(deps)
+	if !strings.HasPrefix(seenPath, "/custom/home") {
+		t.Fatalf("ReadFile path = %q, want it rooted at Home /custom/home", seenPath)
+	}
+	if !strings.HasSuffix(seenPath, ".codex/auth.json") {
+		t.Fatalf("ReadFile path = %q, want suffix .codex/auth.json", seenPath)
+	}
+}
+
+func TestDetectKeychainOnlyConsultedForHarnessesThatDeclareIt(t *testing.T) {
+	calls := map[string]int{}
+	deps := Deps{
+		// Every harness's first binary is "installed" so Detect probes all of them.
+		LookPath: func(name string) (string, error) { return "/fake/bin/" + name, nil },
+		Home:     "/home/u",
+		ReadFile: func(string) ([]byte, error) { return nil, errors.New("no such file") },
+		Keychain: func(service string) ([]byte, error) {
+			calls[service]++
+			return nil, errors.New("not found")
+		},
+	}
+	Detect(deps)
+	if len(calls) != 1 {
+		t.Fatalf("Keychain called for %d distinct services, want 1 (only claude declares KeychainService): %v", len(calls), calls)
+	}
+	if calls["Claude Code-credentials"] == 0 {
+		t.Fatalf("Keychain never called for claude's service: %v", calls)
+	}
+}
+
+func TestDetectOne(t *testing.T) {
+	deps := Deps{
+		LookPath: fakeLookPath("codex"),
+		Home:     "/home/u",
+		ReadFile: func(string) ([]byte, error) { return nil, errors.New("no such file") },
+	}
+	if _, ok := DetectOne("claude", deps); ok {
+		t.Fatal("DetectOne(claude) should fail: not on PATH")
+	}
+	det, ok := DetectOne("codex", deps)
+	if !ok {
+		t.Fatal("DetectOne(codex) should succeed: on PATH")
+	}
+	if det.Harness.ID != "codex" || det.Login != LoggedOut {
+		t.Fatalf("DetectOne(codex) = %+v, want ID=codex Login=LoggedOut", det)
+	}
+	if _, ok := DetectOne("not-a-real-harness", deps); ok {
+		t.Fatal("DetectOne of an unknown id should report false")
+	}
+}
+
+func TestHarnessLoginCommand(t *testing.T) {
+	codex, ok := Lookup("codex")
+	if !ok {
+		t.Fatal("test assumption broken: codex missing from the catalog")
+	}
+	if got := codex.LoginCommand(); got != "codex login" {
+		t.Fatalf("codex.LoginCommand() = %q, want %q (explicit LoginHint)", got, "codex login")
+	}
+
+	claude, ok := Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the catalog")
+	}
+	// claude has no explicit LoginHint — falls back to the first binary name,
+	// which is always a safe suggestion (the CLI walks the user through login
+	// on first interactive run).
+	if got := claude.LoginCommand(); got != "claude" {
+		t.Fatalf("claude.LoginCommand() = %q, want the fallback binary name %q", got, "claude")
+	}
+
+	custom := Harness{ID: "x", LoginHint: "  x auth  ", Binaries: []string{"x"}}
+	if got := custom.LoginCommand(); got != "x auth" {
+		t.Fatalf("LoginCommand() = %q, want the trimmed explicit hint", got)
+	}
+}

--- a/internal/agentcli/credentials.go
+++ b/internal/agentcli/credentials.go
@@ -1,0 +1,148 @@
+package agentcli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Credentials are a harness's stored local credentials, normalized to the
+// shape zero's providers need to reuse them. Fields that don't apply to a
+// given harness are left zero-valued.
+type Credentials struct {
+	APIKey       string    // plain API key, when the CLI stores one
+	AccessToken  string    // OAuth access token
+	RefreshToken string    // OAuth refresh token
+	AccountID    string    // provider account id (e.g. codex's chatgpt-account-id)
+	ExpiresAt    time.Time // zero when unknown
+}
+
+// ExtractCredentials reads and parses h's locally stored credentials.
+//
+// It returns (creds, true, nil) on success, (Credentials{}, false, nil) when h
+// has no reusable credential source (extraction unsupported for this harness)
+// or nothing is currently stored, and a non-nil error only when a credential
+// store was found but could not be parsed (malformed data — a real failure
+// worth surfacing, unlike "not logged in").
+func ExtractCredentials(h Harness, deps Deps) (Credentials, bool, error) {
+	deps = resolveDeps(deps)
+	switch h.ID {
+	case "codex":
+		return extractCodexCredentials(h, deps)
+	case "claude":
+		return extractClaudeCredentials(h, deps)
+	default:
+		return Credentials{}, false, nil
+	}
+}
+
+// codexAuthFile mirrors the relevant subset of ~/.codex/auth.json.
+type codexAuthFile struct {
+	OpenAIAPIKey string `json:"OPENAI_API_KEY"`
+	Tokens       *struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		AccountID    string `json:"account_id"`
+		IDToken      string `json:"id_token"`
+	} `json:"tokens"`
+}
+
+func extractCodexCredentials(h Harness, deps Deps) (Credentials, bool, error) {
+	if len(h.CredFiles) == 0 {
+		return Credentials{}, false, nil
+	}
+	path := homeJoin(deps.Home, h.CredFiles[0])
+	raw, err := deps.ReadFile(path)
+	if err != nil {
+		return Credentials{}, false, nil
+	}
+	var parsed codexAuthFile
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return Credentials{}, false, fmt.Errorf("agentcli: parse %s: %w", path, err)
+	}
+	creds := Credentials{APIKey: parsed.OpenAIAPIKey}
+	if parsed.Tokens != nil {
+		creds.AccessToken = parsed.Tokens.AccessToken
+		creds.RefreshToken = parsed.Tokens.RefreshToken
+		creds.AccountID = parsed.Tokens.AccountID
+	}
+	if creds.APIKey == "" && creds.AccessToken == "" && creds.RefreshToken == "" {
+		return Credentials{}, false, nil
+	}
+	return creds, true, nil
+}
+
+// claudeCredentialsFile mirrors the relevant subset of the JSON blob Claude
+// Code stores both in the macOS keychain (service "Claude Code-credentials")
+// and, as a fallback, at ~/.claude/.credentials.json.
+type claudeCredentialsFile struct {
+	ClaudeAiOauth struct {
+		AccessToken  string `json:"accessToken"`
+		RefreshToken string `json:"refreshToken"`
+		ExpiresAt    int64  `json:"expiresAt"` // unix milliseconds
+	} `json:"claudeAiOauth"`
+}
+
+func extractClaudeCredentials(h Harness, deps Deps) (Credentials, bool, error) {
+	// Try every source in Claude Code's own storage order and take the first
+	// one holding an actual OAuth token. A source merely EXISTING is not enough
+	// to stop the search: the keychain entry can be present while carrying only
+	// MCP-server tokens (no claudeAiOauth key at all) with the real login living
+	// in the credentials file — stopping at the first non-empty blob would
+	// permanently shadow that login.
+	var parseErr error
+	for _, source := range claudeCredentialSources(h, deps) {
+		raw, err := source.read()
+		if err != nil || len(raw) == 0 {
+			continue
+		}
+		var parsed claudeCredentialsFile
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			parseErr = fmt.Errorf("agentcli: parse claude credentials (%s): %w", source.name, err)
+			continue
+		}
+		if parsed.ClaudeAiOauth.AccessToken == "" && parsed.ClaudeAiOauth.RefreshToken == "" {
+			continue
+		}
+		creds := Credentials{
+			AccessToken:  parsed.ClaudeAiOauth.AccessToken,
+			RefreshToken: parsed.ClaudeAiOauth.RefreshToken,
+		}
+		if parsed.ClaudeAiOauth.ExpiresAt > 0 {
+			creds.ExpiresAt = time.UnixMilli(parsed.ClaudeAiOauth.ExpiresAt)
+		}
+		return creds, true, nil
+	}
+	// A malformed source is only worth surfacing when no other source yielded a
+	// token — a usable login elsewhere makes the malformed blob moot.
+	if parseErr != nil {
+		return Credentials{}, false, parseErr
+	}
+	return Credentials{}, false, nil
+}
+
+type claudeCredentialSource struct {
+	name string
+	read func() ([]byte, error)
+}
+
+// claudeCredentialSources lists the places Claude Code stores its login, in
+// the order Claude Code itself consults them: keychain first, then the
+// on-disk credentials file(s).
+func claudeCredentialSources(h Harness, deps Deps) []claudeCredentialSource {
+	sources := []claudeCredentialSource{}
+	if h.KeychainService != "" && deps.Keychain != nil {
+		sources = append(sources, claudeCredentialSource{
+			name: "keychain",
+			read: func() ([]byte, error) { return deps.Keychain(h.KeychainService) },
+		})
+	}
+	for _, file := range h.CredFiles {
+		path := homeJoin(deps.Home, file)
+		sources = append(sources, claudeCredentialSource{
+			name: path,
+			read: func() ([]byte, error) { return deps.ReadFile(path) },
+		})
+	}
+	return sources
+}

--- a/internal/agentcli/credentials_test.go
+++ b/internal/agentcli/credentials_test.go
@@ -1,0 +1,319 @@
+package agentcli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExtractCredentialsUnsupportedHarness(t *testing.T) {
+	h, ok := Lookup("gemini")
+	if !ok {
+		t.Fatal("Lookup(gemini) failed")
+	}
+	creds, ok, err := ExtractCredentials(h, Deps{})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if ok {
+		t.Fatalf("ok = true, want false for a harness with no extractor: %+v", creds)
+	}
+}
+
+// --- codex -----------------------------------------------------------------
+
+func TestExtractCodexCredentials(t *testing.T) {
+	h, ok := Lookup("codex")
+	if !ok {
+		t.Fatal("Lookup(codex) failed")
+	}
+
+	t.Run("full", func(t *testing.T) {
+		deps := Deps{Home: "/home/u", ReadFile: func(path string) ([]byte, error) {
+			return []byte(`{
+				"OPENAI_API_KEY": "sk-plain",
+				"tokens": {
+					"access_token": "at-1",
+					"refresh_token": "rt-1",
+					"account_id": "acct-1",
+					"id_token": "it-1"
+				}
+			}`), nil
+		}}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil || !ok {
+			t.Fatalf("ExtractCredentials: ok=%v err=%v", ok, err)
+		}
+		want := Credentials{APIKey: "sk-plain", AccessToken: "at-1", RefreshToken: "rt-1", AccountID: "acct-1"}
+		if creds != want {
+			t.Fatalf("creds = %+v, want %+v", creds, want)
+		}
+	})
+
+	t.Run("key only", func(t *testing.T) {
+		deps := Deps{Home: "/home/u", ReadFile: func(string) ([]byte, error) {
+			return []byte(`{"OPENAI_API_KEY": "sk-plain"}`), nil
+		}}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil || !ok {
+			t.Fatalf("ExtractCredentials: ok=%v err=%v", ok, err)
+		}
+		if creds.APIKey != "sk-plain" || creds.AccessToken != "" {
+			t.Fatalf("creds = %+v, want only APIKey set", creds)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		deps := Deps{Home: "/home/u", ReadFile: func(string) ([]byte, error) {
+			return nil, errors.New("no such file")
+		}}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil {
+			t.Fatalf("err = %v, want nil for a missing file", err)
+		}
+		if ok {
+			t.Fatalf("ok = true, want false for a missing file: %+v", creds)
+		}
+	})
+
+	t.Run("empty object -> ok false", func(t *testing.T) {
+		deps := Deps{Home: "/home/u", ReadFile: func(string) ([]byte, error) {
+			return []byte(`{}`), nil
+		}}
+		_, ok, err := ExtractCredentials(h, deps)
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if ok {
+			t.Fatal("ok = true, want false for an auth.json with nothing usable in it")
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		deps := Deps{Home: "/home/u", ReadFile: func(string) ([]byte, error) {
+			return []byte(`not json`), nil
+		}}
+		_, ok, err := ExtractCredentials(h, deps)
+		if err == nil {
+			t.Fatal("err = nil, want a parse error for malformed JSON")
+		}
+		if ok {
+			t.Fatal("ok = true, want false alongside the parse error")
+		}
+	})
+
+	t.Run("resolves under Home", func(t *testing.T) {
+		var seenPath string
+		deps := Deps{Home: "/custom/home", ReadFile: func(path string) ([]byte, error) {
+			seenPath = path
+			return nil, errors.New("no such file")
+		}}
+		ExtractCredentials(h, deps)
+		if !strings.HasPrefix(seenPath, "/custom/home") || !strings.HasSuffix(seenPath, ".codex/auth.json") {
+			t.Fatalf("path = %q, want rooted at Home and ending .codex/auth.json", seenPath)
+		}
+	})
+}
+
+// --- claude ------------------------------------------------------------
+
+func TestExtractClaudeCredentials(t *testing.T) {
+	h, ok := Lookup("claude")
+	if !ok {
+		t.Fatal("Lookup(claude) failed")
+	}
+	const blob = `{"claudeAiOauth":{"accessToken":"at-1","refreshToken":"rt-1","expiresAt":1700000000000}}`
+
+	t.Run("keychain hit", func(t *testing.T) {
+		var readFileCalled bool
+		deps := Deps{
+			Home: "/home/u",
+			ReadFile: func(string) ([]byte, error) {
+				readFileCalled = true
+				return nil, errors.New("should not be reached")
+			},
+			Keychain: func(service string) ([]byte, error) {
+				if service != "Claude Code-credentials" {
+					return nil, errors.New("wrong service")
+				}
+				return []byte(blob), nil
+			},
+		}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil || !ok {
+			t.Fatalf("ExtractCredentials: ok=%v err=%v", ok, err)
+		}
+		if readFileCalled {
+			t.Fatal("ReadFile should not be called when the keychain has data")
+		}
+		if creds.AccessToken != "at-1" || creds.RefreshToken != "rt-1" {
+			t.Fatalf("creds = %+v", creds)
+		}
+		wantExpires := time.UnixMilli(1700000000000)
+		if !creds.ExpiresAt.Equal(wantExpires) {
+			t.Fatalf("ExpiresAt = %v, want %v", creds.ExpiresAt, wantExpires)
+		}
+	})
+
+	t.Run("file fallback when keychain misses", func(t *testing.T) {
+		deps := Deps{
+			Home: "/home/u",
+			ReadFile: func(path string) ([]byte, error) {
+				if strings.HasSuffix(path, ".claude/.credentials.json") {
+					return []byte(blob), nil
+				}
+				return nil, errors.New("no such file")
+			},
+			Keychain: func(string) ([]byte, error) {
+				return nil, errors.New("not found")
+			},
+		}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil || !ok {
+			t.Fatalf("ExtractCredentials: ok=%v err=%v", ok, err)
+		}
+		if creds.AccessToken != "at-1" {
+			t.Fatalf("creds = %+v", creds)
+		}
+	})
+
+	t.Run("keychain returns no error but empty data still falls back to file", func(t *testing.T) {
+		// Regression guard for the `len(data) > 0` gate: an err==nil, empty-body
+		// response must not be treated as a hit. Keychain is always explicitly
+		// injected here (never left nil) so the test can't fall through to the
+		// real darwin `security` default and touch this machine's actual
+		// Claude Code keychain entry.
+		deps := Deps{
+			Home: "/home/u",
+			ReadFile: func(path string) ([]byte, error) {
+				if strings.HasSuffix(path, ".claude/.credentials.json") {
+					return []byte(blob), nil
+				}
+				return nil, errors.New("no such file")
+			},
+			Keychain: func(string) ([]byte, error) {
+				return nil, nil
+			},
+		}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil || !ok {
+			t.Fatalf("ExtractCredentials: ok=%v err=%v", ok, err)
+		}
+		if creds.AccessToken != "at-1" {
+			t.Fatalf("creds = %+v", creds)
+		}
+	})
+
+	t.Run("missing everywhere", func(t *testing.T) {
+		deps := Deps{
+			Home:     "/home/u",
+			ReadFile: func(string) ([]byte, error) { return nil, errors.New("no such file") },
+			Keychain: func(string) ([]byte, error) { return nil, errors.New("not found") },
+		}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil {
+			t.Fatalf("err = %v, want nil when nothing is stored", err)
+		}
+		if ok {
+			t.Fatalf("ok = true, want false: %+v", creds)
+		}
+	})
+
+	t.Run("expiresAt zero when absent", func(t *testing.T) {
+		deps := Deps{
+			Home: "/home/u",
+			ReadFile: func(string) ([]byte, error) {
+				return []byte(`{"claudeAiOauth":{"accessToken":"at-1","refreshToken":"rt-1"}}`), nil
+			},
+			Keychain: func(string) ([]byte, error) { return nil, errors.New("not found") },
+		}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil || !ok {
+			t.Fatalf("ExtractCredentials: ok=%v err=%v", ok, err)
+		}
+		if !creds.ExpiresAt.IsZero() {
+			t.Fatalf("ExpiresAt = %v, want zero value", creds.ExpiresAt)
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		deps := Deps{
+			Home:     "/home/u",
+			ReadFile: func(string) ([]byte, error) { return []byte(`not json`), nil },
+			Keychain: func(string) ([]byte, error) { return nil, errors.New("not found") },
+		}
+		_, ok, err := ExtractCredentials(h, deps)
+		if err == nil {
+			t.Fatal("err = nil, want a parse error for malformed JSON")
+		}
+		if ok {
+			t.Fatal("ok = true, want false alongside the parse error")
+		}
+	})
+}
+
+// TestExtractClaudeCredentialsKeychainWithoutOauthFallsThrough locks the fix
+// for a real-world shadowing bug: the keychain entry can exist while holding
+// only MCP-server tokens (a JSON blob with no claudeAiOauth key), with the
+// actual login stored in ~/.claude/.credentials.json. Extraction must fall
+// through to the file instead of stopping at the first non-empty source.
+func TestExtractClaudeCredentialsKeychainWithoutOauthFallsThrough(t *testing.T) {
+	h, ok := Lookup("claude")
+	if !ok {
+		t.Fatal("Lookup(claude) failed")
+	}
+	fileBlob := `{"claudeAiOauth":{"accessToken":"at-file","refreshToken":"rt-file","expiresAt":1700000000000}}`
+
+	t.Run("keychain holds only mcp tokens", func(t *testing.T) {
+		deps := Deps{
+			Home: "/home/u",
+			Keychain: func(string) ([]byte, error) {
+				return []byte(`{"mcpOAuth":{"some-server|abc":{"accessToken":"mcp"}}}`), nil
+			},
+			ReadFile: func(path string) ([]byte, error) {
+				if path != "/home/u/.claude/.credentials.json" {
+					return nil, errors.New("unexpected path " + path)
+				}
+				return []byte(fileBlob), nil
+			},
+		}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil || !ok {
+			t.Fatalf("ExtractCredentials: ok=%v err=%v", ok, err)
+		}
+		if creds.AccessToken != "at-file" {
+			t.Fatalf("AccessToken = %q, want the file's token (keychain blob shadowed the file)", creds.AccessToken)
+		}
+	})
+
+	t.Run("malformed keychain blob still reaches the file", func(t *testing.T) {
+		deps := Deps{
+			Home:     "/home/u",
+			Keychain: func(string) ([]byte, error) { return []byte(`{not json`), nil },
+			ReadFile: func(string) ([]byte, error) { return []byte(fileBlob), nil },
+		}
+		creds, ok, err := ExtractCredentials(h, deps)
+		if err != nil || !ok {
+			t.Fatalf("ExtractCredentials: ok=%v err=%v", ok, err)
+		}
+		if creds.AccessToken != "at-file" {
+			t.Fatalf("AccessToken = %q, want the file's token", creds.AccessToken)
+		}
+	})
+
+	t.Run("malformed keychain surfaces only when nothing else has a token", func(t *testing.T) {
+		deps := Deps{
+			Home:     "/home/u",
+			Keychain: func(string) ([]byte, error) { return []byte(`{not json`), nil },
+			ReadFile: func(string) ([]byte, error) { return nil, errors.New("missing") },
+		}
+		_, ok, err := ExtractCredentials(h, deps)
+		if ok {
+			t.Fatal("no source held a token, ok must be false")
+		}
+		if err == nil {
+			t.Fatal("the malformed keychain blob should surface once no other source yields a token")
+		}
+	})
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/hooks"
 	"github.com/Gitlawb/zero/internal/localcontrol"
@@ -53,9 +54,14 @@ type appDeps struct {
 	// config.SetActiveProviderEnv, set in defaultAppDeps — deliberately NOT filled
 	// by fillAppDeps, so tests never mutate the process environment unless they
 	// inject it). nil ⇒ no export.
-	exportActiveProvider  func(providerName string)
-	probeProviderHealth   func(context.Context, providerhealth.Options) providerhealth.Result
-	detectLocalRuntimes   func(context.Context, provideronboarding.LocalDetectOptions) []provideronboarding.DetectedLocalRuntime
+	exportActiveProvider func(providerName string)
+	probeProviderHealth  func(context.Context, providerhealth.Options) providerhealth.Result
+	detectLocalRuntimes  func(context.Context, provideronboarding.LocalDetectOptions) []provideronboarding.DetectedLocalRuntime
+	// detectAgentCLIs probes the machine for installed agent-CLI harnesses
+	// (Claude Code, Codex, ...) — production: agentcli.Detect with the real
+	// (zero-value) Deps. Tests inject a fake so `zero auth status` and the
+	// credential-advice surfaces never touch a real PATH/keychain.
+	detectAgentCLIs       func(agentcli.Deps) []agentcli.Detection
 	newSessionStore       func() *sessions.Store
 	loadPlugins           func(plugins.LoadOptions) (plugins.LoadResult, error)
 	loadHooks             func(hooks.LoadOptions) (hooks.LoadResult, error)
@@ -136,6 +142,7 @@ func defaultAppDeps() appDeps {
 		},
 		probeProviderHealth: providerhealth.Probe,
 		detectLocalRuntimes: provideronboarding.DetectLocalRuntimes,
+		detectAgentCLIs:     agentcli.Detect,
 		newSessionStore: func() *sessions.Store {
 			return sessions.NewStore(sessions.StoreOptions{})
 		},
@@ -434,6 +441,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.detectLocalRuntimes == nil {
 		deps.detectLocalRuntimes = defaults.detectLocalRuntimes
+	}
+	if deps.detectAgentCLIs == nil {
+		deps.detectAgentCLIs = defaults.detectAgentCLIs
 	}
 	if deps.newSessionStore == nil {
 		deps.newSessionStore = defaults.newSessionStore
@@ -1116,11 +1126,11 @@ func splitLeadingThemeFlag(args []string) (string, []string, error) {
 }
 
 // profileHasCredential reports whether the profile can authenticate: a direct API
-// key, an auth-header value, or an APIKeyEnv whose environment variable is set. The
-// setup result is not env-resolved, so checking APIKey alone would wrongly flag every
-// env-var-based provider as keyless.
+// key, an auth-header value, an APIKeyEnv whose environment variable is set, or a
+// reused agent-CLI login (AuthCLI). The setup result is not env-resolved, so
+// checking APIKey alone would wrongly flag every env-var-based provider as keyless.
 func profileHasCredential(profile config.ProviderProfile) bool {
-	if strings.TrimSpace(profile.APIKey) != "" || profile.APIKeyStored || strings.TrimSpace(profile.AuthHeaderValue) != "" {
+	if profile.HasConfiguredCredential() {
 		return true
 	}
 	if env := strings.TrimSpace(profile.APIKeyEnv); env != "" {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -63,30 +63,35 @@ type appDeps struct {
 	// (Claude Code, Codex, ...) — production: agentcli.Detect with the real
 	// (zero-value) Deps. Tests inject a fake so `zero auth status` and the
 	// credential-advice surfaces never touch a real PATH/keychain.
-	detectAgentCLIs       func(agentcli.Deps) []agentcli.Detection
-	newSessionStore       func() *sessions.Store
-	loadPlugins           func(plugins.LoadOptions) (plugins.LoadResult, error)
-	loadHooks             func(hooks.LoadOptions) (hooks.LoadResult, error)
-	skillsDir             func() string
-	pluginsDir            func() string
-	toolsDir              func() string
-	newMCPStore           func() (*mcp.PermissionStore, error)
-	newMCPTokenStore      func() (*mcp.TokenStore, error)
-	newSandboxStore       func() (*sandbox.GrantStore, error)
-	selectSandboxBackend  func(sandbox.BackendOptions) sandbox.Backend
-	runSandboxSetupHelper func(path string, args []string, stdout io.Writer, stderr io.Writer) error
-	registerMCPTools      func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error)
-	prepareWorktree       func(context.Context, worktrees.Options) (worktrees.Result, error)
-	detectVerifyPlan      func(string) (verify.Plan, error)
-	runVerify             func(context.Context, verify.Plan, verify.RunOptions) verify.Report
-	runSelfVerify         func(context.Context, verify.Plan, selfverify.Options) selfverify.Report
-	runAgentEval          func(context.Context, agentEvalOptions) (agentEvalReport, error)
-	inspectChanges        func(context.Context, zerogit.InspectOptions) (zerogit.ChangeSummary, error)
-	commitChanges         func(context.Context, zerogit.CommitOptions) (zerogit.CommitResult, error)
-	runTUI                func(context.Context, tui.Options) int
-	runEditor             func(string) error
-	checkUpdate           func(context.Context, update.Options) (update.Result, error)
-	now                   func() time.Time
+	detectAgentCLIs func(agentcli.Deps) []agentcli.Detection
+	// extractAgentCLICredentials reads a detected harness's local credential
+	// store — production: agentcli.ExtractCredentials. Tests inject a fake so
+	// `providers models`'s AuthCLI discovery branch (discoveryCredentialProfile)
+	// never touches a real PATH/filesystem/keychain.
+	extractAgentCLICredentials func(agentcli.Harness, agentcli.Deps) (agentcli.Credentials, bool, error)
+	newSessionStore            func() *sessions.Store
+	loadPlugins                func(plugins.LoadOptions) (plugins.LoadResult, error)
+	loadHooks                  func(hooks.LoadOptions) (hooks.LoadResult, error)
+	skillsDir                  func() string
+	pluginsDir                 func() string
+	toolsDir                   func() string
+	newMCPStore                func() (*mcp.PermissionStore, error)
+	newMCPTokenStore           func() (*mcp.TokenStore, error)
+	newSandboxStore            func() (*sandbox.GrantStore, error)
+	selectSandboxBackend       func(sandbox.BackendOptions) sandbox.Backend
+	runSandboxSetupHelper      func(path string, args []string, stdout io.Writer, stderr io.Writer) error
+	registerMCPTools           func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error)
+	prepareWorktree            func(context.Context, worktrees.Options) (worktrees.Result, error)
+	detectVerifyPlan           func(string) (verify.Plan, error)
+	runVerify                  func(context.Context, verify.Plan, verify.RunOptions) verify.Report
+	runSelfVerify              func(context.Context, verify.Plan, selfverify.Options) selfverify.Report
+	runAgentEval               func(context.Context, agentEvalOptions) (agentEvalReport, error)
+	inspectChanges             func(context.Context, zerogit.InspectOptions) (zerogit.ChangeSummary, error)
+	commitChanges              func(context.Context, zerogit.CommitOptions) (zerogit.CommitResult, error)
+	runTUI                     func(context.Context, tui.Options) int
+	runEditor                  func(string) error
+	checkUpdate                func(context.Context, update.Options) (update.Result, error)
+	now                        func() time.Time
 }
 
 type mcpToolRuntime interface {
@@ -142,10 +147,11 @@ func defaultAppDeps() appDeps {
 				OAuthLoginKey: loginKey,
 			})
 		},
-		probeProviderHealth:    providerhealth.Probe,
-		discoverProviderModels: defaultDiscoverProviderModels,
-		detectLocalRuntimes:    provideronboarding.DetectLocalRuntimes,
-		detectAgentCLIs:        agentcli.Detect,
+		probeProviderHealth:        providerhealth.Probe,
+		discoverProviderModels:     defaultDiscoverProviderModels,
+		detectLocalRuntimes:        provideronboarding.DetectLocalRuntimes,
+		detectAgentCLIs:            agentcli.Detect,
+		extractAgentCLICredentials: agentcli.ExtractCredentials,
 		newSessionStore: func() *sessions.Store {
 			return sessions.NewStore(sessions.StoreOptions{})
 		},
@@ -458,6 +464,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.detectAgentCLIs == nil {
 		deps.detectAgentCLIs = defaults.detectAgentCLIs
+	}
+	if deps.extractAgentCLICredentials == nil {
+		deps.extractAgentCLICredentials = defaults.extractAgentCLICredentials
 	}
 	if deps.newSessionStore == nil {
 		deps.newSessionStore = defaults.newSessionStore

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/provideroauth"
@@ -41,6 +42,8 @@ func runAuth(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return runAuthOpenRouter(args[1:], stdout, stderr, deps)
 	case "chatgpt":
 		return runAuthChatGPT(args[1:], stdout, stderr, deps)
+	case "claude":
+		return runAuthClaude(args[1:], stdout, stderr, deps)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown auth subcommand %q", args[0]))
 	}
@@ -139,6 +142,53 @@ func runAuthChatGPT(args []string, stdout io.Writer, stderr io.Writer, deps appD
 		return exitCrash
 	}
 	if _, err := fmt.Fprint(stdout, "\nUse it with zero, e.g.:\n  zero --provider chatgpt --model gpt-5.5\n"); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+// runAuthClaude runs zero's own "Sign in with Claude" paste-code PKCE login
+// and persists the chain under the key the claude CLI-auth resolver reads
+// FIRST (providers.claudeRefreshingBearerResolver's cache). This exists
+// because borrowing the claude CLI's stored login is unreliable on machines
+// where newer Claude Code versions keep their live chain in per-install
+// keychain entries: detection sees "logged in" while every readable token is
+// an abandoned, unrefreshable chain. A login zero owns sidesteps the CLI's
+// storage entirely and self-refreshes via RefreshClaudeCode.
+func runAuthClaude(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	for _, a := range args {
+		if a == "-h" || a == "--help" || a == "help" {
+			_ = writeAuthHelp(stdout)
+			return exitSuccess
+		}
+	}
+	if len(args) > 0 {
+		return writeExecUsageError(stderr, fmt.Sprintf("zero auth claude takes no arguments (got %q)", args[0]))
+	}
+
+	token, err := provideroauth.ClaudeCodeLogin(context.Background(), provideroauth.ClaudeCodeLoginOptions{
+		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+		Out:        stdout,
+		// Print the URL rather than auto-opening a browser, matching the
+		// posture of the other auth subcommands.
+		OpenBrowser: func(string) error { return nil },
+	})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+
+	store, err := oauth.NewStore(oauth.StoreOptions{Now: deps.now})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if err := store.Save("provider:authcli-claude", token); err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	account := ""
+	if strings.TrimSpace(token.Account) != "" {
+		account = " as " + token.Account
+	}
+	if _, err := fmt.Fprintf(stdout, "\nClaude sign-in complete%s — token stored; zero refreshes it automatically.\nUse it with a claude CLI-auth profile, e.g.:\n  zero --provider claude\n", account); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
@@ -393,22 +443,108 @@ func runAuthStatus(args []string, stdout io.Writer, stderr io.Writer, deps appDe
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
-	if len(parsed.positional) == 1 {
+	filtered := len(parsed.positional) == 1
+	if filtered {
 		statuses = filterAuthStatuses(statuses, parsed.positional[0])
+	}
+	// Detected agent CLIs (Claude Code, Codex, ...) are a second, independent
+	// auth surface from zero's own OAuth store — only shown on the unfiltered
+	// `zero auth status` (a `zero auth status <provider>` query is about one
+	// zero-native login, not the whole-machine CLI inventory).
+	var agentCLIs []authAgentCLIStatus
+	if !filtered {
+		agentCLIs = agentCLIAuthStatuses(deps)
 	}
 	if parsed.json {
 		payload := struct {
-			Logins []oauth.Status `json:"logins"`
-		}{Logins: statuses}
+			Logins    []oauth.Status       `json:"logins"`
+			AgentCLIs []authAgentCLIStatus `json:"agentCLIs,omitempty"`
+		}{Logins: statuses, AgentCLIs: agentCLIs}
 		if err := writePrettyJSON(stdout, payload); err != nil {
 			return exitCrash
 		}
 		return exitSuccess
 	}
-	if _, err := fmt.Fprintln(stdout, oauth.FormatStatuses(statuses)); err != nil {
+	out := oauth.FormatStatuses(statuses)
+	if section := formatAgentCLIStatuses(agentCLIs); section != "" {
+		out += "\n\n" + section
+	}
+	if _, err := fmt.Fprintln(stdout, out); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
+}
+
+// authAgentCLIStatus is one detected agent-CLI harness's login state and,
+// when a zero provider profile is configured to reuse it (profile.AuthCLI ==
+// harness.ID), that profile's name.
+type authAgentCLIStatus struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	LoggedIn    bool   `json:"loggedIn"`
+	Reusable    bool   `json:"reusable"`
+	Profile     string `json:"profile,omitempty"`
+}
+
+// agentCLIAuthStatuses lists every agent CLI detected on this machine, its
+// probed login state, and which zero provider profile (if any) reuses its
+// credentials. Config resolution is best-effort: a failure to resolve the
+// workspace config just means every row reports no profile, never an error —
+// `zero auth status` must not fail because the CWD has no zero config.
+func agentCLIAuthStatuses(deps appDeps) []authAgentCLIStatus {
+	detect := deps.detectAgentCLIs
+	if detect == nil {
+		detect = agentcli.Detect
+	}
+	detections := detect(agentcli.Deps{})
+	if len(detections) == 0 {
+		return nil
+	}
+	profileByCLI := map[string]string{}
+	if workspaceRoot, err := resolveWorkspaceRoot("", deps); err == nil {
+		if resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{}); err == nil {
+			for _, profile := range resolved.Providers {
+				if authCLI := strings.TrimSpace(profile.AuthCLI); authCLI != "" {
+					profileByCLI[authCLI] = profile.Name
+				}
+			}
+		}
+	}
+	out := make([]authAgentCLIStatus, 0, len(detections))
+	for _, detection := range detections {
+		out = append(out, authAgentCLIStatus{
+			ID:          detection.Harness.ID,
+			DisplayName: detection.Harness.DisplayName,
+			LoggedIn:    detection.Login == agentcli.LoggedIn,
+			Reusable:    detection.Harness.CatalogID != "",
+			Profile:     profileByCLI[detection.Harness.ID],
+		})
+	}
+	return out
+}
+
+// formatAgentCLIStatuses renders the "Detected agent CLIs" section for the
+// text (non-JSON) `zero auth status` output. Empty when nothing was detected.
+func formatAgentCLIStatuses(statuses []authAgentCLIStatus) string {
+	if len(statuses) == 0 {
+		return ""
+	}
+	lines := []string{"Detected agent CLIs:"}
+	for _, status := range statuses {
+		state := "not logged in"
+		if status.LoggedIn {
+			state = "logged in"
+		}
+		line := fmt.Sprintf("  %s (%s) — %s", status.ID, status.DisplayName, state)
+		switch {
+		case !status.Reusable:
+			line += " — sub-agent harness only, no reusable provider credentials"
+		case status.Profile != "":
+			line += fmt.Sprintf(" — used by profile %q", status.Profile)
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func runAuthRefresh(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -485,6 +621,7 @@ Commands:
   refresh <provider> [--watch]                    Force a token refresh (--watch keeps it fresh)
   openrouter                                      Log in to OpenRouter in the browser; mints an API key
   chatgpt                                         Log in to ChatGPT in the browser (Codex backend, ChatGPT Plus/Pro)
+  claude                                          Sign in with Claude (paste-code flow; Claude subscription auth)
 
 A provider is any OAuth 2.0 / OIDC server. "openrouter" ('zero auth openrouter')
 works out of the box. "xai" ('zero auth login xai') uses a built-in preset that is

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
 )
 
@@ -154,5 +156,107 @@ func TestRunAuthHelp(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("help missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+// authTestAgentCLIDeps stubs appDeps.detectAgentCLIs and resolveConfig so
+// `zero auth status`'s "Detected agent CLIs" section is exercised hermetically
+// — never touching the real PATH, filesystem, or which providers happen to be
+// configured on the machine running the test.
+func authTestAgentCLIDeps(t *testing.T, detections []agentcli.Detection, providers []config.ProviderProfile) appDeps {
+	t.Helper()
+	return appDeps{
+		detectAgentCLIs: func(agentcli.Deps) []agentcli.Detection { return detections },
+		getwd:           func() (string, error) { return t.TempDir(), nil },
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{Providers: providers}, nil
+		},
+	}
+}
+
+func TestRunAuthStatusListsDetectedAgentCLIs(t *testing.T) {
+	withAuthStore(t)
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	codexHarness, ok := agentcli.Lookup("codex")
+	if !ok {
+		t.Fatal("test assumption broken: codex missing from the agentcli catalog")
+	}
+	geminiHarness, ok := agentcli.Lookup("gemini")
+	if !ok {
+		t.Fatal("test assumption broken: gemini missing from the agentcli catalog")
+	}
+	deps := authTestAgentCLIDeps(t,
+		[]agentcli.Detection{
+			{Harness: claudeHarness, Login: agentcli.LoggedIn},
+			{Harness: codexHarness, Login: agentcli.LoggedOut},
+			{Harness: geminiHarness, Login: agentcli.LoggedOut},
+		},
+		[]config.ProviderProfile{{Name: "my-claude", CatalogID: "anthropic", AuthCLI: "claude"}},
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "status"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Detected agent CLIs:") {
+		t.Fatalf("status output missing the agent-CLI section: %q", out)
+	}
+	if !strings.Contains(out, "claude") || !strings.Contains(out, "logged in") {
+		t.Fatalf("status output missing claude's logged-in state: %q", out)
+	}
+	if !strings.Contains(out, `used by profile "my-claude"`) {
+		t.Fatalf("status output should attribute claude to the my-claude profile: %q", out)
+	}
+	if !strings.Contains(out, "codex") || !strings.Contains(out, "not logged in") {
+		t.Fatalf("status output missing codex's logged-out state: %q", out)
+	}
+	if !strings.Contains(out, "gemini") || !strings.Contains(out, "sub-agent harness only") {
+		t.Fatalf("status output should note gemini has no reusable provider credentials: %q", out)
+	}
+}
+
+// TestRunAuthStatusFilteredByProviderOmitsAgentCLIs locks in that the
+// agent-CLI section only appears on the unfiltered `zero auth status` — a
+// `zero auth status <provider>` query is about one zero-native OAuth login,
+// not the whole-machine CLI inventory.
+func TestRunAuthStatusFilteredByProviderOmitsAgentCLIs(t *testing.T) {
+	withAuthStore(t)
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	deps := authTestAgentCLIDeps(t, []agentcli.Detection{{Harness: claudeHarness, Login: agentcli.LoggedIn}}, nil)
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "status", "demo"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Detected agent CLIs:") {
+		t.Fatalf("filtered status should not include the agent-CLI section: %q", stdout.String())
+	}
+}
+
+func TestRunAuthStatusJSONIncludesAgentCLIs(t *testing.T) {
+	withAuthStore(t)
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	deps := authTestAgentCLIDeps(t, []agentcli.Detection{{Harness: claudeHarness, Login: agentcli.LoggedIn}}, nil)
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "status", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"id": "claude"`) {
+		t.Fatalf("JSON status missing agentCLIs[].id: %s", out)
+	}
+	if !strings.Contains(out, `"loggedIn": true`) {
+		t.Fatalf("JSON status missing agentCLIs[].loggedIn: %s", out)
 	}
 }

--- a/internal/cli/provider_detect.go
+++ b/internal/cli/provider_detect.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/provideronboarding"
 )
@@ -65,8 +66,13 @@ func runProvidersDetect(args []string, stdout io.Writer, stderr io.Writer, deps 
 	ctx, stop := signalContext()
 	defer stop()
 	detected := deps.detectLocalRuntimes(ctx, provideronboarding.LocalDetectOptions{})
+	detectAgentCLIs := deps.detectAgentCLIs
+	if detectAgentCLIs == nil {
+		detectAgentCLIs = agentcli.Detect
+	}
+	agentCLIs := detectAgentCLIs(agentcli.Deps{})
 
-	report := buildProviderDetectReport(resolved, detected)
+	report := buildProviderDetectReport(resolved, detected, agentCLIs)
 
 	if options.json {
 		if err := writePrettyJSON(stdout, report); err != nil {
@@ -95,7 +101,7 @@ func parseProviderDetectArgs(args []string) (providerDetectOptions, bool, error)
 	return options, false, nil
 }
 
-func buildProviderDetectReport(resolved config.ResolvedConfig, detected []provideronboarding.DetectedLocalRuntime) providerDetectReport {
+func buildProviderDetectReport(resolved config.ResolvedConfig, detected []provideronboarding.DetectedLocalRuntime, agentCLIs []agentcli.Detection) providerDetectReport {
 	report := providerDetectReport{
 		DetectedRuntimes: make([]providerDetectRuntime, 0, len(detected)),
 		Providers:        make([]providerDetectProvider, 0, len(resolved.Providers)),
@@ -111,7 +117,7 @@ func buildProviderDetectReport(resolved config.ResolvedConfig, detected []provid
 	}
 	for _, profile := range resolved.Providers {
 		active := strings.TrimSpace(profile.Name) != "" && profile.Name == resolved.ActiveProvider
-		state := provideronboarding.ProviderState{Profile: profile, Active: active}
+		state := provideronboarding.ProviderState{Profile: profile, Active: active, Detections: agentCLIs}
 		actions := state.Actions()
 		entry := providerDetectProvider{
 			Name:    profile.Name,

--- a/internal/cli/provider_detect_test.go
+++ b/internal/cli/provider_detect_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/provideronboarding"
 )
@@ -103,5 +104,41 @@ func TestRunProvidersDetectJSONNoRuntimesActiveProvider(t *testing.T) {
 	}
 	if len(payload.Providers[0].Actions) != 1 || payload.Providers[0].Actions[0].Label != "Check provider" {
 		t.Fatalf("expected only a Check action for an active keyed provider, got %#v", payload.Providers[0].Actions)
+	}
+}
+
+// TestRunProvidersDetectSurfacesAgentCLIHint pins the AuthCLI wiring in
+// runProvidersDetect: without deps.detectAgentCLIs plumbed into
+// buildProviderDetectReport, a keyless provider's "Set API key" action would
+// never mention a detected, logged-in agent CLI as an alternative.
+func TestRunProvidersDetectSurfacesAgentCLIHint(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	deps.detectLocalRuntimes = func(context.Context, provideronboarding.LocalDetectOptions) []provideronboarding.DetectedLocalRuntime {
+		return nil
+	}
+	deps.detectAgentCLIs = func(agentcli.Deps) []agentcli.Detection {
+		return []agentcli.Detection{{
+			Harness: agentcli.Harness{DisplayName: "Claude Code", CatalogID: "anthropic"},
+			Login:   agentcli.LoggedIn,
+		}}
+	}
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{
+			Name:         "anthropic",
+			ProviderKind: config.ProviderKindAnthropic,
+			CatalogID:    "anthropic",
+			Model:        "claude-sonnet",
+		}
+		return config.ResolvedConfig{ActiveProvider: "other", Providers: []config.ProviderProfile{profile}}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "detect", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exit=%d stderr=%s", exitCode, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Or reuse your Claude Code") {
+		t.Fatalf("detect JSON missing the agent-CLI credential hint (detectAgentCLIs result never reached the report):\n%s", out)
 	}
 }

--- a/internal/cli/provider_models.go
+++ b/internal/cli/provider_models.go
@@ -47,7 +47,7 @@ func runProvidersModels(args []string, stdout io.Writer, stderr io.Writer, deps 
 
 	ctx, stop := signalContext()
 	defer stop()
-	models, err := deps.discoverProviderModels(ctx, discoveryCredentialProfile(profile))
+	models, err := deps.discoverProviderModels(ctx, discoveryCredentialProfile(profile, deps.extractAgentCLICredentials))
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitProvider)
 	}
@@ -106,8 +106,10 @@ func runProvidersModels(args []string, stdout io.Writer, stderr io.Writer, deps 
 // discoveryCredentialProfile resolves the profile's API key the same way the
 // runtime does — inline, then the stored credential, then the configured env var —
 // so a `providers models` probe authenticates exactly like a real request. Mirrors
-// discoveredModelContextWindow's credential resolution.
-func discoveryCredentialProfile(profile config.ProviderProfile) config.ProviderProfile {
+// discoveredModelContextWindow's credential resolution. extractCreds is
+// deps.extractAgentCLICredentials (agentcli.ExtractCredentials in production);
+// injectable so the AuthCLI branch is testable without a real PATH/keychain.
+func discoveryCredentialProfile(profile config.ProviderProfile, extractCreds func(agentcli.Harness, agentcli.Deps) (agentcli.Credentials, bool, error)) config.ProviderProfile {
 	authed := profile
 	// An AuthCLI profile (e.g. Claude Code) has no API key: its credential is a
 	// live bearer read from the harness's local store. Resolve it first and stamp
@@ -117,7 +119,7 @@ func discoveryCredentialProfile(profile config.ProviderProfile) config.ProviderP
 	// live provider sends). Non-AuthCLI profiles fall through to the key paths.
 	if strings.TrimSpace(authed.AuthCLI) != "" {
 		if harness, ok := agentcli.Lookup(authed.AuthCLI); ok && harness.CatalogID != "" {
-			if creds, ok, err := agentcli.ExtractCredentials(harness, agentcli.Deps{}); err == nil && ok {
+			if creds, ok, err := extractCreds(harness, agentcli.Deps{}); err == nil && ok {
 				authed = applyAuthCLIDiscoveryCredential(authed, harness.CatalogID, creds)
 			}
 		}

--- a/internal/cli/provider_models_test.go
+++ b/internal/cli/provider_models_test.go
@@ -206,3 +206,40 @@ func TestApplyAuthCLIDiscoveryCredential(t *testing.T) {
 		}
 	})
 }
+
+// TestRunProvidersModelsAuthCLIDispatchUsesInjectedCredentialExtraction covers
+// the full discoveryCredentialProfile AuthCLI branch — harness lookup PLUS
+// credential extraction — through deps.extractAgentCLICredentials, not just
+// the pure applyAuthCLIDiscoveryCredential helper above. Before this seam
+// existed, this branch called agentcli.ExtractCredentials directly and could
+// only be exercised by touching a real PATH/filesystem/keychain.
+func TestRunProvidersModelsAuthCLIDispatchUsesInjectedCredentialExtraction(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{Name: "claude-code", ProviderKind: config.ProviderKindAnthropic, AuthCLI: "claude", Model: "claude-sonnet-4.5"}
+		return config.ResolvedConfig{ActiveProvider: "claude-code", Providers: []config.ProviderProfile{profile}, Provider: profile, MaxTurns: 7}, nil
+	}
+	var extractCalledWith agentcli.Harness
+	deps.extractAgentCLICredentials = func(h agentcli.Harness, _ agentcli.Deps) (agentcli.Credentials, bool, error) {
+		extractCalledWith = h
+		return agentcli.Credentials{AccessToken: "tok-from-fake"}, true, nil
+	}
+	var probed config.ProviderProfile
+	deps.discoverProviderModels = func(_ context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+		probed = profile
+		return nil, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "models"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", exitCode, exitSuccess, stderr.String())
+	}
+	if extractCalledWith.ID != "claude" {
+		t.Fatalf("extractAgentCLICredentials called with harness %#v, want claude", extractCalledWith)
+	}
+	if probed.AuthHeaderValue != "Bearer tok-from-fake" {
+		t.Fatalf("probed.AuthHeaderValue = %q, want the fake-extracted token, proving the injected seam (not a real ExtractCredentials call) fed the discovery request", probed.AuthHeaderValue)
+	}
+}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -259,6 +259,16 @@ func saveSetupProvider(deps appDeps, selection tui.SetupSelection, options setup
 		profile.APIKey = apiKey
 		profile.APIKeyEnv = ""
 	}
+	// A CLI-method selection reuses a detected agent CLI's own login: clear
+	// whatever providerProfileForAdd auto-filled into APIKeyEnv (it defaults to
+	// the catalog's first AuthEnvVars entry, e.g. ANTHROPIC_API_KEY for the
+	// anthropic descriptor) so this profile never silently picks up an ambient
+	// env var instead of the CLI login it was created to use.
+	if authCLI := strings.TrimSpace(selection.AuthCLI); authCLI != "" {
+		profile.AuthCLI = authCLI
+		profile.APIKey = ""
+		profile.APIKeyEnv = ""
+	}
 	configPath, err := deps.userConfigPath()
 	if err != nil {
 		return tui.SetupResult{}, err

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -238,6 +238,49 @@ func TestSaveSetupProviderCLIOptionsOverrideCustomEndpointSelection(t *testing.T
 	}
 }
 
+func TestSaveSetupProviderCLISelectionKeepsProfileKeyless(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	// "anthropic" has an AuthEnvVars entry (ANTHROPIC_API_KEY): without the
+	// AuthCLI branch, providerProfileForAdd would auto-fill APIKeyEnv and this
+	// profile would silently route requests through an ambient env var
+	// instead of the CLI login the user picked.
+	result, err := saveSetupProvider(appDeps{
+		userConfigPath: func() (string, error) {
+			return configPath, nil
+		},
+	}, tui.SetupSelection{
+		CatalogID: "anthropic",
+		Model:     "claude-opus-4",
+		AuthCLI:   "claude",
+	}, setupSaveOptions{})
+	if err != nil {
+		t.Fatalf("saveSetupProvider() error = %v", err)
+	}
+
+	if result.Provider.AuthCLI != "claude" {
+		t.Fatalf("Provider.AuthCLI = %q, want claude", result.Provider.AuthCLI)
+	}
+	if result.Provider.APIKey != "" {
+		t.Fatalf("Provider.APIKey = %q, want empty for a CLI-authed profile", result.Provider.APIKey)
+	}
+	if result.Provider.APIKeyEnv != "" {
+		t.Fatalf("Provider.APIKeyEnv = %q, want empty for a CLI-authed profile", result.Provider.APIKeyEnv)
+	}
+
+	cfg := readFileConfig(t, configPath)
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("Providers = %#v, want one provider", cfg.Providers)
+	}
+	profile := cfg.Providers[0]
+	if profile.AuthCLI != "claude" {
+		t.Fatalf("stored AuthCLI = %q, want claude", profile.AuthCLI)
+	}
+	if profile.APIKey != "" || profile.APIKeyEnv != "" || profile.APIKeyStored {
+		t.Fatalf("stored provider must stay keyless for AuthCLI: %#v", profile)
+	}
+}
+
 func TestVerifySetupProviderDistinguishesMissingFromRejectedKey(t *testing.T) {
 	// AUDIT-M1: verifying a remote provider with no key must say "no API key found",
 	// not probe and report "the provider rejected the API key". The probe must not run.

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -156,16 +156,21 @@ func MigratePlaintextProviderKeys(path string, store APIKeySetter) (int, error) 
 }
 
 // HasConfiguredCredential reports whether the profile is set up to authenticate
-// with its own API key (inline, stored, or a raw auth header). It is the single
-// definition of "this profile is key-authed", shared by OAuthLoginCandidates and
-// the cli/tui setup surfaces so they never disagree about whether a profile is
-// keyed. APIKeyEnv is deliberately NOT included: an env var may be unset at
-// runtime while the profile actually relies on an OAuth login, so an
-// env-configured-but-empty profile must still be allowed to resolve a token.
+// with its own API key (inline, stored, or a raw auth header) or a reused
+// agent-CLI login (AuthCLI). It is the single definition of "this profile is
+// already credentialed", shared by OAuthLoginCandidates and the cli/tui setup
+// surfaces so they never disagree. APIKeyEnv is deliberately NOT included: an
+// env var may be unset at runtime while the profile actually relies on an
+// OAuth login, so an env-configured-but-empty profile must still be allowed to
+// resolve a token. AuthCLI IS included: a profile that reuses a harness CLI's
+// login carries no key at all, and without this gate OAuthLoginCandidates would
+// attach zero's generic OAuth resolver on top of it, letting a same-named
+// zero-native login silently hijack the keyless CLI profile.
 func (profile ProviderProfile) HasConfiguredCredential() bool {
 	return strings.TrimSpace(profile.APIKey) != "" ||
 		profile.APIKeyStored ||
-		strings.TrimSpace(profile.AuthHeaderValue) != ""
+		strings.TrimSpace(profile.AuthHeaderValue) != "" ||
+		strings.TrimSpace(profile.AuthCLI) != ""
 }
 
 // OAuthLoginCandidates returns the login names to try, in order, when resolving

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -238,3 +238,48 @@ func TestOAuthLoginCandidates(t *testing.T) {
 		})
 	}
 }
+
+// TestHasConfiguredCredentialAuthCLI locks in that AuthCLI counts as a
+// configured credential: without this, OAuthLoginCandidates would attach
+// zero's generic OAuth resolver on top of a keyless CLI-authed profile,
+// letting a same-named zero-native login silently hijack it.
+func TestHasConfiguredCredentialAuthCLI(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile ProviderProfile
+		want    bool
+	}{
+		{
+			name:    "AuthCLI alone is a configured credential",
+			profile: ProviderProfile{Name: "claude", CatalogID: "anthropic", AuthCLI: "claude"},
+			want:    true,
+		},
+		{
+			name:    "whitespace-only AuthCLI is not configured",
+			profile: ProviderProfile{Name: "claude", CatalogID: "anthropic", AuthCLI: "   "},
+			want:    false,
+		},
+		{
+			name:    "no credential at all",
+			profile: ProviderProfile{Name: "anthropic", CatalogID: "anthropic"},
+			want:    false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.profile.HasConfiguredCredential(); got != c.want {
+				t.Fatalf("HasConfiguredCredential() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestOAuthLoginCandidatesAuthCLIBlocksCandidates locks in that a CLI-authed
+// profile yields no OAuth login candidates — the whole point of gating
+// HasConfiguredCredential on AuthCLI.
+func TestOAuthLoginCandidatesAuthCLIBlocksCandidates(t *testing.T) {
+	profile := ProviderProfile{Name: "claude", CatalogID: "anthropic", AuthCLI: "claude"}
+	if got := profile.OAuthLoginCandidates(); got != nil {
+		t.Fatalf("OAuthLoginCandidates() = %#v, want nil for an AuthCLI profile", got)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -32,7 +32,14 @@ type ProviderProfile struct {
 	// credential store (internal/credstore), not inline in APIKey. The effective
 	// key is loaded from the store at provider-build time; config.json holds only
 	// this marker, never the secret.
-	APIKeyStored    bool              `json:"apiKeyStored,omitempty"`
+	APIKeyStored bool `json:"apiKeyStored,omitempty"`
+	// AuthCLI names an agentcli harness (e.g. "claude", "codex") whose locally
+	// stored login this profile reuses instead of an API key. Set by the
+	// provider wizard's CLI method; the provider factory resolves live
+	// credentials from the harness at build/refresh time (see
+	// internal/providers/agentclicreds.go). Mutually exclusive with APIKey /
+	// APIKeyEnv in practice, though nothing enforces that at the type level.
+	AuthCLI         string            `json:"authCLI,omitempty"`
 	APIFormat       string            `json:"apiFormat,omitempty"`
 	AuthHeader      string            `json:"authHeader,omitempty"`
 	AuthScheme      string            `json:"authScheme,omitempty"`
@@ -51,6 +58,7 @@ func HasProviderProfile(profile ProviderProfile) bool {
 		strings.TrimSpace(profile.BaseURL) != "" ||
 		strings.TrimSpace(profile.APIKey) != "" ||
 		strings.TrimSpace(profile.APIKeyEnv) != "" ||
+		strings.TrimSpace(profile.AuthCLI) != "" ||
 		strings.TrimSpace(profile.APIFormat) != "" ||
 		strings.TrimSpace(profile.AuthHeader) != "" ||
 		strings.TrimSpace(profile.AuthScheme) != "" ||
@@ -496,6 +504,8 @@ func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {
 		APIKeyEnvSnake       string            `json:"api_key_env"`
 		APIKeyStored         bool              `json:"apiKeyStored"`
 		APIKeyStoredSnake    bool              `json:"api_key_stored"`
+		AuthCLI              string            `json:"authCLI"`
+		AuthCLISnake         string            `json:"auth_cli"`
 		APIFormat            string            `json:"apiFormat"`
 		APIFormatSnake       string            `json:"api_format"`
 		AuthHeader           string            `json:"authHeader"`
@@ -526,6 +536,7 @@ func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {
 	profile.APIKey = firstNonEmpty(raw.APIKey, raw.APIKeySnake)
 	profile.APIKeyEnv = strings.TrimSpace(firstNonEmpty(raw.APIKeyEnv, raw.APIKeyEnvSnake))
 	profile.APIKeyStored = raw.APIKeyStored || raw.APIKeyStoredSnake
+	profile.AuthCLI = strings.TrimSpace(firstNonEmpty(raw.AuthCLI, raw.AuthCLISnake))
 	profile.APIFormat = strings.TrimSpace(firstNonEmpty(raw.APIFormat, raw.APIFormatSnake))
 	profile.AuthHeader = strings.TrimSpace(firstNonEmpty(raw.AuthHeader, raw.AuthHeaderSnake))
 	profile.AuthScheme = strings.TrimSpace(firstNonEmpty(raw.AuthScheme, raw.AuthSchemeSnake))

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -32,6 +32,45 @@ func TestToolsConfigJSONRoundTrip(t *testing.T) {
 	}
 }
 
+// TestProviderProfileAuthCLIJSONRoundTrip locks in that AuthCLI survives both
+// directions of JSON: Marshal via the field's own struct tag (ProviderProfile
+// has no custom MarshalJSON) and Unmarshal via the custom UnmarshalJSON, which
+// must list authCLI/auth_cli in its rawProfile shadow struct or the field
+// would silently fail to decode despite encoding correctly.
+func TestProviderProfileAuthCLIJSONRoundTrip(t *testing.T) {
+	original := ProviderProfile{Name: "claude", CatalogID: "anthropic", AuthCLI: "claude"}
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var decoded ProviderProfile
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if decoded.AuthCLI != "claude" {
+		t.Fatalf("AuthCLI round-trip = %q, want %q (encoded: %s)", decoded.AuthCLI, "claude", encoded)
+	}
+
+	// The snake_case alias must also decode (matches every other field's
+	// camel+snake pattern in UnmarshalJSON).
+	var snake ProviderProfile
+	if err := snake.UnmarshalJSON([]byte(`{"name":"codex","auth_cli":"codex"}`)); err != nil {
+		t.Fatalf("UnmarshalJSON(snake) error = %v", err)
+	}
+	if snake.AuthCLI != "codex" {
+		t.Fatalf("auth_cli decode = %q, want %q", snake.AuthCLI, "codex")
+	}
+
+	// omitempty: a profile with no AuthCLI must not emit the field.
+	emptyEncoded, err := json.Marshal(ProviderProfile{Name: "openai"})
+	if err != nil {
+		t.Fatalf("Marshal(empty) error = %v", err)
+	}
+	if string(emptyEncoded) != `{"name":"openai"}` {
+		t.Fatalf("Marshal(empty) = %s, want no authCLI field", emptyEncoded)
+	}
+}
+
 func TestToolsConfigPresentOnOverridesAndResolved(t *testing.T) {
 	// Compile-time guard that Overrides and ResolvedConfig carry the field too.
 	overrides := Overrides{Tools: ToolsConfig{DeferThreshold: 3}}

--- a/internal/modelregistry/modes.go
+++ b/internal/modelregistry/modes.go
@@ -8,9 +8,11 @@ import "strings"
 // command instead of tuning --model/--reasoning-effort/--max-turns by hand.
 //
 // Model holds a registry id or alias (resolved through Resolve/ResolveWithFallback
-// at apply time so deprecation fallbacks and fuzzy aliases stay honored). MaxTurns
-// of 0 means "leave the configured/default turn budget untouched". Effort of ""
-// means "let the model's effective default apply".
+// at apply time so deprecation fallbacks and fuzzy aliases stay honored). Model of
+// "" means "leave the configured model untouched" (see applyExecMode), matching
+// the same zero-value convention as MaxTurns and Effort below. MaxTurns of 0 means
+// "leave the configured/default turn budget untouched". Effort of "" means "let
+// the model's effective default apply".
 type Mode struct {
 	Name        string
 	Description string
@@ -59,6 +61,25 @@ var defaultModes = []Mode{
 		Description: "Careful, high-effort reasoning for exacting changes.",
 		Model:       "claude-sonnet-4.5",
 		Effort:      ReasoningEffortHigh,
+	},
+	{
+		Name:        "onlybash",
+		Description: "Minimal mode: bash + skills only; tools cannot be added.",
+		// Model/Effort/MaxTurns are intentionally left at their zero values — this
+		// mode narrows the tool surface only, it does not change which model runs.
+		//
+		// The tool names below are string literals, not the tools package's
+		// exported constants (Tool.Name(), tools.ToolSearchToolName), because
+		// internal/tools already imports internal/modelregistry (escalate_model.go)
+		// — importing it back here would create a cycle. internal/tools/onlybash_test.go
+		// asserts these literals stay in sync with the real registered tool names.
+		//
+		// EnabledTools is an allowlist: tool_search is exempted from allowlist
+		// rejection by design (see agent/loop.go executeToolCall) so it must be
+		// blocked explicitly via DisabledTools, or the model could still discover
+		// and load deferred/MCP tools through it.
+		EnabledTools:  []string{"bash", "skill"},
+		DisabledTools: []string{"tool_search"},
 	},
 }
 

--- a/internal/modelregistry/modes_test.go
+++ b/internal/modelregistry/modes_test.go
@@ -30,6 +30,29 @@ func TestLookupModeIsCaseInsensitiveAndTrimmed(t *testing.T) {
 	}
 }
 
+func TestLookupModeOnlyBash(t *testing.T) {
+	mode, ok := LookupMode("onlybash")
+	if !ok {
+		t.Fatal("LookupMode(\"onlybash\") = _, false; want a registered mode")
+	}
+	if mode.Model != "" || mode.Effort != "" || mode.MaxTurns != 0 {
+		t.Fatalf("onlybash mode should leave model/effort/turns untouched, got Model=%q Effort=%q MaxTurns=%d", mode.Model, mode.Effort, mode.MaxTurns)
+	}
+	wantEnabled := []string{"bash", "skill"}
+	if len(mode.EnabledTools) != len(wantEnabled) {
+		t.Fatalf("onlybash EnabledTools = %v; want %v", mode.EnabledTools, wantEnabled)
+	}
+	for index, name := range wantEnabled {
+		if mode.EnabledTools[index] != name {
+			t.Fatalf("onlybash EnabledTools = %v; want %v", mode.EnabledTools, wantEnabled)
+		}
+	}
+	wantDisabled := []string{"tool_search"}
+	if len(mode.DisabledTools) != len(wantDisabled) || mode.DisabledTools[0] != wantDisabled[0] {
+		t.Fatalf("onlybash DisabledTools = %v; want %v", mode.DisabledTools, wantDisabled)
+	}
+}
+
 func TestLookupModeUnknown(t *testing.T) {
 	for _, name := range []string{"", "   ", "turbo", "genius"} {
 		if _, ok := LookupMode(name); ok {
@@ -68,6 +91,11 @@ func TestEveryModeResolvesToRealRegistryModel(t *testing.T) {
 		t.Fatalf("DefaultRegistry: %v", err)
 	}
 	for _, mode := range Modes() {
+		if mode.Model == "" {
+			// Zero value means "leave the configured model untouched" (e.g.
+			// onlybash, which only narrows the tool surface) — nothing to resolve.
+			continue
+		}
 		entry, ok := registry.Resolve(mode.Model)
 		if !ok {
 			t.Fatalf("mode %q references model %q that does not resolve in the registry", mode.Name, mode.Model)

--- a/internal/provideroauth/claudecode.go
+++ b/internal/provideroauth/claudecode.go
@@ -1,0 +1,349 @@
+// Claude Code token refresh. See openrouter.go for the package doc.
+package provideroauth
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/oauth"
+)
+
+// claudeCodeClientID is Claude Code's public OAuth client id. Tokens minted for
+// this client (the ones the claude CLI stores locally) can only be refreshed
+// against it; it is a public identifier by design (the CLI ships it), not a
+// secret.
+const claudeCodeClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+// claudeCodeTokenEndpoint is Anthropic's OAuth token endpoint for the Claude
+// Code client. (The former console.anthropic.com path now 404s — the console
+// moved to platform.claude.com; api.anthropic.com serves the same endpoint.)
+const claudeCodeTokenEndpoint = "https://platform.claude.com/v1/oauth/token"
+
+// claudeCodeUserAgent identifies the refresh request. The endpoint sits behind
+// Cloudflare rules that reject bare default library user agents (error 1010),
+// so an explicit product string is load-bearing, not cosmetic.
+const claudeCodeUserAgent = "zero-cli (claude-code-token-refresh)"
+
+// claudeCodeAuthorizeURL is the browser page where the user approves the
+// Claude Code client. With code=true the page displays a "code#state" string
+// to paste back (no loopback server needed).
+const claudeCodeAuthorizeURL = "https://claude.ai/oauth/authorize"
+
+// claudeCodeRedirectURI is the registered redirect for the paste-code flow;
+// the callback page renders the code for copying rather than delivering it to
+// a local listener.
+const claudeCodeRedirectURI = "https://platform.claude.com/oauth/code/callback"
+
+// claudeCodeScopes are the scopes Claude Code itself requests; user:inference
+// is the one the completion API needs.
+const claudeCodeScopes = "org:create_api_key user:profile user:inference"
+
+// ClaudeCodeLoginOptions configures ClaudeCodeLogin.
+type ClaudeCodeLoginOptions struct {
+	// HTTPClient performs the token exchange; nil => a client with a sane timeout.
+	HTTPClient *http.Client
+	// Endpoint overrides the token endpoint; "" => the real endpoint. For tests.
+	Endpoint string
+	// Out receives the "open this URL" and prompt lines; nil discards them.
+	Out io.Writer
+	// In supplies the pasted "code#state" line; nil => os.Stdin.
+	In io.Reader
+	// OpenBrowser is invoked with the authorize URL; nil => URL is only printed.
+	OpenBrowser func(authURL string) error
+	// Now is the time source; nil => time.Now. For tests.
+	Now func() time.Time
+	// randReader overrides crypto/rand for deterministic tests.
+	randReader io.Reader
+}
+
+// ClaudeCodeLogin runs the "Sign in with Claude" paste-code PKCE flow against
+// the Claude Code public client and returns the minted token chain. Zero runs
+// this flow ITSELF (rather than borrowing the claude CLI's stored login)
+// because newer CLI versions keep their live chain in per-install keychain
+// entries that cannot be discovered, leaving only dead chains readable — a
+// login zero owns, stored in zero's own token store, is refreshable forever
+// via RefreshClaudeCode. Returning the token keeps the function composable,
+// mirroring ChatGPTLogin; the caller persists it.
+func ClaudeCodeLogin(ctx context.Context, opts ClaudeCodeLoginOptions) (oauth.Token, error) {
+	out := opts.Out
+	if out == nil {
+		out = io.Discard
+	}
+	in := opts.In
+	if in == nil {
+		in = os.Stdin
+	}
+	randSource := opts.randReader
+	if randSource == nil {
+		randSource = rand.Reader
+	}
+
+	verifier, challenge, err := pkcePair(randSource)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code login: %w", err)
+	}
+	state, err := randomURLSafe(randSource, 32)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code login: %w", err)
+	}
+
+	query := url.Values{
+		"code":                  {"true"},
+		"client_id":             {claudeCodeClientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {claudeCodeRedirectURI},
+		"scope":                 {claudeCodeScopes},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {state},
+	}
+	authURL := claudeCodeAuthorizeURL + "?" + query.Encode()
+	fmt.Fprintf(out, "Open this URL to sign in with Claude:\n\n  %s\n\nThen paste the code shown after approval.\n", authURL)
+	if opts.OpenBrowser != nil {
+		_ = opts.OpenBrowser(authURL)
+	}
+	fmt.Fprint(out, "Paste code here: ")
+
+	line, err := readTrimmedLine(ctx, in)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code login: read code: %w", err)
+	}
+	code, returnedState := line, ""
+	if hash := strings.IndexByte(line, '#'); hash >= 0 {
+		code, returnedState = line[:hash], line[hash+1:]
+	}
+	if strings.TrimSpace(code) == "" {
+		return oauth.Token{}, fmt.Errorf("claude code login: empty code")
+	}
+	// The pasted blob carries the state back; a mismatch means the paste came
+	// from a different (possibly attacker-initiated) authorization.
+	if returnedState != "" && returnedState != state {
+		return oauth.Token{}, fmt.Errorf("claude code login: state mismatch")
+	}
+
+	return exchangeClaudeCodeCode(ctx, code, state, verifier, opts)
+}
+
+func exchangeClaudeCodeCode(ctx context.Context, code, state, verifier string, opts ClaudeCodeLoginOptions) (oauth.Token, error) {
+	endpoint := opts.Endpoint
+	if endpoint == "" {
+		endpoint = claudeCodeTokenEndpoint
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"grant_type":    "authorization_code",
+		"code":          code,
+		"state":         state,
+		"client_id":     claudeCodeClientID,
+		"redirect_uri":  claudeCodeRedirectURI,
+		"code_verifier": verifier,
+	})
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code login: encode exchange: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code login: build exchange: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", claudeCodeUserAgent)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code login: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	payload, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code login: read exchange response: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		return oauth.Token{}, fmt.Errorf("claude code login: token endpoint returned %s", response.Status)
+	}
+
+	var parsed struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+		Account      struct {
+			EmailAddress string `json:"email_address"`
+		} `json:"account"`
+	}
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code login: parse exchange response: %w", err)
+	}
+	if strings.TrimSpace(parsed.AccessToken) == "" {
+		return oauth.Token{}, fmt.Errorf("claude code login: response carried no access token")
+	}
+	token := oauth.Token{
+		AccessToken:  parsed.AccessToken,
+		RefreshToken: parsed.RefreshToken,
+		TokenType:    "Bearer",
+		Account:      parsed.Account.EmailAddress,
+	}
+	if parsed.ExpiresIn > 0 {
+		token.ExpiresAt = now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
+	}
+	return token, nil
+}
+
+// pkcePair returns a PKCE code_verifier and its S256 code_challenge.
+func pkcePair(randSource io.Reader) (verifier, challenge string, err error) {
+	verifier, err = randomURLSafe(randSource, 64)
+	if err != nil {
+		return "", "", err
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	return verifier, base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}
+
+func randomURLSafe(randSource io.Reader, size int) (string, error) {
+	buf := make([]byte, size)
+	if _, err := io.ReadFull(randSource, buf); err != nil {
+		return "", fmt.Errorf("entropy: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// readTrimmedLine reads one line from in, honoring ctx cancellation (stdin
+// reads cannot otherwise be interrupted).
+func readTrimmedLine(ctx context.Context, in io.Reader) (string, error) {
+	type result struct {
+		line string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		reader := bufio.NewReader(in)
+		line, err := reader.ReadString('\n')
+		if err != nil && line == "" {
+			ch <- result{"", err}
+			return
+		}
+		ch <- result{strings.TrimSpace(line), nil}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case r := <-ch:
+		return r.line, r.err
+	}
+}
+
+// ClaudeCodeRefreshOptions configures RefreshClaudeCode.
+type ClaudeCodeRefreshOptions struct {
+	// HTTPClient performs the token exchange; nil => a client with a sane timeout.
+	HTTPClient *http.Client
+	// Endpoint overrides the token endpoint; "" => the real Anthropic endpoint.
+	// Injected by tests.
+	Endpoint string
+	// Now is the time source used to compute ExpiresAt from expires_in; nil =>
+	// time.Now. Injected by tests.
+	Now func() time.Time
+}
+
+// RefreshClaudeCode exchanges a Claude Code refresh token for a fresh access
+// token. Zero uses this when a profile authenticates via the claude CLI's
+// stored login (profile.AuthCLI == "claude") and the extracted access token has
+// expired: the CLI only refreshes its own store when IT runs, and newer CLI
+// versions migrate their live token chain to per-install keychain entries that
+// cannot be reliably discovered — so zero must be able to walk the refresh
+// chain itself. Returning the token (rather than persisting it) keeps the
+// function composable, mirroring ChatGPTLogin; the caller decides where the
+// refreshed pair lives.
+func RefreshClaudeCode(ctx context.Context, refreshToken string, opts ClaudeCodeRefreshOptions) (oauth.Token, error) {
+	refreshToken = strings.TrimSpace(refreshToken)
+	if refreshToken == "" {
+		return oauth.Token{}, fmt.Errorf("claude code refresh: no refresh token")
+	}
+	endpoint := opts.Endpoint
+	if endpoint == "" {
+		endpoint = claudeCodeTokenEndpoint
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+		"client_id":     claudeCodeClientID,
+	})
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code refresh: encode request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code refresh: build request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", claudeCodeUserAgent)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code refresh: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	payload, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code refresh: read response: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		// The body may carry an OAuth error code but could also echo request
+		// material — surface only the status, which is enough to diagnose
+		// (401/400 => revoked or rotated-away refresh token; re-login fixes it).
+		return oauth.Token{}, fmt.Errorf("claude code refresh: token endpoint returned %s", response.Status)
+	}
+
+	var parsed struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return oauth.Token{}, fmt.Errorf("claude code refresh: parse response: %w", err)
+	}
+	if strings.TrimSpace(parsed.AccessToken) == "" {
+		return oauth.Token{}, fmt.Errorf("claude code refresh: response carried no access token")
+	}
+	token := oauth.Token{
+		AccessToken: parsed.AccessToken,
+		// A rotated refresh token replaces the old one; when the server omits
+		// it, the one we just used remains valid — keep it so the chain never
+		// dead-ends.
+		RefreshToken: parsed.RefreshToken,
+		TokenType:    "Bearer",
+	}
+	if token.RefreshToken == "" {
+		token.RefreshToken = refreshToken
+	}
+	if parsed.ExpiresIn > 0 {
+		token.ExpiresAt = now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
+	}
+	return token, nil
+}

--- a/internal/provideroauth/claudecode.go
+++ b/internal/provideroauth/claudecode.go
@@ -143,7 +143,13 @@ func exchangeClaudeCodeCode(ctx context.Context, code, state, verifier string, o
 	}
 	client := opts.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: 30 * time.Second}
+		// Matches the 60s override callers like runAuthClaude/`zero auth claude`
+		// already use for this same endpoint: third-party reports describe
+		// 40-60s responses during platform degradation, and this default is also
+		// on the silent per-request refresh path (agentclicreds.go), where a
+		// false timeout surfaces as a mid-conversation auth error, not just a
+		// slow login screen.
+		client = &http.Client{Timeout: 60 * time.Second}
 	}
 	now := opts.Now
 	if now == nil {
@@ -282,7 +288,13 @@ func RefreshClaudeCode(ctx context.Context, refreshToken string, opts ClaudeCode
 	}
 	client := opts.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: 30 * time.Second}
+		// Matches the 60s override callers like runAuthClaude/`zero auth claude`
+		// already use for this same endpoint: third-party reports describe
+		// 40-60s responses during platform degradation, and this default is also
+		// on the silent per-request refresh path (agentclicreds.go), where a
+		// false timeout surfaces as a mid-conversation auth error, not just a
+		// slow login screen.
+		client = &http.Client{Timeout: 60 * time.Second}
 	}
 	now := opts.Now
 	if now == nil {

--- a/internal/provideroauth/claudecode_test.go
+++ b/internal/provideroauth/claudecode_test.go
@@ -1,0 +1,204 @@
+package provideroauth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRefreshClaudeCode(t *testing.T) {
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+
+	t.Run("happy path", func(t *testing.T) {
+		var got map[string]string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %s, want POST", r.Method)
+			}
+			if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+				t.Errorf("content-type = %q", ct)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode request: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "at-new",
+				"refresh_token": "rt-new",
+				"expires_in":    3600,
+			})
+		}))
+		defer server.Close()
+
+		token, err := RefreshClaudeCode(context.Background(), "rt-old", ClaudeCodeRefreshOptions{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			Now:        func() time.Time { return now },
+		})
+		if err != nil {
+			t.Fatalf("RefreshClaudeCode: %v", err)
+		}
+		if got["grant_type"] != "refresh_token" || got["refresh_token"] != "rt-old" || got["client_id"] != claudeCodeClientID {
+			t.Fatalf("request body = %v", got)
+		}
+		if token.AccessToken != "at-new" || token.RefreshToken != "rt-new" {
+			t.Fatalf("token = %+v", token)
+		}
+		if want := now.Add(time.Hour); !token.ExpiresAt.Equal(want) {
+			t.Fatalf("ExpiresAt = %v, want %v", token.ExpiresAt, want)
+		}
+	})
+
+	t.Run("rotation omitted keeps the old refresh token", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "at-new"})
+		}))
+		defer server.Close()
+		token, err := RefreshClaudeCode(context.Background(), "rt-old", ClaudeCodeRefreshOptions{
+			HTTPClient: server.Client(), Endpoint: server.URL,
+		})
+		if err != nil {
+			t.Fatalf("RefreshClaudeCode: %v", err)
+		}
+		if token.RefreshToken != "rt-old" {
+			t.Fatalf("RefreshToken = %q, want the old token carried forward", token.RefreshToken)
+		}
+		if !token.ExpiresAt.IsZero() {
+			t.Fatalf("ExpiresAt = %v, want zero when expires_in absent", token.ExpiresAt)
+		}
+	})
+
+	t.Run("non-2xx surfaces the status only", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, `{"error":"invalid_grant","echo":"rt-old"}`, http.StatusUnauthorized)
+		}))
+		defer server.Close()
+		_, err := RefreshClaudeCode(context.Background(), "rt-old", ClaudeCodeRefreshOptions{
+			HTTPClient: server.Client(), Endpoint: server.URL,
+		})
+		if err == nil {
+			t.Fatal("want error on 401")
+		}
+		if got := err.Error(); !strings.Contains(got, "401") || strings.Contains(got, "rt-old") {
+			t.Fatalf("error = %q, want the status and no echoed request material", got)
+		}
+	})
+
+	t.Run("empty refresh token is rejected before any request", func(t *testing.T) {
+		if _, err := RefreshClaudeCode(context.Background(), "  ", ClaudeCodeRefreshOptions{}); err == nil {
+			t.Fatal("want error for empty refresh token")
+		}
+	})
+
+	t.Run("missing access token in response is an error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"refresh_token": "rt-new"})
+		}))
+		defer server.Close()
+		if _, err := RefreshClaudeCode(context.Background(), "rt-old", ClaudeCodeRefreshOptions{
+			HTTPClient: server.Client(), Endpoint: server.URL,
+		}); err == nil {
+			t.Fatal("want error when access_token absent")
+		}
+	})
+}
+
+func TestClaudeCodeLogin(t *testing.T) {
+	now := time.Date(2026, 7, 2, 14, 0, 0, 0, time.UTC)
+	// Deterministic entropy so verifier/state are stable across the fake flow.
+	entropy := strings.NewReader(strings.Repeat("e", 512))
+
+	t.Run("happy path", func(t *testing.T) {
+		var got map[string]string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode exchange: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "at-login",
+				"refresh_token": "rt-login",
+				"expires_in":    28800,
+				"account":       map[string]any{"email_address": "user@example.com"},
+			})
+		}))
+		defer server.Close()
+
+		var out strings.Builder
+		// The authorize page returns "code#state" for pasting; recover the state
+		// zero generated from the printed URL to build a valid paste.
+		var pasted strings.Builder
+		reader, writer := io.Pipe()
+		opts := ClaudeCodeLoginOptions{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			Out:        &out,
+			In:         reader,
+			Now:        func() time.Time { return now },
+			randReader: entropy,
+			OpenBrowser: func(authURL string) error {
+				parsed, err := url.Parse(authURL)
+				if err != nil {
+					t.Errorf("authorize URL: %v", err)
+					return nil
+				}
+				query := parsed.Query()
+				if query.Get("code_challenge_method") != "S256" || query.Get("code_challenge") == "" {
+					t.Errorf("authorize URL missing PKCE: %s", authURL)
+				}
+				if query.Get("client_id") != claudeCodeClientID {
+					t.Errorf("client_id = %q", query.Get("client_id"))
+				}
+				pasted.WriteString("the-code#" + query.Get("state") + "\n")
+				go func() { _, _ = writer.Write([]byte(pasted.String())) }()
+				return nil
+			},
+		}
+		token, err := ClaudeCodeLogin(context.Background(), opts)
+		if err != nil {
+			t.Fatalf("ClaudeCodeLogin: %v", err)
+		}
+		if token.AccessToken != "at-login" || token.RefreshToken != "rt-login" || token.Account != "user@example.com" {
+			t.Fatalf("token = %+v", token)
+		}
+		if want := now.Add(8 * time.Hour); !token.ExpiresAt.Equal(want) {
+			t.Fatalf("ExpiresAt = %v, want %v", token.ExpiresAt, want)
+		}
+		if got["grant_type"] != "authorization_code" || got["code"] != "the-code" || got["code_verifier"] == "" {
+			t.Fatalf("exchange body = %v", got)
+		}
+		if got["redirect_uri"] != claudeCodeRedirectURI {
+			t.Fatalf("redirect_uri = %q", got["redirect_uri"])
+		}
+	})
+
+	t.Run("state mismatch is rejected before any exchange", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			t.Error("exchange must not run on state mismatch")
+		}))
+		defer server.Close()
+		_, err := ClaudeCodeLogin(context.Background(), ClaudeCodeLoginOptions{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			In:         strings.NewReader("the-code#wrong-state\n"),
+			randReader: strings.NewReader(strings.Repeat("x", 512)),
+		})
+		if err == nil || !strings.Contains(err.Error(), "state mismatch") {
+			t.Fatalf("err = %v, want state mismatch", err)
+		}
+	})
+
+	t.Run("empty paste is rejected", func(t *testing.T) {
+		_, err := ClaudeCodeLogin(context.Background(), ClaudeCodeLoginOptions{
+			In:         strings.NewReader("\n"),
+			randReader: strings.NewReader(strings.Repeat("x", 512)),
+		})
+		if err == nil || !strings.Contains(err.Error(), "empty code") {
+			t.Fatalf("err = %v, want empty code", err)
+		}
+	})
+}

--- a/internal/provideronboarding/advice.go
+++ b/internal/provideronboarding/advice.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 )
@@ -18,10 +19,14 @@ type Action struct {
 type ProviderState struct {
 	Profile config.ProviderProfile
 	Active  bool
+	// Detections are the machine's detected agent-CLI harnesses (agentcli.Detect),
+	// optional. Nil/empty just means "no CLI advice available" — Actions() then
+	// behaves exactly as it did before AuthCLI existed.
+	Detections []agentcli.Detection
 }
 
 func (state ProviderState) Actions() []Action {
-	return ProviderActions(state.Profile, state.Active)
+	return ProviderActionsWithDetections(state.Profile, state.Active, state.Detections)
 }
 
 func SetupCommand(descriptor providercatalog.Descriptor, name string, setActive bool) string {
@@ -60,6 +65,15 @@ func CheckCommand(name string, connectivity bool) string {
 }
 
 func MissingCredentialAction(profile config.ProviderProfile) (Action, bool) {
+	return MissingCredentialActionWithDetections(profile, nil)
+}
+
+// MissingCredentialActionWithDetections is MissingCredentialAction plus a hint
+// that a detected, logged-in agent-CLI harness could supply this provider's
+// credentials instead of an API key (see cliCredentialHint). detections is
+// typically agentcli.Detect's result; nil behaves exactly like
+// MissingCredentialAction.
+func MissingCredentialActionWithDetections(profile config.ProviderProfile, detections []agentcli.Detection) (Action, bool) {
 	advice := credentialAdviceForProfile(profile)
 	if !advice.requiresAuth || providerProfileHasCredential(profile) {
 		return Action{}, false
@@ -71,6 +85,9 @@ func MissingCredentialAction(profile config.ProviderProfile) (Action, bool) {
 		detail = "Set " + advice.envVar + " to your provider API key before using this provider."
 		command = "set " + advice.envVar + " in your shell"
 	}
+	if hint := cliCredentialHint(profile.CatalogID, detections); hint != "" {
+		detail += " " + hint
+	}
 	return Action{
 		Label:   "Set API key",
 		Command: command,
@@ -78,7 +95,32 @@ func MissingCredentialAction(profile config.ProviderProfile) (Action, bool) {
 	}, true
 }
 
+// cliCredentialHint returns an aside noting that a detected, logged-in agent
+// CLI (e.g. Claude Code) could supply this catalog id's credentials instead of
+// an API key — surfaced so a user who already has that CLI installed sees the
+// CLI connect method as an alternative to pasting a key. Empty when no
+// detection matches catalogID or none of the matches are logged in.
+func cliCredentialHint(catalogID string, detections []agentcli.Detection) string {
+	catalogID = strings.TrimSpace(catalogID)
+	if catalogID == "" {
+		return ""
+	}
+	for _, detection := range detections {
+		if detection.Harness.CatalogID == catalogID && detection.Login == agentcli.LoggedIn {
+			return "Or reuse your " + detection.Harness.DisplayName +
+				" login instead — open /provider and choose \"Use " + detection.Harness.DisplayName + " login\"."
+		}
+	}
+	return ""
+}
+
 func ProviderActions(profile config.ProviderProfile, active bool) []Action {
+	return ProviderActionsWithDetections(profile, active, nil)
+}
+
+// ProviderActionsWithDetections is ProviderActions plus agent-CLI detections
+// threaded through to MissingCredentialActionWithDetections.
+func ProviderActionsWithDetections(profile config.ProviderProfile, active bool, detections []agentcli.Detection) []Action {
 	name := strings.TrimSpace(profile.Name)
 	actions := make([]Action, 0, 3)
 	if name != "" && !active {
@@ -95,7 +137,7 @@ func ProviderActions(profile config.ProviderProfile, active bool) []Action {
 			Detail:  "Validate the provider profile without probing network connectivity.",
 		})
 	}
-	if action, ok := MissingCredentialAction(profile); ok {
+	if action, ok := MissingCredentialActionWithDetections(profile, detections); ok {
 		actions = append(actions, action)
 	}
 	return actions
@@ -140,7 +182,9 @@ func effectiveProviderKind(profile config.ProviderProfile) config.ProviderKind {
 }
 
 func providerProfileHasCredential(profile config.ProviderProfile) bool {
-	return strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != ""
+	return strings.TrimSpace(profile.APIKey) != "" ||
+		strings.TrimSpace(profile.AuthHeaderValue) != "" ||
+		strings.TrimSpace(profile.AuthCLI) != ""
 }
 
 func firstAuthEnvVar(descriptor providercatalog.Descriptor) string {

--- a/internal/provideronboarding/advice.go
+++ b/internal/provideronboarding/advice.go
@@ -181,10 +181,12 @@ func effectiveProviderKind(profile config.ProviderProfile) config.ProviderKind {
 	return ""
 }
 
+// providerProfileHasCredential delegates to the canonical check so a future
+// credential type added there (as APIKeyStored already was) flows into
+// onboarding advice automatically. Verified equivalent for the dimensions this
+// package cares about — it also does not fold in APIKeyEnv resolution.
 func providerProfileHasCredential(profile config.ProviderProfile) bool {
-	return strings.TrimSpace(profile.APIKey) != "" ||
-		strings.TrimSpace(profile.AuthHeaderValue) != "" ||
-		strings.TrimSpace(profile.AuthCLI) != ""
+	return profile.HasConfiguredCredential()
 }
 
 func firstAuthEnvVar(descriptor providercatalog.Descriptor) string {

--- a/internal/provideronboarding/advice_test.go
+++ b/internal/provideronboarding/advice_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 )
@@ -214,6 +215,64 @@ func TestProviderActionsDoNotLeakStoredSecrets(t *testing.T) {
 
 	actions := ProviderActions(profile, false)
 	assertNoSecretLeak(t, actions, apiKey, headerValue)
+}
+
+// TestMissingCredentialActionAuthCLISkipsProfile locks in that a CLI-authed
+// profile (AuthCLI set, no key) is treated as already credentialed — without
+// this, MissingCredentialAction would tell a user who chose the CLI connect
+// method to go paste an API key.
+func TestMissingCredentialActionAuthCLISkipsProfile(t *testing.T) {
+	profile := config.ProviderProfile{
+		Name:      "claude",
+		CatalogID: "anthropic",
+		AuthCLI:   "claude",
+	}
+	if _, ok := MissingCredentialAction(profile); ok {
+		t.Fatal("MissingCredentialAction() ok = true, want false for an AuthCLI profile")
+	}
+}
+
+// TestMissingCredentialActionWithDetectionsMentionsLoggedInCLI covers "surface
+// the CLI option when the harness is detected": a profile missing a key gets
+// a hint pointing at a detected, logged-in matching harness.
+func TestMissingCredentialActionWithDetectionsMentionsLoggedInCLI(t *testing.T) {
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	profile := config.ProviderProfile{Name: "anthropic", CatalogID: "anthropic"}
+
+	// No detections at all: MissingCredentialAction (detections=nil) behaves
+	// exactly as before — no CLI hint.
+	before, ok := MissingCredentialAction(profile)
+	if !ok {
+		t.Fatal("MissingCredentialAction() ok = false, want true (no credential configured)")
+	}
+	if strings.Contains(before.Detail, "Claude Code") {
+		t.Fatalf("Detail should not mention Claude Code with no detections: %q", before.Detail)
+	}
+
+	// A logged-in claude detection adds the hint.
+	withHint, ok := MissingCredentialActionWithDetections(profile, []agentcli.Detection{
+		{Harness: claudeHarness, Login: agentcli.LoggedIn},
+	})
+	if !ok {
+		t.Fatal("MissingCredentialActionWithDetections() ok = false, want true")
+	}
+	if !strings.Contains(withHint.Detail, "Claude Code") {
+		t.Fatalf("Detail = %q, want it to mention the detected Claude Code login", withHint.Detail)
+	}
+
+	// A logged-OUT claude detection must NOT add the hint (nothing to reuse yet).
+	loggedOut, ok := MissingCredentialActionWithDetections(profile, []agentcli.Detection{
+		{Harness: claudeHarness, Login: agentcli.LoggedOut},
+	})
+	if !ok {
+		t.Fatal("MissingCredentialActionWithDetections() ok = false, want true")
+	}
+	if strings.Contains(loggedOut.Detail, "Claude Code") {
+		t.Fatalf("Detail = %q, should not mention a logged-out CLI", loggedOut.Detail)
+	}
 }
 
 func assertNoSecretLeak(t *testing.T, actions []Action, secrets ...string) {

--- a/internal/provideronboarding/advice_test.go
+++ b/internal/provideronboarding/advice_test.go
@@ -162,6 +162,19 @@ func TestMissingCredentialActionSkipsLocalAndCredentialedProfiles(t *testing.T) 
 				AuthHeaderValue: "Bearer actual-token",
 			},
 		},
+		{
+			// providerProfileHasCredential delegates to
+			// config.ProviderProfile.HasConfiguredCredential() specifically so this
+			// case — a key held in the encrypted store, not in-memory on the
+			// profile — isn't missed: before that delegation, onboarding advice
+			// would wrongly nag for a credential this profile already has.
+			name: "api key is in the encrypted store (APIKeyStored), not held in-memory",
+			profile: config.ProviderProfile{
+				Name:         "openai",
+				ProviderKind: config.ProviderKindOpenAI,
+				APIKeyStored: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/providers/agentclicreds.go
+++ b/internal/providers/agentclicreds.go
@@ -1,0 +1,242 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/agentcli"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
+	"github.com/Gitlawb/zero/internal/provideroauth"
+	"github.com/Gitlawb/zero/internal/providers/anthropic"
+	"github.com/Gitlawb/zero/internal/providers/openai"
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// newCLIAuthedProvider builds a provider that authenticates using credentials
+// extracted live from a detected agent-CLI's local credential store
+// (agentcli.ExtractCredentials) rather than a zero-managed API key or OAuth
+// login. profile.AuthCLI names the harness ("claude", "codex", ...); the
+// harness's CatalogID (fixed by the agentcli catalog, not user-editable)
+// decides which provider flavor to build, mirroring isCodexCatalog/newCodexProvider
+// for the zero-native OAuth path. Credentials are re-read from disk on EVERY
+// call the resulting resolver makes — including the forced retry after a 401 —
+// never cached here, so a refresh the harness CLI performs on disk between
+// calls (its own token rotation) takes effect immediately without restarting
+// zero.
+func newCLIAuthedProvider(profile config.ProviderProfile, resolved resolvedProfile, authCLI string, options Options) (zeroruntime.Provider, error) {
+	harness, ok := agentcli.Lookup(authCLI)
+	if !ok {
+		return nil, fmt.Errorf("provider %s: unknown auth CLI %q", profile.Name, authCLI)
+	}
+	if harness.CatalogID == "" {
+		return nil, fmt.Errorf("provider %s: %s has no reusable provider credentials", profile.Name, harness.DisplayName)
+	}
+	deps := options.AgentCLIDeps
+
+	switch harness.CatalogID {
+	case "chatgpt":
+		resolver := cliBearerResolver(harness, deps)
+		accountResolver := cliAccountResolver(harness, deps)
+		return openai.NewCodexProvider(openai.CodexOptions{
+			Options: openai.Options{
+				BaseURL:        resolved.baseURL,
+				Model:          resolved.apiModel,
+				OAuthResolver:  resolver,
+				MaxTokens:      resolved.maxOutputTokens,
+				HTTPClient:     options.HTTPClient,
+				UserAgent:      options.UserAgent,
+				ParseThinkTags: parseThinkTagsForProfile(profile, resolved),
+			},
+			AccountResolver: accountResolver,
+		})
+	case "anthropic":
+		return anthropic.New(anthropic.Options{
+			BaseURL:       resolved.baseURL,
+			Model:         resolved.apiModel,
+			OAuthResolver: claudeRefreshingBearerResolver(harness, deps, defaultCLIAuthTokenStore(), defaultClaudeRefresh(options)),
+			// Claude Code's OAuth bearer authenticates with this beta flag
+			// instead of the normal x-api-key credential. The resolver above
+			// always supplies the bearer for THIS provider instance (its
+			// APIKey is always empty — see providerWizardCLIProfile), so the
+			// header is only ever sent on a CLI-authed request; the ordinary
+			// x-api-key path (built with Options.Beta unset) is untouched.
+			Beta: "oauth-2025-04-20",
+			// A Claude Code subscription token is only served to requests that
+			// identify as Claude Code (the claude-code beta + the "You are
+			// Claude Code" system block); without it Anthropic 429s regardless
+			// of the account's real quota. The anthropic provider injects both.
+			ClaudeCodeIdentity: true,
+			MaxTokens:          resolved.maxOutputTokens,
+			HTTPClient:         options.HTTPClient,
+			UserAgent:          options.UserAgent,
+		})
+	default:
+		return nil, fmt.Errorf("provider %s: auth CLI %q (catalog %q) is not wired for CLI-reused credentials", profile.Name, authCLI, harness.CatalogID)
+	}
+}
+
+// cliBearerResolver builds a providerio.TokenResolver over a harness's locally
+// stored credentials. It is called once per outbound request (and again, with
+// forceRefresh, on the 401 retry) and re-reads the credential store fresh every
+// time — zero performs no refresh of its own here; the harness CLI (claude,
+// codex, ...) is solely responsible for keeping its on-disk token current, and
+// this resolver just picks up whatever it finds.
+func cliBearerResolver(harness agentcli.Harness, deps agentcli.Deps) providerio.TokenResolver {
+	return func(_ context.Context, _ bool) (string, string, bool, error) {
+		creds, ok, err := agentcli.ExtractCredentials(harness, deps)
+		if err != nil {
+			return "", "", false, fmt.Errorf("%s credentials: %w", harness.DisplayName, err)
+		}
+		if !ok || strings.TrimSpace(creds.AccessToken) == "" {
+			return "", "", false, cliLoginExpiredError(harness)
+		}
+		if !creds.ExpiresAt.IsZero() && !creds.ExpiresAt.After(time.Now()) {
+			return "", "", false, cliLoginExpiredError(harness)
+		}
+		return "Authorization", "Bearer " + creds.AccessToken, true, nil
+	}
+}
+
+// cliAuthTokenStoreKey is where zero caches the refresh chain it adopts from
+// the claude CLI's store. It lives in ZERO's own oauth token store — never the
+// CLI's files or keychain — so zero's rotations cannot disturb the CLI's login.
+const cliAuthTokenStoreKey = "provider:authcli-claude"
+
+// claudeRefreshBuffer is how close to expiry a token counts as "needs refresh":
+// refreshing a few minutes early avoids racing a request against the boundary.
+const claudeRefreshBuffer = 5 * time.Minute
+
+// claudeRefreshFunc walks one link of the Claude Code OAuth refresh chain.
+type claudeRefreshFunc func(ctx context.Context, refreshToken string) (oauth.Token, error)
+
+// cliAuthTokenStore is the minimal token-store surface the refreshing resolver
+// needs; *oauth.Store satisfies it and tests inject a fake.
+type cliAuthTokenStore interface {
+	Load(key string) (oauth.Token, bool, error)
+	Save(key string, token oauth.Token) error
+}
+
+func defaultCLIAuthTokenStore() cliAuthTokenStore {
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		// Without a store the resolver still works (extract + refresh per
+		// request); it just cannot cache rotations across calls.
+		return nil
+	}
+	return store
+}
+
+func defaultClaudeRefresh(options Options) claudeRefreshFunc {
+	return func(ctx context.Context, refreshToken string) (oauth.Token, error) {
+		return provideroauth.RefreshClaudeCode(ctx, refreshToken, provideroauth.ClaudeCodeRefreshOptions{
+			HTTPClient: options.HTTPClient,
+		})
+	}
+}
+
+// claudeRefreshingBearerResolver resolves the claude bearer with zero-side
+// refresh. The claude CLI only refreshes its stored token when IT runs, and
+// newer versions migrate the live chain to per-install keychain entries zero
+// cannot reliably discover — so the extracted store often holds an expired
+// access token plus a still-usable refresh token. Resolution order:
+//
+//  1. zero's own cached token (a chain zero already adopted), if fresh;
+//  2. the CLI's extracted token, if fresh (a CLI-side refresh wins the race);
+//  3. refresh, using the refresh token from whichever source carries the
+//     LATER expiry — a later ExpiresAt marks the newer link of the chain —
+//     persisting the rotated pair back to zero's store.
+//
+// forceRefresh (the 401 retry) skips 1 and 2: a token that just 401'd is not
+// worth re-serving, however fresh it looks.
+func claudeRefreshingBearerResolver(harness agentcli.Harness, deps agentcli.Deps, store cliAuthTokenStore, refresh claudeRefreshFunc) providerio.TokenResolver {
+	return func(ctx context.Context, forceRefresh bool) (string, string, bool, error) {
+		now := time.Now()
+		var cached oauth.Token
+		if store != nil {
+			if token, ok, err := store.Load(cliAuthTokenStoreKey); err == nil && ok {
+				cached = token
+			}
+		}
+		if !forceRefresh && cached.AccessToken != "" && !cached.NeedsRefresh(now, claudeRefreshBuffer) {
+			return "Authorization", "Bearer " + cached.AccessToken, true, nil
+		}
+
+		creds, ok, err := agentcli.ExtractCredentials(harness, deps)
+		if err != nil {
+			return "", "", false, fmt.Errorf("%s credentials: %w", harness.DisplayName, err)
+		}
+		if !ok {
+			creds = agentcli.Credentials{}
+		}
+		extractedFresh := strings.TrimSpace(creds.AccessToken) != "" &&
+			!creds.ExpiresAt.IsZero() && creds.ExpiresAt.After(now.Add(claudeRefreshBuffer))
+		if !forceRefresh && extractedFresh {
+			return "Authorization", "Bearer " + creds.AccessToken, true, nil
+		}
+
+		refreshToken := newestClaudeRefreshToken(cached, creds)
+		if refreshToken == "" {
+			return "", "", false, cliLoginExpiredError(harness)
+		}
+		token, refreshErr := refresh(ctx, refreshToken)
+		if refreshErr != nil {
+			return "", "", false, fmt.Errorf("%w (auto-refresh failed: %v)", cliLoginExpiredError(harness), refreshErr)
+		}
+		if store != nil {
+			// A failed save only costs a redundant refresh next call; the token
+			// in hand is still good.
+			_ = store.Save(cliAuthTokenStoreKey, token)
+		}
+		return "Authorization", "Bearer " + token.AccessToken, true, nil
+	}
+}
+
+// newestClaudeRefreshToken picks the refresh token from whichever source holds
+// the later access-token expiry: refresh chains rotate, and the later expiry
+// marks the later (still-valid) link. A source without a refresh token never
+// wins; ties go to zero's own cache, whose chain zero rotated most recently.
+func newestClaudeRefreshToken(cached oauth.Token, extracted agentcli.Credentials) string {
+	cachedToken := strings.TrimSpace(cached.RefreshToken)
+	extractedToken := strings.TrimSpace(extracted.RefreshToken)
+	switch {
+	case cachedToken == "":
+		return extractedToken
+	case extractedToken == "":
+		return cachedToken
+	case extracted.ExpiresAt.After(cached.ExpiresAt):
+		return extractedToken
+	default:
+		return cachedToken
+	}
+}
+
+// cliAccountResolver mirrors cliBearerResolver for the Codex chatgpt-account-id
+// header: it reads the harness's stored AccountID fresh on every call. Unlike
+// the bearer resolver, a missing account id is not a hard error — ok=false just
+// omits the header (openai.CodexProvider's own convention), since the bearer
+// resolver above is the one place that surfaces a "you're logged out" error to
+// the caller.
+func cliAccountResolver(harness agentcli.Harness, deps agentcli.Deps) openai.CodexAccountResolver {
+	return func(_ context.Context) (string, bool, error) {
+		creds, ok, err := agentcli.ExtractCredentials(harness, deps)
+		if err != nil || !ok {
+			return "", false, nil
+		}
+		account := strings.TrimSpace(creds.AccountID)
+		if account == "" {
+			return "", false, nil
+		}
+		return account, true, nil
+	}
+}
+
+// cliLoginExpiredError is the actionable error surfaced when a profile.AuthCLI
+// provider's harness has no usable local credential (never logged in, or its
+// token expired): it names the harness and the command that fixes it.
+func cliLoginExpiredError(harness agentcli.Harness) error {
+	return fmt.Errorf("%s login has expired — run %q to refresh, or switch auth with /provider", harness.ID, harness.LoginCommand())
+}

--- a/internal/providers/agentclicreds.go
+++ b/internal/providers/agentclicreds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Gitlawb/zero/internal/agentcli"
@@ -153,7 +154,16 @@ func defaultClaudeRefresh(options Options) claudeRefreshFunc {
 // forceRefresh (the 401 retry) skips 1 and 2: a token that just 401'd is not
 // worth re-serving, however fresh it looks.
 func claudeRefreshingBearerResolver(harness agentcli.Harness, deps agentcli.Deps, store cliAuthTokenStore, refresh claudeRefreshFunc) providerio.TokenResolver {
+	var mu sync.Mutex
 	return func(ctx context.Context, forceRefresh bool) (string, string, bool, error) {
+		// Concurrent StreamCompletion calls (e.g. parallel tool calls) share this
+		// resolver. Without serializing, two calls that both see a stale token
+		// would race to refresh with the SAME refresh token — and OAuth refresh
+		// tokens are commonly single-use/rotated server-side, so the losing call
+		// fails with a spurious auth error instead of transparently reusing the
+		// winner's freshly-rotated token.
+		mu.Lock()
+		defer mu.Unlock()
 		now := time.Now()
 		var cached oauth.Token
 		if store != nil {

--- a/internal/providers/agentclicreds_test.go
+++ b/internal/providers/agentclicreds_test.go
@@ -1,0 +1,471 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/agentcli"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// notFoundKeychain is a Deps.Keychain stub that always reports "not found" —
+// injected into every claude-related test so ExtractCredentials falls through
+// to the (fake) CredFiles path instead of ever touching the real macOS
+// keychain on a developer machine.
+func notFoundKeychain(string) ([]byte, error) {
+	return nil, errors.New("keychain: not found")
+}
+
+func TestNewCLIAuthedProviderAnthropicUsesBearerAndBetaHeader(t *testing.T) {
+	isolateCLIAuthTokenStore(t)
+	transport := &captureTransport{responseBody: "data: [DONE]\n\n"}
+	future := time.Now().Add(time.Hour).UnixMilli()
+	deps := agentcli.Deps{
+		Keychain: notFoundKeychain,
+		ReadFile: func(path string) ([]byte, error) {
+			if strings.HasSuffix(path, ".claude/.credentials.json") {
+				return []byte(fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"tok-claude","refreshToken":"r","expiresAt":%d}}`, future)), nil
+			}
+			return nil, os.ErrNotExist
+		},
+	}
+
+	provider, err := New(config.ProviderProfile{
+		Name:      "claude",
+		CatalogID: "anthropic",
+		AuthCLI:   "claude",
+		Model:     "claude-cli-test-model",
+	}, Options{
+		HTTPClient:   &http.Client{Transport: transport},
+		AgentCLIDeps: deps,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	for range stream {
+	}
+
+	if transport.request == nil {
+		t.Fatal("HTTP client was not used")
+	}
+	if got := transport.request.Header.Get("Authorization"); got != "Bearer tok-claude" {
+		t.Fatalf("Authorization = %q, want Bearer tok-claude", got)
+	}
+	if got := transport.request.Header.Get("x-api-key"); got != "" {
+		t.Fatalf("x-api-key = %q, want empty — the bearer must replace it entirely", got)
+	}
+	// The claude CLI path must send BOTH the oauth beta and the claude-code
+	// beta — a Claude Code subscription token is only served to a request that
+	// identifies as Claude Code.
+	if got := transport.request.Header.Get("anthropic-beta"); !strings.Contains(got, "oauth-2025-04-20") || !strings.Contains(got, "claude-code-20250219") {
+		t.Fatalf("anthropic-beta = %q, want both the oauth and claude-code flags", got)
+	}
+	// The first system block must be the exact Claude Code identity string.
+	var sent struct {
+		System []struct {
+			Text string `json:"text"`
+		} `json:"system"`
+	}
+	if err := json.Unmarshal([]byte(transport.requestBody), &sent); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if len(sent.System) == 0 || sent.System[0].Text != "You are Claude Code, Anthropic's official CLI for Claude." {
+		t.Fatalf("system[0] = %+v, want the Claude Code identity block first", sent.System)
+	}
+}
+
+// isolateCLIAuthTokenStore points the resolver's token cache at a throwaway
+// path so provider-level tests never read (or, after a refresh, write) the
+// developer's real oauth token store.
+func isolateCLIAuthTokenStore(t *testing.T) {
+	t.Helper()
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", filepath.Join(t.TempDir(), "oauth-tokens.json"))
+}
+
+// TestNewCLIAuthedProviderAnthropicExpiredCredsError locks in the behavior for
+// an expired harness login: zero attempts ONE auto-refresh against the OAuth
+// token endpoint, and when that fails the stream's error event names the
+// harness, the fix command, and the refresh failure — the completion API is
+// never called without a valid bearer.
+func TestNewCLIAuthedProviderAnthropicExpiredCredsError(t *testing.T) {
+	isolateCLIAuthTokenStore(t)
+	transport := &captureTransport{responseBody: "data: [DONE]\n\n"}
+	past := time.Now().Add(-time.Hour).UnixMilli()
+	deps := agentcli.Deps{
+		Keychain: notFoundKeychain,
+		ReadFile: func(path string) ([]byte, error) {
+			if strings.HasSuffix(path, ".claude/.credentials.json") {
+				return []byte(fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"tok-claude","refreshToken":"r","expiresAt":%d}}`, past)), nil
+			}
+			return nil, os.ErrNotExist
+		},
+	}
+
+	provider, err := New(config.ProviderProfile{
+		Name:      "claude",
+		CatalogID: "anthropic",
+		AuthCLI:   "claude",
+		Model:     "claude-cli-test-model",
+	}, Options{
+		HTTPClient:   &http.Client{Transport: transport},
+		AgentCLIDeps: deps,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	var gotErr string
+	for event := range stream {
+		if event.Type == zeroruntime.StreamEventError {
+			gotErr = event.Error
+		}
+	}
+	if !strings.Contains(gotErr, "login has expired") || !strings.Contains(gotErr, "claude") {
+		t.Fatalf("stream error = %q, want an actionable claude-login-expired message", gotErr)
+	}
+	if !strings.Contains(gotErr, "auto-refresh failed") {
+		t.Fatalf("stream error = %q, want it to show the refresh was attempted", gotErr)
+	}
+	// The one permitted request is the refresh attempt against the OAuth token
+	// endpoint (which this transport answers with garbage, failing the refresh);
+	// the completion API itself must never be called without a valid bearer.
+	if transport.request == nil {
+		t.Fatal("expected an auto-refresh attempt for expired CLI credentials")
+	}
+	if got := transport.request.URL.String(); !strings.Contains(got, "platform.claude.com/v1/oauth/token") {
+		t.Fatalf("request went to %q, want only the OAuth token endpoint", got)
+	}
+}
+
+// TestNewCLIAuthedProviderAnthropicMissingCredsError covers the "never logged
+// in" case (no credentials file at all), which must fail the same way as an
+// expired token rather than falling back to an unauthenticated request.
+func TestNewCLIAuthedProviderAnthropicMissingCredsError(t *testing.T) {
+	isolateCLIAuthTokenStore(t)
+	transport := &captureTransport{responseBody: "data: [DONE]\n\n"}
+	deps := agentcli.Deps{
+		Keychain: notFoundKeychain,
+		ReadFile: func(string) ([]byte, error) { return nil, os.ErrNotExist },
+	}
+
+	provider, err := New(config.ProviderProfile{
+		Name:      "claude",
+		CatalogID: "anthropic",
+		AuthCLI:   "claude",
+		Model:     "claude-cli-test-model",
+	}, Options{
+		HTTPClient:   &http.Client{Transport: transport},
+		AgentCLIDeps: deps,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	var gotErr string
+	for event := range stream {
+		if event.Type == zeroruntime.StreamEventError {
+			gotErr = event.Error
+		}
+	}
+	if !strings.Contains(gotErr, "login has expired") {
+		t.Fatalf("stream error = %q, want the same actionable message for a never-logged-in harness", gotErr)
+	}
+}
+
+func TestNewCLIAuthedProviderCodexUsesBearerAndAccountHeader(t *testing.T) {
+	transport := &captureTransport{responseBody: "data: [DONE]\n\n"}
+	deps := agentcli.Deps{
+		ReadFile: func(path string) ([]byte, error) {
+			if strings.HasSuffix(path, ".codex/auth.json") {
+				return []byte(`{"tokens":{"access_token":"tok-codex","refresh_token":"r","account_id":"acct-codex-1"}}`), nil
+			}
+			return nil, os.ErrNotExist
+		},
+	}
+
+	provider, err := New(config.ProviderProfile{
+		Name:      "codex",
+		CatalogID: "chatgpt",
+		AuthCLI:   "codex",
+		Model:     "gpt-5.5",
+	}, Options{
+		HTTPClient:   &http.Client{Transport: transport},
+		UserAgent:    "zero-agentcli-test",
+		AgentCLIDeps: deps,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	for range stream {
+	}
+
+	if transport.request == nil {
+		t.Fatal("HTTP client was not used")
+	}
+	if !strings.HasSuffix(transport.request.URL.Path, "/responses") {
+		t.Fatalf("request URL path = %q, want .../responses", transport.request.URL.Path)
+	}
+	if got := transport.request.Header.Get("Authorization"); got != "Bearer tok-codex" {
+		t.Fatalf("Authorization = %q, want Bearer tok-codex", got)
+	}
+	if got := transport.request.Header.Get("chatgpt-account-id"); got != "acct-codex-1" {
+		t.Fatalf("chatgpt-account-id = %q, want acct-codex-1", got)
+	}
+	if got := transport.request.Header.Get("originator"); got != "codex_cli_rs" {
+		t.Fatalf("originator = %q, want codex_cli_rs", got)
+	}
+}
+
+// TestNewCLIAuthedProviderCodexNoAccountIDOmitsHeader mirrors the zero-native
+// OAuth path's convention (openai.CodexProvider): a missing account id just
+// omits the header rather than failing the whole request — only a missing/
+// expired bearer is a hard error (see cliBearerResolver vs cliAccountResolver).
+func TestNewCLIAuthedProviderCodexNoAccountIDOmitsHeader(t *testing.T) {
+	transport := &captureTransport{responseBody: "data: [DONE]\n\n"}
+	deps := agentcli.Deps{
+		ReadFile: func(path string) ([]byte, error) {
+			if strings.HasSuffix(path, ".codex/auth.json") {
+				return []byte(`{"tokens":{"access_token":"tok-codex","refresh_token":"r"}}`), nil
+			}
+			return nil, os.ErrNotExist
+		},
+	}
+
+	provider, err := New(config.ProviderProfile{
+		Name:      "codex",
+		CatalogID: "chatgpt",
+		AuthCLI:   "codex",
+		Model:     "gpt-5.5",
+	}, Options{HTTPClient: &http.Client{Transport: transport}, AgentCLIDeps: deps})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	for range stream {
+	}
+	if got := transport.request.Header.Get("Authorization"); got != "Bearer tok-codex" {
+		t.Fatalf("Authorization = %q, want Bearer tok-codex", got)
+	}
+	if got := transport.request.Header.Get("chatgpt-account-id"); got != "" {
+		t.Fatalf("chatgpt-account-id = %q, want empty when the harness has no stored account id", got)
+	}
+}
+
+func TestNewCLIAuthedProviderUnknownHarnessErrors(t *testing.T) {
+	_, err := New(config.ProviderProfile{
+		Name: "x", CatalogID: "anthropic", AuthCLI: "not-a-real-harness", Model: "m",
+	}, Options{})
+	if err == nil {
+		t.Fatal("expected an error for an unknown AuthCLI harness")
+	}
+}
+
+// TestNewCLIAuthedProviderHarnessWithoutReusableCredsErrors covers a detected
+// harness with no CatalogID (e.g. gemini/qwen) named as AuthCLI — this should
+// never happen from the wizard (those harnesses render as disabled rows), but
+// the factory must still fail clearly rather than silently building a
+// keyless, unauthenticated provider.
+func TestNewCLIAuthedProviderHarnessWithoutReusableCredsErrors(t *testing.T) {
+	if _, ok := agentcli.Lookup("gemini"); !ok {
+		t.Fatal("test assumption broken: gemini is no longer in the agentcli catalog")
+	}
+	_, err := New(config.ProviderProfile{
+		Name: "g", CatalogID: "google", AuthCLI: "gemini", Model: "m",
+	}, Options{})
+	if err == nil {
+		t.Fatal("expected an error: gemini has no reusable provider credentials")
+	}
+}
+
+// fakeCLIAuthTokenStore is an in-memory cliAuthTokenStore.
+type fakeCLIAuthTokenStore struct {
+	tokens map[string]oauth.Token
+	saves  int
+}
+
+func (s *fakeCLIAuthTokenStore) Load(key string) (oauth.Token, bool, error) {
+	token, ok := s.tokens[key]
+	return token, ok, nil
+}
+
+func (s *fakeCLIAuthTokenStore) Save(key string, token oauth.Token) error {
+	if s.tokens == nil {
+		s.tokens = map[string]oauth.Token{}
+	}
+	s.tokens[key] = token
+	s.saves++
+	return nil
+}
+
+// claudeResolverFixture wires a claudeRefreshingBearerResolver with fully fake
+// deps: an extracted credential blob, a store state, and a scripted refresh.
+func claudeResolverFixture(t *testing.T, fileBlob string, store *fakeCLIAuthTokenStore, refresh claudeRefreshFunc) (providerio.TokenResolver, *int) {
+	t.Helper()
+	harness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("Lookup(claude) failed")
+	}
+	reads := 0
+	deps := agentcli.Deps{
+		Home:     "/home/u",
+		Keychain: func(string) ([]byte, error) { return nil, errors.New("not found") },
+		ReadFile: func(string) ([]byte, error) {
+			reads++
+			if fileBlob == "" {
+				return nil, errors.New("missing")
+			}
+			return []byte(fileBlob), nil
+		},
+	}
+	return claudeRefreshingBearerResolver(harness, deps, store, refresh), &reads
+}
+
+func claudeBlob(access, refreshToken string, expires time.Time) string {
+	return `{"claudeAiOauth":{"accessToken":"` + access + `","refreshToken":"` + refreshToken +
+		`","expiresAt":` + strconv.FormatInt(expires.UnixMilli(), 10) + `}}`
+}
+
+func TestClaudeRefreshingBearerResolver(t *testing.T) {
+	future := time.Now().Add(2 * time.Hour)
+	past := time.Now().Add(-time.Hour)
+	noRefresh := claudeRefreshFunc(func(context.Context, string) (oauth.Token, error) {
+		return oauth.Token{}, errors.New("refresh must not be called")
+	})
+
+	t.Run("cached store token short-circuits extraction and refresh", func(t *testing.T) {
+		store := &fakeCLIAuthTokenStore{tokens: map[string]oauth.Token{
+			cliAuthTokenStoreKey: {AccessToken: "at-cached", ExpiresAt: future},
+		}}
+		resolver, reads := claudeResolverFixture(t, claudeBlob("at-file", "rt-file", future), store, noRefresh)
+		_, value, ok, err := resolver(context.Background(), false)
+		if err != nil || !ok || value != "Bearer at-cached" {
+			t.Fatalf("resolver = %q ok=%v err=%v", value, ok, err)
+		}
+		if *reads != 0 {
+			t.Fatalf("extraction ran %d times, want 0 when the cache is fresh", *reads)
+		}
+	})
+
+	t.Run("fresh extracted token used without refresh", func(t *testing.T) {
+		resolver, _ := claudeResolverFixture(t, claudeBlob("at-file", "rt-file", future), &fakeCLIAuthTokenStore{}, noRefresh)
+		_, value, ok, err := resolver(context.Background(), false)
+		if err != nil || !ok || value != "Bearer at-file" {
+			t.Fatalf("resolver = %q ok=%v err=%v", value, ok, err)
+		}
+	})
+
+	t.Run("expired extracted token refreshes and persists", func(t *testing.T) {
+		store := &fakeCLIAuthTokenStore{}
+		var gotRefreshToken string
+		refresh := claudeRefreshFunc(func(_ context.Context, rt string) (oauth.Token, error) {
+			gotRefreshToken = rt
+			return oauth.Token{AccessToken: "at-new", RefreshToken: "rt-new", ExpiresAt: future}, nil
+		})
+		resolver, _ := claudeResolverFixture(t, claudeBlob("at-old", "rt-old", past), store, refresh)
+		_, value, ok, err := resolver(context.Background(), false)
+		if err != nil || !ok || value != "Bearer at-new" {
+			t.Fatalf("resolver = %q ok=%v err=%v", value, ok, err)
+		}
+		if gotRefreshToken != "rt-old" {
+			t.Fatalf("refresh used %q, want the extracted refresh token", gotRefreshToken)
+		}
+		saved := store.tokens[cliAuthTokenStoreKey]
+		if saved.AccessToken != "at-new" || saved.RefreshToken != "rt-new" {
+			t.Fatalf("persisted token = %+v", saved)
+		}
+	})
+
+	t.Run("refresh failure surfaces the actionable login error", func(t *testing.T) {
+		refresh := claudeRefreshFunc(func(context.Context, string) (oauth.Token, error) {
+			return oauth.Token{}, errors.New("token endpoint returned 401 Unauthorized")
+		})
+		resolver, _ := claudeResolverFixture(t, claudeBlob("at-old", "rt-old", past), &fakeCLIAuthTokenStore{}, refresh)
+		_, _, _, err := resolver(context.Background(), false)
+		if err == nil {
+			t.Fatal("want error when refresh fails")
+		}
+		if !strings.Contains(err.Error(), "run \"claude\"") || !strings.Contains(err.Error(), "auto-refresh failed") {
+			t.Fatalf("error = %q, want the actionable hint plus the refresh failure", err)
+		}
+	})
+
+	t.Run("no refresh token anywhere is the plain expired error", func(t *testing.T) {
+		resolver, _ := claudeResolverFixture(t, claudeBlob("at-old", "", past), &fakeCLIAuthTokenStore{}, noRefresh)
+		_, _, _, err := resolver(context.Background(), false)
+		if err == nil || !strings.Contains(err.Error(), "login has expired") {
+			t.Fatalf("error = %v, want the expired-login error", err)
+		}
+	})
+
+	t.Run("forceRefresh bypasses fresh cache and extraction", func(t *testing.T) {
+		store := &fakeCLIAuthTokenStore{tokens: map[string]oauth.Token{
+			cliAuthTokenStoreKey: {AccessToken: "at-cached", RefreshToken: "rt-cached", ExpiresAt: future},
+		}}
+		refreshed := false
+		refresh := claudeRefreshFunc(func(context.Context, string) (oauth.Token, error) {
+			refreshed = true
+			return oauth.Token{AccessToken: "at-forced", ExpiresAt: future}, nil
+		})
+		resolver, _ := claudeResolverFixture(t, claudeBlob("at-file", "rt-file", future), store, refresh)
+		_, value, ok, err := resolver(context.Background(), true)
+		if err != nil || !ok || value != "Bearer at-forced" {
+			t.Fatalf("resolver = %q ok=%v err=%v", value, ok, err)
+		}
+		if !refreshed {
+			t.Fatal("forceRefresh must invoke the refresh flow")
+		}
+	})
+
+	t.Run("newer-expiry source wins the refresh token choice", func(t *testing.T) {
+		cached := oauth.Token{RefreshToken: "rt-cached", ExpiresAt: past.Add(-time.Hour)}
+		extracted := agentcli.Credentials{RefreshToken: "rt-file", ExpiresAt: past}
+		if got := newestClaudeRefreshToken(cached, extracted); got != "rt-file" {
+			t.Fatalf("newestClaudeRefreshToken = %q, want the later-expiry source", got)
+		}
+		if got := newestClaudeRefreshToken(oauth.Token{RefreshToken: "rt-cached", ExpiresAt: future}, extracted); got != "rt-cached" {
+			t.Fatalf("newestClaudeRefreshToken = %q, want the cached chain when it is newer", got)
+		}
+		if got := newestClaudeRefreshToken(oauth.Token{}, extracted); got != "rt-file" {
+			t.Fatalf("newestClaudeRefreshToken = %q, want the only source with a token", got)
+		}
+	})
+}

--- a/internal/providers/agentclicreds_test.go
+++ b/internal/providers/agentclicreds_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -468,4 +470,58 @@ func TestClaudeRefreshingBearerResolver(t *testing.T) {
 			t.Fatalf("newestClaudeRefreshToken = %q, want the only source with a token", got)
 		}
 	})
+}
+
+// TestClaudeRefreshingBearerResolverSerializesConcurrentRefresh proves the
+// resolver's mutex prevents the race CodeRabbit flagged: concurrent
+// StreamCompletion calls (e.g. parallel tool calls) sharing one resolver must
+// not both see a stale token and both call refresh with the SAME (commonly
+// single-use/rotated) refresh token. Without the lock, every one of the
+// concurrent callers would race into the refresh branch; with it, only the
+// first acquires an expired token, refreshes and saves it, and every other
+// caller — blocked until that finishes — re-checks the now-fresh cached token
+// and short-circuits instead of refreshing again.
+func TestClaudeRefreshingBearerResolverSerializesConcurrentRefresh(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(2 * time.Hour)
+	store := &fakeCLIAuthTokenStore{tokens: map[string]oauth.Token{
+		cliAuthTokenStoreKey: {AccessToken: "at-stale", RefreshToken: "rt-stale", ExpiresAt: past},
+	}}
+
+	var refreshCalls int32
+	var concurrentInFlight int32
+	refresh := claudeRefreshFunc(func(context.Context, string) (oauth.Token, error) {
+		if atomic.AddInt32(&concurrentInFlight, 1) > 1 {
+			t.Error("refresh invoked concurrently: resolver is not serializing access")
+		}
+		defer atomic.AddInt32(&concurrentInFlight, -1)
+		atomic.AddInt32(&refreshCalls, 1)
+		time.Sleep(20 * time.Millisecond) // widen the race window
+		return oauth.Token{AccessToken: "at-fresh", RefreshToken: "rt-fresh", ExpiresAt: future}, nil
+	})
+	// Extracted file credentials are also expired, so every caller that misses
+	// the (initially stale) cache falls through to the refresh branch too.
+	resolver, _ := claudeResolverFixture(t, claudeBlob("at-file-stale", "rt-file-stale", past), store, refresh)
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _, _, err := resolver(context.Background(), false)
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d: resolver returned error: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&refreshCalls); got != 1 {
+		t.Fatalf("refresh called %d times, want exactly 1 (later callers should reuse the winner's saved token)", got)
+	}
 }

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -86,6 +86,15 @@ type Options struct {
 	// is preferred over APIKey; a nil resolver (or one that yields ok=false) uses
 	// the API key. See providerio.SendWithAuthRetry.
 	OAuthResolver providerio.TokenResolver
+	// ClaudeCodeIdentity marks this provider as authenticating with a Claude
+	// Code subscription OAuth token (the claude CLI login). Anthropic only
+	// serves those tokens to requests that identify as Claude Code: the
+	// `claude-code-20250219` beta must be present AND the first system block
+	// must be exactly claudeCodeSystemPrompt. Without both, the API returns a
+	// 429 rate_limit_error regardless of the account's real quota. Enabling
+	// this makes the provider inject both. It is meaningless (and unset) for
+	// ordinary x-api-key auth.
+	ClaudeCodeIdentity bool
 	// StreamIdleTimeout aborts the stream if no data arrives for this long.
 	// When unset, Zero uses providerio.ResolveStreamIdleTimeout — the
 	// ZERO_STREAM_IDLE_TIMEOUT override or providerio.DefaultStreamIdleTimeout.
@@ -94,21 +103,32 @@ type Options struct {
 
 // Provider streams completions from Anthropic's Messages API.
 type Provider struct {
-	apiKey            string
-	baseURL           string
-	model             string
-	maxTokens         int
-	version           string
-	beta              string
-	authHeader        string
-	authScheme        string
-	authHeaderValue   string
-	customHeaders     map[string]string
-	oauthResolver     providerio.TokenResolver
-	httpClient        *http.Client
-	userAgent         string
-	streamIdleTimeout time.Duration
+	apiKey             string
+	baseURL            string
+	model              string
+	maxTokens          int
+	version            string
+	beta               string
+	authHeader         string
+	authScheme         string
+	authHeaderValue    string
+	customHeaders      map[string]string
+	oauthResolver      providerio.TokenResolver
+	claudeCodeIdentity bool
+	httpClient         *http.Client
+	userAgent          string
+	streamIdleTimeout  time.Duration
 }
+
+// claudeCodeSystemPrompt is the exact first system block Anthropic requires on
+// requests authenticated with a Claude Code subscription OAuth token. It is a
+// verbatim identity string, not instructions; zero's real system prompt
+// follows it as a second block.
+const claudeCodeSystemPrompt = "You are Claude Code, Anthropic's official CLI for Claude."
+
+// claudeCodeBeta is the beta flag that pairs with claudeCodeSystemPrompt to
+// unlock a subscription OAuth token.
+const claudeCodeBeta = "claude-code-20250219"
 
 // New creates an Anthropic provider.
 func New(options Options) (*Provider, error) {
@@ -128,21 +148,26 @@ func New(options Options) (*Provider, error) {
 	if version == "" {
 		version = defaultVersion
 	}
+	beta := strings.TrimSpace(options.Beta)
+	if options.ClaudeCodeIdentity {
+		beta = appendBeta(beta, claudeCodeBeta)
+	}
 	return &Provider{
-		apiKey:            options.APIKey,
-		baseURL:           baseURL,
-		model:             model,
-		maxTokens:         maxTokens,
-		version:           version,
-		beta:              strings.TrimSpace(options.Beta),
-		authHeader:        strings.TrimSpace(options.AuthHeader),
-		authScheme:        strings.TrimSpace(options.AuthScheme),
-		authHeaderValue:   strings.TrimSpace(options.AuthHeaderValue),
-		customHeaders:     providerio.CopyHeaders(options.CustomHeaders),
-		oauthResolver:     options.OAuthResolver,
-		httpClient:        providerio.HTTPClient(options.HTTPClient),
-		userAgent:         options.UserAgent,
-		streamIdleTimeout: providerio.ResolveStreamIdleTimeout(options.StreamIdleTimeout),
+		apiKey:             options.APIKey,
+		baseURL:            baseURL,
+		model:              model,
+		maxTokens:          maxTokens,
+		version:            version,
+		beta:               beta,
+		authHeader:         strings.TrimSpace(options.AuthHeader),
+		authScheme:         strings.TrimSpace(options.AuthScheme),
+		authHeaderValue:    strings.TrimSpace(options.AuthHeaderValue),
+		customHeaders:      providerio.CopyHeaders(options.CustomHeaders),
+		oauthResolver:      options.OAuthResolver,
+		claudeCodeIdentity: options.ClaudeCodeIdentity,
+		httpClient:         providerio.HTTPClient(options.HTTPClient),
+		userAgent:          options.UserAgent,
+		streamIdleTimeout:  providerio.ResolveStreamIdleTimeout(options.StreamIdleTimeout),
 	}, nil
 }
 
@@ -358,6 +383,21 @@ func (provider *Provider) emitHTTPError(ctx context.Context, response *http.Resp
 	})
 }
 
+// appendBeta adds one beta flag to a comma-separated anthropic-beta value,
+// preserving existing entries and avoiding a duplicate.
+func appendBeta(existing, add string) string {
+	existing = strings.TrimSpace(existing)
+	if existing == "" {
+		return add
+	}
+	for _, part := range strings.Split(existing, ",") {
+		if strings.TrimSpace(part) == add {
+			return existing
+		}
+	}
+	return existing + "," + add
+}
+
 func (provider *Provider) anthropicRequest(request zeroruntime.CompletionRequest) (messagesRequest, error) {
 	system, messages, err := mapMessages(request.Messages)
 	if err != nil {
@@ -387,12 +427,26 @@ func (provider *Provider) anthropicRequest(request zeroruntime.CompletionRequest
 	// whole system prompt; the breakpoint on the last tool covers all tool defs.
 	// Cache hits show up as cache_read_input_tokens in the usage. Non-caching
 	// providers ignore the field, and Anthropic accepts an empty/omitted system.
+	systemBlocks := []systemBlock{}
+	// A Claude Code OAuth token is only served when the FIRST system block is
+	// exactly the Claude Code identity string (see claudeCodeSystemPrompt); it
+	// leads, and zero's own system prompt follows as a second block.
+	if provider.claudeCodeIdentity {
+		systemBlocks = append(systemBlocks, systemBlock{Type: "text", Text: claudeCodeSystemPrompt})
+	}
 	if strings.TrimSpace(system) != "" {
-		mapped.System = []systemBlock{{
+		systemBlocks = append(systemBlocks, systemBlock{
 			Type:         "text",
 			Text:         system,
 			CacheControl: &cacheControl{Type: cacheEphemeral},
-		}}
+		})
+	} else if len(systemBlocks) > 0 {
+		// No zero system prompt, but the identity block still needs a cache
+		// breakpoint to be a well-formed cacheable system array.
+		systemBlocks[len(systemBlocks)-1].CacheControl = &cacheControl{Type: cacheEphemeral}
+	}
+	if len(systemBlocks) > 0 {
+		mapped.System = systemBlocks
 	}
 	if len(request.Tools) > 0 {
 		mapped.Tools = make([]anthropicTool, 0, len(request.Tools))

--- a/internal/providers/anthropic/provider_test.go
+++ b/internal/providers/anthropic/provider_test.go
@@ -583,3 +583,90 @@ func eventsOfType(events []zeroruntime.StreamEvent, eventType zeroruntime.Stream
 	}
 	return matching
 }
+
+// TestClaudeCodeIdentityInjectsPromptAndBeta verifies that a Claude Code
+// subscription OAuth provider sends what Anthropic requires to serve the token:
+// the claude-code beta flag and an exact identity system block leading the
+// system array, with zero's own system prompt following it.
+func TestClaudeCodeIdentityInjectsPromptAndBeta(t *testing.T) {
+	provider, err := New(Options{
+		Model:              "claude-sonnet-4-5",
+		Beta:               "oauth-2025-04-20",
+		ClaudeCodeIdentity: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !strings.Contains(provider.beta, "oauth-2025-04-20") || !strings.Contains(provider.beta, claudeCodeBeta) {
+		t.Fatalf("beta = %q, want both oauth and claude-code flags", provider.beta)
+	}
+
+	mapped, err := provider.anthropicRequest(zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: "zero real system prompt"},
+			{Role: zeroruntime.MessageRoleUser, Content: "hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("anthropicRequest: %v", err)
+	}
+	blocks, ok := mapped.System.([]systemBlock)
+	if !ok || len(blocks) != 2 {
+		t.Fatalf("System = %#v, want 2 blocks", mapped.System)
+	}
+	if blocks[0].Text != claudeCodeSystemPrompt {
+		t.Fatalf("first block = %q, want the exact Claude Code identity line", blocks[0].Text)
+	}
+	if blocks[1].Text != "zero real system prompt" {
+		t.Fatalf("second block = %q, want zero's own system prompt", blocks[1].Text)
+	}
+}
+
+// TestClaudeCodeIdentityWithoutSystemPromptStillLeadsWithIdentity covers a run
+// with no zero system prompt: the identity block must still be present and
+// carry the cache breakpoint so the system array is well-formed.
+func TestClaudeCodeIdentityWithoutSystemPromptStillLeadsWithIdentity(t *testing.T) {
+	provider, err := New(Options{Model: "claude-sonnet-4-5", ClaudeCodeIdentity: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	mapped, err := provider.anthropicRequest(zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("anthropicRequest: %v", err)
+	}
+	blocks, ok := mapped.System.([]systemBlock)
+	if !ok || len(blocks) != 1 || blocks[0].Text != claudeCodeSystemPrompt {
+		t.Fatalf("System = %#v, want a single identity block", mapped.System)
+	}
+	if blocks[0].CacheControl == nil {
+		t.Fatal("identity block missing cache breakpoint")
+	}
+}
+
+// TestNoClaudeCodeIdentityLeavesSystemUnchanged: an ordinary provider (x-api-key
+// or plain OAuth) must NOT inject the identity block or beta — that spoof is
+// only correct for a Claude Code subscription token.
+func TestNoClaudeCodeIdentityLeavesSystemUnchanged(t *testing.T) {
+	provider, err := New(Options{Model: "claude-sonnet-4-5"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if strings.Contains(provider.beta, claudeCodeBeta) {
+		t.Fatalf("beta = %q, want no claude-code flag for ordinary auth", provider.beta)
+	}
+	mapped, err := provider.anthropicRequest(zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: "zero real system prompt"},
+			{Role: zeroruntime.MessageRoleUser, Content: "hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("anthropicRequest: %v", err)
+	}
+	blocks, ok := mapped.System.([]systemBlock)
+	if !ok || len(blocks) != 1 || blocks[0].Text != "zero real system prompt" {
+		t.Fatalf("System = %#v, want only zero's own system block", mapped.System)
+	}
+}

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/oauth"
@@ -33,6 +34,12 @@ type Options struct {
 	// independent lookup that could pick a different login (a backend-rejected
 	// mismatch).
 	OAuthLoginKey string
+	// AgentCLIDeps are the agentcli.Deps used to extract credentials for a
+	// profile.AuthCLI-authenticated provider (see agentclicreds.go). The zero
+	// value resolves to the real filesystem/keychain (production default);
+	// tests inject fakes so credential resolution never touches a real PATH,
+	// disk, or the macOS keychain.
+	AgentCLIDeps agentcli.Deps
 }
 
 // New creates a runtime provider for a resolved provider profile.
@@ -40,6 +47,16 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 	resolved, err := resolveProfile(profile, options)
 	if err != nil {
 		return nil, err
+	}
+
+	// A profile.AuthCLI profile authenticates with a detected agent-CLI's own
+	// local login (Claude Code, Codex, ...) instead of a zero-managed API key
+	// or OAuth login. This branch takes priority over isCodexCatalog below —
+	// a CLI-authed chatgpt profile still needs the Codex-flavored provider,
+	// just with credentials sourced from agentcli instead of zero's OAuth
+	// store, so it is handled entirely inside newCLIAuthedProvider.
+	if authCLI := strings.TrimSpace(profile.AuthCLI); authCLI != "" {
+		return newCLIAuthedProvider(profile, resolved, authCLI, options)
 	}
 
 	// The ChatGPT (Codex) catalog requires the Codex-flavored provider: the

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -33,6 +33,12 @@ type NewSessionIDFunc func() (string, error)
 type WritePromptFileFunc func(prompt string) (string, error)
 type LoadFunc func(LoadOptions) (LoadResult, error)
 type RunChildFunc func(ctx context.Context, binaryPath string, args []string, progress func(streamjson.Event)) (ChildRunResult, error)
+
+// zeroProviderEnvVar mirrors config.ActiveProviderEnv ("ZERO_PROVIDER") without
+// importing internal/config: a per-child provider override just needs the env
+// var name a self-exec zero child reads at startup to resolve its profile.
+const zeroProviderEnvVar = "ZERO_PROVIDER"
+
 type LaunchBackgroundFunc func(binaryPath string, args []string, outputFile string, onExit func(exitCode int)) (int, error)
 type BackgroundManagerFunc func() (*background.Manager, error)
 
@@ -327,6 +333,16 @@ func (executor Executor) runFresh(ctx context.Context, params TaskParameters, op
 	if err != nil {
 		return ExecResult{}, err
 	}
+	if harnessID := strings.TrimSpace(manifest.Metadata.Harness); harnessID != "" {
+		// A harness-backed specialist drives an external agent CLI (claude,
+		// codex, ...) instead of self-exec zero; it has no background-launch
+		// path (runBackground assumes a self-exec zero child it can register
+		// with background.Manager and resume via zero's own session store).
+		if params.RunInBackground {
+			return ExecResult{}, fmt.Errorf("specialist %q runs on harness %q, which cannot run in background", manifest.Metadata.Name, harnessID)
+		}
+		return executor.runHarness(ctx, manifest, params, options)
+	}
 	built, err := executor.BuildArgs(BuildArgsInput{
 		Manifest:              manifest,
 		Prompt:                params.Prompt,
@@ -565,7 +581,7 @@ func (executor Executor) runBuiltArgs(ctx context.Context, built BuildArgsResult
 		Background:      false,
 	}
 	executor.recordSpecialistStart(accounting)
-	run, err := executor.runChild(ctx, binaryPath, built.Args, progress)
+	run, err := executor.runChild(ctx, binaryPath, built.Args, childProviderEnv(manifest.Metadata.Provider), progress)
 	if err != nil {
 		exitCode := run.exitCodeOr(-1)
 		summary := SummarizeStream(run.Events, exitCode)
@@ -635,11 +651,27 @@ func (executor Executor) binaryPath() (string, error) {
 	return path, nil
 }
 
-func (executor Executor) runChild(ctx context.Context, binaryPath string, args []string, progress func(streamjson.Event)) (ChildRunResult, error) {
+func (executor Executor) runChild(ctx context.Context, binaryPath string, args []string, env []string, progress func(streamjson.Event)) (ChildRunResult, error) {
 	if executor.RunChild != nil {
+		// The injectable RunChildFunc seam predates per-child env overrides and
+		// only exercises argv/progress in tests; env only matters on the real
+		// child-process path below, which every production caller uses.
 		return executor.RunChild(ctx, binaryPath, append([]string(nil), args...), progress)
 	}
-	return runChildProcess(ctx, binaryPath, args, progress)
+	return runChildProcess(ctx, binaryPath, args, env, progress)
+}
+
+// childProviderEnv returns the child process environment when the specialist
+// manifest pins a provider profile: the parent's environment plus a
+// ZERO_PROVIDER override, so a self-exec zero child resolves that profile
+// instead of inheriting the orchestrator's active provider. Returns nil
+// (inherit the process environment unchanged) when no provider is pinned.
+func childProviderEnv(provider string) []string {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return nil
+	}
+	return append(os.Environ(), zeroProviderEnvVar+"="+provider)
 }
 
 func (executor Executor) launchBackground(binaryPath string, args []string, outputFile string, onExit func(exitCode int)) (int, error) {
@@ -768,12 +800,59 @@ func cleanupPromptFile(promptFile string) {
 	_ = os.Remove(promptFile)
 }
 
-func runChildProcess(ctx context.Context, binaryPath string, args []string, progress func(streamjson.Event)) (ChildRunResult, error) {
+// childDecoder turns one child process's stdout into stream-json events. It is
+// the seam that lets runChildWithDecoder's process-management skeleton (start,
+// stream stdout, harden, wait, capture exit/signal) be shared between the
+// self-exec zero child (zeroLineDecoder, each line already IS a
+// streamjson.Event) and external harness-CLI children (harness_decode.go,
+// which translate a foreign stdout format into zero's event shape).
+type childDecoder interface {
+	// decodeLine turns one non-empty line of child stdout into zero or more
+	// stream-json events, in emission order.
+	decodeLine(line string) []streamjson.Event
+	// finish is called once after the child's stdout closes, with the process's
+	// exit code, so a decoder that only knows its final answer at stream end
+	// (e.g. "last message before task_complete", or raw accumulated text) can
+	// emit its closing events (typically an EventFinal).
+	finish(exitCode int) []streamjson.Event
+}
+
+// zeroLineDecoder decodes a self-exec zero child's stream-json stdout: every
+// line is already one streamjson.Event. A malformed line becomes a recorded
+// EventError instead of aborting the run — ParseStream did the same.
+type zeroLineDecoder struct{}
+
+func (zeroLineDecoder) decodeLine(line string) []streamjson.Event {
+	var event streamjson.Event
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return []streamjson.Event{{Type: streamjson.EventError, Message: fmt.Sprintf("parse stream-json line: %v", err)}}
+	}
+	return []streamjson.Event{event}
+}
+
+func (zeroLineDecoder) finish(int) []streamjson.Event { return nil }
+
+func runChildProcess(ctx context.Context, binaryPath string, args []string, env []string, progress func(streamjson.Event)) (ChildRunResult, error) {
+	return runChildWithDecoder(ctx, binaryPath, args, env, "", zeroLineDecoder{}, progress)
+}
+
+// runChildWithDecoder drives one child subprocess to completion: process-group
+// hardening + group-kill on cancel/timeout (so a build/server/bash the child
+// forked dies with it instead of orphaning, M6), line-buffered stdout
+// streaming through decoder, and exit/signal capture. env, when non-empty,
+// replaces the inherited process environment; dir, when non-empty, sets the
+// child's working directory (a self-exec zero child instead receives its
+// workspace root via a "--cwd" argv flag, so runChildProcess always passes "").
+func runChildWithDecoder(ctx context.Context, binaryPath string, args []string, env []string, dir string, decoder childDecoder, progress func(streamjson.Event)) (ChildRunResult, error) {
 	var stderr bytes.Buffer
 	command := osexec.CommandContext(ctx, binaryPath, args...)
-	// Put the child in its own process group and group-kill on cancel/timeout, so a
-	// build/server/bash the sub-agent forked dies with it instead of orphaning (M6).
 	hardenSpecialistChild(command)
+	if len(env) > 0 {
+		command.Env = env
+	}
+	if dir != "" {
+		command.Dir = dir
+	}
 	command.Stderr = &stderr
 	stdout, err := command.StdoutPipe()
 	if err != nil {
@@ -783,23 +862,20 @@ func runChildProcess(ctx context.Context, binaryPath string, args []string, prog
 		return ChildRunResult{Stderr: stderr.String()}, fmt.Errorf("start specialist child: %w", err)
 	}
 	events := []streamjson.Event{}
+	emit := func(decoded []streamjson.Event) {
+		for _, event := range decoded {
+			events = append(events, event)
+			if progress != nil {
+				progress(event)
+			}
+		}
+	}
 	reader := bufio.NewReader(stdout)
 	for {
 		line, readErr := reader.ReadString('\n')
 		line = strings.TrimSpace(line)
 		if line != "" {
-			var event streamjson.Event
-			if err := json.Unmarshal([]byte(line), &event); err != nil {
-				// Surface parse errors instead of silently dropping lines —
-				// ParseStream did this too. Accumulate what we have and let
-				// the caller decide via the error.
-				events = append(events, streamjson.Event{Type: streamjson.EventError, Message: fmt.Sprintf("parse stream-json line: %v", err)})
-			} else {
-				events = append(events, event)
-				if progress != nil {
-					progress(event)
-				}
-			}
+			emit(decoder.decodeLine(line))
 		}
 		if readErr != nil {
 			if readErr != io.EOF {
@@ -825,6 +901,7 @@ func runChildProcess(ctx context.Context, binaryPath string, args []string, prog
 			return ChildRunResult{Events: events, Stderr: stderr.String(), ExitCode: -1, Started: started}, fmt.Errorf("run specialist child: %w", err)
 		}
 	}
+	emit(decoder.finish(exitCode))
 	return ChildRunResult{Events: events, Stderr: stderr.String(), ExitCode: exitCode, Signal: signalDesc, Started: started}, nil
 }
 

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -48,6 +48,7 @@ type Executor struct {
 	PromptFileMaxSize     int
 	Load                  LoadFunc
 	RunChild              RunChildFunc
+	RunHarnessChild       runHarnessChildFunc
 	LaunchBackground      LaunchBackgroundFunc
 	BinaryPath            string
 	Paths                 Paths

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -6,7 +6,21 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
 )
+
+// TestZeroProviderEnvVarMatchesConfigActiveProviderEnv guards zeroProviderEnvVar
+// against silently drifting from config.ActiveProviderEnv. The two are
+// deliberately separate literals (see zeroProviderEnvVar's doc comment: this
+// package avoids importing internal/config just for one env var name), which
+// means a future rename of one would NOT be caught by the compiler — only by
+// this test actually comparing the values.
+func TestZeroProviderEnvVarMatchesConfigActiveProviderEnv(t *testing.T) {
+	if zeroProviderEnvVar != config.ActiveProviderEnv {
+		t.Fatalf("zeroProviderEnvVar = %q, config.ActiveProviderEnv = %q, want equal", zeroProviderEnvVar, config.ActiveProviderEnv)
+	}
+}
 
 func TestBuildArgsCreatesFreshSpecialistExecInvocation(t *testing.T) {
 	executor := Executor{

--- a/internal/specialist/format.go
+++ b/internal/specialist/format.go
@@ -43,6 +43,12 @@ func FormatShow(manifest Manifest) string {
 	if manifest.Metadata.ReasoningEffort != "" {
 		lines = append(lines, "reasoning effort: "+manifest.Metadata.ReasoningEffort)
 	}
+	if manifest.Metadata.Harness != "" {
+		lines = append(lines, "harness: "+manifest.Metadata.Harness)
+	}
+	if manifest.Metadata.Provider != "" {
+		lines = append(lines, "provider: "+manifest.Metadata.Provider)
+	}
 	tools := formatTools(manifest)
 	if tools != "" {
 		lines = append(lines, "tools: "+tools)

--- a/internal/specialist/harness.go
+++ b/internal/specialist/harness.go
@@ -1,0 +1,61 @@
+package specialist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/agentcli"
+)
+
+// runHarness runs a specialist whose manifest pins an external agent-harness
+// CLI (claude, codex, gemini, ...) instead of self-exec zero. It shares
+// accounting (recordSpecialistStart/Stop, usage rollup) and the final-result
+// shaping (BuildFinalResult) with the self-exec path in exec.go, and shares
+// child-process lifecycle management with it via runChildWithDecoder — only
+// the line decoder (harness_decode.go) and the resolved binary/argv differ.
+func (executor Executor) runHarness(ctx context.Context, manifest Manifest, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
+	harnessID := strings.TrimSpace(manifest.Metadata.Harness)
+	detection, ok := agentcli.DetectOne(harnessID, agentcli.Deps{})
+	if !ok {
+		return ExecResult{}, fmt.Errorf("%s is not installed or not on PATH", harnessID)
+	}
+
+	sessionID, err := executor.newSessionID()
+	if err != nil {
+		return ExecResult{}, err
+	}
+
+	wrappedPrompt := WrapSystemPrompt(manifest.Metadata.Name, manifest.SystemPrompt, params.Prompt, params.Description)
+	args := append(detection.Harness.PrintArgs(wrappedPrompt), manifest.Metadata.HarnessArgs...)
+
+	accounting := specialistAccountingInput{
+		ParentSessionID: options.ParentSessionID,
+		ChildSessionID:  sessionID,
+		SpecialistName:  manifest.Metadata.Name,
+		Description:     params.Description,
+		ToolCallID:      options.ToolCallID,
+		Mode:            "harness",
+		Background:      false,
+	}
+	executor.recordSpecialistStart(accounting)
+
+	// The Provider pin is deliberately NOT applied here: ZERO_PROVIDER only
+	// means something to a self-exec zero child that reads it at startup, and a
+	// harness child is a foreign CLI with its own credential/config store.
+	decoder := newHarnessDecoder(detection.Harness.Stream)
+	run, err := runChildWithDecoder(ctx, detection.Path, args, nil, strings.TrimSpace(options.Cwd), decoder, options.Progress)
+	if err != nil {
+		exitCode := run.exitCodeOr(-1)
+		summary := SummarizeStream(run.Events, exitCode)
+		executor.recordSpecialistStop(accounting, summary, "error", summary.ExitCode, err, false)
+		return ExecResult{SessionID: sessionID}, err
+	}
+	summary := SummarizeStream(run.Events, run.ExitCode)
+	rolledUp := executor.rollUpSpecialistUsage(accounting, summary)
+	executor.recordSpecialistStop(accounting, summary, summary.Status, summary.ExitCode, nil, rolledUp)
+	return ExecResult{
+		Result:    BuildFinalResult(run.Events, run.Stderr, run.ExitCode, run.Signal),
+		SessionID: sessionID,
+	}, nil
+}

--- a/internal/specialist/harness.go
+++ b/internal/specialist/harness.go
@@ -6,7 +6,16 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/agentcli"
+	"github.com/Gitlawb/zero/internal/streamjson"
 )
+
+// runHarnessChildFunc runs one harness child to completion; the production
+// default (runHarness's nil case) wraps runChildWithDecoder. Injectable via
+// Executor.RunHarnessChild — mirrors RunChildFunc's role for the self-exec
+// path (executor.runChild) — so tests can stub the child process and exercise
+// runHarness's own logic (session/accounting wiring, decoder selection,
+// result shaping) without spawning a real claude/codex process.
+type runHarnessChildFunc func(ctx context.Context, binaryPath string, args []string, dir string, decoder childDecoder, progress func(streamjson.Event)) (ChildRunResult, error)
 
 // runHarness runs a specialist whose manifest pins an external agent-harness
 // CLI (claude, codex, gemini, ...) instead of self-exec zero. It shares
@@ -44,7 +53,13 @@ func (executor Executor) runHarness(ctx context.Context, manifest Manifest, para
 	// means something to a self-exec zero child that reads it at startup, and a
 	// harness child is a foreign CLI with its own credential/config store.
 	decoder := newHarnessDecoder(detection.Harness.Stream)
-	run, err := runChildWithDecoder(ctx, detection.Path, args, nil, strings.TrimSpace(options.Cwd), decoder, options.Progress)
+	runChild := executor.RunHarnessChild
+	if runChild == nil {
+		runChild = func(ctx context.Context, binaryPath string, args []string, dir string, decoder childDecoder, progress func(streamjson.Event)) (ChildRunResult, error) {
+			return runChildWithDecoder(ctx, binaryPath, args, nil, dir, decoder, progress)
+		}
+	}
+	run, err := runChild(ctx, detection.Path, args, strings.TrimSpace(options.Cwd), decoder, options.Progress)
 	if err != nil {
 		exitCode := run.exitCodeOr(-1)
 		summary := SummarizeStream(run.Events, exitCode)

--- a/internal/specialist/harness_child_test.go
+++ b/internal/specialist/harness_child_test.go
@@ -1,0 +1,132 @@
+package specialist
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/streamjson"
+)
+
+func TestChildProviderEnvAppendsOverrideAndKeepsInheritedVars(t *testing.T) {
+	t.Setenv("ZERO_SPECIALIST_ENV_PROBE", "keep-me")
+
+	env := childProviderEnv("work-openai")
+	if env == nil {
+		t.Fatal("expected a non-nil env when a provider is pinned")
+	}
+	if last := env[len(env)-1]; last != "ZERO_PROVIDER=work-openai" {
+		t.Fatalf("last env entry = %q, want ZERO_PROVIDER=work-openai", last)
+	}
+	found := false
+	for _, kv := range env {
+		if kv == "ZERO_SPECIALIST_ENV_PROBE=keep-me" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("childProviderEnv dropped an inherited environment variable")
+	}
+}
+
+func TestChildProviderEnvNilWhenNoProviderPinned(t *testing.T) {
+	if env := childProviderEnv(""); env != nil {
+		t.Fatalf("childProviderEnv(\"\") = %#v, want nil (inherit unchanged)", env)
+	}
+	if env := childProviderEnv("   "); env != nil {
+		t.Fatalf("childProviderEnv(whitespace) = %#v, want nil (inherit unchanged)", env)
+	}
+}
+
+func requireSh(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("requires /bin/sh")
+	}
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available")
+	}
+}
+
+// TestRunChildWithDecoderAppliesEnvAndWorkingDir exercises the shared
+// process-management skeleton (runChildWithDecoder) end-to-end against a real
+// subprocess, proving both the env-override construction (childProviderEnv)
+// and the harness working-directory wiring reach the actual child process —
+// not just the struct fields.
+func TestRunChildWithDecoderAppliesEnvAndWorkingDir(t *testing.T) {
+	requireSh(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "marker.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write marker file: %v", err)
+	}
+	env := childProviderEnv("work-openai")
+	script := `echo "provider=$ZERO_PROVIDER"; test -f marker.txt && echo "cwd-ok"`
+	run, err := runChildWithDecoder(context.Background(), "/bin/sh", []string{"-c", script}, env, dir, &textDecoder{}, nil)
+	if err != nil {
+		t.Fatalf("runChildWithDecoder returned error: %v", err)
+	}
+	if run.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0 (stderr: %s)", run.ExitCode, run.Stderr)
+	}
+	final := finalText(run.Events)
+	if !strings.Contains(final, "provider=work-openai") {
+		t.Fatalf("child output %q missing the ZERO_PROVIDER override", final)
+	}
+	if !strings.Contains(final, "cwd-ok") {
+		t.Fatalf("child output %q missing the working-directory marker", final)
+	}
+}
+
+// TestRunChildWithDecoderCapturesNonZeroExitAndStderr is the exit-code error
+// path shared by both runChildProcess (self-exec zero) and the harness path:
+// a failing child's exit code and stderr must both survive into
+// ChildRunResult regardless of which decoder is driving it.
+func TestRunChildWithDecoderCapturesNonZeroExitAndStderr(t *testing.T) {
+	requireSh(t)
+	run, err := runChildWithDecoder(context.Background(), "/bin/sh", []string{"-c", "echo boom 1>&2; exit 7"}, nil, "", &textDecoder{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if run.ExitCode != 7 {
+		t.Fatalf("ExitCode = %d, want 7", run.ExitCode)
+	}
+	if !strings.Contains(run.Stderr, "boom") {
+		t.Fatalf("Stderr = %q, want to contain boom", run.Stderr)
+	}
+	// textDecoder.finish suppresses the synthetic final on a non-zero exit (see
+	// harness_decode_test.go), so BuildFinalResult falls back to stderr/errors.
+	if text := finalText(run.Events); text != "" {
+		t.Fatalf("expected no synthesized final text on non-zero exit, got %q", text)
+	}
+}
+
+// TestRunChildWithDecoderProgressReceivesEveryEvent proves the harness
+// decoding path feeds the SAME progress callback contract as the self-exec
+// zero path (runChildProcess): every emitted event, including decoder-side
+// synthesized ones like EventFinal, reaches progress in order.
+func TestRunChildWithDecoderProgressReceivesEveryEvent(t *testing.T) {
+	requireSh(t)
+	var seen []streamjson.EventType
+	_, err := runChildWithDecoder(context.Background(), "/bin/sh", []string{"-c", "echo hello"}, nil, "", &textDecoder{}, func(event streamjson.Event) {
+		seen = append(seen, event.Type)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(seen) != 2 || seen[0] != streamjson.EventText || seen[1] != streamjson.EventFinal {
+		t.Fatalf("progress saw %#v, want [text final]", seen)
+	}
+}
+
+func finalText(events []streamjson.Event) string {
+	for _, event := range events {
+		if event.Type == streamjson.EventFinal {
+			return event.Text
+		}
+	}
+	return ""
+}

--- a/internal/specialist/harness_decode.go
+++ b/internal/specialist/harness_decode.go
@@ -1,0 +1,175 @@
+package specialist
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/streamjson"
+)
+
+// newHarnessDecoder selects the childDecoder for a harness's stdout format
+// (agentcli.Harness.Stream). An unrecognized value — including "text" itself,
+// and any future format the catalog names before a dedicated decoder exists —
+// falls back to textDecoder, which treats stdout as opaque prose: a new
+// harness catalog entry never hard-fails a run just because its stream format
+// isn't specially understood yet.
+func newHarnessDecoder(stream string) childDecoder {
+	switch stream {
+	case "claude-stream-json":
+		return &claudeStreamDecoder{}
+	case "codex-json":
+		return &codexJSONDecoder{}
+	default:
+		return &textDecoder{}
+	}
+}
+
+// claudeStreamDecoder decodes the NDJSON stdout produced by `claude -p
+// --output-format stream-json` (and cursor-agent's compatible format): a
+// "system" line is startup noise (ignored), an "assistant" line's message
+// content blocks become text/tool_call events, and a "result" line carries
+// the run's final answer.
+type claudeStreamDecoder struct {
+	gotResult bool
+}
+
+type claudeStreamLine struct {
+	Type    string `json:"type"`
+	Message *struct {
+		Content []struct {
+			Type  string          `json:"type"`
+			Text  string          `json:"text"`
+			ID    string          `json:"id"`
+			Name  string          `json:"name"`
+			Input json.RawMessage `json:"input"`
+		} `json:"content"`
+	} `json:"message"`
+	Result string `json:"result"`
+}
+
+func (d *claudeStreamDecoder) decodeLine(line string) []streamjson.Event {
+	var parsed claudeStreamLine
+	// A malformed or shape-mismatched line is tolerated, not fatal — the
+	// harness's protocol may add fields/line types this decoder doesn't know
+	// about yet.
+	if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+		return nil
+	}
+	switch parsed.Type {
+	case "assistant":
+		if parsed.Message == nil {
+			return nil
+		}
+		var events []streamjson.Event
+		for _, block := range parsed.Message.Content {
+			switch block.Type {
+			case "text":
+				if block.Text != "" {
+					events = append(events, streamjson.Event{Type: streamjson.EventText, Delta: block.Text})
+				}
+			case "tool_use":
+				var args any
+				if len(block.Input) > 0 {
+					_ = json.Unmarshal(block.Input, &args)
+				}
+				events = append(events, streamjson.Event{Type: streamjson.EventToolCall, ID: block.ID, Name: block.Name, Args: args})
+			}
+		}
+		return events
+	case "result":
+		d.gotResult = true
+		return []streamjson.Event{{Type: streamjson.EventFinal, Text: parsed.Result}}
+	default:
+		// "system"/"init" and any other line types carry nothing the specialist
+		// pipeline needs.
+		return nil
+	}
+}
+
+func (d *claudeStreamDecoder) finish(int) []streamjson.Event {
+	// No synthetic final when the stream never produced a "result" line (e.g.
+	// the CLI crashed mid-run): BuildFinalResult already reports a non-zero
+	// exit as an error using stderr, and inventing a final here would just mask
+	// the missing result.
+	return nil
+}
+
+// codexJSONDecoder decodes the NDJSON stdout produced by `codex exec --json`:
+// each line wraps a "msg" whose "type" distinguishes an assistant text chunk
+// ("agent_message"), the run's completion marker ("task_complete"), and a
+// best-effort token usage report ("token_count"). Codex's final answer is
+// "the last agent_message seen", not a dedicated field, so the decoder must
+// remember it across lines.
+type codexJSONDecoder struct {
+	lastMessage string
+	done        bool
+}
+
+type codexLine struct {
+	Msg struct {
+		Type         string `json:"type"`
+		Message      string `json:"message"`
+		InputTokens  *int   `json:"input_tokens"`
+		OutputTokens *int   `json:"output_tokens"`
+		TotalTokens  *int   `json:"total_tokens"`
+	} `json:"msg"`
+}
+
+func (d *codexJSONDecoder) decodeLine(line string) []streamjson.Event {
+	var parsed codexLine
+	if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+		return nil
+	}
+	switch parsed.Msg.Type {
+	case "agent_message":
+		if parsed.Msg.Message == "" {
+			return nil
+		}
+		d.lastMessage = parsed.Msg.Message
+		return []streamjson.Event{{Type: streamjson.EventText, Delta: parsed.Msg.Message}}
+	case "task_complete":
+		d.done = true
+		return []streamjson.Event{{Type: streamjson.EventFinal, Text: d.lastMessage}}
+	case "token_count":
+		event := streamjson.Event{Type: streamjson.EventUsage}
+		event.PromptTokens = parsed.Msg.InputTokens
+		event.CompletionTokens = parsed.Msg.OutputTokens
+		event.TotalTokens = parsed.Msg.TotalTokens
+		return []streamjson.Event{event}
+	default:
+		return nil
+	}
+}
+
+func (d *codexJSONDecoder) finish(int) []streamjson.Event {
+	// task_complete never arrived (e.g. the CLI was killed mid-run) but there
+	// was at least one agent_message — still surface it as the final answer
+	// rather than losing it.
+	if d.done || d.lastMessage == "" {
+		return nil
+	}
+	return []streamjson.Event{{Type: streamjson.EventFinal, Text: d.lastMessage}}
+}
+
+// textDecoder is the fallback for any harness whose Stream is "text" (or
+// unrecognized): stdout is opaque prose, streamed line-by-line as text
+// events, with the full accumulated output surfaced as the final answer once
+// the process exits cleanly.
+type textDecoder struct {
+	lines []string
+}
+
+func (d *textDecoder) decodeLine(line string) []streamjson.Event {
+	d.lines = append(d.lines, line)
+	return []streamjson.Event{{Type: streamjson.EventText, Delta: line + "\n"}}
+}
+
+func (d *textDecoder) finish(exitCode int) []streamjson.Event {
+	if exitCode != 0 {
+		// A non-zero exit is reported as an error by BuildFinalResult using
+		// stderr; the accumulated stdout is still available via the text deltas
+		// already emitted above, so no separate final event is needed here.
+		return nil
+	}
+	return []streamjson.Event{{Type: streamjson.EventFinal, Text: strings.TrimSpace(strings.Join(d.lines, "\n"))}}
+}

--- a/internal/specialist/harness_decode.go
+++ b/internal/specialist/harness_decode.go
@@ -94,25 +94,38 @@ func (d *claudeStreamDecoder) finish(int) []streamjson.Event {
 	return nil
 }
 
-// codexJSONDecoder decodes the NDJSON stdout produced by `codex exec --json`:
-// each line wraps a "msg" whose "type" distinguishes an assistant text chunk
-// ("agent_message"), the run's completion marker ("task_complete"), and a
-// best-effort token usage report ("token_count"). Codex's final answer is
-// "the last agent_message seen", not a dedicated field, so the decoder must
-// remember it across lines.
+// codexJSONDecoder decodes the NDJSON stdout produced by `codex exec --json`.
+// Grounded against a real capture (codex-cli 0.142.5, `codex exec --json
+// --skip-git-repo-check "reply with exactly: hi"`), which emits top-level
+// events — not the legacy `{"msg":{"type":...}}` wrapper this decoder
+// previously expected:
+//
+//	{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"hi"}}
+//	{"type":"turn.completed","usage":{"input_tokens":27089,"cached_input_tokens":4992,"output_tokens":24,"reasoning_output_tokens":17}}
+//
+// "item.completed" fires once per item reaching a terminal state; only
+// item.type "agent_message" carries assistant text the specialist pipeline
+// cares about (other item types — "error" for config/tooling warnings,
+// "command_execution", "file_change" — are noise for this decoder's scope,
+// same as legacy's silent drop of "reasoning"/unknown msg types). Codex's
+// final answer is "the last agent_message seen", not a dedicated field, so
+// the decoder must remember it across lines. "turn.completed" is the run's
+// completion marker and carries token usage.
 type codexJSONDecoder struct {
 	lastMessage string
 	done        bool
 }
 
 type codexLine struct {
-	Msg struct {
-		Type         string `json:"type"`
-		Message      string `json:"message"`
-		InputTokens  *int   `json:"input_tokens"`
-		OutputTokens *int   `json:"output_tokens"`
-		TotalTokens  *int   `json:"total_tokens"`
-	} `json:"msg"`
+	Type string `json:"type"`
+	Item *struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"item"`
+	Usage *struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
 }
 
 func (d *codexJSONDecoder) decodeLine(line string) []streamjson.Event {
@@ -120,29 +133,34 @@ func (d *codexJSONDecoder) decodeLine(line string) []streamjson.Event {
 	if err := json.Unmarshal([]byte(line), &parsed); err != nil {
 		return nil
 	}
-	switch parsed.Msg.Type {
-	case "agent_message":
-		if parsed.Msg.Message == "" {
+	switch parsed.Type {
+	case "item.completed":
+		if parsed.Item == nil || parsed.Item.Type != "agent_message" || parsed.Item.Text == "" {
 			return nil
 		}
-		d.lastMessage = parsed.Msg.Message
-		return []streamjson.Event{{Type: streamjson.EventText, Delta: parsed.Msg.Message}}
-	case "task_complete":
+		d.lastMessage = parsed.Item.Text
+		return []streamjson.Event{{Type: streamjson.EventText, Delta: parsed.Item.Text}}
+	case "turn.completed":
 		d.done = true
-		return []streamjson.Event{{Type: streamjson.EventFinal, Text: d.lastMessage}}
-	case "token_count":
-		event := streamjson.Event{Type: streamjson.EventUsage}
-		event.PromptTokens = parsed.Msg.InputTokens
-		event.CompletionTokens = parsed.Msg.OutputTokens
-		event.TotalTokens = parsed.Msg.TotalTokens
-		return []streamjson.Event{event}
+		var events []streamjson.Event
+		if parsed.Usage != nil {
+			input, output := parsed.Usage.InputTokens, parsed.Usage.OutputTokens
+			total := input + output
+			events = append(events, streamjson.Event{
+				Type:             streamjson.EventUsage,
+				PromptTokens:     &input,
+				CompletionTokens: &output,
+				TotalTokens:      &total,
+			})
+		}
+		return append(events, streamjson.Event{Type: streamjson.EventFinal, Text: d.lastMessage})
 	default:
 		return nil
 	}
 }
 
 func (d *codexJSONDecoder) finish(int) []streamjson.Event {
-	// task_complete never arrived (e.g. the CLI was killed mid-run) but there
+	// turn.completed never arrived (e.g. the CLI was killed mid-run) but there
 	// was at least one agent_message — still surface it as the final answer
 	// rather than losing it.
 	if d.done || d.lastMessage == "" {

--- a/internal/specialist/harness_decode_test.go
+++ b/internal/specialist/harness_decode_test.go
@@ -1,0 +1,172 @@
+package specialist
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/streamjson"
+)
+
+// runDecoder feeds lines through a fresh decoder (as runChildWithDecoder
+// would: decodeLine per non-empty line, then finish once at exit) and
+// collects every emitted event, so decoder behavior is testable without
+// spawning a real child process.
+func runDecoder(decoder childDecoder, lines []string, exitCode int) []streamjson.Event {
+	var events []streamjson.Event
+	for _, line := range lines {
+		events = append(events, decoder.decodeLine(line)...)
+	}
+	events = append(events, decoder.finish(exitCode)...)
+	return events
+}
+
+func TestNewHarnessDecoderSelectsByStreamFormat(t *testing.T) {
+	cases := map[string]childDecoder{
+		"claude-stream-json": &claudeStreamDecoder{},
+		"codex-json":         &codexJSONDecoder{},
+		"text":               &textDecoder{},
+		"gemini-json":        &textDecoder{}, // unrecognized -> text fallback
+		"":                   &textDecoder{}, // unrecognized -> text fallback
+	}
+	for stream, want := range cases {
+		t.Run(stream, func(t *testing.T) {
+			got := newHarnessDecoder(stream)
+			gotType := typeName(got)
+			wantType := typeName(want)
+			if gotType != wantType {
+				t.Fatalf("newHarnessDecoder(%q) = %s, want %s", stream, gotType, wantType)
+			}
+		})
+	}
+}
+
+func typeName(decoder childDecoder) string {
+	switch decoder.(type) {
+	case *claudeStreamDecoder:
+		return "claude"
+	case *codexJSONDecoder:
+		return "codex"
+	case *textDecoder:
+		return "text"
+	default:
+		return "unknown"
+	}
+}
+
+func TestClaudeStreamDecoderTextAndToolCallAndFinal(t *testing.T) {
+	lines := []string{
+		`{"type":"system","subtype":"init","cwd":"/tmp"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Looking at the file"},{"type":"tool_use","id":"call_1","name":"read_file","input":{"path":"a.go"}}]}}`,
+		`{"type":"result","subtype":"success","result":"All done"}`,
+	}
+	events := runDecoder(&claudeStreamDecoder{}, lines, 0)
+
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3: %#v", len(events), events)
+	}
+	if events[0].Type != streamjson.EventText || events[0].Delta != "Looking at the file" {
+		t.Fatalf("event 0 = %#v", events[0])
+	}
+	if events[1].Type != streamjson.EventToolCall || events[1].Name != "read_file" || events[1].ID != "call_1" {
+		t.Fatalf("event 1 = %#v", events[1])
+	}
+	if args, ok := events[1].Args.(map[string]any); !ok || args["path"] != "a.go" {
+		t.Fatalf("event 1 args = %#v, want map with path=a.go", events[1].Args)
+	}
+	if events[2].Type != streamjson.EventFinal || events[2].Text != "All done" {
+		t.Fatalf("event 2 = %#v", events[2])
+	}
+}
+
+func TestClaudeStreamDecoderTolerantOfMalformedAndUnknownLines(t *testing.T) {
+	lines := []string{
+		`not json at all`,
+		`{"type":"ping"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`,
+	}
+	events := runDecoder(&claudeStreamDecoder{}, lines, 0)
+	if len(events) != 1 || events[0].Type != streamjson.EventText || events[0].Delta != "hi" {
+		t.Fatalf("unexpected events: %#v", events)
+	}
+}
+
+func TestClaudeStreamDecoderNoSyntheticFinalWithoutResultLine(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"partial"}]}}`,
+	}
+	events := runDecoder(&claudeStreamDecoder{}, lines, 1)
+	for _, event := range events {
+		if event.Type == streamjson.EventFinal {
+			t.Fatalf("expected no synthetic final event, got %#v", events)
+		}
+	}
+}
+
+func TestCodexJSONDecoderAgentMessageAndTaskComplete(t *testing.T) {
+	lines := []string{
+		`{"msg":{"type":"agent_message","message":"step one"}}`,
+		`{"msg":{"type":"agent_message","message":"step two"}}`,
+		`{"msg":{"type":"token_count","input_tokens":10,"output_tokens":5,"total_tokens":15}}`,
+		`{"msg":{"type":"task_complete"}}`,
+	}
+	events := runDecoder(&codexJSONDecoder{}, lines, 0)
+	if len(events) != 4 {
+		t.Fatalf("got %d events, want 4: %#v", len(events), events)
+	}
+	if events[0].Type != streamjson.EventText || events[0].Delta != "step one" {
+		t.Fatalf("event 0 = %#v", events[0])
+	}
+	if events[1].Type != streamjson.EventText || events[1].Delta != "step two" {
+		t.Fatalf("event 1 = %#v", events[1])
+	}
+	if events[2].Type != streamjson.EventUsage || events[2].PromptTokens == nil || *events[2].PromptTokens != 10 {
+		t.Fatalf("event 2 = %#v", events[2])
+	}
+	if events[3].Type != streamjson.EventFinal || events[3].Text != "step two" {
+		t.Fatalf("event 3 = %#v, want final with last agent_message", events[3])
+	}
+}
+
+func TestCodexJSONDecoderFinalizesOnLastMessageWhenStreamEndsWithoutTaskComplete(t *testing.T) {
+	lines := []string{
+		`{"msg":{"type":"agent_message","message":"only message"}}`,
+	}
+	events := runDecoder(&codexJSONDecoder{}, lines, -1)
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2 (text + synthesized final): %#v", len(events), events)
+	}
+	if events[1].Type != streamjson.EventFinal || events[1].Text != "only message" {
+		t.Fatalf("event 1 = %#v", events[1])
+	}
+}
+
+func TestCodexJSONDecoderIgnoresMalformedAndUnknownLines(t *testing.T) {
+	lines := []string{
+		`{not json`,
+		`{"msg":{"type":"reasoning","message":"thinking..."}}`,
+	}
+	events := runDecoder(&codexJSONDecoder{}, lines, 0)
+	if len(events) != 0 {
+		t.Fatalf("expected no events, got %#v", events)
+	}
+}
+
+func TestTextDecoderStreamsAndFinalizesOnCleanExit(t *testing.T) {
+	lines := []string{"line one", "line two"}
+	events := runDecoder(&textDecoder{}, lines, 0)
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3: %#v", len(events), events)
+	}
+	if events[0].Type != streamjson.EventText || events[0].Delta != "line one\n" {
+		t.Fatalf("event 0 = %#v", events[0])
+	}
+	if events[2].Type != streamjson.EventFinal || events[2].Text != "line one\nline two" {
+		t.Fatalf("event 2 = %#v", events[2])
+	}
+}
+
+func TestTextDecoderNoFinalOnNonZeroExit(t *testing.T) {
+	events := runDecoder(&textDecoder{}, []string{"oops"}, 1)
+	if len(events) != 1 || events[0].Type != streamjson.EventText {
+		t.Fatalf("expected only the streamed text event, got %#v", events)
+	}
+}

--- a/internal/specialist/harness_decode_test.go
+++ b/internal/specialist/harness_decode_test.go
@@ -101,12 +101,17 @@ func TestClaudeStreamDecoderNoSyntheticFinalWithoutResultLine(t *testing.T) {
 	}
 }
 
-func TestCodexJSONDecoderAgentMessageAndTaskComplete(t *testing.T) {
+// The lines below are captured from a real run (codex-cli 0.142.5): `codex
+// exec --json --skip-git-repo-check "reply with exactly: hi" < /dev/null`,
+// with unrelated noise (thread.started, deprecation/plugin-config error
+// items, MCP transport errors) stripped — see harness_decode.go's decoder doc
+// comment for the untrimmed capture. The legacy `{"msg":{"type":...}}` shape
+// these tests exercised before no longer appears in real codex output at all.
+func TestCodexJSONDecoderAgentMessageAndTurnCompleted(t *testing.T) {
 	lines := []string{
-		`{"msg":{"type":"agent_message","message":"step one"}}`,
-		`{"msg":{"type":"agent_message","message":"step two"}}`,
-		`{"msg":{"type":"token_count","input_tokens":10,"output_tokens":5,"total_tokens":15}}`,
-		`{"msg":{"type":"task_complete"}}`,
+		`{"type":"item.completed","item":{"id":"item_a","type":"agent_message","text":"step one"}}`,
+		`{"type":"item.completed","item":{"id":"item_b","type":"agent_message","text":"step two"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":27089,"cached_input_tokens":4992,"output_tokens":24,"reasoning_output_tokens":17}}`,
 	}
 	events := runDecoder(&codexJSONDecoder{}, lines, 0)
 	if len(events) != 4 {
@@ -118,17 +123,23 @@ func TestCodexJSONDecoderAgentMessageAndTaskComplete(t *testing.T) {
 	if events[1].Type != streamjson.EventText || events[1].Delta != "step two" {
 		t.Fatalf("event 1 = %#v", events[1])
 	}
-	if events[2].Type != streamjson.EventUsage || events[2].PromptTokens == nil || *events[2].PromptTokens != 10 {
+	if events[2].Type != streamjson.EventUsage || events[2].PromptTokens == nil || *events[2].PromptTokens != 27089 {
 		t.Fatalf("event 2 = %#v", events[2])
+	}
+	if events[2].CompletionTokens == nil || *events[2].CompletionTokens != 24 {
+		t.Fatalf("event 2 completion tokens = %#v", events[2])
+	}
+	if events[2].TotalTokens == nil || *events[2].TotalTokens != 27113 {
+		t.Fatalf("event 2 total tokens = %#v, want input+output", events[2])
 	}
 	if events[3].Type != streamjson.EventFinal || events[3].Text != "step two" {
 		t.Fatalf("event 3 = %#v, want final with last agent_message", events[3])
 	}
 }
 
-func TestCodexJSONDecoderFinalizesOnLastMessageWhenStreamEndsWithoutTaskComplete(t *testing.T) {
+func TestCodexJSONDecoderFinalizesOnLastMessageWhenStreamEndsWithoutTurnCompleted(t *testing.T) {
 	lines := []string{
-		`{"msg":{"type":"agent_message","message":"only message"}}`,
+		`{"type":"item.completed","item":{"id":"item_a","type":"agent_message","text":"only message"}}`,
 	}
 	events := runDecoder(&codexJSONDecoder{}, lines, -1)
 	if len(events) != 2 {
@@ -139,14 +150,68 @@ func TestCodexJSONDecoderFinalizesOnLastMessageWhenStreamEndsWithoutTaskComplete
 	}
 }
 
-func TestCodexJSONDecoderIgnoresMalformedAndUnknownLines(t *testing.T) {
+func TestCodexJSONDecoderIgnoresNonAgentMessageItemsAndMalformedLines(t *testing.T) {
 	lines := []string{
 		`{not json`,
-		`{"msg":{"type":"reasoning","message":"thinking..."}}`,
+		// Real noise seen in captures: deprecation/plugin-config warnings surface
+		// as item.completed items of type "error", not the final answer.
+		`{"type":"item.completed","item":{"id":"item_0","type":"error","message":"some config warning"}}`,
+		`{"type":"item.completed","item":{"id":"item_1","type":"reasoning","text":"thinking..."}}`,
+		`{"type":"turn.started"}`,
 	}
 	events := runDecoder(&codexJSONDecoder{}, lines, 0)
 	if len(events) != 0 {
 		t.Fatalf("expected no events, got %#v", events)
+	}
+}
+
+// TestCodexJSONDecoderRealCaptureEndToEnd replays the UNTRIMMED real capture
+// (codex-cli 0.142.5, `codex exec --json --skip-git-repo-check "reply with
+// exactly: hi" < /dev/null`) verbatim, including lines the legacy decoder
+// never had to handle: a leading non-JSON stdin-prompt line, and mid-stream
+// plain-text Rust log lines from failed MCP transport workers (these came out
+// on stdout interleaved with the NDJSON, not stderr, in this capture). Every
+// non-agent_message/turn.completed line must be silently ignored and the
+// decoder must still land on exactly the real final answer and usage.
+func TestCodexJSONDecoderRealCaptureEndToEnd(t *testing.T) {
+	lines := []string{
+		`Reading additional input from stdin...`,
+		`{"type":"thread.started","thread_id":"019f2779-ba38-7782-8c13-5168ea9f776b"}`,
+		"{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"error\",\"message\":\"`[features].codex_hooks` is deprecated. Use `[features].hooks` instead.\"}}",
+		`{"type":"item.completed","item":{"id":"item_1","type":"error","message":"failed to parse plugin hooks config"}}`,
+		`{"type":"turn.started"}`,
+		`2026-07-03T10:15:18.625718Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer error=\"invalid_token\"" })`,
+		`2026-07-03T10:15:18.689968Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer resource_metadata=\"https://mcp.slack.com/.well-known/oauth-protected-resource\"" })`,
+		`{"type":"item.completed","item":{"id":"item_2","type":"error","message":"Exceeded skills context budget of 2%."}}`,
+		`{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"hi"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":27089,"cached_input_tokens":4992,"output_tokens":24,"reasoning_output_tokens":17}}`,
+	}
+	events := runDecoder(&codexJSONDecoder{}, lines, 0)
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3 (text + usage + final): %#v", len(events), events)
+	}
+	if events[0].Type != streamjson.EventText || events[0].Delta != "hi" {
+		t.Fatalf("event 0 = %#v", events[0])
+	}
+	if events[1].Type != streamjson.EventUsage || events[1].PromptTokens == nil || *events[1].PromptTokens != 27089 {
+		t.Fatalf("event 1 = %#v", events[1])
+	}
+	if events[2].Type != streamjson.EventFinal || events[2].Text != "hi" {
+		t.Fatalf("event 2 = %#v, want final answer \"hi\"", events[2])
+	}
+}
+
+func TestCodexJSONDecoderTurnCompletedWithoutUsageStillEmitsFinal(t *testing.T) {
+	lines := []string{
+		`{"type":"item.completed","item":{"id":"item_a","type":"agent_message","text":"done"}}`,
+		`{"type":"turn.completed"}`,
+	}
+	events := runDecoder(&codexJSONDecoder{}, lines, 0)
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2 (text + final, no usage event): %#v", len(events), events)
+	}
+	if events[1].Type != streamjson.EventFinal || events[1].Text != "done" {
+		t.Fatalf("event 1 = %#v", events[1])
 	}
 }
 

--- a/internal/specialist/harness_dispatch_test.go
+++ b/internal/specialist/harness_dispatch_test.go
@@ -1,0 +1,69 @@
+package specialist
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// harnessManifest builds a minimal valid manifest pinned to the given
+// agentcli harness id, for exercising runFresh's harness-dispatch branch
+// without going through the markdown loader.
+func harnessManifest(t *testing.T, harness string) *Manifest {
+	t.Helper()
+	manifest, err := ParseMarkdown(`---
+name: harness-worker
+description: Runs on an external harness
+harness: ` + harness + `
+---
+Do the task.`)
+	if err != nil {
+		t.Fatalf("ParseMarkdown: %v", err)
+	}
+	return &manifest
+}
+
+// TestRunFreshHarnessRejectsRunInBackground locks in that a harness-backed
+// specialist (Metadata.Harness set) refuses RunInBackground before ever
+// touching runHarness/agentcli.DetectOne — the background-launch path assumes
+// a self-exec zero child it can register with background.Manager, which a
+// foreign harness CLI is not.
+func TestRunFreshHarnessRejectsRunInBackground(t *testing.T) {
+	executor := Executor{}
+	_, err := executor.Run(context.Background(), TaskParameters{
+		Prompt:          "do the thing",
+		RunInBackground: true,
+		Manifest:        harnessManifest(t, "codex"),
+	}, TaskRunOptions{})
+	if err == nil {
+		t.Fatal("expected an error for a harness specialist run in background")
+	}
+	if !strings.Contains(err.Error(), "cannot run in background") {
+		t.Fatalf("error = %q, want mention of \"cannot run in background\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "codex") {
+		t.Fatalf("error = %q, want it to name the harness", err.Error())
+	}
+}
+
+// TestRunFreshDispatchesHarnessNotInstalled locks in that runFresh routes a
+// harness-pinned manifest to runHarness (rather than the self-exec BuildArgs
+// path), by observing runHarness's "not installed" error when the harness
+// binary cannot be found on PATH. PATH is redirected to an empty directory so
+// this is deterministic regardless of what happens to be installed on the
+// host running the test.
+func TestRunFreshDispatchesHarnessNotInstalled(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	executor := Executor{}
+	_, err := executor.Run(context.Background(), TaskParameters{
+		Prompt:   "do the thing",
+		Manifest: harnessManifest(t, "codex"),
+	}, TaskRunOptions{})
+	if err == nil {
+		t.Fatal("expected an error when the harness binary is not on PATH")
+	}
+	if !strings.Contains(err.Error(), "codex") || !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("error = %q, want a \"codex ... not installed\" message", err.Error())
+	}
+}

--- a/internal/specialist/harness_dispatch_test.go
+++ b/internal/specialist/harness_dispatch_test.go
@@ -2,9 +2,27 @@ package specialist
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/streamjson"
 )
+
+// stubHarnessOnPath creates an empty (never executed — RunHarnessChild
+// intercepts before any real exec) executable file named binary under a fresh
+// temp dir and points PATH at it, so agentcli.DetectOne(binary, ...) resolves
+// successfully without needing the real CLI installed.
+func stubHarnessOnPath(t *testing.T, binary string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, binary)
+	if err := os.WriteFile(path, []byte(""), 0o755); err != nil {
+		t.Fatalf("write stub binary: %v", err)
+	}
+	t.Setenv("PATH", dir)
+}
 
 // harnessManifest builds a minimal valid manifest pinned to the given
 // agentcli harness id, for exercising runFresh's harness-dispatch branch
@@ -65,5 +83,55 @@ func TestRunFreshDispatchesHarnessNotInstalled(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "codex") || !strings.Contains(err.Error(), "not installed") {
 		t.Fatalf("error = %q, want a \"codex ... not installed\" message", err.Error())
+	}
+}
+
+// TestRunHarnessSuccessWiresAccountingAndResultViaStubbedChild covers the
+// success path runHarness's RunHarnessChild seam exists for: session ID
+// resolution, decoder selection (codex-json), and BuildFinalResult shaping —
+// end to end, without spawning a real codex process. Before this seam
+// existed, exercising this path required an actual installed claude/codex
+// binary.
+func TestRunHarnessSuccessWiresAccountingAndResultViaStubbedChild(t *testing.T) {
+	stubHarnessOnPath(t, "codex")
+
+	var gotBinaryPath string
+	var gotArgs []string
+	executor := Executor{
+		NewSessionID: func() (string, error) { return "harness_child_session", nil },
+		RunHarnessChild: func(_ context.Context, binaryPath string, args []string, _ string, decoder childDecoder, _ func(streamjson.Event)) (ChildRunResult, error) {
+			gotBinaryPath = binaryPath
+			gotArgs = args
+			if _, ok := decoder.(*codexJSONDecoder); !ok {
+				t.Fatalf("decoder = %T, want *codexJSONDecoder for the codex harness", decoder)
+			}
+			return ChildRunResult{
+				Events: []streamjson.Event{
+					{Type: streamjson.EventText, Delta: "hi"},
+					{Type: streamjson.EventFinal, Text: "hi"},
+				},
+				ExitCode: 0,
+			}, nil
+		},
+	}
+
+	result, err := executor.Run(context.Background(), TaskParameters{
+		Prompt:   "reply with exactly: hi",
+		Manifest: harnessManifest(t, "codex"),
+	}, TaskRunOptions{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.SessionID != "harness_child_session" {
+		t.Fatalf("SessionID = %q, want the injected NewSessionID value", result.SessionID)
+	}
+	if !strings.HasSuffix(gotBinaryPath, "codex") {
+		t.Fatalf("binaryPath = %q, want the stubbed codex path", gotBinaryPath)
+	}
+	if len(gotArgs) == 0 {
+		t.Fatal("expected PrintArgs to have built a non-empty argv for the stubbed child")
+	}
+	if result.Result.Output != "hi" {
+		t.Fatalf("Result.Output = %q, want %q (from BuildFinalResult over the stubbed child's events)", result.Result.Output, "hi")
 	}
 }

--- a/internal/specialist/harness_manifest_test.go
+++ b/internal/specialist/harness_manifest_test.go
@@ -1,0 +1,142 @@
+package specialist
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseMarkdownHarnessAndProviderHappyPath(t *testing.T) {
+	manifest, err := ParseMarkdown(`---
+name: codex-worker
+description: Runs on the Codex CLI
+harness: codex
+provider: work-openai
+harnessArgs: [--full-auto]
+---
+Do the task.`)
+	if err != nil {
+		t.Fatalf("ParseMarkdown returned error: %v", err)
+	}
+	if manifest.Metadata.Harness != "codex" {
+		t.Fatalf("Harness = %q, want codex", manifest.Metadata.Harness)
+	}
+	if manifest.Metadata.Provider != "work-openai" {
+		t.Fatalf("Provider = %q, want work-openai", manifest.Metadata.Provider)
+	}
+	if len(manifest.Metadata.HarnessArgs) != 1 || manifest.Metadata.HarnessArgs[0] != "--full-auto" {
+		t.Fatalf("HarnessArgs = %#v, want [--full-auto]", manifest.Metadata.HarnessArgs)
+	}
+}
+
+func TestParseMarkdownHarnessIsNormalizedToLowercase(t *testing.T) {
+	manifest, err := ParseMarkdown(`---
+name: claude-worker
+description: Runs on Claude Code
+harness: CLAUDE
+---
+Do the task.`)
+	if err != nil {
+		t.Fatalf("ParseMarkdown returned error: %v", err)
+	}
+	if manifest.Metadata.Harness != "claude" {
+		t.Fatalf("Harness = %q, want normalized claude", manifest.Metadata.Harness)
+	}
+}
+
+func TestParseMarkdownRejectsUnknownHarness(t *testing.T) {
+	_, err := ParseMarkdown(`---
+name: mystery-worker
+description: Runs on a made-up CLI
+harness: not-a-real-cli
+---
+Do the task.`)
+	if err == nil {
+		t.Fatal("expected an error for an unknown harness")
+	}
+	if !strings.Contains(err.Error(), `unknown harness "not-a-real-cli"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The error must be actionable: list at least one real catalog id.
+	if !strings.Contains(err.Error(), "codex") || !strings.Contains(err.Error(), "claude") {
+		t.Fatalf("expected error to list available harnesses, got: %v", err)
+	}
+}
+
+func TestParseMarkdownRejectsScalarHarnessArgs(t *testing.T) {
+	_, err := ParseMarkdown(`---
+name: bad-args
+description: Bad harnessArgs shape
+harness: codex
+harnessArgs: --full-auto
+---
+Do the task.`)
+	if err == nil || !strings.Contains(err.Error(), "harnessArgs must be an array") {
+		t.Fatalf("expected harnessArgs array error, got %v", err)
+	}
+}
+
+func TestMergeExtendsPropagatesHarnessProviderAndHarnessArgs(t *testing.T) {
+	tempDir := t.TempDir()
+	writeManifest(t, filepath.Join(tempDir, "base.md"), `---
+name: base
+description: Base specialist
+harness: codex
+provider: work-openai
+harnessArgs: [--full-auto]
+---
+Base prompt.`)
+	writeManifest(t, filepath.Join(tempDir, "child.md"), `---
+name: child
+extends: base
+description: Child specialist
+---
+Child prompt.`)
+
+	result, err := Load(LoadOptions{Paths: Paths{UserDir: tempDir}})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	child, ok := Find(result, "child")
+	if !ok {
+		t.Fatal("child manifest not found")
+	}
+	if child.Metadata.Harness != "codex" {
+		t.Fatalf("child Harness = %q, want inherited codex", child.Metadata.Harness)
+	}
+	if child.Metadata.Provider != "work-openai" {
+		t.Fatalf("child Provider = %q, want inherited work-openai", child.Metadata.Provider)
+	}
+	if len(child.Metadata.HarnessArgs) != 1 || child.Metadata.HarnessArgs[0] != "--full-auto" {
+		t.Fatalf("child HarnessArgs = %#v, want inherited [--full-auto]", child.Metadata.HarnessArgs)
+	}
+}
+
+func TestMergeExtendsChildHarnessOverridesBase(t *testing.T) {
+	tempDir := t.TempDir()
+	writeManifest(t, filepath.Join(tempDir, "base.md"), `---
+name: base
+description: Base specialist
+harness: codex
+---
+Base prompt.`)
+	writeManifest(t, filepath.Join(tempDir, "child.md"), `---
+name: child
+extends: base
+description: Child specialist
+harness: claude
+---
+Child prompt.`)
+
+	result, err := Load(LoadOptions{Paths: Paths{UserDir: tempDir}})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	child, ok := Find(result, "child")
+	if !ok {
+		t.Fatal("child manifest not found")
+	}
+	if child.Metadata.Harness != "claude" {
+		t.Fatalf("child Harness = %q, want override claude", child.Metadata.Harness)
+	}
+}

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 )
 
@@ -29,6 +30,19 @@ type Metadata struct {
 	Model           string   `json:"model,omitempty"`
 	ReasoningEffort string   `json:"reasoningEffort,omitempty"`
 	Tools           []string `json:"tools,omitempty"`
+	// Harness, when set, is an agentcli.Harness id ("claude", "codex", ...): the
+	// specialist runs that external agent CLI instead of self-exec zero. Empty
+	// means the default self-exec behavior.
+	Harness string `json:"harness,omitempty"`
+	// Provider pins a config provider profile name for this specialist's child
+	// process via the ZERO_PROVIDER env var. Only meaningful for a self-exec zero
+	// child (Harness empty); the profile name is passed through unvalidated, so
+	// an unknown profile surfaces as the child's own resolver error.
+	Provider string `json:"provider,omitempty"`
+	// HarnessArgs are extra argv appended after the harness's own PrintArgs, for
+	// harness-specific flags (e.g. a model override). Only meaningful when
+	// Harness is set.
+	HarnessArgs []string `json:"harnessArgs,omitempty"`
 }
 
 type Manifest struct {
@@ -49,6 +63,8 @@ type Summary struct {
 	ReasoningEffort string   `json:"reasoningEffort,omitempty"`
 	Tools           []string `json:"tools,omitempty"`
 	ResolvedTools   []string `json:"resolvedTools,omitempty"`
+	Harness         string   `json:"harness,omitempty"`
+	Provider        string   `json:"provider,omitempty"`
 	Location        Location `json:"location"`
 	FilePath        string   `json:"filePath"`
 	Warnings        []string `json:"warnings,omitempty"`
@@ -78,6 +94,9 @@ var knownMetadataKeys = map[string]bool{
 	"model":           true,
 	"reasoningEffort": true,
 	"tools":           true,
+	"harness":         true,
+	"provider":        true,
+	"harnessArgs":     true,
 }
 
 var toolCategories = map[string][]string{
@@ -187,6 +206,8 @@ func Summaries(manifests []Manifest) []Summary {
 			ReasoningEffort: manifest.Metadata.ReasoningEffort,
 			Tools:           append([]string(nil), manifest.Metadata.Tools...),
 			ResolvedTools:   append([]string(nil), manifest.ResolvedTools...),
+			Harness:         manifest.Metadata.Harness,
+			Provider:        manifest.Metadata.Provider,
 			Location:        manifest.Location,
 			FilePath:        manifest.FilePath,
 			Warnings:        append([]string(nil), manifest.Warnings...),
@@ -234,6 +255,8 @@ func Validate(manifest *Manifest) error {
 	manifest.Metadata.Extends = strings.TrimSpace(manifest.Metadata.Extends)
 	manifest.Metadata.Model = strings.TrimSpace(manifest.Metadata.Model)
 	manifest.Metadata.ReasoningEffort = strings.TrimSpace(manifest.Metadata.ReasoningEffort)
+	manifest.Metadata.Harness = strings.TrimSpace(manifest.Metadata.Harness)
+	manifest.Metadata.Provider = strings.TrimSpace(manifest.Metadata.Provider)
 	if manifest.Metadata.Name == "" {
 		return fmt.Errorf("specialist name is required")
 	}
@@ -264,12 +287,31 @@ func Validate(manifest *Manifest) error {
 		}
 		manifest.Metadata.ReasoningEffort = effort
 	}
+	if manifest.Metadata.Harness != "" {
+		normalized := strings.ToLower(manifest.Metadata.Harness)
+		if _, ok := agentcli.Lookup(normalized); !ok {
+			return fmt.Errorf("specialist %q references unknown harness %q: available harnesses: %s", manifest.Metadata.Name, manifest.Metadata.Harness, availableHarnessIDs())
+		}
+		manifest.Metadata.Harness = normalized
+	}
 	resolved, err := ResolveTools(manifest.Metadata.Tools)
 	if err != nil {
 		return fmt.Errorf("specialist %q: %w", manifest.Metadata.Name, err)
 	}
 	manifest.ResolvedTools = resolved
 	return nil
+}
+
+// availableHarnessIDs renders the known agentcli harness ids for a corrective
+// "unknown harness" error, mirroring availableSpecialistList's approach for
+// specialist names.
+func availableHarnessIDs() string {
+	harnesses := agentcli.Harnesses()
+	ids := make([]string, 0, len(harnesses))
+	for _, harness := range harnesses {
+		ids = append(ids, harness.ID)
+	}
+	return strings.Join(ids, ", ")
 }
 
 func ResolveTools(selection []string) ([]string, error) {
@@ -386,13 +428,23 @@ func manifestFromRaw(raw map[string]any) (Manifest, error) {
 				return Manifest{}, fmt.Errorf("tools must be an array")
 			}
 			metadata.Tools = values
+		case "harness":
+			metadata.Harness = stringValue(value)
+		case "provider":
+			metadata.Provider = stringValue(value)
+		case "harnessArgs":
+			values, ok := value.([]string)
+			if !ok {
+				return Manifest{}, fmt.Errorf("harnessArgs must be an array")
+			}
+			metadata.HarnessArgs = values
 		}
 	}
 	return Manifest{Metadata: metadata}, nil
 }
 
 func isListKey(key string) bool {
-	return key == "tools"
+	return key == "tools" || key == "harnessArgs"
 }
 
 func parseBlockList(lines []string, start int) ([]string, int, error) {
@@ -582,6 +634,15 @@ func mergeExtends(base Manifest, child Manifest) Manifest {
 	}
 	if merged.Metadata.ReasoningEffort == "" {
 		merged.Metadata.ReasoningEffort = base.Metadata.ReasoningEffort
+	}
+	if merged.Metadata.Harness == "" {
+		merged.Metadata.Harness = base.Metadata.Harness
+	}
+	if merged.Metadata.Provider == "" {
+		merged.Metadata.Provider = base.Metadata.Provider
+	}
+	if len(merged.Metadata.HarnessArgs) == 0 {
+		merged.Metadata.HarnessArgs = append([]string(nil), base.Metadata.HarnessArgs...)
 	}
 	if len(merged.Metadata.Tools) == 0 {
 		merged.Metadata.Tools = append([]string(nil), base.Metadata.Tools...)

--- a/internal/swarm/definition.go
+++ b/internal/swarm/definition.go
@@ -32,6 +32,13 @@ type Definition struct {
 	WhenToUse      string
 	Model          string // "inherit" => use the orchestrator's model
 	PermissionMode string
+	// Harness, when set, is an agentcli.Harness id: members of this agent type
+	// run that external agent CLI instead of self-exec zero. See
+	// MemberSpec.Harness.
+	Harness string
+	// Provider pins a config provider profile name for members of this agent
+	// type. See MemberSpec.Provider.
+	Provider string
 	// SystemPrompt returns the member's system prompt for the given task context.
 	// It is a func so a definition can fold the task briefing in.
 	SystemPrompt func(ctx PromptContext) string

--- a/internal/swarm/harness_test.go
+++ b/internal/swarm/harness_test.go
@@ -1,0 +1,74 @@
+package swarm
+
+import "testing"
+
+// TestBuildSpecThreadsHarnessAndProvider guards the per-member harness/provider
+// override: a Definition pinning an external CLI and/or provider profile must
+// reach the launched MemberSpec unchanged, so different swarm members can run
+// on different backends. buildSpec touches no Swarm state, so a zero-value
+// Swarm is enough to call it directly.
+func TestBuildSpecThreadsHarnessAndProvider(t *testing.T) {
+	pol := Policy{Model: "orchestrator-model"}
+	def := Definition{
+		AgentType: "codex-worker",
+		Model:     modelInherit,
+		Harness:   "codex",
+		Provider:  "work-openai",
+		SystemPrompt: func(ctx PromptContext) string {
+			return "task: " + ctx.Task
+		},
+	}
+	s := &Swarm{}
+	spec := s.buildSpec(pol, "m1", "m1", "team", def, "do it", "/workspace")
+	if spec.Harness != "codex" {
+		t.Fatalf("Harness = %q, want codex", spec.Harness)
+	}
+	if spec.Provider != "work-openai" {
+		t.Fatalf("Provider = %q, want work-openai", spec.Provider)
+	}
+	if spec.SystemPrompt != "task: do it" {
+		t.Fatalf("SystemPrompt = %q, unexpected", spec.SystemPrompt)
+	}
+}
+
+// TestBuildSpecOmitsHarnessAndProviderByDefault ensures a definition that
+// never sets these fields produces a MemberSpec that runs self-exec zero with
+// no provider pin — the pre-existing behavior for teammate/subagent.
+func TestBuildSpecOmitsHarnessAndProviderByDefault(t *testing.T) {
+	pol := Policy{Model: "orchestrator-model"}
+	def := Definition{AgentType: "subagent", Model: modelInherit}
+	s := &Swarm{}
+	spec := s.buildSpec(pol, "m1", "m1", "team", def, "do it", "/workspace")
+	if spec.Harness != "" {
+		t.Fatalf("Harness = %q, want empty", spec.Harness)
+	}
+	if spec.Provider != "" {
+		t.Fatalf("Provider = %q, want empty", spec.Provider)
+	}
+}
+
+// TestSpecialistManifestForMemberThreadsHarnessAndProvider guards the launcher
+// side: specialistManifestForMember builds the inline specialist.Manifest that
+// executor.Run actually runs from, so MemberSpec.Harness/Provider must land on
+// Manifest.Metadata for the harness-execution branch in
+// internal/specialist/harness.go to ever trigger for a swarm member.
+func TestSpecialistManifestForMemberThreadsHarnessAndProvider(t *testing.T) {
+	spec := MemberSpec{
+		AgentType:    "codex-worker",
+		Team:         "probe",
+		Task:         "count files",
+		SystemPrompt: "You are a codex-worker.",
+		Harness:      "codex",
+		Provider:     "work-openai",
+	}
+	manifest := specialistManifestForMember(spec)
+	if manifest.Metadata.Harness != "codex" {
+		t.Fatalf("Metadata.Harness = %q, want codex", manifest.Metadata.Harness)
+	}
+	if manifest.Metadata.Provider != "work-openai" {
+		t.Fatalf("Metadata.Provider = %q, want work-openai", manifest.Metadata.Provider)
+	}
+	if manifest.SystemPrompt != spec.SystemPrompt {
+		t.Fatalf("SystemPrompt = %q, want %q", manifest.SystemPrompt, spec.SystemPrompt)
+	}
+}

--- a/internal/swarm/launcher_specialist.go
+++ b/internal/swarm/launcher_specialist.go
@@ -89,6 +89,14 @@ func specialistManifestForMember(spec MemberSpec) specialist.Manifest {
 			Name:        spec.AgentType,
 			Description: "Swarm " + spec.AgentType + " member.",
 			Tools:       swarmMemberToolGroups,
+			// Harness/Provider let different swarm members run on different
+			// external agent CLIs and/or provider profiles; empty means the
+			// default self-exec zero behavior. specialist.Validate (invoked via
+			// executor.Run -> freshManifest) rejects an unknown harness id, so a
+			// bad Definition.Harness surfaces as a member failure with a clear
+			// error rather than silently running self-exec.
+			Harness:  spec.Harness,
+			Provider: spec.Provider,
 		},
 		SystemPrompt: spec.SystemPrompt,
 		Location:     specialist.LocationBuiltin,

--- a/internal/swarm/member.go
+++ b/internal/swarm/member.go
@@ -23,6 +23,15 @@ type MemberSpec struct {
 	Model          string // resolved (never the "inherit" sentinel)
 	PermissionMode string
 	SystemPrompt   string
+	// Harness, when set, is an agentcli.Harness id ("claude", "codex", ...): the
+	// member runs that external agent CLI instead of self-exec zero. Empty means
+	// the default self-exec behavior. Swarm itself never imports agentcli —
+	// validation happens where the launcher builds the specialist manifest.
+	Harness string
+	// Provider pins a config provider profile name for this member's child
+	// process (self-exec zero only; meaningless alongside Harness). Passed
+	// through unvalidated, same as specialist.Metadata.Provider.
+	Provider string
 }
 
 // MemberResult is what a finished member returns.

--- a/internal/swarm/team.go
+++ b/internal/swarm/team.go
@@ -370,6 +370,8 @@ func (s *Swarm) buildSpec(pol Policy, memberID, taskID, team string, def Definit
 		Model:          resolveModel(pol, def),
 		PermissionMode: resolvePermissionMode(pol, def),
 		SystemPrompt:   prompt,
+		Harness:        def.Harness,
+		Provider:       def.Provider,
 	}
 }
 

--- a/internal/tools/onlybash_mode_test.go
+++ b/internal/tools/onlybash_mode_test.go
@@ -1,0 +1,45 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+)
+
+// TestOnlyBashModeToolNamesMatchRegisteredTools locks the modelregistry
+// "onlybash" preset's EnabledTools/DisabledTools string literals to the real
+// registered tool names. modes.go can't import this package to reference
+// NewBashTool(...).Name() / NewSkillTool(...).Name() / ToolSearchToolName
+// directly (internal/tools already imports internal/modelregistry via
+// escalate_model.go, so the reverse import would cycle) — this test is the
+// other half of that contract: it fails loudly if a tool is ever renamed
+// without updating the mode preset.
+func TestOnlyBashModeToolNamesMatchRegisteredTools(t *testing.T) {
+	mode, ok := modelregistry.LookupMode("onlybash")
+	if !ok {
+		t.Fatal("modelregistry.LookupMode(\"onlybash\") = _, false; want a registered mode")
+	}
+
+	bashName := NewBashTool(t.TempDir()).Name()
+	skillName := NewSkillTool(t.TempDir()).Name()
+
+	wantEnabled := []string{bashName, skillName}
+	if len(mode.EnabledTools) != len(wantEnabled) {
+		t.Fatalf("onlybash EnabledTools = %v; want %v", mode.EnabledTools, wantEnabled)
+	}
+	for index, name := range wantEnabled {
+		if mode.EnabledTools[index] != name {
+			t.Fatalf("onlybash EnabledTools = %v; want %v", mode.EnabledTools, wantEnabled)
+		}
+	}
+
+	wantDisabled := []string{ToolSearchToolName}
+	if len(mode.DisabledTools) != len(wantDisabled) {
+		t.Fatalf("onlybash DisabledTools = %v; want %v", mode.DisabledTools, wantDisabled)
+	}
+	for index, name := range wantDisabled {
+		if mode.DisabledTools[index] != name {
+			t.Fatalf("onlybash DisabledTools = %v; want %v", mode.DisabledTools, wantDisabled)
+		}
+	}
+}

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -507,7 +507,12 @@ func (m model) switchProviderModel(providerName, modelID string) (model, string,
 	// Gate on the resolved credential, not the APIKeyStored marker: if the stored key
 	// was deleted/unreadable the marker can still be set, and building a keyless
 	// provider would only fail later with a 401. Local/no-auth providers need no key.
-	if strings.TrimSpace(target.APIKey) == "" && strings.TrimSpace(target.AuthHeaderValue) == "" && !(hasDescriptor && descriptor.Local) {
+	// AuthCLI profiles are deliberately exempt: their credential is live-read from
+	// the agent CLI's own store inside the provider factory, so an empty APIKey here
+	// is the normal, healthy state — the factory surfaces its own actionable error
+	// (e.g. "claude login has expired") if the CLI login is actually unusable.
+	if strings.TrimSpace(target.APIKey) == "" && strings.TrimSpace(target.AuthHeaderValue) == "" &&
+		strings.TrimSpace(target.AuthCLI) == "" && !(hasDescriptor && descriptor.Local) {
 		return m, "Model\nprovider " + strconv.Quote(providerName) + " has no usable credential — run setup or `zero auth login " + providerName + "`.", nil
 	}
 	next, err := m.newProvider(target)

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -41,6 +41,7 @@ const (
 	commandAddDir
 	commandSelfCorrect
 	commandTurns
+	commandOnlyBash
 	commandUnknown
 )
 
@@ -248,6 +249,13 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "Show or set the per-run tool-turn budget for this session (raise it for long multi-step tasks).",
 		kind:        commandTurns,
+	},
+	{
+		name:        "/onlybash",
+		usage:       "/onlybash [on|off|status]",
+		group:       commandGroupRuntime,
+		description: "Restrict the tool surface to bash + skill only, with tool_search disabled so no other tool can be added back. Bare form toggles.",
+		kind:        commandOnlyBash,
 	},
 	{
 		name:        "/help",

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -985,6 +985,25 @@ func TestParseBackgroundTerminalCommands(t *testing.T) {
 	}
 }
 
+func TestParseOnlyBashCommand(t *testing.T) {
+	cases := []struct {
+		input string
+		kind  commandKind
+		text  string
+	}{
+		{input: "/onlybash", kind: commandOnlyBash, text: ""},
+		{input: "/onlybash on", kind: commandOnlyBash, text: "on"},
+		{input: "/onlybash off", kind: commandOnlyBash, text: "off"},
+		{input: "/onlybash status", kind: commandOnlyBash, text: "status"},
+	}
+	for _, tc := range cases {
+		got := parseCommand(tc.input)
+		if got.kind != tc.kind || got.text != tc.text {
+			t.Fatalf("%q: got kind=%v text=%q, want kind=%v text=%q", tc.input, got.kind, got.text, tc.kind, tc.text)
+		}
+	}
+}
+
 func TestCommandSelectionRequiresInputFromUsage(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -100,45 +100,58 @@ type model struct {
 	titledSessions map[string]bool
 	// retitle* drive the sequential /retitle backfill: queued session ids still
 	// awaiting a title, whether a backfill is running, and its progress counters.
-	retitleQueue          []string
-	retitleActive         bool
-	retitleTotal          int
-	retitleDone           int
-	retitleOK             int
-	usageTracker          *usage.Tracker
-	sessionCompactor      SessionCompactor
-	prService             *PrService
-	prState               PrState
-	prWatcherStop         func()
-	runtimeMessageSink    func(tea.Msg)
-	agentOptions          agent.Options
-	notifier              *notify.Notifier
-	permissionMode        agent.PermissionMode
-	selfCorrectTests      bool
-	reasoningEffort       modelregistry.ReasoningEffort
-	responseStyle         string
-	themeMode             themeMode // palette preference: auto (default), dark, light
-	hasDarkBg             bool      // last terminal background-detection result (auto mode)
-	userAgent             string
-	compactRequests       int
-	compactInFlight       bool
-	compactFrame          int
-	lastCompactResult     *CompactResult
-	lastCompactError      string
-	unpricedRequests      int
-	unpricedTokens        int
-	lastUsage             usage.Normalized
-	lastUsageSeen         bool
-	transcript            []transcriptRow
-	transcriptDetailed    bool
-	helpOverlay           bool // the `?` keyboard-shortcut overlay is open
-	transcriptBodyHeights *transcriptBodyHeightCache
-	input                 textinput.Model
-	composer              composerState
-	composerActive        bool
-	composerCursorVisible bool
-	composerPastePreviews []composerPastePreview
-	composerSelection     composerSelectionState
+	retitleQueue       []string
+	retitleActive      bool
+	retitleTotal       int
+	retitleDone        int
+	retitleOK          int
+	usageTracker       *usage.Tracker
+	sessionCompactor   SessionCompactor
+	prService          *PrService
+	prState            PrState
+	prWatcherStop      func()
+	runtimeMessageSink func(tea.Msg)
+	agentOptions       agent.Options
+	notifier           *notify.Notifier
+	permissionMode     agent.PermissionMode
+	selfCorrectTests   bool
+	// onlyBashActive is /onlybash's toggle state: while true, m.agentOptions
+	// carries the onlybash tool filter (EnabledTools=[bash,skill],
+	// DisabledTools=[tool_search]) so every subsequent run in this session is
+	// restricted to it. onlyBashStashedEnabledTools/onlyBashStashedDisabledTools
+	// hold whatever operator-configured filters were on m.agentOptions the
+	// moment the mode was turned on, so turning it back off restores them
+	// exactly instead of clobbering them with onlybash's own lists or an empty
+	// filter. The stash is only captured on an inactive->active transition (see
+	// handleOnlyBashCommand) — re-enabling while already active must NOT
+	// re-stash onlybash's own filter as if it were the operator's.
+	onlyBashActive               bool
+	onlyBashStashedEnabledTools  []string
+	onlyBashStashedDisabledTools []string
+	reasoningEffort              modelregistry.ReasoningEffort
+	responseStyle                string
+	themeMode                    themeMode // palette preference: auto (default), dark, light
+	hasDarkBg                    bool      // last terminal background-detection result (auto mode)
+	userAgent                    string
+	compactRequests              int
+	compactInFlight              bool
+	compactFrame                 int
+	lastCompactResult            *CompactResult
+	lastCompactError             string
+	unpricedRequests             int
+	unpricedTokens               int
+	lastUsage                    usage.Normalized
+	lastUsageSeen                bool
+	transcript                   []transcriptRow
+	transcriptDetailed           bool
+	helpOverlay                  bool // the `?` keyboard-shortcut overlay is open
+	transcriptBodyHeights        *transcriptBodyHeightCache
+	input                        textinput.Model
+	composer                     composerState
+	composerActive               bool
+	composerCursorVisible        bool
+	composerPastePreviews        []composerPastePreview
+	composerSelection            composerSelectionState
 	// plan holds the sticky plan panel state (steps, expansion, timings)
 	// synced from the update_plan tool. See plan_panel.go.
 	plan            planPanelState
@@ -3765,6 +3778,11 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		}
 		text := ""
 		m, text = m.handleTurnsCommand(command.text)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		return m, nil
+	case commandOnlyBash:
+		text := ""
+		m, text = m.handleOnlyBashCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
 	case commandTheme:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -17,6 +17,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/doctor"
 	"github.com/Gitlawb/zero/internal/lsp"
@@ -74,25 +75,30 @@ type model struct {
 	probeProviderHealth         func(context.Context, providerhealth.Options) providerhealth.Result
 	discoverProviderModels      func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	discoverOllamaContextWindow func(ctx context.Context, baseURL string, model string) (int, error)
-	registry                    *tools.Registry
-	sessionStore                *sessions.Store
-	sandboxStore                *sandbox.GrantStore
-	mcpConfig                   config.MCPConfig
-	mcpPermissionStore          *internalmcp.PermissionStore
-	mcpTokenStore               *internalmcp.TokenStore
-	mcpCommand                  func(context.Context, []string) MCPCommandResult
-	sandboxSetupCommand         func(context.Context) SandboxSetupCommandResult
-	mcpViewStateCache           MCPViewState
-	mcpViewStateReady           bool
-	mcpCommandSeq               int
-	mcpCommandCancel            context.CancelFunc
-	sandboxSetupSeq             int
-	sandboxSetupInFlight        bool
-	doctorCommandSeq            int
-	doctorInFlight              bool
-	doctorFrame                 int
-	activeSession               sessions.Metadata
-	sessionEvents               []sessions.Event
+	// detectAgentCLIs probes for installed agent-CLI harnesses (see
+	// agentcli.Detect). Injectable via Options.DetectAgentCLIs so tests can
+	// supply a fake instead of touching the real PATH/filesystem/keychain;
+	// newModel defaults it to agentcli.Detect when unset.
+	detectAgentCLIs      func(agentcli.Deps) []agentcli.Detection
+	registry             *tools.Registry
+	sessionStore         *sessions.Store
+	sandboxStore         *sandbox.GrantStore
+	mcpConfig            config.MCPConfig
+	mcpPermissionStore   *internalmcp.PermissionStore
+	mcpTokenStore        *internalmcp.TokenStore
+	mcpCommand           func(context.Context, []string) MCPCommandResult
+	sandboxSetupCommand  func(context.Context) SandboxSetupCommandResult
+	mcpViewStateCache    MCPViewState
+	mcpViewStateReady    bool
+	mcpCommandSeq        int
+	mcpCommandCancel     context.CancelFunc
+	sandboxSetupSeq      int
+	sandboxSetupInFlight bool
+	doctorCommandSeq     int
+	doctorInFlight       bool
+	doctorFrame          int
+	activeSession        sessions.Metadata
+	sessionEvents        []sessions.Event
 	// titledSessions records session ids for which a model-generated title has
 	// already been attempted this process, so a finished turn re-fires the title
 	// generator at most once per session (even before its async result lands).
@@ -684,6 +690,11 @@ func newModel(ctx context.Context, options Options) model {
 		permissionMode = agent.PermissionModeAuto
 	}
 
+	detectAgentCLIs := options.DetectAgentCLIs
+	if detectAgentCLIs == nil {
+		detectAgentCLIs = agentcli.Detect
+	}
+
 	input := textinput.New()
 	input.Prompt = "❯ "
 	input.Placeholder = composerPlaceholder
@@ -725,6 +736,7 @@ func newModel(ctx context.Context, options Options) model {
 		probeProviderHealth:         options.ProbeProviderHealth,
 		discoverProviderModels:      options.DiscoverProviderModels,
 		discoverOllamaContextWindow: options.DiscoverOllamaContextWindow,
+		detectAgentCLIs:             detectAgentCLIs,
 		registry:                    registry,
 		sessionStore:                sessionStore,
 		sandboxStore:                sandboxStore,
@@ -754,7 +766,7 @@ func newModel(ctx context.Context, options Options) model {
 		altScreen:                   options.AltScreen,
 		liveUsageCounts:             map[int]int{},
 		swarmSessionMap:             map[string]string{},
-		setup:                       newSetupState(options.Setup),
+		setup:                       newSetupState(options.Setup, detectAgentCLIs),
 		setupSave:                   options.Setup.Save,
 	}
 	// Apply an explicit theme immediately; auto stays on the dark default until

--- a/internal/tui/model_switch_cli_test.go
+++ b/internal/tui/model_switch_cli_test.go
@@ -1,0 +1,114 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// TestSwitchProviderModelAllowsAuthCLIProfile: an AuthCLI profile carries no
+// APIKey/AuthHeaderValue by design — its credential is live-read from the agent
+// CLI's own store inside the provider factory. The picker's credential gate
+// previously rejected such profiles with "no usable credential", which made a
+// logged-in Claude Code profile unusable from /model even though it builds and
+// runs fine.
+func TestSwitchProviderModelAllowsAuthCLIProfile(t *testing.T) {
+	built := 0
+	m := newModel(context.Background(), Options{
+		ProviderName:    "openrouter",
+		ModelName:       "anthropic/claude-sonnet-5",
+		Provider:        &fakeProvider{},
+		ProviderProfile: config.ProviderProfile{Name: "openrouter", CatalogID: "openrouter", Model: "anthropic/claude-sonnet-5"},
+		SavedProviders: []config.ProviderProfile{
+			{Name: "openrouter", CatalogID: "openrouter", Model: "anthropic/claude-sonnet-5"},
+			{Name: "claude", CatalogID: "anthropic", ProviderKind: config.ProviderKindAnthropic, AuthCLI: "claude", Model: "claude-sonnet-5"},
+		},
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			built++
+			if profile.AuthCLI != "claude" {
+				t.Fatalf("provider built from profile without AuthCLI: %+v", profile)
+			}
+			return &fakeProvider{}, nil
+		},
+	})
+
+	next, text, _ := m.switchProviderModel("claude", "claude-opus-4.8")
+	if strings.Contains(text, "no usable credential") {
+		t.Fatalf("AuthCLI profile rejected by the credential gate: %q", text)
+	}
+	if !strings.Contains(text, "Switched to claude") {
+		t.Fatalf("switch notice = %q, want it to confirm the switch", text)
+	}
+	if built != 1 {
+		t.Fatalf("provider builds = %d, want 1", built)
+	}
+	if next.providerName != "claude" || next.modelName != "claude-opus-4.8" {
+		t.Fatalf("model/provider not switched: providerName=%q modelName=%q", next.providerName, next.modelName)
+	}
+}
+
+// TestModelPickerProviderGroupCLIProfileDistinct: a CLI-authenticated profile
+// resolves to the same catalog descriptor as a plain API-key profile for that
+// provider, so its picker group must carry a "via <CLI>" suffix — both so the
+// user can see which login the models run on and so the picker's per-group
+// dedup cannot silently drop one of the two profiles.
+func TestModelPickerProviderGroupCLIProfileDistinct(t *testing.T) {
+	descriptor, ok := providercatalog.Get("anthropic")
+	if !ok {
+		t.Fatal("anthropic catalog descriptor missing")
+	}
+
+	plain := config.ProviderProfile{Name: "anthropic", CatalogID: "anthropic"}
+	cli := config.ProviderProfile{Name: "claude", CatalogID: "anthropic", AuthCLI: "claude"}
+
+	plainGroup := modelPickerProviderGroup(plain, descriptor, true)
+	cliGroup := modelPickerProviderGroup(cli, descriptor, true)
+	if plainGroup == cliGroup {
+		t.Fatalf("CLI profile group %q collides with plain profile group — dedup would drop one", cliGroup)
+	}
+	if !strings.Contains(cliGroup, "Claude Code") {
+		t.Fatalf("CLI profile group = %q, want the harness display name in it", cliGroup)
+	}
+
+	// An unknown harness id still yields a distinct group (raw id fallback)
+	// rather than colliding with the plain profile.
+	unknown := config.ProviderProfile{Name: "custom", CatalogID: "anthropic", AuthCLI: "some-future-cli"}
+	unknownGroup := modelPickerProviderGroup(unknown, descriptor, true)
+	if unknownGroup == plainGroup || !strings.Contains(unknownGroup, "some-future-cli") {
+		t.Fatalf("unknown-harness group = %q, want distinct raw-id fallback", unknownGroup)
+	}
+}
+
+// TestNormalizeProfileForProviderPreservesCLIProfile: switching models within
+// a CLI-authenticated profile must not normalize its identity to the catalog
+// id — that made persistence miss the real profile ("not saved: provider
+// \"anthropic\" not found") — and must not autofill APIKeyEnv/APIKey, which
+// would displace the CLI login with an ambient env key.
+func TestNormalizeProfileForProviderPreservesCLIProfile(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "ambient-key-must-not-be-used")
+	descriptor, ok := providercatalog.Get("anthropic")
+	if !ok {
+		t.Fatal("anthropic catalog descriptor missing")
+	}
+	m := newModel(context.Background(), Options{
+		ProviderName:    "claude",
+		ModelName:       "claude-sonnet-5",
+		Provider:        &fakeProvider{},
+		ProviderProfile: config.ProviderProfile{Name: "claude", CatalogID: "anthropic", AuthCLI: "claude", Model: "claude-sonnet-5"},
+	})
+
+	profile := m.normalizeProfileForProvider(descriptor)
+	if profile.Name != "claude" {
+		t.Fatalf("Name = %q, want the CLI profile name preserved", profile.Name)
+	}
+	if profile.APIKeyEnv != "" || profile.APIKey != "" {
+		t.Fatalf("APIKeyEnv=%q APIKey=%q, want both empty — CLI profiles stay keyless", profile.APIKeyEnv, profile.APIKey)
+	}
+	if profile.AuthCLI != "claude" {
+		t.Fatalf("AuthCLI = %q, want preserved", profile.AuthCLI)
+	}
+}

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
@@ -49,19 +50,26 @@ type setupState struct {
 	oauthDevice           bool
 	deviceUserCode        string
 	deviceVerificationURI string
-	stage                 setupStage
-	err                   string
-	baseURL               string
-	name                  string
-	apiKey                textinput.Model
-	models                []providerWizardModel
-	modelIndex            int
-	modelQuery            string
-	modelForID            string
-	modelLoad             bool
-	modelErr              string
-	modelSrc              string
-	modelGen              uint64
+	// agentCLIDetections is captured ONCE at setup construction (newSetupState)
+	// rather than reprobed on every render/keystroke — see the identical note on
+	// providerWizardState.agentCLIDetections.
+	agentCLIDetections []agentcli.Detection
+	// cliHarness is set when the CLI connect method was chosen: setup skips the
+	// provider-chooser stage entirely (the row already names the provider).
+	cliHarness *agentcli.Harness
+	stage      setupStage
+	err        string
+	baseURL    string
+	name       string
+	apiKey     textinput.Model
+	models     []providerWizardModel
+	modelIndex int
+	modelQuery string
+	modelForID string
+	modelLoad  bool
+	modelErr   string
+	modelSrc   string
+	modelGen   uint64
 }
 
 // setupOAuthMsg carries the result of a first-run browser OAuth login.
@@ -113,14 +121,62 @@ func newSetupState(options SetupOptions) setupState {
 	// terminal bracketed paste (Paste: true) is the single paste path.
 	apiKey.KeyMap.Paste.SetEnabled(false)
 	apiKey.Focus()
-	return setupState{
-		visible:      options.Visible,
-		required:     options.Required,
-		configPath:   strings.TrimSpace(options.ConfigPath),
-		providers:    providers,
-		allProviders: providers,
-		apiKey:       apiKey,
+	detections := agentcli.Detect(agentcli.Deps{})
+	state := setupState{
+		visible:            options.Visible,
+		required:           options.Required,
+		configPath:         strings.TrimSpace(options.ConfigPath),
+		providers:          providers,
+		allProviders:       providers,
+		apiKey:             apiKey,
+		agentCLIDetections: detections,
 	}
+	// Don't open the method chooser with the cursor parked on an informational
+	// (unselectable) CLI row — mirrors providerWizardState's identical guard.
+	state.selectedMethod = firstSelectableMethodIndex(filterSetupMethodOptions(providerWizardMethodOptions(detections), providers))
+	return state
+}
+
+// filterSetupMethodOptions drops rows this setup run cannot honor: the OAuth
+// row when this setup's provider list has no OAuth-capable entry (so the user
+// can't pick OAuth and land on an empty provider list — pre-existing
+// behavior), and a selectable CLI row whose harness's catalog provider isn't
+// in this setup's allowed provider list. Informational (disabled) CLI rows are
+// never filtered — they don't commit to a provider, so they're always safe to
+// show.
+func filterSetupMethodOptions(options []providerWizardMethodOption, allProviders []SetupProviderOption) []providerWizardMethodOption {
+	hasOAuth := len(setupOAuthProviderOptions(allProviders)) > 0
+	filtered := make([]providerWizardMethodOption, 0, len(options))
+	for _, option := range options {
+		if option.kind == providerWizardMethodOAuth && !hasOAuth {
+			continue
+		}
+		if option.kind == providerWizardMethodCLI && !option.disabled && !setupProvidersInclude(allProviders, option.harness.CatalogID) {
+			continue
+		}
+		filtered = append(filtered, option)
+	}
+	return filtered
+}
+
+// setupProvidersInclude reports whether catalogID is one of the provider IDs
+// this setup run is allowed to offer.
+func setupProvidersInclude(providers []SetupProviderOption, catalogID string) bool {
+	_, ok := setupProviderForCatalogID(providers, catalogID)
+	return ok
+}
+
+// setupProviderForCatalogID finds the SetupProviderOption matching catalogID,
+// used to resolve a CLI method row's harness.CatalogID into the provider
+// option setup should offer directly (skipping the provider chooser).
+func setupProviderForCatalogID(providers []SetupProviderOption, catalogID string) (SetupProviderOption, bool) {
+	catalogID = strings.TrimSpace(catalogID)
+	for _, provider := range providers {
+		if strings.EqualFold(strings.TrimSpace(provider.ID), catalogID) {
+			return provider, true
+		}
+	}
+	return SetupProviderOption{}, false
 }
 
 func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -420,6 +476,12 @@ func setupContentTop(height int, contentLines int, hasError bool) int {
 
 func (m model) setupStages() []setupStage {
 	stages := []setupStage{setupStageWelcome, setupStageMethod}
+	if m.setup.cliHarness != nil {
+		// CLI path skips the provider chooser too (the method row already named
+		// the provider) as well as endpoint/name/credentials (the harness login
+		// provides the credential).
+		return append(stages, setupStageModel, setupStageSafety, setupStageReady)
+	}
 	if m.setup.oauthMode {
 		// OAuth path skips endpoint/name/credentials (the login provides the credential).
 		return append(stages, setupStageProvider, setupStageModel, setupStageSafety, setupStageReady)
@@ -432,36 +494,25 @@ func (m model) setupStages() []setupStage {
 	return stages
 }
 
-// setupReturnToMethod resets the OAuth selection when navigating back to the
-// connect-method chooser.
+// setupReturnToMethod resets the OAuth/CLI selection when navigating back to
+// the connect-method chooser.
 func (m model) setupReturnToMethod() model {
 	m.setup.oauthMode = false
 	m.setup.oauthErr = ""
 	m.setup.oauthDevice = false
 	m.setup.deviceUserCode = ""
 	m.setup.deviceVerificationURI = ""
+	m.setup.cliHarness = nil
 	m.setup.providers = m.setup.allProviders
 	m.setup.selected = 0
 	m.resetSetupModels()
 	return m
 }
 
-// setupMethodOptions returns the connect-method choices for this run, dropping the
-// OAuth option when this setup's own provider list has no OAuth-capable entry — so
-// the user can't pick OAuth and land on an empty provider list.
+// setupMethodOptions returns the connect-method choices for this run — see
+// filterSetupMethodOptions for what gets dropped.
 func (m model) setupMethodOptions() []providerWizardMethodOption {
-	options := providerWizardMethodOptions()
-	if len(setupOAuthProviderOptions(m.setup.allProviders)) > 0 {
-		return options
-	}
-	filtered := make([]providerWizardMethodOption, 0, len(options))
-	for _, option := range options {
-		if option.oauth {
-			continue
-		}
-		filtered = append(filtered, option)
-	}
-	return filtered
+	return filterSetupMethodOptions(providerWizardMethodOptions(m.setup.agentCLIDetections), m.setup.allProviders)
 }
 
 func (m *model) moveSetupMethod(delta int) {
@@ -469,7 +520,17 @@ func (m *model) moveSetupMethod(delta int) {
 	if len(options) == 0 {
 		return
 	}
-	m.setup.selectedMethod = ((m.setup.selectedMethod+delta)%len(options) + len(options)) % len(options)
+	next := m.setup.selectedMethod
+	// Skip disabled (informational-only) rows, same as the /provider wizard —
+	// bounded by len(options) since "paste an API key" is always present and
+	// never disabled.
+	for i := 0; i < len(options); i++ {
+		next = ((next+delta)%len(options) + len(options)) % len(options)
+		if !options[next].disabled {
+			break
+		}
+	}
+	m.setup.selectedMethod = next
 }
 
 // setupOAuthCmd runs the chosen provider's browser OAuth login off the UI
@@ -639,18 +700,59 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 		if m.setup.stage == setupStageMethod {
 			options := m.setupMethodOptions()
 			m.setup.selectedMethod = clamp(m.setup.selectedMethod, 0, maxInt(0, len(options)-1))
-			if len(options) > 0 && options[m.setup.selectedMethod].oauth {
+			m.setup.err = ""
+			if len(options) == 0 {
+				return m, nil
+			}
+			selected := options[m.setup.selectedMethod]
+			m.setup.oauthMode = false
+			m.setup.cliHarness = nil
+			switch selected.kind {
+			case providerWizardMethodOAuth:
 				m.setup.oauthMode = true
 				m.setup.providers = setupOAuthProviderOptions(m.setup.allProviders)
-			} else {
-				m.setup.oauthMode = false
+				m.setup.selected = 0
+				m.resetSetupModels()
+				m.setup.stage = setupStageProvider
+				return m, nil
+			case providerWizardMethodCLI:
+				if selected.disabled {
+					m.setup.err = selected.harness.DisplayName + " has no reusable credentials — it can still run as a sub-agent harness."
+					return m, nil
+				}
+				if !selected.loggedIn {
+					m.setup.err = selected.harness.DisplayName + " is not logged in — run `" +
+						selected.harness.LoginCommand() + "` to log in, then try again."
+					return m, nil
+				}
+				provider, ok := setupProviderForCatalogID(m.setup.allProviders, selected.harness.CatalogID)
+				if !ok {
+					m.setup.err = "no provider option for " + selected.harness.CatalogID
+					return m, nil
+				}
+				harness := selected.harness
+				m.setup.cliHarness = &harness
+				m.setup.providers = []SetupProviderOption{provider}
+				m.setup.selected = 0
+				m.setup.apiKey.SetValue("")
+				m.setup.baseURL = ""
+				m.setup.name = ""
+				m.resetSetupModels()
+				// The CLI row already named the provider — skip straight to model
+				// selection, mirroring applySetupOAuth's post-login jump.
+				m.setup.stage = setupStageModel
+				m.setup.modelErr = ""
+				m.setup.modelGen++
+				cmd := m.setupModelDiscoveryCmd(m.setup.modelGen)
+				m.setup.modelLoad = cmd != nil
+				return m, cmd
+			default:
 				m.setup.providers = m.setup.allProviders
+				m.setup.selected = 0
+				m.resetSetupModels()
+				m.setup.stage = setupStageProvider
+				return m, nil
 			}
-			m.setup.selected = 0
-			m.resetSetupModels()
-			m.setup.stage = setupStageProvider
-			m.setup.err = ""
-			return m, nil
 		}
 		// OAuth path: advancing from the OAuth provider list starts the browser login.
 		if m.setup.stage == setupStageProvider && m.setup.oauthMode {
@@ -729,6 +831,7 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 
 	name := m.setupProfileName(option)
 	apiKey := m.setupCredentialAPIKey(option)
+	authCLI := ""
 	// OAuth token login (e.g. xAI): the credential is the OAuth token stored under
 	// provider:<id>; name the profile after the provider id so the runtime resolver
 	// attaches the bearer, and store no API key.
@@ -736,12 +839,21 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 		name = option.ID
 		apiKey = ""
 	}
+	// CLI login: the credential is a detected agent-CLI's own local login, not a
+	// key or a zero-managed OAuth token — name the profile after the harness so
+	// it's recognizable, and store no API key/env.
+	if m.setup.cliHarness != nil {
+		name = m.setup.cliHarness.ID
+		apiKey = ""
+		authCLI = m.setup.cliHarness.ID
+	}
 	result, err := m.setupSave(SetupSelection{
 		CatalogID: option.ID,
 		Name:      name,
 		BaseURL:   m.setupBaseURL(option),
 		Model:     m.setupCurrentModel().ID,
 		APIKey:    apiKey,
+		AuthCLI:   authCLI,
 	})
 	if err != nil {
 		m.setup.err = err.Error()
@@ -1433,6 +1545,11 @@ func (m model) setupMethodLines(width int) []string {
 		blankSetupBlockLine(rowWidth),
 	}
 	for index, option := range options {
+		if option.disabled {
+			lines = append(lines, padSetupLine("  "+zeroTheme.faint.Render(option.label), rowWidth))
+			lines = append(lines, padSetupLine("    "+zeroTheme.faint.Render(option.subtitle), rowWidth))
+			continue
+		}
 		marker := "  "
 		style := zeroTheme.ink
 		if index == idx {
@@ -1626,6 +1743,9 @@ func (m model) setupAPIKeyInputLine(width int) string {
 }
 
 func (m model) setupCredentialSummary(option SetupProviderOption) string {
+	if m.setup.cliHarness != nil {
+		return m.setup.cliHarness.DisplayName + " login"
+	}
 	// An OAuth token-login provider (e.g. xAI) is authenticated by a stored,
 	// refreshable token, not an API key — don't advertise an env var for it on the
 	// Ready screen. (Key-minting OAuth like OpenRouter still ends up as a saved key.)

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -101,7 +101,13 @@ type setupModelsDiscoveredMsg struct {
 	err              error
 }
 
-func newSetupState(options SetupOptions) setupState {
+// detect probes for installed agent-CLI harnesses; pass agentcli.Detect for
+// real detection or a fake for hermetic tests (see the identical seam on
+// model.detectAgentCLIs / Options.DetectAgentCLIs).
+func newSetupState(options SetupOptions, detect func(agentcli.Deps) []agentcli.Detection) setupState {
+	if detect == nil {
+		detect = agentcli.Detect
+	}
 	providers := append([]SetupProviderOption{}, options.Providers...)
 	if len(providers) == 0 {
 		providers = []SetupProviderOption{{
@@ -121,7 +127,7 @@ func newSetupState(options SetupOptions) setupState {
 	// terminal bracketed paste (Paste: true) is the single paste path.
 	apiKey.KeyMap.Paste.SetEnabled(false)
 	apiKey.Focus()
-	detections := agentcli.Detect(agentcli.Deps{})
+	detections := detect(agentcli.Deps{})
 	state := setupState{
 		visible:            options.Visible,
 		required:           options.Required,
@@ -737,15 +743,10 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 				m.setup.apiKey.SetValue("")
 				m.setup.baseURL = ""
 				m.setup.name = ""
-				m.resetSetupModels()
 				// The CLI row already named the provider — skip straight to model
 				// selection, mirroring applySetupOAuth's post-login jump.
 				m.setup.stage = setupStageModel
-				m.setup.modelErr = ""
-				m.setup.modelGen++
-				cmd := m.setupModelDiscoveryCmd(m.setup.modelGen)
-				m.setup.modelLoad = cmd != nil
-				return m, cmd
+				return m, m.enterModelStage()
 			default:
 				m.setup.providers = m.setup.allProviders
 				m.setup.selected = 0
@@ -795,12 +796,7 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 		m.setup.stage = m.nextSetupStage()
 		m.setup.err = ""
 		if m.setup.stage == setupStageModel {
-			m.resetSetupModels()
-			m.setup.modelErr = ""
-			m.setup.modelGen++
-			cmd := m.setupModelDiscoveryCmd(m.setup.modelGen)
-			m.setup.modelLoad = cmd != nil
-			return m, cmd
+			return m, m.enterModelStage()
 		}
 		return m, nil
 	}
@@ -907,6 +903,20 @@ func (m *model) resetSetupModels() {
 	m.setup.modelLoad = false
 	m.setup.modelErr = ""
 	m.setup.modelSrc = "fallback"
+}
+
+// enterModelStage bootstraps the model-selection stage: reset any stale model
+// list/query, clear the last discovery error, bump modelGen (invalidating any
+// in-flight discovery response for a prior provider), and kick off a fresh
+// discovery command. Shared by the CLI-connect fast path (which jumps straight
+// to Model) and the generic advance-to-Model path, so the two can't drift.
+func (m *model) enterModelStage() tea.Cmd {
+	m.resetSetupModels()
+	m.setup.modelErr = ""
+	m.setup.modelGen++
+	cmd := m.setupModelDiscoveryCmd(m.setup.modelGen)
+	m.setup.modelLoad = cmd != nil
+	return cmd
 }
 
 func (m model) setupModelDiscoveryCmd(gen uint64) tea.Cmd {

--- a/internal/tui/onboarding_cli_test.go
+++ b/internal/tui/onboarding_cli_test.go
@@ -1,0 +1,189 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/agentcli"
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+// setupModelWithProviders builds a first-run setup model, injects the given
+// agent-CLI detections directly (so the test never touches a real PATH or
+// keychain), and advances Welcome -> Method.
+func setupModelWithProviders(t *testing.T, providers []SetupProviderOption, detections []agentcli.Detection) model {
+	t.Helper()
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible:   true,
+		Providers: providers,
+	}})
+	m.width = 100
+	m.height = 30
+	m.setup.agentCLIDetections = detections
+	m.setup.selectedMethod = firstSelectableMethodIndex(m.setupMethodOptions())
+	return pressSetupContinueOnce(m) // Welcome -> Method
+}
+
+// TestSetupMethodChooserCLIPathSkipsProviderStep drives first-run setup
+// through the Method chooser exactly as a user would: land on Method, select
+// a logged-in CLI row, press Enter. It must skip the provider chooser AND the
+// endpoint/name/credentials stages and land on Model with cliHarness set.
+func TestSetupMethodChooserCLIPathSkipsProviderStep(t *testing.T) {
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	m := setupModelWithProviders(t,
+		[]SetupProviderOption{
+			{ID: "anthropic", Name: "Anthropic", DefaultModel: "claude-sonnet-4.5", EnvVar: "ANTHROPIC_API_KEY", RequiresAuth: true},
+			{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+		},
+		[]agentcli.Detection{{Harness: claudeHarness, Path: "/usr/local/bin/claude", Login: agentcli.LoggedIn}},
+	)
+	if m.setup.stage != setupStageMethod {
+		t.Fatalf("stage = %v, want method chooser", m.setup.stage)
+	}
+
+	options := m.setupMethodOptions()
+	index := -1
+	for i, option := range options {
+		if option.kind == providerWizardMethodCLI && option.harness.ID == "claude" {
+			index = i
+		}
+	}
+	if index < 0 {
+		t.Fatalf("expected a claude CLI row in %#v", options)
+	}
+	m.setup.selectedMethod = index
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	if next.setup.stage != setupStageModel {
+		t.Fatalf("stage = %v, want Model (CLI method skips provider/endpoint/name/credentials)", next.setup.stage)
+	}
+	if next.setup.cliHarness == nil || next.setup.cliHarness.ID != "claude" {
+		t.Fatalf("cliHarness = %#v, want claude", next.setup.cliHarness)
+	}
+	if len(next.setup.providers) != 1 || next.setup.providers[0].ID != "anthropic" {
+		t.Fatalf("providers = %#v, want exactly the anthropic option", next.setup.providers)
+	}
+
+	// Retreating from Model must go straight back to Method and clear cliHarness.
+	back, _ := next.Update(testKey(tea.KeyLeft))
+	nextBack := back.(model)
+	if nextBack.setup.stage != setupStageMethod {
+		t.Fatalf("retreat stage = %v, want Method", nextBack.setup.stage)
+	}
+	if nextBack.setup.cliHarness != nil {
+		t.Fatal("expected cliHarness to be cleared after retreating to Method")
+	}
+}
+
+// TestSetupMethodChooserLoggedOutCLIShowsHint mirrors the equivalent
+// /provider-wizard test: choosing a not-logged-in CLI row must not advance
+// the stage, and must surface the harness's login hint.
+func TestSetupMethodChooserLoggedOutCLIShowsHint(t *testing.T) {
+	codexHarness, ok := agentcli.Lookup("codex")
+	if !ok {
+		t.Fatal("test assumption broken: codex missing from the agentcli catalog")
+	}
+	m := setupModelWithProviders(t,
+		[]SetupProviderOption{{ID: "chatgpt", Name: "ChatGPT", DefaultModel: "gpt-5.5"}},
+		[]agentcli.Detection{{Harness: codexHarness, Path: "/usr/local/bin/codex", Login: agentcli.LoggedOut}},
+	)
+	options := m.setupMethodOptions()
+	index := -1
+	for i, option := range options {
+		if option.kind == providerWizardMethodCLI && option.harness.ID == "codex" {
+			index = i
+		}
+	}
+	if index < 0 {
+		t.Fatalf("expected a codex CLI row in %#v", options)
+	}
+	m.setup.selectedMethod = index
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	if next.setup.stage != setupStageMethod {
+		t.Fatalf("stage = %v, want to stay on Method", next.setup.stage)
+	}
+	if !strings.Contains(next.setup.err, "codex login") {
+		t.Fatalf("err = %q, want it to mention the `codex login` hint", next.setup.err)
+	}
+}
+
+// TestSetupMethodOptionsFiltersCLIRowsNotInProviderList mirrors the existing
+// OAuth-filtering behavior (TestSetupMethodOptionsDropsOAuthWithoutOAuthProviders):
+// a selectable CLI row for a harness whose catalog provider isn't offered by
+// this setup run must be dropped, since selecting it would commit to a
+// provider outside the allowed list.
+func TestSetupMethodOptionsFiltersCLIRowsNotInProviderList(t *testing.T) {
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible: true,
+		// No "anthropic" entry offered by this setup run.
+		Providers: []SetupProviderOption{{ID: "openai", Name: "OpenAI", EnvVar: "OPENAI_API_KEY", RequiresAuth: true}},
+	}})
+	m.setup.agentCLIDetections = []agentcli.Detection{
+		{Harness: claudeHarness, Path: "/usr/local/bin/claude", Login: agentcli.LoggedIn},
+	}
+	for _, option := range m.setupMethodOptions() {
+		if option.kind == providerWizardMethodCLI && option.harness.ID == "claude" {
+			t.Fatalf("claude CLI row must be filtered out when anthropic isn't in this setup's provider list: %#v", option)
+		}
+	}
+}
+
+// TestCompleteSetupCLIModePassesAuthCLI drives completeSetup for a CLI-mode
+// setup and checks the SetupSelection handed to Save.
+func TestCompleteSetupCLIModePassesAuthCLI(t *testing.T) {
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	var gotSelection SetupSelection
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible: true,
+		Providers: []SetupProviderOption{
+			{ID: "anthropic", Name: "Anthropic", DefaultModel: "claude-sonnet-4.5", EnvVar: "ANTHROPIC_API_KEY", RequiresAuth: true},
+		},
+		Save: func(selection SetupSelection) (SetupResult, error) {
+			gotSelection = selection
+			return SetupResult{
+				Provider: config.ProviderProfile{
+					Name:      selection.Name,
+					CatalogID: selection.CatalogID,
+					Model:     selection.Model,
+					AuthCLI:   selection.AuthCLI,
+				},
+			}, nil
+		},
+	}})
+	m.width = 100
+	m.height = 30
+	m.setup.cliHarness = &claudeHarness
+	m.setup.providers = []SetupProviderOption{{ID: "anthropic", Name: "Anthropic", DefaultModel: "claude-sonnet-4.5"}}
+	m.setup.stage = setupStageReady
+
+	updated, _ := m.completeSetup()
+	next := updated.(model)
+
+	if gotSelection.AuthCLI != "claude" {
+		t.Fatalf("SetupSelection.AuthCLI = %q, want claude", gotSelection.AuthCLI)
+	}
+	if gotSelection.APIKey != "" {
+		t.Fatalf("SetupSelection.APIKey = %q, want empty for a CLI-authed profile", gotSelection.APIKey)
+	}
+	if next.providerProfile.AuthCLI != "claude" {
+		t.Fatalf("committed profile AuthCLI = %q, want claude", next.providerProfile.AuthCLI)
+	}
+}

--- a/internal/tui/onboarding_cli_test.go
+++ b/internal/tui/onboarding_cli_test.go
@@ -16,14 +16,15 @@ import (
 // keychain), and advances Welcome -> Method.
 func setupModelWithProviders(t *testing.T, providers []SetupProviderOption, detections []agentcli.Detection) model {
 	t.Helper()
-	m := newModel(context.Background(), Options{Setup: SetupOptions{
-		Visible:   true,
-		Providers: providers,
-	}})
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible:   true,
+			Providers: providers,
+		},
+		DetectAgentCLIs: func(agentcli.Deps) []agentcli.Detection { return detections },
+	})
 	m.width = 100
 	m.height = 30
-	m.setup.agentCLIDetections = detections
-	m.setup.selectedMethod = firstSelectableMethodIndex(m.setupMethodOptions())
 	return pressSetupContinueOnce(m) // Welcome -> Method
 }
 
@@ -128,14 +129,17 @@ func TestSetupMethodOptionsFiltersCLIRowsNotInProviderList(t *testing.T) {
 	if !ok {
 		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
 	}
-	m := newModel(context.Background(), Options{Setup: SetupOptions{
-		Visible: true,
-		// No "anthropic" entry offered by this setup run.
-		Providers: []SetupProviderOption{{ID: "openai", Name: "OpenAI", EnvVar: "OPENAI_API_KEY", RequiresAuth: true}},
-	}})
-	m.setup.agentCLIDetections = []agentcli.Detection{
+	detections := []agentcli.Detection{
 		{Harness: claudeHarness, Path: "/usr/local/bin/claude", Login: agentcli.LoggedIn},
 	}
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			// No "anthropic" entry offered by this setup run.
+			Providers: []SetupProviderOption{{ID: "openai", Name: "OpenAI", EnvVar: "OPENAI_API_KEY", RequiresAuth: true}},
+		},
+		DetectAgentCLIs: func(agentcli.Deps) []agentcli.Detection { return detections },
+	})
 	for _, option := range m.setupMethodOptions() {
 		if option.kind == providerWizardMethodCLI && option.harness.ID == "claude" {
 			t.Fatalf("claude CLI row must be filtered out when anthropic isn't in this setup's provider list: %#v", option)

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -28,7 +28,7 @@ func TestSetupMethodOptionsDropsOAuthWithoutOAuthProviders(t *testing.T) {
 		{ID: "ollama", Name: "Ollama Local", Local: true},
 	})
 	for _, option := range noOAuth.setupMethodOptions() {
-		if option.oauth {
+		if option.kind == providerWizardMethodOAuth {
 			t.Fatal("OAuth method must be hidden when the setup has no OAuth providers")
 		}
 	}
@@ -40,7 +40,7 @@ func TestSetupMethodOptionsDropsOAuthWithoutOAuthProviders(t *testing.T) {
 	})
 	hasOAuth := false
 	for _, option := range withOAuth.setupMethodOptions() {
-		if option.oauth {
+		if option.kind == providerWizardMethodOAuth {
 			hasOAuth = true
 		}
 	}

--- a/internal/tui/onlybash_command_test.go
+++ b/internal/tui/onlybash_command_test.go
@@ -1,0 +1,127 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHandleOnlyBashCommand(t *testing.T) {
+	t.Run("on restricts the tool surface to bash + skill with tool_search disabled", func(t *testing.T) {
+		got, out := model{}.handleOnlyBashCommand("on")
+		if !got.onlyBashActive {
+			t.Fatal("onlyBashActive should be true after /onlybash on")
+		}
+		if want := []string{"bash", "skill"}; !stringSlicesEqual(got.agentOptions.EnabledTools, want) {
+			t.Fatalf("EnabledTools = %v, want %v", got.agentOptions.EnabledTools, want)
+		}
+		if want := []string{"tool_search"}; !stringSlicesEqual(got.agentOptions.DisabledTools, want) {
+			t.Fatalf("DisabledTools = %v, want %v", got.agentOptions.DisabledTools, want)
+		}
+		if !strings.Contains(out, "onlybash: on") {
+			t.Fatalf("status output should report onlybash: on, got %q", out)
+		}
+	})
+
+	t.Run("off with no prior filters restores an unrestricted tool surface", func(t *testing.T) {
+		m := model{}
+		m, _ = m.handleOnlyBashCommand("on")
+		got, out := m.handleOnlyBashCommand("off")
+		if got.onlyBashActive {
+			t.Fatal("onlyBashActive should be false after /onlybash off")
+		}
+		if len(got.agentOptions.EnabledTools) != 0 {
+			t.Fatalf("EnabledTools = %v, want empty (restored to pre-onlybash state)", got.agentOptions.EnabledTools)
+		}
+		if len(got.agentOptions.DisabledTools) != 0 {
+			t.Fatalf("DisabledTools = %v, want empty (restored to pre-onlybash state)", got.agentOptions.DisabledTools)
+		}
+		if !strings.Contains(out, "onlybash: off") {
+			t.Fatalf("status output should report onlybash: off, got %q", out)
+		}
+	})
+
+	t.Run("off restores operator-configured filters that predate onlybash", func(t *testing.T) {
+		m := model{}
+		m.agentOptions.EnabledTools = []string{"read_file", "grep"}
+		m.agentOptions.DisabledTools = []string{"bash"}
+
+		m, _ = m.handleOnlyBashCommand("on")
+		if want := []string{"bash", "skill"}; !stringSlicesEqual(m.agentOptions.EnabledTools, want) {
+			t.Fatalf("EnabledTools while on = %v, want %v", m.agentOptions.EnabledTools, want)
+		}
+
+		got, _ := m.handleOnlyBashCommand("off")
+		if want := []string{"read_file", "grep"}; !stringSlicesEqual(got.agentOptions.EnabledTools, want) {
+			t.Fatalf("EnabledTools after off = %v, want restored operator filter %v", got.agentOptions.EnabledTools, want)
+		}
+		if want := []string{"bash"}; !stringSlicesEqual(got.agentOptions.DisabledTools, want) {
+			t.Fatalf("DisabledTools after off = %v, want restored operator filter %v", got.agentOptions.DisabledTools, want)
+		}
+	})
+
+	t.Run("a redundant on while already active does not re-stash onlybash's own filter", func(t *testing.T) {
+		m := model{}
+		m.agentOptions.EnabledTools = []string{"read_file"}
+		m.agentOptions.DisabledTools = []string{"write_file"}
+
+		m, _ = m.handleOnlyBashCommand("on")
+		// Redundant "on": must be a no-op on the stash, not re-capture onlybash's
+		// own [bash,skill]/[tool_search] as if it were the operator's filter.
+		m, _ = m.handleOnlyBashCommand("on")
+
+		got, _ := m.handleOnlyBashCommand("off")
+		if want := []string{"read_file"}; !stringSlicesEqual(got.agentOptions.EnabledTools, want) {
+			t.Fatalf("EnabledTools after off = %v, want original operator filter %v (stash must not have been clobbered by the redundant /onlybash on)", got.agentOptions.EnabledTools, want)
+		}
+		if want := []string{"write_file"}; !stringSlicesEqual(got.agentOptions.DisabledTools, want) {
+			t.Fatalf("DisabledTools after off = %v, want original operator filter %v", got.agentOptions.DisabledTools, want)
+		}
+	})
+
+	t.Run("bare form toggles", func(t *testing.T) {
+		m := model{}
+		m, _ = m.handleOnlyBashCommand("")
+		if !m.onlyBashActive {
+			t.Fatal("bare /onlybash should turn onlybash on from off")
+		}
+		m, _ = m.handleOnlyBashCommand("")
+		if m.onlyBashActive {
+			t.Fatal("bare /onlybash should turn onlybash off from on")
+		}
+	})
+
+	t.Run("status reports current state without mutating it", func(t *testing.T) {
+		m := model{}
+		m, _ = m.handleOnlyBashCommand("on")
+		got, out := m.handleOnlyBashCommand("status")
+		if !got.onlyBashActive {
+			t.Fatal("status must not change onlyBashActive")
+		}
+		if !strings.Contains(out, "onlybash: on") {
+			t.Fatalf("status output should report onlybash: on, got %q", out)
+		}
+	})
+
+	t.Run("unknown argument shows usage without changing state", func(t *testing.T) {
+		m := model{}
+		got, out := m.handleOnlyBashCommand("bogus")
+		if got.onlyBashActive {
+			t.Fatal("unknown argument must not enable onlybash")
+		}
+		if !strings.Contains(out, "Usage") {
+			t.Fatalf("unknown argument should show usage, got %q", out)
+		}
+	})
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/onlybash_command_test.go
+++ b/internal/tui/onlybash_command_test.go
@@ -59,6 +59,26 @@ func TestHandleOnlyBashCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("off while never turned on does not clobber a pre-existing operator filter", func(t *testing.T) {
+		m := model{}
+		m.agentOptions.EnabledTools = []string{"read_file", "grep"}
+		m.agentOptions.DisabledTools = []string{"bash"}
+
+		got, out := m.handleOnlyBashCommand("off")
+		if got.onlyBashActive {
+			t.Fatal("onlyBashActive should stay false")
+		}
+		if want := []string{"read_file", "grep"}; !stringSlicesEqual(got.agentOptions.EnabledTools, want) {
+			t.Fatalf("EnabledTools = %v, want unchanged operator filter %v (onlybash was never on, so off must be a no-op)", got.agentOptions.EnabledTools, want)
+		}
+		if want := []string{"bash"}; !stringSlicesEqual(got.agentOptions.DisabledTools, want) {
+			t.Fatalf("DisabledTools = %v, want unchanged operator filter %v", got.agentOptions.DisabledTools, want)
+		}
+		if !strings.Contains(out, "onlybash: off") {
+			t.Fatalf("status output should still report onlybash: off, got %q", out)
+		}
+	})
+
 	t.Run("a redundant on while already active does not re-stash onlybash's own filter", func(t *testing.T) {
 		m := model{}
 		m.agentOptions.EnabledTools = []string{"read_file"}

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -114,6 +114,10 @@ type SetupSelection struct {
 	BaseURL   string
 	Model     string
 	APIKey    string
+	// AuthCLI names a detected agent-CLI harness (e.g. "claude", "codex") whose
+	// local login this selection reuses instead of an API key. Empty for the
+	// key/OAuth connect methods.
+	AuthCLI string
 }
 
 // SetupResult describes a completed setup write.

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -6,6 +6,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/modelregistry"
@@ -35,18 +36,23 @@ type Options struct {
 	ProbeProviderHealth         func(context.Context, providerhealth.Options) providerhealth.Result
 	DiscoverProviderModels      func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	DiscoverOllamaContextWindow func(ctx context.Context, baseURL string, model string) (int, error)
-	RuntimeMessageSink          func(tea.Msg)
-	Registry                    *tools.Registry
-	SessionStore                *sessions.Store
-	SandboxStore                *sandbox.GrantStore
-	MCPConfig                   config.MCPConfig
-	MCPPermissionStore          *mcp.PermissionStore
-	MCPTokenStore               *mcp.TokenStore
-	MCPCommand                  func(context.Context, []string) MCPCommandResult
-	SandboxSetupCommand         func(context.Context) SandboxSetupCommandResult
-	UsageTracker                *usage.Tracker
-	SessionCompactor            SessionCompactor
-	PrService                   *PrService
+	// DetectAgentCLIs probes the machine for installed agent-CLI harnesses (see
+	// agentcli.Detect). Injectable so tests can supply a fake instead of
+	// touching the real PATH/filesystem/keychain; nil defaults to
+	// agentcli.Detect in newModel.
+	DetectAgentCLIs     func(agentcli.Deps) []agentcli.Detection
+	RuntimeMessageSink  func(tea.Msg)
+	Registry            *tools.Registry
+	SessionStore        *sessions.Store
+	SandboxStore        *sandbox.GrantStore
+	MCPConfig           config.MCPConfig
+	MCPPermissionStore  *mcp.PermissionStore
+	MCPTokenStore       *mcp.TokenStore
+	MCPCommand          func(context.Context, []string) MCPCommandResult
+	SandboxSetupCommand func(context.Context) SandboxSetupCommandResult
+	UsageTracker        *usage.Tracker
+	SessionCompactor    SessionCompactor
+	PrService           *PrService
 
 	AgentOptions    agent.Options
 	PermissionMode  agent.PermissionMode

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/providercatalog"
@@ -242,13 +243,24 @@ func (m model) descriptorForProfile(profile config.ProviderProfile) (providercat
 }
 
 func modelPickerProviderGroup(profile config.ProviderProfile, descriptor providercatalog.Descriptor, hasDescriptor bool) string {
+	base := "Provider"
 	if hasDescriptor && strings.TrimSpace(descriptor.Name) != "" {
-		return descriptor.Name
+		base = descriptor.Name
+	} else if name := strings.TrimSpace(profile.Name); name != "" {
+		base = name
 	}
-	if name := strings.TrimSpace(profile.Name); name != "" {
-		return name
+	// A CLI-authenticated profile shares its catalog descriptor with any plain
+	// API-key profile for the same provider, so an unsuffixed group label would
+	// (a) hide which login the models run on and (b) collide in the picker's
+	// per-group dedup, dropping one of the two profiles from the list entirely.
+	if cli := strings.TrimSpace(profile.AuthCLI); cli != "" {
+		display := cli
+		if harness, ok := agentcli.Lookup(cli); ok {
+			display = harness.DisplayName
+		}
+		return base + " · via " + display
 	}
-	return "Provider"
+	return base
 }
 
 func (m model) openModelPicker() (model, tea.Cmd) {
@@ -612,6 +624,13 @@ func (m model) normalizeProfileForProvider(provider providercatalog.Descriptor) 
 		genericProviderCatalogID(profile.CatalogID) ||
 		strings.TrimSpace(profile.Name) == "" ||
 		strings.TrimSpace(profile.CatalogID) == ""
+	// A CLI-authenticated profile's NAME is its credential binding: renaming it
+	// to the catalog id makes persistence miss the real profile ("provider
+	// \"anthropic\" not found") and the APIKeyEnv autofill below would displace
+	// the CLI login with an ambient env key. Keep its identity untouched.
+	if strings.TrimSpace(profile.AuthCLI) != "" {
+		normalizeIdentity = false
+	}
 	if normalizeIdentity {
 		profile.Name = provider.ID
 		profile.CatalogID = provider.ID
@@ -625,11 +644,16 @@ func (m model) normalizeProfileForProvider(provider providercatalog.Descriptor) 
 	if strings.TrimSpace(profile.APIFormat) == "" {
 		profile.APIFormat = providerWizardAPIFormat(provider)
 	}
-	if len(provider.AuthEnvVars) > 0 && (strings.TrimSpace(profile.APIKeyEnv) == "" || normalizeIdentity) {
-		profile.APIKeyEnv = provider.AuthEnvVars[0]
-	}
-	if strings.TrimSpace(profile.APIKey) == "" && strings.TrimSpace(profile.APIKeyEnv) != "" {
-		profile.APIKey = strings.TrimSpace(os.Getenv(profile.APIKeyEnv))
+	// CLI-auth profiles stay keyless by design (see providerWizardCLIProfile):
+	// filling APIKeyEnv/APIKey here would route requests to an ambient env key
+	// instead of the CLI login the user chose.
+	if strings.TrimSpace(profile.AuthCLI) == "" {
+		if len(provider.AuthEnvVars) > 0 && (strings.TrimSpace(profile.APIKeyEnv) == "" || normalizeIdentity) {
+			profile.APIKeyEnv = provider.AuthEnvVars[0]
+		}
+		if strings.TrimSpace(profile.APIKey) == "" && strings.TrimSpace(profile.APIKeyEnv) != "" {
+			profile.APIKey = strings.TrimSpace(os.Getenv(profile.APIKeyEnv))
+		}
 	}
 	return profile
 }

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -14,6 +14,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/Gitlawb/zero/internal/agentcli"
 	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
@@ -251,30 +252,107 @@ const (
 	providerWizardStepDone
 )
 
+// providerWizardMethodKind distinguishes the three ways the wizard can connect
+// a provider: a pasted/env API key, zero's own browser OAuth login, or reusing
+// a detected agent-CLI's (Claude Code, Codex, ...) existing local login.
+type providerWizardMethodKind int
+
+const (
+	providerWizardMethodKey providerWizardMethodKind = iota
+	providerWizardMethodOAuth
+	providerWizardMethodCLI
+)
+
 // providerWizardMethodOption is a row in the "How do you want to connect?" step.
 type providerWizardMethodOption struct {
-	oauth    bool
+	kind     providerWizardMethodKind
 	label    string
 	subtitle string
+	// harness and loggedIn are set only for kind == providerWizardMethodCLI:
+	// harness is the detected agent CLI this row reuses credentials from, and
+	// loggedIn mirrors its probed agentcli.LoginState (LoggedIn == true).
+	harness  agentcli.Harness
+	loggedIn bool
+	// disabled marks an informational-only CLI row: a detected harness with no
+	// reusable provider credentials (agentcli.Harness.CatalogID == ""), shown
+	// so the user sees it was auto-detected as a sub-agent harness but cannot
+	// be selected as a connect method.
+	disabled bool
 }
 
-// providerWizardMethodOptions returns the connect-method rows. OAuth is listed
-// first (and is the default) when any OAuth-capable provider exists.
-func providerWizardMethodOptions() []providerWizardMethodOption {
+// providerWizardMethodOptions returns the connect-method rows: OAuth first (when
+// any OAuth-capable provider exists), then one row per detected agent CLI, then
+// "paste an API key" last. Detections come from the caller (agentcli.Detect,
+// run once at wizard construction — see providerWizardState.agentCLIDetections)
+// rather than probed here, so this function is cheap to call on every
+// render/keystroke and is trivially testable with a hand-built detection list.
+func providerWizardMethodOptions(detections []agentcli.Detection) []providerWizardMethodOption {
 	options := []providerWizardMethodOption{}
 	if len(providercatalog.OAuthProviders()) > 0 {
 		options = append(options, providerWizardMethodOption{
-			oauth:    true,
+			kind:     providerWizardMethodOAuth,
 			label:    "Sign in with OAuth",
 			subtitle: "One-click browser login, no API key to copy (OpenRouter, xAI, ChatGPT, Hugging Face).",
 		})
 	}
+	options = append(options, providerWizardCLIMethodOptions(detections)...)
 	options = append(options, providerWizardMethodOption{
-		oauth:    false,
+		kind:     providerWizardMethodKey,
 		label:    "Paste an API key / browse providers",
 		subtitle: "Any of 20+ providers, a local model, or a subscription via proxy.",
 	})
 	return options
+}
+
+// providerWizardCLIMethodOptions builds one method row per detected agent CLI:
+// a selectable "Use <name> login" row when the harness's credentials are
+// reusable by a zero provider (Harness.CatalogID != ""), or a disabled
+// informational row otherwise — so a detected gemini/qwen/etc CLI is visible
+// (confirming auto-detection worked) even though it has no zero provider to
+// attach to and can only run as a sub-agent harness.
+func providerWizardCLIMethodOptions(detections []agentcli.Detection) []providerWizardMethodOption {
+	options := make([]providerWizardMethodOption, 0, len(detections))
+	for _, detection := range detections {
+		harness := detection.Harness
+		if harness.CatalogID == "" {
+			options = append(options, providerWizardMethodOption{
+				kind:     providerWizardMethodCLI,
+				disabled: true,
+				harness:  harness,
+				label:    harness.DisplayName,
+				subtitle: "Detected — usable as a sub-agent harness; no reusable API credentials.",
+			})
+			continue
+		}
+		loggedIn := detection.Login == agentcli.LoggedIn
+		state := "installed, not logged in"
+		switch detection.Login {
+		case agentcli.LoggedIn:
+			state = "logged in"
+		case agentcli.LoginUnknown:
+			state = "installed"
+		}
+		options = append(options, providerWizardMethodOption{
+			kind:     providerWizardMethodCLI,
+			harness:  harness,
+			loggedIn: loggedIn,
+			label:    "Use " + harness.DisplayName + " login",
+			subtitle: "Detected — " + state + ". Reuses its credentials, no separate key.",
+		})
+	}
+	return options
+}
+
+// firstSelectableMethodIndex returns the index of the first non-disabled row,
+// so a wizard/setup never opens with the cursor parked on an informational
+// (unselectable) CLI row.
+func firstSelectableMethodIndex(options []providerWizardMethodOption) int {
+	for index, option := range options {
+		if !option.disabled {
+			return index
+		}
+	}
+	return 0
 }
 
 // providerWizardOAuthDescriptors returns the OAuth-capable providers as the
@@ -318,17 +396,38 @@ type providerWizardState struct {
 	oauthDevice           bool
 	deviceUserCode        string
 	deviceVerificationURI string
+	// agentCLIDetections is captured ONCE at wizard construction (see
+	// newProviderWizard) rather than reprobed on every render/keystroke —
+	// agentcli.Detect shells out to `security` for the macOS keychain, which
+	// would make every method-step render/move/canAdvance call pay that cost.
+	agentCLIDetections []agentcli.Detection
+	// cliHarness is set when the CLI connect method was chosen: the wizard
+	// skips the provider-chooser step entirely (the row already names the
+	// provider) and jumps straight to model selection.
+	cliHarness *agentcli.Harness
 }
 
 func (m model) newProviderWizard() *providerWizardState {
+	detections := agentcli.Detect(agentcli.Deps{})
 	providers := providerWizardProviders()
 	wizard := &providerWizardState{
-		step:             providerWizardStepMethod,
-		providers:        providers,
-		selectedProvider: 0,
+		step:               providerWizardStepMethod,
+		providers:          providers,
+		selectedProvider:   0,
+		agentCLIDetections: detections,
 	}
+	wizard.selectedMethod = firstSelectableMethodIndex(wizard.methodOptions())
 	wizard.refreshModels()
 	return wizard
+}
+
+// methodOptions returns this wizard's connect-method rows, built from the
+// detections captured once at construction (see agentCLIDetections).
+func (wizard *providerWizardState) methodOptions() []providerWizardMethodOption {
+	if wizard == nil {
+		return nil
+	}
+	return providerWizardMethodOptions(wizard.agentCLIDetections)
 }
 
 func providerWizardProviders() []providercatalog.Descriptor {
@@ -393,11 +492,21 @@ func (wizard *providerWizardState) move(delta int) {
 	}
 	switch wizard.step {
 	case providerWizardStepMethod:
-		options := providerWizardMethodOptions()
+		options := wizard.methodOptions()
 		if len(options) == 0 {
 			return
 		}
-		wizard.selectedMethod = ((wizard.selectedMethod+delta)%len(options) + len(options)) % len(options)
+		next := wizard.selectedMethod
+		// Skip disabled (informational-only) rows — they are visible but not
+		// selectable. Bounded by len(options): "paste an API key" is always
+		// present and never disabled, so this always terminates.
+		for i := 0; i < len(options); i++ {
+			next = ((next+delta)%len(options) + len(options)) % len(options)
+			if !options[next].disabled {
+				break
+			}
+		}
+		wizard.selectedMethod = next
 	case providerWizardStepProvider:
 		if len(wizard.providers) == 0 {
 			return
@@ -431,19 +540,56 @@ func (wizard *providerWizardState) advance() {
 	}
 	switch wizard.step {
 	case providerWizardStepMethod:
-		options := providerWizardMethodOptions()
+		options := wizard.methodOptions()
 		wizard.selectedMethod = clampInt(wizard.selectedMethod, 0, maxInt(0, len(options)-1))
 		wizard.err = ""
-		if len(options) > 0 && options[wizard.selectedMethod].oauth {
+		if len(options) == 0 {
+			return
+		}
+		selected := options[wizard.selectedMethod]
+		wizard.oauthMode = false
+		wizard.cliHarness = nil
+		switch selected.kind {
+		case providerWizardMethodOAuth:
 			wizard.oauthMode = true
 			wizard.providers = providerWizardOAuthDescriptors()
-		} else {
-			wizard.oauthMode = false
+			wizard.selectedProvider = 0
+			wizard.refreshModels()
+			wizard.step = providerWizardStepProvider
+		case providerWizardMethodCLI:
+			if selected.disabled {
+				// Informational row only — nothing to advance into.
+				return
+			}
+			if !selected.loggedIn {
+				wizard.err = selected.harness.DisplayName + " is not logged in — run `" +
+					selected.harness.LoginCommand() + "` to log in, then try again."
+				return
+			}
+			descriptor, ok := providercatalog.Get(selected.harness.CatalogID)
+			if !ok {
+				wizard.err = "no provider catalog entry for " + selected.harness.CatalogID
+				return
+			}
+			harness := selected.harness
+			wizard.cliHarness = &harness
+			wizard.providers = []providercatalog.Descriptor{descriptor}
+			wizard.selectedProvider = 0
+			wizard.apiKey = ""
+			wizard.baseURL = ""
+			wizard.profileName = ""
+			wizard.refreshModels()
+			// The CLI row already names the provider — skip the provider
+			// chooser and the credential step (the login IS the credential)
+			// and go straight to model selection, mirroring how a successful
+			// OAuth login (applyProviderWizardOAuth) skips ahead too.
+			wizard.step = providerWizardStepModel
+		default:
 			wizard.providers = providerWizardProviders()
+			wizard.selectedProvider = 0
+			wizard.refreshModels()
+			wizard.step = providerWizardStepProvider
 		}
-		wizard.selectedProvider = 0
-		wizard.refreshModels()
-		wizard.step = providerWizardStepProvider
 	case providerWizardStepProvider:
 		// In OAuth mode, advancing starts the browser/device login (dispatched by
 		// advanceProviderWizard at the model level), not the key/endpoint flow.
@@ -524,7 +670,12 @@ func (wizard *providerWizardState) retreat() {
 			wizard.step = providerWizardStepProvider
 		}
 	case providerWizardStepModel:
-		if providerWizardNeedsCredential(wizard.currentProvider()) {
+		if wizard.cliHarness != nil {
+			// CLI mode jumped straight from Method to Model (no provider/
+			// credential step was ever shown), so back up straight to Method.
+			wizard.cliHarness = nil
+			wizard.step = providerWizardStepMethod
+		} else if providerWizardNeedsCredential(wizard.currentProvider()) {
 			wizard.step = providerWizardStepCredential
 		} else if providerWizardNeedsEndpoint(wizard.currentProvider()) {
 			wizard.step = providerWizardStepEndpoint
@@ -764,7 +915,12 @@ func (wizard *providerWizardState) canAdvanceWithRight() bool {
 	}
 	switch wizard.step {
 	case providerWizardStepMethod:
-		return len(providerWizardMethodOptions()) > 0
+		options := wizard.methodOptions()
+		if len(options) == 0 {
+			return false
+		}
+		index := clampInt(wizard.selectedMethod, 0, len(options)-1)
+		return !options[index].disabled
 	case providerWizardStepProvider:
 		return strings.TrimSpace(wizard.currentProvider().ID) != ""
 	case providerWizardStepEndpoint:
@@ -886,7 +1042,12 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 	}
 	provider := wizard.currentProvider()
 	modelChoice := wizard.currentModel()
-	profile := providerWizardProfile(provider, modelChoice.ID, wizard.apiKey, wizard.baseURL, wizard.profileName)
+	var profile config.ProviderProfile
+	if wizard.cliHarness != nil {
+		profile = providerWizardCLIProfile(*wizard.cliHarness, provider, modelChoice.ID)
+	} else {
+		profile = providerWizardProfile(provider, modelChoice.ID, wizard.apiKey, wizard.baseURL, wizard.profileName)
+	}
 	runtimeProfile := providerWizardRuntimeProfile(profile)
 
 	// Build and persist into LOCALS first, committing live state only once BOTH
@@ -1124,6 +1285,15 @@ func providerWizardStepLine(wizard *providerWizardState) string {
 		{providerWizardStepProvider, "2 provider"},
 	}
 	switch {
+	case wizard.cliHarness != nil:
+		// CLI path skips the provider chooser too — the method row already
+		// named the provider — so it never shows "2 provider" as a step of
+		// its own; jump straight from method to model.
+		steps = []stepLabel{
+			{providerWizardStepMethod, "1 method"},
+			{providerWizardStepModel, "2 model"},
+			{providerWizardStepDone, "3 ready"},
+		}
 	case wizard.oauthMode:
 		// OAuth path skips endpoint/name/key entirely.
 		steps = append(steps,
@@ -1158,10 +1328,17 @@ func providerWizardStepLine(wizard *providerWizardState) string {
 
 // renderMethodStep renders the "How do you want to connect?" chooser.
 func (wizard *providerWizardState) renderMethodStep(width int) []string {
-	options := providerWizardMethodOptions()
+	options := wizard.methodOptions()
 	wizard.selectedMethod = clampInt(wizard.selectedMethod, 0, maxInt(0, len(options)-1))
 	lines := []string{zeroTheme.accent.Render("How do you want to connect?")}
 	for index, option := range options {
+		if option.disabled {
+			// Informational-only row: always faint, never shows a selection
+			// marker (move() never parks the cursor here).
+			lines = append(lines, fitStyledLine("  "+zeroTheme.faint.Render(option.label), width))
+			lines = append(lines, fitStyledLine("    "+zeroTheme.faint.Render(option.subtitle), width))
+			continue
+		}
 		surface := transparentSurface
 		marker := surface(zeroTheme.faintest).Render("  ")
 		if index == wizard.selectedMethod {
@@ -1541,10 +1718,14 @@ func (wizard *providerWizardState) renderDoneStep(width int) []string {
 	if providerWizardNeedsEndpoint(provider) {
 		lines = append(lines, zeroTheme.ink.Render("Endpoint    "+strings.TrimSpace(wizard.baseURL)))
 	}
+	credential := providerWizardCredentialLabel(provider, wizard.apiKey)
+	if wizard.cliHarness != nil {
+		credential = wizard.cliHarness.DisplayName + " login"
+	}
 	lines = append(lines,
 		zeroTheme.ink.Render("Name        "+providerWizardDisplayName(provider, wizard.baseURL, wizard.profileName)),
 		zeroTheme.ink.Render("Model       "+model.ID),
-		zeroTheme.ink.Render("Credential  "+providerWizardCredentialLabel(provider, wizard.apiKey)),
+		zeroTheme.ink.Render("Credential  "+credential),
 		"",
 		zeroTheme.faint.Render("Press Enter to save and start using this provider."),
 	)
@@ -1587,6 +1768,23 @@ func providerWizardProfile(provider providercatalog.Descriptor, model string, ap
 		profile.APIKeyEnv = env
 	}
 	return profile
+}
+
+// providerWizardCLIProfile builds a keyless profile for the CLI connect method:
+// AuthCLI names the harness whose local login this profile reuses. APIKey and
+// APIKeyEnv are deliberately left unset — providerWizardProfile would populate
+// APIKeyEnv for a RequiresAuth descriptor (e.g. Anthropic's ANTHROPIC_API_KEY),
+// and providerWizardRuntimeProfile would then read an ambient env var at build
+// time, silently displacing the CLI login this profile exists to use.
+func providerWizardCLIProfile(harness agentcli.Harness, provider providercatalog.Descriptor, model string) config.ProviderProfile {
+	return config.ProviderProfile{
+		Name:         harness.ID,
+		ProviderKind: providerWizardProviderKind(provider),
+		CatalogID:    provider.ID,
+		APIFormat:    providerWizardAPIFormat(provider),
+		Model:        firstProviderDisplayValue(model, provider.DefaultModel),
+		AuthCLI:      harness.ID,
+	}
 }
 
 func providerWizardEndpointError(value string) string {

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -314,16 +314,6 @@ func providerWizardCLIMethodOptions(detections []agentcli.Detection) []providerW
 	options := make([]providerWizardMethodOption, 0, len(detections))
 	for _, detection := range detections {
 		harness := detection.Harness
-		if harness.CatalogID == "" {
-			options = append(options, providerWizardMethodOption{
-				kind:     providerWizardMethodCLI,
-				disabled: true,
-				harness:  harness,
-				label:    harness.DisplayName,
-				subtitle: "Detected — usable as a sub-agent harness; no reusable API credentials.",
-			})
-			continue
-		}
 		loggedIn := detection.Login == agentcli.LoggedIn
 		state := "installed, not logged in"
 		switch detection.Login {
@@ -331,6 +321,17 @@ func providerWizardCLIMethodOptions(detections []agentcli.Detection) []providerW
 			state = "logged in"
 		case agentcli.LoginUnknown:
 			state = "installed"
+		}
+		if harness.CatalogID == "" {
+			options = append(options, providerWizardMethodOption{
+				kind:     providerWizardMethodCLI,
+				disabled: true,
+				harness:  harness,
+				loggedIn: loggedIn,
+				label:    harness.DisplayName,
+				subtitle: "Detected — " + state + "; usable as a sub-agent harness, no reusable API credentials.",
+			})
+			continue
 		}
 		options = append(options, providerWizardMethodOption{
 			kind:     providerWizardMethodCLI,
@@ -400,7 +401,15 @@ type providerWizardState struct {
 	// newProviderWizard) rather than reprobed on every render/keystroke —
 	// agentcli.Detect shells out to `security` for the macOS keychain, which
 	// would make every method-step render/move/canAdvance call pay that cost.
+	// The one exception is advance()'s logged-out rejection path: reprobing
+	// there (not on every render) is what lets a user who just logged in retry
+	// without reopening the wizard.
 	agentCLIDetections []agentcli.Detection
+	// detect is the same probe used to build agentCLIDetections, kept around so
+	// advance() can reprobe a single harness on a logged-out rejection instead
+	// of trusting detection state that's stale by definition (it was captured
+	// at construction, before the user could have run a login command).
+	detect func(agentcli.Deps) []agentcli.Detection
 	// cliHarness is set when the CLI connect method was chosen: the wizard
 	// skips the provider-chooser step entirely (the row already names the
 	// provider) and jumps straight to model selection.
@@ -408,13 +417,18 @@ type providerWizardState struct {
 }
 
 func (m model) newProviderWizard() *providerWizardState {
-	detections := agentcli.Detect(agentcli.Deps{})
+	detect := m.detectAgentCLIs
+	if detect == nil {
+		detect = agentcli.Detect
+	}
+	detections := detect(agentcli.Deps{})
 	providers := providerWizardProviders()
 	wizard := &providerWizardState{
 		step:               providerWizardStepMethod,
 		providers:          providers,
 		selectedProvider:   0,
 		agentCLIDetections: detections,
+		detect:             detect,
 	}
 	wizard.selectedMethod = firstSelectableMethodIndex(wizard.methodOptions())
 	wizard.refreshModels()
@@ -428,6 +442,26 @@ func (wizard *providerWizardState) methodOptions() []providerWizardMethodOption 
 		return nil
 	}
 	return providerWizardMethodOptions(wizard.agentCLIDetections)
+}
+
+// reprobeSelectedHarness re-runs detection and, if harnessID now reports
+// LoggedIn, updates wizard.agentCLIDetections in place and returns the
+// harness's refreshed method-option row. Used only from advance()'s
+// logged-out rejection path — never on every render, so this doesn't reinstate
+// the per-keystroke keychain-probing cost agentCLIDetections' construction-time
+// capture exists to avoid.
+func (wizard *providerWizardState) reprobeSelectedHarness(harnessID string) (providerWizardMethodOption, bool) {
+	if wizard == nil || wizard.detect == nil {
+		return providerWizardMethodOption{}, false
+	}
+	fresh := wizard.detect(agentcli.Deps{})
+	wizard.agentCLIDetections = fresh
+	for _, option := range providerWizardMethodOptions(fresh) {
+		if option.kind == providerWizardMethodCLI && option.harness.ID == harnessID {
+			return option, true
+		}
+	}
+	return providerWizardMethodOption{}, false
 }
 
 func providerWizardProviders() []providercatalog.Descriptor {
@@ -562,9 +596,17 @@ func (wizard *providerWizardState) advance() {
 				return
 			}
 			if !selected.loggedIn {
-				wizard.err = selected.harness.DisplayName + " is not logged in — run `" +
-					selected.harness.LoginCommand() + "` to log in, then try again."
-				return
+				// agentCLIDetections was captured once at construction, so it's
+				// stale by definition — the user may have just run the login
+				// command this same error is telling them to run. Reprobe before
+				// rejecting so a retry (without reopening the wizard) can succeed.
+				if refreshed, ok := wizard.reprobeSelectedHarness(selected.harness.ID); ok && refreshed.loggedIn {
+					selected = refreshed
+				} else {
+					wizard.err = selected.harness.DisplayName + " is not logged in — run `" +
+						selected.harness.LoginCommand() + "` to log in, then try again."
+					return
+				}
 			}
 			descriptor, ok := providercatalog.Get(selected.harness.CatalogID)
 			if !ok {
@@ -1781,6 +1823,7 @@ func providerWizardCLIProfile(harness agentcli.Harness, provider providercatalog
 		Name:         harness.ID,
 		ProviderKind: providerWizardProviderKind(provider),
 		CatalogID:    provider.ID,
+		BaseURL:      provider.DefaultBaseURL,
 		APIFormat:    providerWizardAPIFormat(provider),
 		Model:        firstProviderDisplayValue(model, provider.DefaultModel),
 		AuthCLI:      harness.ID,

--- a/internal/tui/provider_wizard_cli_test.go
+++ b/internal/tui/provider_wizard_cli_test.go
@@ -1,0 +1,281 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/agentcli"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// fakeAgentCLIDeps builds an agentcli.Deps that reports `present` binaries on
+// PATH, a not-found keychain (never leave this nil in a claude-related test —
+// the real keychain leaks in on dev Macs), and ReadFile serving `credFiles`
+// (path -> contents) for anything else not found.
+func fakeAgentCLIDeps(present map[string]bool, credFiles map[string]string) agentcli.Deps {
+	return agentcli.Deps{
+		LookPath: func(name string) (string, error) {
+			if present[name] {
+				return "/usr/local/bin/" + name, nil
+			}
+			return "", errors.New("not found")
+		},
+		Keychain: func(string) ([]byte, error) { return nil, errors.New("keychain: not found") },
+		ReadFile: func(path string) ([]byte, error) {
+			for suffix, contents := range credFiles {
+				if strings.HasSuffix(path, suffix) {
+					return []byte(contents), nil
+				}
+			}
+			return nil, os.ErrNotExist
+		},
+	}
+}
+
+// TestProviderWizardCLIMethodOptionsFromDetections exercises the whole
+// detect -> build-rows path with injected agentcli.Deps: claude is installed
+// and logged in (selectable "Use Claude Code login" row), codex is installed
+// but logged out (selectable, loggedIn=false), gemini is installed but has no
+// reusable provider credentials (informational/disabled row).
+func TestProviderWizardCLIMethodOptionsFromDetections(t *testing.T) {
+	deps := fakeAgentCLIDeps(
+		map[string]bool{"claude": true, "codex": true, "gemini": true},
+		map[string]string{
+			".claude/.credentials.json": `{"claudeAiOauth":{"accessToken":"tok","refreshToken":"r","expiresAt":9999999999999}}`,
+			// codex's auth.json intentionally absent -> logged out.
+			// gemini's oauth_creds.json intentionally absent -> irrelevant, it has no CatalogID anyway.
+		},
+	)
+	detections := agentcli.Detect(deps)
+
+	options := providerWizardCLIMethodOptions(detections)
+
+	var claudeRow, codexRow, geminiRow *providerWizardMethodOption
+	for index := range options {
+		switch options[index].harness.ID {
+		case "claude":
+			claudeRow = &options[index]
+		case "codex":
+			codexRow = &options[index]
+		case "gemini":
+			geminiRow = &options[index]
+		}
+	}
+	if claudeRow == nil || codexRow == nil || geminiRow == nil {
+		t.Fatalf("expected claude, codex, and gemini rows, got %#v", options)
+	}
+	if claudeRow.kind != providerWizardMethodCLI || claudeRow.disabled || !claudeRow.loggedIn {
+		t.Fatalf("claude row = %#v, want selectable + logged in", *claudeRow)
+	}
+	if !strings.Contains(claudeRow.label, "Claude Code") {
+		t.Fatalf("claude row label = %q, want it to name Claude Code", claudeRow.label)
+	}
+	if codexRow.disabled || codexRow.loggedIn {
+		t.Fatalf("codex row = %#v, want selectable + logged OUT", *codexRow)
+	}
+	if !geminiRow.disabled {
+		t.Fatalf("gemini row = %#v, want disabled (no reusable provider credentials)", *geminiRow)
+	}
+}
+
+// TestProviderWizardMethodOptionsKeepsAPIKeyLast locks in the ordering
+// invariant several existing tests rely on (selectedMethod = len(options)-1
+// selects "Paste an API key / browse providers"): CLI rows must be inserted
+// between OAuth and the key option, never after it.
+func TestProviderWizardMethodOptionsKeepsAPIKeyLast(t *testing.T) {
+	deps := fakeAgentCLIDeps(map[string]bool{"claude": true}, map[string]string{
+		".claude/.credentials.json": `{"claudeAiOauth":{"accessToken":"tok","refreshToken":"r"}}`,
+	})
+	options := providerWizardMethodOptions(agentcli.Detect(deps))
+	if len(options) < 2 {
+		t.Fatalf("expected at least [oauth-or-cli..., key], got %d options", len(options))
+	}
+	last := options[len(options)-1]
+	if last.kind != providerWizardMethodKey {
+		t.Fatalf("last option = %#v, want the API-key method", last)
+	}
+}
+
+// TestProviderWizardAdvanceIntoCLIMethodSkipsProviderStep drives the wizard's
+// key-handling exactly as a user would: land on Method, select a logged-in
+// CLI row, press Enter. It must skip the provider chooser entirely and land on
+// Model selection with cliHarness recorded.
+func TestProviderWizardAdvanceIntoCLIMethodSkipsProviderStep(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.providerWizard = m.newProviderWizard()
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	m.providerWizard.agentCLIDetections = []agentcli.Detection{
+		{Harness: claudeHarness, Path: "/usr/local/bin/claude", Login: agentcli.LoggedIn},
+	}
+	options := m.providerWizard.methodOptions()
+	index := -1
+	for i, option := range options {
+		if option.kind == providerWizardMethodCLI && option.harness.ID == "claude" {
+			index = i
+		}
+	}
+	if index < 0 {
+		t.Fatalf("expected a claude CLI row in %#v", options)
+	}
+	m.providerWizard.selectedMethod = index
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	if next.providerWizard == nil {
+		t.Fatal("expected the wizard to stay open")
+	}
+	if next.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("step = %v, want Model (CLI method skips the provider chooser)", next.providerWizard.step)
+	}
+	if next.providerWizard.cliHarness == nil || next.providerWizard.cliHarness.ID != "claude" {
+		t.Fatalf("cliHarness = %#v, want claude", next.providerWizard.cliHarness)
+	}
+	if len(next.providerWizard.providers) != 1 || next.providerWizard.providers[0].ID != "anthropic" {
+		t.Fatalf("providers = %#v, want exactly the anthropic descriptor", next.providerWizard.providers)
+	}
+
+	// Retreating from Model must go straight back to Method (not Provider,
+	// which CLI mode never visits) and clear cliHarness.
+	back, _ := next.Update(testKey(tea.KeyLeft))
+	nextBack := back.(model)
+	if nextBack.providerWizard.step != providerWizardStepMethod {
+		t.Fatalf("retreat step = %v, want Method", nextBack.providerWizard.step)
+	}
+	if nextBack.providerWizard.cliHarness != nil {
+		t.Fatal("expected cliHarness to be cleared after retreating to Method")
+	}
+}
+
+// TestProviderWizardAdvanceIntoLoggedOutCLIShowsHint covers "choosing CLI when
+// logged out shows the harness's login hint rather than failing later": the
+// wizard must stay on the Method step and surface an actionable error instead
+// of silently building a doomed provider.
+func TestProviderWizardAdvanceIntoLoggedOutCLIShowsHint(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.providerWizard = m.newProviderWizard()
+	codexHarness, ok := agentcli.Lookup("codex")
+	if !ok {
+		t.Fatal("test assumption broken: codex missing from the agentcli catalog")
+	}
+	m.providerWizard.agentCLIDetections = []agentcli.Detection{
+		{Harness: codexHarness, Path: "/usr/local/bin/codex", Login: agentcli.LoggedOut},
+	}
+	options := m.providerWizard.methodOptions()
+	index := -1
+	for i, option := range options {
+		if option.kind == providerWizardMethodCLI && option.harness.ID == "codex" {
+			index = i
+		}
+	}
+	if index < 0 {
+		t.Fatalf("expected a codex CLI row in %#v", options)
+	}
+	m.providerWizard.selectedMethod = index
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	if next.providerWizard == nil || next.providerWizard.step != providerWizardStepMethod {
+		t.Fatalf("expected to stay on the Method step, got %#v", next.providerWizard)
+	}
+	if !strings.Contains(next.providerWizard.err, "codex login") {
+		t.Fatalf("err = %q, want it to mention the `codex login` hint", next.providerWizard.err)
+	}
+}
+
+// TestProviderWizardCLIProfileHasNoAPIKeyOrEnv locks in the credential shape a
+// CLI method selection must produce: AuthCLI set, APIKey/APIKeyEnv both empty
+// — providerWizardProfile would otherwise populate APIKeyEnv for a
+// RequiresAuth descriptor like Anthropic's, and providerWizardRuntimeProfile
+// would then read an ambient env var, silently displacing the CLI login.
+func TestProviderWizardCLIProfileHasNoAPIKeyOrEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ambient-should-be-ignored")
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	descriptor, ok := providercatalog.Get("anthropic")
+	if !ok {
+		t.Fatal("test assumption broken: anthropic missing from the provider catalog")
+	}
+
+	profile := providerWizardCLIProfile(claudeHarness, descriptor, "claude-cli-test-model")
+
+	if profile.AuthCLI != "claude" {
+		t.Fatalf("AuthCLI = %q, want claude", profile.AuthCLI)
+	}
+	if profile.APIKey != "" {
+		t.Fatalf("APIKey = %q, want empty", profile.APIKey)
+	}
+	if profile.APIKeyEnv != "" {
+		t.Fatalf("APIKeyEnv = %q, want empty (must not fall back to an ambient env var)", profile.APIKeyEnv)
+	}
+	runtimeProfile := providerWizardRuntimeProfile(profile)
+	if runtimeProfile.APIKey != "" {
+		t.Fatalf("runtime APIKey = %q, want empty even with ANTHROPIC_API_KEY set in the environment", runtimeProfile.APIKey)
+	}
+}
+
+// TestApplyProviderWizardCLIModePersistsAuthCLI drives applyProviderWizard for
+// a CLI-mode wizard state (mirroring TestApplyProviderWizardExportsActiveProviderEnv's
+// harness) and checks the committed/persisted profile carries AuthCLI and no key.
+func TestApplyProviderWizardCLIModePersistsAuthCLI(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.userConfigPath = filepath.Join(t.TempDir(), "config.json")
+	m.newProvider = func(config.ProviderProfile) (zeroruntime.Provider, error) {
+		return &fakeProvider{}, nil
+	}
+	claudeHarness, ok := agentcli.Lookup("claude")
+	if !ok {
+		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
+	}
+	m.providerWizard = &providerWizardState{
+		step:       providerWizardStepModel,
+		cliHarness: &claudeHarness,
+		providers: []providercatalog.Descriptor{{
+			ID:           "anthropic",
+			Name:         "Anthropic",
+			Transport:    providercatalog.TransportAnthropic,
+			DefaultModel: "claude-sonnet-4.5",
+			AuthEnvVars:  []string{"ANTHROPIC_API_KEY"},
+			RequiresAuth: true,
+		}},
+		models: []providerWizardModel{{ID: "claude-sonnet-4.5", Description: "Claude Sonnet 4.5"}},
+	}
+
+	updated, _ := m.applyProviderWizard()
+	next := updated
+
+	if next.providerWizard != nil {
+		t.Fatalf("expected the wizard to close on successful apply, got %#v", next.providerWizard)
+	}
+	if next.providerProfile.AuthCLI != "claude" {
+		t.Fatalf("committed profile AuthCLI = %q, want claude", next.providerProfile.AuthCLI)
+	}
+	if next.providerProfile.APIKey != "" || next.providerProfile.APIKeyEnv != "" {
+		t.Fatalf("committed profile carries a key (APIKey=%q APIKeyEnv=%q), want neither for a CLI-authed profile",
+			next.providerProfile.APIKey, next.providerProfile.APIKeyEnv)
+	}
+
+	// The persisted config must round-trip AuthCLI too — this is the on-disk
+	// artifact the provider factory reads on the next launch.
+	raw, err := os.ReadFile(m.userConfigPath)
+	if err != nil {
+		t.Fatalf("read persisted config: %v", err)
+	}
+	if !strings.Contains(string(raw), `"authCLI": "claude"`) {
+		t.Fatalf("persisted config = %s, want it to contain \"authCLI\": \"claude\"", raw)
+	}
+}

--- a/internal/tui/provider_wizard_cli_test.go
+++ b/internal/tui/provider_wizard_cli_test.go
@@ -84,6 +84,40 @@ func TestProviderWizardCLIMethodOptionsFromDetections(t *testing.T) {
 	if !geminiRow.disabled {
 		t.Fatalf("gemini row = %#v, want disabled (no reusable provider credentials)", *geminiRow)
 	}
+	if geminiRow.loggedIn {
+		t.Fatalf("gemini row = %#v, want loggedIn false (no oauth_creds.json in this fixture)", *geminiRow)
+	}
+	if !strings.Contains(geminiRow.subtitle, "not logged in") {
+		t.Fatalf("gemini row subtitle = %q, want it to report login state even though it is disabled", geminiRow.subtitle)
+	}
+}
+
+// TestProviderWizardCLIMethodOptionsReportsLoginStateForNoCatalogHarness locks
+// in that a disabled (no-CatalogID) row still reflects the real probed login
+// state instead of a generic message — a detected-and-logged-in sub-agent-only
+// harness like Gemini CLI must say so, not just "no reusable API credentials".
+func TestProviderWizardCLIMethodOptionsReportsLoginStateForNoCatalogHarness(t *testing.T) {
+	deps := fakeAgentCLIDeps(
+		map[string]bool{"gemini": true},
+		map[string]string{".gemini/oauth_creds.json": `{"access_token":"tok"}`},
+	)
+	detections := agentcli.Detect(deps)
+
+	options := providerWizardCLIMethodOptions(detections)
+
+	if len(options) != 1 {
+		t.Fatalf("options = %#v, want exactly one gemini row", options)
+	}
+	gemini := options[0]
+	if !gemini.disabled {
+		t.Fatalf("gemini row = %#v, want disabled (no reusable provider credentials)", gemini)
+	}
+	if !gemini.loggedIn {
+		t.Fatalf("gemini row = %#v, want loggedIn true (oauth_creds.json present)", gemini)
+	}
+	if !strings.Contains(gemini.subtitle, "logged in") || strings.Contains(gemini.subtitle, "not logged in") {
+		t.Fatalf("gemini row subtitle = %q, want it to say logged in", gemini.subtitle)
+	}
 }
 
 // TestProviderWizardMethodOptionsKeepsAPIKeyLast locks in the ordering
@@ -109,15 +143,17 @@ func TestProviderWizardMethodOptionsKeepsAPIKeyLast(t *testing.T) {
 // CLI row, press Enter. It must skip the provider chooser entirely and land on
 // Model selection with cliHarness recorded.
 func TestProviderWizardAdvanceIntoCLIMethodSkipsProviderStep(t *testing.T) {
-	m := newModel(context.Background(), Options{})
-	m.providerWizard = m.newProviderWizard()
 	claudeHarness, ok := agentcli.Lookup("claude")
 	if !ok {
 		t.Fatal("test assumption broken: claude missing from the agentcli catalog")
 	}
-	m.providerWizard.agentCLIDetections = []agentcli.Detection{
+	detections := []agentcli.Detection{
 		{Harness: claudeHarness, Path: "/usr/local/bin/claude", Login: agentcli.LoggedIn},
 	}
+	m := newModel(context.Background(), Options{
+		DetectAgentCLIs: func(agentcli.Deps) []agentcli.Detection { return detections },
+	})
+	m.providerWizard = m.newProviderWizard()
 	options := m.providerWizard.methodOptions()
 	index := -1
 	for i, option := range options {
@@ -163,15 +199,17 @@ func TestProviderWizardAdvanceIntoCLIMethodSkipsProviderStep(t *testing.T) {
 // wizard must stay on the Method step and surface an actionable error instead
 // of silently building a doomed provider.
 func TestProviderWizardAdvanceIntoLoggedOutCLIShowsHint(t *testing.T) {
-	m := newModel(context.Background(), Options{})
-	m.providerWizard = m.newProviderWizard()
 	codexHarness, ok := agentcli.Lookup("codex")
 	if !ok {
 		t.Fatal("test assumption broken: codex missing from the agentcli catalog")
 	}
-	m.providerWizard.agentCLIDetections = []agentcli.Detection{
+	detections := []agentcli.Detection{
 		{Harness: codexHarness, Path: "/usr/local/bin/codex", Login: agentcli.LoggedOut},
 	}
+	m := newModel(context.Background(), Options{
+		DetectAgentCLIs: func(agentcli.Deps) []agentcli.Detection { return detections },
+	})
+	m.providerWizard = m.newProviderWizard()
 	options := m.providerWizard.methodOptions()
 	index := -1
 	for i, option := range options {
@@ -192,6 +230,76 @@ func TestProviderWizardAdvanceIntoLoggedOutCLIShowsHint(t *testing.T) {
 	}
 	if !strings.Contains(next.providerWizard.err, "codex login") {
 		t.Fatalf("err = %q, want it to mention the `codex login` hint", next.providerWizard.err)
+	}
+}
+
+// TestProviderWizardRetriesLoginAfterRejection covers the fix for stale login
+// state: agentCLIDetections is captured once at wizard construction, so a
+// user who logs in AFTER opening the wizard (exactly what the "not logged in"
+// error tells them to do) must be able to retry in the same wizard session —
+// not have to close and reopen it — because advance() reprobes on rejection.
+func TestProviderWizardRetriesLoginAfterRejection(t *testing.T) {
+	codexHarness, ok := agentcli.Lookup("codex")
+	if !ok {
+		t.Fatal("test assumption broken: codex missing from the agentcli catalog")
+	}
+	loggedIn := false // flips to true between the two detect() calls, like a real `codex login`
+	calls := 0
+	m := newModel(context.Background(), Options{
+		DetectAgentCLIs: func(agentcli.Deps) []agentcli.Detection {
+			calls++
+			state := agentcli.LoggedOut
+			if loggedIn {
+				state = agentcli.LoggedIn
+			}
+			return []agentcli.Detection{{Harness: codexHarness, Path: "/usr/local/bin/codex", Login: state}}
+		},
+	})
+	m.providerWizard = m.newProviderWizard()
+	options := m.providerWizard.methodOptions()
+	index := -1
+	for i, option := range options {
+		if option.kind == providerWizardMethodCLI && option.harness.ID == "codex" {
+			index = i
+		}
+	}
+	if index < 0 {
+		t.Fatalf("expected a codex CLI row in %#v", options)
+	}
+	m.providerWizard.selectedMethod = index
+
+	// First attempt: still logged out (matches TestProviderWizardAdvanceIntoLoggedOutCLIShowsHint).
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	if next.providerWizard == nil || next.providerWizard.step != providerWizardStepMethod {
+		t.Fatalf("expected to stay on the Method step after first attempt, got %#v", next.providerWizard)
+	}
+	if !strings.Contains(next.providerWizard.err, "codex login") {
+		t.Fatalf("err = %q, want it to mention the `codex login` hint", next.providerWizard.err)
+	}
+	callsBeforeRetry := calls
+	if callsBeforeRetry < 2 {
+		t.Fatalf("calls = %d, want at least 2 (construction plus advance()'s reprobe-before-reject)", callsBeforeRetry)
+	}
+
+	// User runs `codex login` in another terminal; retry in the SAME wizard.
+	loggedIn = true
+	retried, _ := next.Update(testKey(tea.KeyEnter))
+	after := retried.(model)
+	if after.providerWizard == nil {
+		t.Fatal("expected the wizard to stay open")
+	}
+	if after.providerWizard.err != "" {
+		t.Fatalf("err = %q, want cleared after a successful retry", after.providerWizard.err)
+	}
+	if after.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("step = %v, want Model (retry should succeed and skip the provider chooser)", after.providerWizard.step)
+	}
+	if after.providerWizard.cliHarness == nil || after.providerWizard.cliHarness.ID != "codex" {
+		t.Fatalf("cliHarness = %#v, want codex", after.providerWizard.cliHarness)
+	}
+	if calls <= callsBeforeRetry {
+		t.Fatalf("calls = %d (was %d before retry), want a fresh reprobe on the second advance() too", calls, callsBeforeRetry)
 	}
 }
 
@@ -221,6 +329,9 @@ func TestProviderWizardCLIProfileHasNoAPIKeyOrEnv(t *testing.T) {
 	}
 	if profile.APIKeyEnv != "" {
 		t.Fatalf("APIKeyEnv = %q, want empty (must not fall back to an ambient env var)", profile.APIKeyEnv)
+	}
+	if profile.BaseURL != descriptor.DefaultBaseURL {
+		t.Fatalf("BaseURL = %q, want the descriptor's default %q (provider construction/reload should not depend on later default hydration)", profile.BaseURL, descriptor.DefaultBaseURL)
 	}
 	runtimeProfile := providerWizardRuntimeProfile(profile)
 	if runtimeProfile.APIKey != "" {

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -55,7 +55,7 @@ func TestProviderWizardMethodChooserOAuthPath(t *testing.T) {
 func TestProviderWizardMethodChooserBrowsePath(t *testing.T) {
 	m := mouseTestModel()
 	m.providerWizard = m.newProviderWizard()
-	m.providerWizard.selectedMethod = len(providerWizardMethodOptions()) - 1 // "browse / API key"
+	m.providerWizard.selectedMethod = len(m.providerWizard.methodOptions()) - 1 // "browse / API key"
 	next, _ := m.advanceProviderWizard()
 	w := next.providerWizard
 	if w.step != providerWizardStepProvider || w.oauthMode {

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -49,7 +49,7 @@ func TestProviderCommandOpensOnboardingWizard(t *testing.T) {
 	}
 
 	// Choosing the API-key method reveals the full provider catalog.
-	next.providerWizard.selectedMethod = len(providerWizardMethodOptions()) - 1
+	next.providerWizard.selectedMethod = len(next.providerWizard.methodOptions()) - 1
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 	listView := plainRender(t, next.View())
@@ -1034,7 +1034,7 @@ func openProviderWizardForTest(t *testing.T, m model) model {
 	// API-key / browse path, so select that method and advance into the provider
 	// list (the OAuth path is covered by the OAuth-specific tests).
 	if next.providerWizard.step == providerWizardStepMethod {
-		options := providerWizardMethodOptions()
+		options := next.providerWizard.methodOptions()
 		next.providerWizard.selectedMethod = len(options) - 1 // last = "browse / API key"
 		u2, _ := next.Update(testKey(tea.KeyEnter))
 		next = u2.(model)

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -293,6 +293,93 @@ func (m model) turnsText() string {
 	})
 }
 
+// handleOnlyBashCommand implements /onlybash [on|off|status]. Bare "/onlybash"
+// (and "/onlybash toggle") flips the current state; "status" just reports it.
+// The actual filter mutation lives in enableOnlyBash/disableOnlyBash so the
+// stash-on-first-enable invariant has one place to be correct.
+func (m model) handleOnlyBashCommand(args string) (model, string) {
+	args = strings.TrimSpace(strings.ToLower(args))
+	switch args {
+	case "", "toggle":
+		if m.onlyBashActive {
+			m = m.disableOnlyBash()
+		} else {
+			m = m.enableOnlyBash()
+		}
+	case "on":
+		m = m.enableOnlyBash()
+	case "off":
+		m = m.disableOnlyBash()
+	case "status":
+		// report only — fall through to onlyBashText() below
+	default:
+		return m, "Onlybash\nUsage: /onlybash [on|off|status]"
+	}
+	return m, m.onlyBashText()
+}
+
+// enableOnlyBash switches m.agentOptions to the modelregistry "onlybash"
+// preset's tool filter (bash + skill only, tool_search disabled). It stashes
+// the PRIOR filter only on an inactive->active transition: calling this while
+// onlybash is already active (e.g. a redundant "/onlybash on") must not
+// re-stash onlybash's own [bash,skill]/[tool_search] filter as if it were the
+// operator's original configuration — that would make disableOnlyBash restore
+// onlybash's filter instead of the real one, permanently losing the operator's
+// setting for the rest of the session.
+func (m model) enableOnlyBash() model {
+	if !m.onlyBashActive {
+		m.onlyBashStashedEnabledTools = append([]string{}, m.agentOptions.EnabledTools...)
+		m.onlyBashStashedDisabledTools = append([]string{}, m.agentOptions.DisabledTools...)
+	}
+	if mode, ok := modelregistry.LookupMode("onlybash"); ok {
+		m.agentOptions.EnabledTools = mode.EnabledTools
+		m.agentOptions.DisabledTools = mode.DisabledTools
+	}
+	m.onlyBashActive = true
+	return m
+}
+
+// disableOnlyBash restores whatever tool filter was active before /onlybash
+// on, clearing the stash. Applies to the NEXT run, same as /turns — there is
+// no mid-run env propagation to worry about here (unlike /turns' ZERO_MAX_TURNS),
+// so no pending-run guard is needed.
+func (m model) disableOnlyBash() model {
+	m.agentOptions.EnabledTools = m.onlyBashStashedEnabledTools
+	m.agentOptions.DisabledTools = m.onlyBashStashedDisabledTools
+	m.onlyBashStashedEnabledTools = nil
+	m.onlyBashStashedDisabledTools = nil
+	m.onlyBashActive = false
+	return m
+}
+
+func (m model) onlyBashText() string {
+	state := "off"
+	if m.onlyBashActive {
+		state = "on"
+	}
+	enabled := "unrestricted"
+	if len(m.agentOptions.EnabledTools) > 0 {
+		enabled = strings.Join(m.agentOptions.EnabledTools, ", ")
+	}
+	disabled := "none"
+	if len(m.agentOptions.DisabledTools) > 0 {
+		disabled = strings.Join(m.agentOptions.DisabledTools, ", ")
+	}
+	return renderCommandOutput(commandOutput{
+		Title:  "Onlybash",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "State",
+			Lines: []string{
+				"onlybash: " + state,
+				"enabled tools: " + enabled,
+				"disabled tools: " + disabled,
+			},
+		}},
+		Hints: []string{"/onlybash on restricts this session to bash + skill (tool_search disabled, tools cannot be added back); /onlybash off restores prior filters; applies to the next run"},
+	})
+}
+
 func (m model) selfCorrectText() string {
 	depth := "LSP diagnostics only — fast, scoped to changed files"
 	if m.selfCorrectTests {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -342,8 +342,14 @@ func (m model) enableOnlyBash() model {
 // disableOnlyBash restores whatever tool filter was active before /onlybash
 // on, clearing the stash. Applies to the NEXT run, same as /turns — there is
 // no mid-run env propagation to worry about here (unlike /turns' ZERO_MAX_TURNS),
-// so no pending-run guard is needed.
+// so no pending-run guard is needed. Mirrors enableOnlyBash's guard: a no-op
+// unless onlybash is actually active, so "/onlybash off" while it was never
+// turned on can't clobber an operator-configured tool restriction with the
+// (empty) stash fields.
 func (m model) disableOnlyBash() model {
+	if !m.onlyBashActive {
+		return m
+	}
 	m.agentOptions.EnabledTools = m.onlyBashStashedEnabledTools
 	m.agentOptions.DisabledTools = m.onlyBashStashedDisabledTools
 	m.onlyBashStashedEnabledTools = nil


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Linked issue
This pull request introduces a new package, `internal/agentcli`, which provides a unified API for detecting, probing, and extracting credentials from third-party agent CLI tools (such as Claude, Codex, Gemini CLI, etc.). It also adds comprehensive tests for this package, and strengthens invariants in the agent tool filtering logic. Additionally, it documents a full code review and records that no defects were found in a recent audit.

The most important changes are:

### New agent CLI detection and credential extraction API

* Added the `agentcli` package, which catalogs known agent CLI harnesses, provides functions to detect their presence on `PATH`, probes their login state via credential files or keychain entries, and exposes a stable, testable API for other packages to build on. This centralizes all harness-specific logic in one place, making maintenance and updates easier. (`internal/agentcli/agentcli.go`)
* The catalog includes detailed metadata for each harness (ID, binaries, vendor, credential file/keychain locations, etc.) and supports testable dependency injection for all side-effecting operations. (`internal/agentcli/agentcli.go`)

### Comprehensive tests for agentcli

* Added a full test suite for the `agentcli` package, covering catalog invariants, detection logic, credential probing (including file and keychain scenarios), and API behaviors. (`internal/agentcli/agentcli_test.go`)

### Strengthened tool filtering invariants

* Added a test to lock down the invariant that `/onlybash` mode strictly allowlists only `bash` and `skill` tools, ensuring that delegation (e.g., to "Task") is blocked and cannot escape the restricted surface. (`internal/agent/loop_test.go`)

### Documentation and audit records

* Added a task file describing the scope and goals of a full code review for the repository, prioritizing correctness, security, and maintainability. (`cascade/00-task.txt`)
* Recorded that a full review found zero defects in the prioritized packages, with race and vet checks passing. (`cascade/10-findings.cf`)
<!-- Per CONTRIBUTING.md, PRs need an approved parent issue with the `issue-approved` label. -->
Fixes #

## Checklist

- [ ] The linked issue already has the `issue-approved` label.
- [ ] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [ ] `gofmt` clean.
- [ ] Tests added/updated for the change (and run under `-race` where relevant).
- [ ] UI changes include screenshots or a short recording where possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for connecting using installed local agent CLIs, including login-state detection, setup flow, and provider/model discovery from CLI credentials.
  * `zero auth` adds a Claude Code “paste-code” login command; `zero auth status` now lists detected agent CLIs (and `--json` includes them).
  * Added `/onlybash` to switch to a bash/skill-only tool surface with proper status output.
  * Specialist manifests can now run via external harnesses, and show output includes harness/provider metadata.
  * Anthropic Claude Code identity injection support (system prompt + beta flag).

* **Bug Fixes**
  * Credential gating now correctly treats CLI-based connections as keyless while preventing conflicting credential sources.
  * `/onlybash` now preserves/restores prior operator tool filters reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->