### PR TITLE
feat(tui): add search/filter to provider picker in setup wizard

### DIFF
--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -297,6 +297,7 @@ type providerWizardState struct {
 	selectedProvider int
 	models           []providerWizardModel
 	selectedModel    int
+	providerSearch   string
 	modelSearch      string
 	baseURL          string
 	profileName      string
@@ -343,7 +344,18 @@ func providerWizardProviders() []providercatalog.Descriptor {
 }
 
 func (wizard *providerWizardState) currentProvider() providercatalog.Descriptor {
-	if wizard == nil || len(wizard.providers) == 0 {
+	if wizard == nil {
+		return providercatalog.Descriptor{}
+	}
+	if wizard.step == providerWizardStepProvider {
+		providers := wizard.filteredProviders()
+		if len(providers) == 0 {
+			return providercatalog.Descriptor{}
+		}
+		wizard.selectedProvider = clampInt(wizard.selectedProvider, 0, len(providers)-1)
+		return providers[wizard.selectedProvider]
+	}
+	if len(wizard.providers) == 0 {
 		return providercatalog.Descriptor{}
 	}
 	wizard.selectedProvider = clampInt(wizard.selectedProvider, 0, len(wizard.providers)-1)
@@ -399,10 +411,11 @@ func (wizard *providerWizardState) move(delta int) {
 		}
 		wizard.selectedMethod = ((wizard.selectedMethod+delta)%len(options) + len(options)) % len(options)
 	case providerWizardStepProvider:
-		if len(wizard.providers) == 0 {
+		providers := wizard.filteredProviders()
+		if len(providers) == 0 {
 			return
 		}
-		wizard.selectedProvider = ((wizard.selectedProvider+delta)%len(wizard.providers) + len(wizard.providers)) % len(wizard.providers)
+		wizard.selectedProvider = ((wizard.selectedProvider+delta)%len(providers) + len(providers)) % len(providers)
 		wizard.selectedModel = 0
 		wizard.modelSearch = ""
 		wizard.baseURL = ""
@@ -450,6 +463,7 @@ func (wizard *providerWizardState) advance() {
 		if wizard.oauthMode {
 			return
 		}
+		wizard.providerSearch = ""
 		wizard.refreshModels()
 		wizard.err = ""
 		if providerWizardNeedsEndpoint(wizard.currentProvider()) {
@@ -513,6 +527,7 @@ func (wizard *providerWizardState) retreat() {
 		wizard.step = providerWizardStepMethod
 	case providerWizardStepEndpoint:
 		wizard.step = providerWizardStepProvider
+		wizard.providerSearch = ""
 	case providerWizardStepName:
 		wizard.step = providerWizardStepEndpoint
 	case providerWizardStepCredential:
@@ -627,6 +642,20 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		(keyText(msg) == "d" || keyText(msg) == "D") &&
 		m.providerWizard.currentProvider().OAuthDeviceFlow {
 		return m.startProviderDeviceLogin()
+	}
+	if m.providerWizard.step == providerWizardStepProvider {
+		switch {
+		case keyText(msg) != "":
+			m.providerWizard.appendProviderSearch(keyRunes(msg))
+			return m, nil
+		case keyBackspace(msg):
+			m.providerWizard.deleteProviderSearchRune()
+			return m, nil
+		case keyCtrl(msg, 'u'):
+			m.providerWizard.providerSearch = ""
+			m.providerWizard.selectedProvider = 0
+			return m, nil
+		}
 	}
 	if m.providerWizard.step == providerWizardStepEndpoint {
 		switch {
@@ -746,6 +775,8 @@ func (m model) handleProviderWizardPaste(content string) (model, tea.Cmd) {
 		return m, nil
 	}
 	switch m.providerWizard.step {
+	case providerWizardStepProvider:
+		m.providerWizard.appendProviderSearch([]rune(content))
 	case providerWizardStepEndpoint:
 		m.providerWizard.appendBaseURL([]rune(content))
 	case providerWizardStepName:
@@ -877,6 +908,50 @@ func (wizard *providerWizardState) deleteModelSearchRune() {
 	runes := []rune(wizard.modelSearch)
 	wizard.modelSearch = string(runes[:len(runes)-1])
 	wizard.selectedModel = 0
+}
+
+func (wizard *providerWizardState) appendProviderSearch(runes []rune) {
+	for _, r := range runes {
+		if unicode.IsControl(r) {
+			continue
+		}
+		wizard.providerSearch += string(r)
+	}
+	wizard.selectedProvider = 0
+}
+
+func (wizard *providerWizardState) deleteProviderSearchRune() {
+	if wizard.providerSearch == "" {
+		return
+	}
+	runes := []rune(wizard.providerSearch)
+	wizard.providerSearch = string(runes[:len(runes)-1])
+	wizard.selectedProvider = 0
+}
+
+func (wizard *providerWizardState) filteredProviders() []providercatalog.Descriptor {
+	if wizard == nil {
+		return nil
+	}
+	query := strings.ToLower(strings.TrimSpace(wizard.providerSearch))
+	if query == "" {
+		return append([]providercatalog.Descriptor{}, wizard.providers...)
+	}
+	providers := make([]providercatalog.Descriptor, 0, len(wizard.providers))
+	for _, provider := range wizard.providers {
+		if providerMatchesQuery(provider, query) {
+			providers = append(providers, provider)
+		}
+	}
+	return providers
+}
+
+func providerMatchesQuery(provider providercatalog.Descriptor, query string) bool {
+	if query == "" {
+		return true
+	}
+	haystack := strings.ToLower(strings.Join([]string{provider.ID, provider.Name, strings.Join(provider.Aliases, " ")}, " "))
+	return strings.Contains(haystack, query)
 }
 
 func (m model) applyProviderWizard() (model, tea.Cmd) {
@@ -1248,9 +1323,15 @@ func (wizard *providerWizardState) renderProviderStep(width int) []string {
 		header = "Choose an OAuth provider"
 	}
 	lines := []string{zeroTheme.accent.Render(header)}
-	maxVisible := minInt(maxProviderWizardProvidersVisible, len(wizard.providers))
-	start := selectableListStart(len(wizard.providers), maxVisible, wizard.selectedProvider)
-	for offset, provider := range wizard.providers[start : start+maxVisible] {
+	lines = append(lines, wizard.renderProviderSearch(width))
+	providers := wizard.filteredProviders()
+	if len(providers) == 0 {
+		lines = append(lines, zeroTheme.faint.Render("  no matching providers"))
+		return lines
+	}
+	maxVisible := minInt(maxProviderWizardProvidersVisible, len(providers))
+	start := selectableListStart(len(providers), maxVisible, wizard.selectedProvider)
+	for offset, provider := range providers[start : start+maxVisible] {
 		lines = append(lines, wizard.renderSelectableProvider(width, start+offset, provider))
 	}
 	// A failed OAuth attempt leaves the wizard on this list (it does not advance),
@@ -1263,6 +1344,11 @@ func (wizard *providerWizardState) renderProviderStep(width int) []string {
 		}
 	}
 	return lines
+}
+
+func (wizard *providerWizardState) renderProviderSearch(width int) string {
+	query := strings.TrimSpace(wizard.providerSearch)
+	return providerWizardInputLine("search > ", query, "provider name...", width)
 }
 
 // providerWizardOAuthErrHint returns a provider-specific next step for a failed

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -463,6 +463,9 @@ func (wizard *providerWizardState) advance() {
 		if wizard.oauthMode {
 			return
 		}
+		if len(wizard.filteredProviders()) == 0 {
+			return
+		}
 		// Resolve the selected provider's index in the full list before clearing
 		// the search — selectedProvider is an index into the filtered slice, and
 		// clearing the search swaps to the full list.

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -463,6 +463,17 @@ func (wizard *providerWizardState) advance() {
 		if wizard.oauthMode {
 			return
 		}
+		// Resolve the selected provider's index in the full list before clearing
+		// the search — selectedProvider is an index into the filtered slice, and
+		// clearing the search swaps to the full list.
+		if selected := wizard.currentProvider(); selected.ID != "" {
+			for i, p := range wizard.providers {
+				if p.ID == selected.ID {
+					wizard.selectedProvider = i
+					break
+				}
+			}
+		}
 		wizard.providerSearch = ""
 		wizard.refreshModels()
 		wizard.err = ""
@@ -1348,7 +1359,7 @@ func (wizard *providerWizardState) renderProviderStep(width int) []string {
 
 func (wizard *providerWizardState) renderProviderSearch(width int) string {
 	query := strings.TrimSpace(wizard.providerSearch)
-	return providerWizardInputLine("search > ", query, "provider name...", width)
+	return providerWizardInputLine("search > ", query, "provider name, id, or alias...", width)
 }
 
 // providerWizardOAuthErrHint returns a provider-specific next step for a failed

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1290,3 +1290,139 @@ func TestApplyProviderWizardPersistFailureLeavesLiveStateUnchanged(t *testing.T)
 		t.Fatalf("%s = %q, want it unchanged on persist failure (children would diverge from parent)", config.ActiveProviderEnv, got)
 	}
 }
+
+func TestProviderSearchFiltersByNameIDAndAlias(t *testing.T) {
+	wizard := &providerWizardState{
+		step: providerWizardStepProvider,
+		providers: []providercatalog.Descriptor{
+			{ID: "openai", Name: "OpenAI", Aliases: []string{"chatgpt"}},
+			{ID: "anthropic", Name: "Anthropic", Aliases: []string{"claude"}},
+			{ID: "google", Name: "Google", Aliases: []string{"gemini"}},
+			{ID: "groq", Name: "Groq", Aliases: []string{}},
+		},
+	}
+
+	tests := []struct {
+		query string
+		want  []string
+	}{
+		{"openai", []string{"openai"}},
+		{"anthropic", []string{"anthropic"}},
+		{"claude", []string{"anthropic"}},
+		{"gemini", []string{"google"}},
+		{"chatgpt", []string{"openai"}},
+		{"groq", []string{"groq"}},
+		{"GROQ", []string{"groq"}},
+		{"nomatch", nil},
+		{"", []string{"openai", "anthropic", "google", "groq"}},
+	}
+
+	for _, tt := range tests {
+		t.Run("query="+tt.query, func(t *testing.T) {
+			wizard.providerSearch = tt.query
+			got := wizard.filteredProviders()
+			if len(got) != len(tt.want) {
+				t.Fatalf("filteredProviders(%q) = %d results, want %d", tt.query, len(got), len(tt.want))
+			}
+			for i, id := range tt.want {
+				if got[i].ID != id {
+					t.Fatalf("filteredProviders(%q)[%d] = %q, want %q", tt.query, i, got[i].ID, id)
+				}
+			}
+		})
+	}
+}
+
+func TestProviderSearchResetsSelectedProviderOnEdit(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = openProviderWizardForTest(t, m)
+
+	// Move to a later provider, then type a search query.
+	m.providerWizard.selectedProvider = 3
+	updated, _ := m.Update(testKeyText("anth"))
+	next := updated.(model)
+	if next.providerWizard.selectedProvider != 0 {
+		t.Fatalf("selectedProvider after typing = %d, want 0 (reset on edit)", next.providerWizard.selectedProvider)
+	}
+}
+
+func TestProviderSearchFilteredAdvanceSelectsCorrectProvider(t *testing.T) {
+	wizard := &providerWizardState{
+		step: providerWizardStepProvider,
+		providers: []providercatalog.Descriptor{
+			{ID: "openai", Name: "OpenAI", AuthEnvVars: []string{"OPENAI_API_KEY"}, RequiresAuth: true},
+			{ID: "anthropic", Name: "Anthropic", AuthEnvVars: []string{"ANTHROPIC_API_KEY"}, RequiresAuth: true},
+			{ID: "google", Name: "Google", AuthEnvVars: []string{"GOOGLE_API_KEY"}, RequiresAuth: true},
+			{ID: "groq", Name: "Groq", AuthEnvVars: []string{"GROQ_API_KEY"}, RequiresAuth: true},
+		},
+		selectedProvider: 0,
+	}
+
+	// Type a search that matches exactly "groq".
+	wizard.providerSearch = "groq"
+	filtered := wizard.filteredProviders()
+	if len(filtered) != 1 || filtered[0].ID != "groq" {
+		t.Fatalf("expected exactly groq in filtered results, got %v", providerWizardIDs(filtered))
+	}
+
+	// currentProvider() via filtered list should be groq.
+	if got := wizard.currentProvider().ID; got != "groq" {
+		t.Fatalf("currentProvider() = %q, want groq", got)
+	}
+}
+
+func TestProviderSearchEmptyMatchEnterIsNoop(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = openProviderWizardForTest(t, m)
+
+	// Type a query that matches nothing.
+	updated, _ := m.Update(testKeyText("zzzzz"))
+	next := updated.(model)
+	if len(next.providerWizard.filteredProviders()) != 0 {
+		t.Fatal("expected zero filtered providers")
+	}
+
+	// Enter should be a no-op.
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepProvider {
+		t.Fatalf("wizard step = %v, want provider (empty match Enter should be no-op)", next.providerWizard.step)
+	}
+	if next.providerWizard.providerSearch != "zzzzz" {
+		t.Fatalf("providerSearch = %q, want query preserved on noop", next.providerWizard.providerSearch)
+	}
+}
+
+func TestProviderSearchClearRestoresFullList(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = openProviderWizardForTest(t, m)
+
+	initialCount := len(m.providerWizard.filteredProviders())
+	if initialCount == 0 {
+		t.Fatal("expected providers in the wizard")
+	}
+
+	// Type a search query.
+	updated, _ := m.Update(testKeyText("open"))
+	next := updated.(model)
+	filtered := next.providerWizard.filteredProviders()
+	if len(filtered) >= initialCount {
+		t.Fatalf("search should narrow results: got %d, want < %d", len(filtered), initialCount)
+	}
+
+	// Ctrl+U clears the search.
+	updated, _ = next.Update(testKeyCtrl('u'))
+	next = updated.(model)
+	restored := next.providerWizard.filteredProviders()
+	if len(restored) != initialCount {
+		t.Fatalf("after clear, filtered count = %d, want %d", len(restored), initialCount)
+	}
+}
+
+func providerWizardIDs(descriptors []providercatalog.Descriptor) []string {
+	ids := make([]string, len(descriptors))
+	for i, d := range descriptors {
+		ids[i] = d.ID
+	}
+	return ids
+}


### PR DESCRIPTION
## Summary
- Add a search input to the provider step of the setup wizard
- Filters providers in real-time via case-insensitive substring matching on name, ID, and aliases
- Consistent with the existing model picker search UX (`/model` command)

## Changes
- `internal/tui/provider_wizard.go`: 92 additions, 6 deletions

## What changed
- Added `providerSearch` field to `providerWizardState` struct
- Added `appendProviderSearch()`, `deleteProviderSearchRune()`, `filteredProviders()`, `providerMatchesQuery()` methods
- Updated `renderProviderStep()` to show search input and render filtered results
- Updated `currentProvider()` to use filtered list when on provider step
- Updated `move()` to navigate within filtered results
- Added key handling: printable chars → search, backspace → delete, Ctrl+U → clear
- Added paste support for provider search
- Search is cleared when advancing/retreating from provider step

## Motivation
With 28+ providers now in the catalog, scrolling through the full list is tedious. The model picker already has search — this brings the same UX to the provider picker.

## Testing
- `go build ./...` passes
- `go test ./internal/tui/...` passes
- `go vet ./internal/tui/...` passes

Fixes #392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider search and filtering in the setup wizard.
  * The provider step now includes a live search field (matches provider ID, name, and aliases).

* **Bug Fixes**
  * Selection and navigation stay consistent with the filtered results.
  * When no providers match, you get clear “no matching providers” feedback, and selection won’t advance unexpectedly.

* **Chores**
  * Search input supports backspace/delete, paste, and quick clearing with `Ctrl+U` (resetting selection to the first match).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->