### PR TITLE
fix(provider-wizard): allow multiple custom OpenAI-compatible providers

### DIFF
--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -44,6 +44,20 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 	// keep/replace/remove before re-entering credentials.
 	if m.providerWizard.step == providerWizardStepProvider && !m.providerWizard.oauthMode {
 		if name, ok := m.wizardProviderStoredKey(m.providerWizard.currentProvider()); ok {
+			// Generic/custom providers (custom-openai-compatible etc.) all share
+			// the same CatalogID — matching on CatalogID would block creating a
+			// second instance. Skip ManageKey and route directly to the endpoint
+			// step; the user can overwrite an existing instance by re-entering
+			// the same name, or create a new one with a different name.
+			if providerWizardNeedsEndpoint(m.providerWizard.currentProvider()) {
+				m.providerWizard.manageProviderName = ""
+				previous := m.providerWizard.step
+				m.providerWizard.advance()
+				if m.providerWizard.step == providerWizardStepModel && previous != providerWizardStepModel {
+					return m, m.providerModelDiscoveryCmd()
+				}
+				return m, nil
+			}
 			m.providerWizard.manageProviderName = name
 			m.providerWizard.manageKeyCursor = 0
 			m.providerWizard.err = ""

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -46,23 +46,17 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 		if name, ok := m.wizardProviderStoredKey(m.providerWizard.currentProvider()); ok {
 			// Generic/custom providers (custom-openai-compatible etc.) all share
 			// the same CatalogID — matching on CatalogID would block creating a
-			// second instance. Skip ManageKey and route directly to the endpoint
-			// step; the user can overwrite an existing instance by re-entering
-			// the same name, or create a new one with a different name.
-			if providerWizardNeedsEndpoint(m.providerWizard.currentProvider()) {
-				m.providerWizard.manageProviderName = ""
-				previous := m.providerWizard.step
-				m.providerWizard.advance()
-				if m.providerWizard.step == providerWizardStepModel && previous != providerWizardStepModel {
-					return m, m.providerModelDiscoveryCmd()
-				}
+			// second instance. Skip ManageKey and fall through to the shared
+			// advance() path below; the user can overwrite by re-entering the
+			// same name or create a new one with a different name.
+			if !providerWizardNeedsEndpoint(m.providerWizard.currentProvider()) {
+				m.providerWizard.manageProviderName = name
+				m.providerWizard.manageKeyCursor = 0
+				m.providerWizard.err = ""
+				m.providerWizard.step = providerWizardStepManageKey
 				return m, nil
 			}
-			m.providerWizard.manageProviderName = name
-			m.providerWizard.manageKeyCursor = 0
-			m.providerWizard.err = ""
-			m.providerWizard.step = providerWizardStepManageKey
-			return m, nil
+			m.providerWizard.manageProviderName = ""
 		}
 	}
 	previous := m.providerWizard.step

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1168,26 +1168,46 @@ func TestProviderWizardManageKeyReplaceAndKeep(t *testing.T) {
 }
 
 func TestAdvanceProviderWizardCustomSkipsManageKey(t *testing.T) {
-	m := model{savedProviders: []config.ProviderProfile{
-		{Name: "my-gateway", CatalogID: "custom-openai-compatible", APIKeyStored: true},
-	}}
-	m.providerWizard = &providerWizardState{
-		step:    providerWizardStepProvider,
-		providers: []providercatalog.Descriptor{
-			{ID: "custom-openai-compatible", Name: "Custom OpenAI-compatible", Transport: providercatalog.TransportOpenAICompatible},
+	tests := []struct {
+		name      string
+		catalogID string
+		transport providercatalog.Transport
+	}{
+		{
+			name:      "custom-openai-compatible",
+			catalogID: "custom-openai-compatible",
+			transport: providercatalog.TransportOpenAICompatible,
 		},
-		selectedProvider: 0,
+		{
+			name:      "custom-anthropic-compatible",
+			catalogID: "custom-anthropic-compatible",
+			transport: providercatalog.TransportAnthropicCompatible,
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model{savedProviders: []config.ProviderProfile{
+				{Name: "my-gateway", CatalogID: tt.catalogID, APIKeyStored: true},
+			}}
+			m.providerWizard = &providerWizardState{
+				step: providerWizardStepProvider,
+				providers: []providercatalog.Descriptor{
+					{ID: tt.catalogID, Name: tt.name, Transport: tt.transport},
+				},
+				selectedProvider: 0,
+			}
 
-	next, _ := m.advanceProviderWizard()
-	if next.providerWizard == nil {
-		t.Fatal("wizard should not be nil after advancing from provider step")
-	}
-	if next.providerWizard.step == providerWizardStepManageKey {
-		t.Fatal("custom provider should skip ManageKey and route to endpoint, got ManageKey")
-	}
-	if next.providerWizard.step != providerWizardStepEndpoint {
-		t.Fatalf("custom provider should route to endpoint step, got step: %v", next.providerWizard.step)
+			next, _ := m.advanceProviderWizard()
+			if next.providerWizard == nil {
+				t.Fatal("wizard should not be nil after advancing from provider step")
+			}
+			if next.providerWizard.step == providerWizardStepManageKey {
+				t.Fatal("custom provider should skip ManageKey and route to endpoint, got ManageKey")
+			}
+			if next.providerWizard.step != providerWizardStepEndpoint {
+				t.Fatalf("custom provider should route to endpoint step, got step: %v", next.providerWizard.step)
+			}
+		})
 	}
 }
 
@@ -1196,7 +1216,7 @@ func TestAdvanceProviderWizardNamedShowsManageKey(t *testing.T) {
 		{Name: "openai", CatalogID: "openai", APIKeyStored: true},
 	}}
 	m.providerWizard = &providerWizardState{
-		step:    providerWizardStepProvider,
+		step: providerWizardStepProvider,
 		providers: []providercatalog.Descriptor{
 			{ID: "openai", Name: "OpenAI", Transport: providercatalog.TransportOpenAI},
 		},

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1167,6 +1167,51 @@ func TestProviderWizardManageKeyReplaceAndKeep(t *testing.T) {
 	}
 }
 
+func TestAdvanceProviderWizardCustomSkipsManageKey(t *testing.T) {
+	m := model{savedProviders: []config.ProviderProfile{
+		{Name: "my-gateway", CatalogID: "custom-openai-compatible", APIKeyStored: true},
+	}}
+	m.providerWizard = &providerWizardState{
+		step:    providerWizardStepProvider,
+		providers: []providercatalog.Descriptor{
+			{ID: "custom-openai-compatible", Name: "Custom OpenAI-compatible", Transport: providercatalog.TransportOpenAICompatible},
+		},
+		selectedProvider: 0,
+	}
+
+	next, _ := m.advanceProviderWizard()
+	if next.providerWizard == nil {
+		t.Fatal("wizard should not be nil after advancing from provider step")
+	}
+	if next.providerWizard.step == providerWizardStepManageKey {
+		t.Fatal("custom provider should skip ManageKey and route to endpoint, got ManageKey")
+	}
+	if next.providerWizard.step != providerWizardStepEndpoint {
+		t.Fatalf("custom provider should route to endpoint step, got step: %v", next.providerWizard.step)
+	}
+}
+
+func TestAdvanceProviderWizardNamedShowsManageKey(t *testing.T) {
+	m := model{savedProviders: []config.ProviderProfile{
+		{Name: "openai", CatalogID: "openai", APIKeyStored: true},
+	}}
+	m.providerWizard = &providerWizardState{
+		step:    providerWizardStepProvider,
+		providers: []providercatalog.Descriptor{
+			{ID: "openai", Name: "OpenAI", Transport: providercatalog.TransportOpenAI},
+		},
+		selectedProvider: 0,
+	}
+
+	next, _ := m.advanceProviderWizard()
+	if next.providerWizard == nil {
+		t.Fatal("wizard should not be nil after advancing from provider step")
+	}
+	if next.providerWizard.step != providerWizardStepManageKey {
+		t.Fatalf("named provider should route to ManageKey step, got step: %v", next.providerWizard.step)
+	}
+}
+
 func readProviderWizardConfigFixture(t *testing.T, path string) config.FileConfig {
 	t.Helper()
 


### PR DESCRIPTION
## Problem

Issue #375: After setting up one custom OpenAI-compatible provider, configuring a second one is blocked. The wizard diverts to the Keep/Replace/Remove screen instead of allowing a new setup.

## Root Cause

`wizardProviderStoredKey` matches saved providers by `CatalogID`. All generic/custom providers share the same `CatalogID` (`"custom-openai-compatible"` or `"custom-anthropic-compatible"`), so saving one creates a match that blocks creating another.

## Fix

In `advanceProviderWizard` (`internal/tui/provider_wizard_discovery.go`), skip the ManageKey diversion for custom providers and route directly to the endpoint step. The user can:

- **Overwrite** an existing instance by re-entering the same base URL and name
- **Create a new** instance by entering a different base URL or name

Named providers (OpenAI, Anthropic, Groq, etc.) are **unaffected** — ManageKey is still shown for them.

## Changes

| File | Change |
|------|--------|
| `internal/tui/provider_wizard_discovery.go` | +14 lines — skip ManageKey for custom providers |
| `internal/tui/provider_wizard.go` | 0 lines — untouched |
| `internal/tui/provider_wizard_test.go` | +45 lines — 2 new tests |

## Testing

- `TestAdvanceProviderWizardCustomSkipsManageKey` — custom provider with saved key routes to Endpoint step, not ManageKey
- `TestAdvanceProviderWizardNamedShowsManageKey` — named provider with saved key still routes to ManageKey (no regression)
- All existing provider wizard tests pass (ManageKey remove, replace, keep, stored key matching)

Fixes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the provider setup wizard for accounts with saved credentials.
  * For non-OAuth providers where an endpoint is not required, the wizard now skips key management and proceeds directly to endpoint setup.
  * Model discovery is now started only when the wizard advances into the model-selection step.

* **Tests**
  * Added unit tests covering the custom-provider skip behavior and the named-provider key-management flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->