### PR TITLE
fix(install): persist install dir to user PATH on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -149,9 +149,20 @@ try {
   $targetPath = Join-Path $InstallDir "zero.exe"
   Write-Host "Installed $targetPath"
 
-  $pathEntries = $env:PATH -split [System.IO.Path]::PathSeparator
-  if ($pathEntries -notcontains $InstallDir) {
-    Write-Host "Add $InstallDir to PATH to run zero from any directory."
+  $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+  $userPathEntries = @()
+  if (-not [string]::IsNullOrEmpty($userPath)) {
+    $userPathEntries = $userPath -split [System.IO.Path]::PathSeparator
+  }
+  if ($userPathEntries -notcontains $InstallDir) {
+    $newUserPath = if ([string]::IsNullOrEmpty($userPath)) { $InstallDir } else { "$userPath;$InstallDir" }
+    [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
+    Write-Host "Added $InstallDir to your user PATH. Restart your terminal to use 'zero'."
+  }
+
+  $sessionPathEntries = $env:PATH -split [System.IO.Path]::PathSeparator
+  if ($sessionPathEntries -notcontains $InstallDir) {
+    $env:PATH = "$env:PATH;$InstallDir"
   }
 } finally {
   if (Test-Path $tempDir) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -62,6 +62,19 @@ function Find-ZeroExtractedFile {
   throw "Release archive did not contain exactly one $FileName"
 }
 
+function Test-ZeroPathContainsDir {
+  param(
+    [string]$PathValue,
+    [string]$Dir
+  )
+
+  if ([string]::IsNullOrEmpty($PathValue)) {
+    return $false
+  }
+
+  return @($PathValue -split [System.IO.Path]::PathSeparator) -contains $Dir
+}
+
 function Find-ZeroOptionalExtractedDirectory {
   param(
     [string]$Root,
@@ -150,18 +163,18 @@ try {
   Write-Host "Installed $targetPath"
 
   $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-  $userPathEntries = @()
-  if (-not [string]::IsNullOrEmpty($userPath)) {
-    $userPathEntries = $userPath -split [System.IO.Path]::PathSeparator
-  }
-  if ($userPathEntries -notcontains $InstallDir) {
-    $newUserPath = if ([string]::IsNullOrEmpty($userPath)) { $InstallDir } else { "$userPath;$InstallDir" }
-    [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
-    Write-Host "Added $InstallDir to your user PATH. Restart your terminal to use 'zero'."
+  if (-not (Test-ZeroPathContainsDir -PathValue $userPath -Dir $InstallDir)) {
+    try {
+      $newUserPath = if ([string]::IsNullOrEmpty($userPath)) { $InstallDir } else { "$userPath;$InstallDir" }
+      [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
+      Write-Host "Added $InstallDir to your user PATH. Restart your terminal to use 'zero'."
+    } catch {
+      Write-Warning "Could not update your user PATH automatically: $_"
+      Write-Warning "Add $InstallDir to PATH manually to run zero from any directory."
+    }
   }
 
-  $sessionPathEntries = $env:PATH -split [System.IO.Path]::PathSeparator
-  if ($sessionPathEntries -notcontains $InstallDir) {
+  if (-not (Test-ZeroPathContainsDir -PathValue $env:PATH -Dir $InstallDir)) {
     $env:PATH = "$env:PATH;$InstallDir"
   }
 } finally {


### PR DESCRIPTION
## Summary

The PowerShell installer only printed a suggestion to add the install directory to PATH but never actually did it, so `zero` was unusable from a fresh terminal after install. This change persists the install directory to the user's PATH via `[Environment]::SetEnvironmentVariable` and also updates the current session's `$env:PATH` so `zero` works immediately after install without a terminal restart.

## Linked issue

Fixes #406

## Checklist

- [ ] The linked issue already has the `issue-approved` label.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] `gofmt` clean.
- [ ] Tests added/updated for the change (and run under `-race` where relevant).
- [ ] UI changes include screenshots or a short recording where possible.

### Verification notes

- `go build ./...` and `go vet ./...` pass clean.
- `go test ./...` has 4 pre-existing failures unrelated to this change (env has no provider/API key configured, a Windows file-lock permission error in `internal/oauth`, and a TUI string-match assertion in `internal/tui`) — none touch install/PATH logic, and this PR does not modify any `.go` files.
- `gofmt -l` flags nearly the whole repo pre-existing due to `core.autocrlf=true` on Windows (CRLF vs LF); not introduced by this change and no `.go` files are touched here.
- No automated tests exist for `scripts/install.ps1`; verified manually by reproducing the bug (fresh install, PATH unchanged, `zero` not found) and confirming the fix persists the entry via `[Environment]::SetEnvironmentVariable("PATH", ..., "User")` and that `zero` resolves afterward.
- Not a UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now more reliably adds the install location to `PATH` only when it’s missing.
  * Current terminal sessions are updated without duplicating the path entry.
  * If automatic `PATH` updates fail, clearer warnings guide you to update it manually.
  * You’ll now be prompted to restart your terminal after a successful user `PATH` update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->