### PR TITLE
fix(tools): flag piped POSIX utilities before running on Windows

### DIFF
--- a/internal/tools/bash_tool_test.go
+++ b/internal/tools/bash_tool_test.go
@@ -180,6 +180,9 @@ func TestDetectShellCommandIssueAllowsUnrelatedCommands(t *testing.T) {
 		`dir /b`,
 		`findstr /r "summary" file.txt`,
 		`echo header text`,
+		`tail-log.sh`,
+		`grep-cli --version`,
+		`sed.exe --help`,
 	} {
 		if issue := detectShellCommandIssue(command, "windows"); issue != nil {
 			t.Fatalf("expected unrelated command to pass for %q, got %#v", command, issue)

--- a/internal/tools/bash_tool_test.go
+++ b/internal/tools/bash_tool_test.go
@@ -161,6 +161,32 @@ func TestDetectShellCommandIssueRequiresActualLSCommand(t *testing.T) {
 	}
 }
 
+func TestDetectShellCommandIssueFlagsPipedPosixUtilities(t *testing.T) {
+	for _, command := range []string{
+		`git log --oneline -- pinokio_compat.py | head`,
+		`git blame -L 40,46 pinokio_compat.py --format=%author | grep summary`,
+		`cat file.txt | wc -l`,
+		`some_command | tail -n 20`,
+	} {
+		if issue := detectShellCommandIssue(command, "windows"); issue == nil {
+			t.Fatalf("expected POSIX utility pipeline to be flagged for %q", command)
+		}
+	}
+}
+
+func TestDetectShellCommandIssueAllowsUnrelatedCommands(t *testing.T) {
+	for _, command := range []string{
+		`git log --oneline`,
+		`dir /b`,
+		`findstr /r "summary" file.txt`,
+		`echo header text`,
+	} {
+		if issue := detectShellCommandIssue(command, "windows"); issue != nil {
+			t.Fatalf("expected unrelated command to pass for %q, got %#v", command, issue)
+		}
+	}
+}
+
 func TestDetectShellOutputIssueAddsWindowsSyntaxHint(t *testing.T) {
 	issue := detectShellOutputIssue(`cd /d/tmp/zero-pr-158 && ls -la`, "The syntax of the command is incorrect.", "windows")
 	if issue == nil {

--- a/internal/tools/shell_runtime.go
+++ b/internal/tools/shell_runtime.go
@@ -20,6 +20,11 @@ type shellIssue struct {
 var (
 	windowsBashStyleCDPattern = regexp.MustCompile(`(?i)(^|[&|;]\s*)cd\s+/(?:[a-ce-z0-9_./~-]|d[a-z0-9_./~-])[a-z0-9_./~-]*`)
 	windowsLSCommandPattern   = regexp.MustCompile(`(?i)(^|[&|;]\s*)ls\b(?:\s+|$)`)
+	// windowsPosixUtilityPattern catches the other common POSIX coreutils/grep
+	// family commands cmd.exe has no equivalent for (unlike `dir`/`findstr`,
+	// which sound similar enough that a model might reach for the POSIX name
+	// instead) — most often seen piped in, e.g. `git log ... | head`.
+	windowsPosixUtilityPattern = regexp.MustCompile(`(?i)(^|[&|;]\s*)(head|tail|grep|wc|awk|sed|cut|xargs|tr)\b`)
 )
 
 func detectShellRuntime(goos string) shellRuntime {
@@ -55,6 +60,13 @@ func detectShellCommandIssue(command string, goos string) *shellIssue {
 			Kind:       "windows_shell_syntax",
 			Message:    "Command looks like POSIX/Bash syntax, but Zero runs bash tool commands through Windows cmd.exe on this host.",
 			Suggestion: "Use the cwd argument instead of cd, use Windows cmd.exe syntax, or use native tools such as list_directory, read_file, grep, and glob.",
+		}
+	}
+	if windowsPosixUtilityPattern.MatchString(trimmed) {
+		return &shellIssue{
+			Kind:       "windows_shell_syntax",
+			Message:    "Command uses a POSIX utility (head/tail/grep/wc/awk/sed/cut/xargs/tr) that Windows cmd.exe does not have.",
+			Suggestion: "Use cmd.exe equivalents (e.g. `findstr` for grep, `more` to page output) or Zero's native tools (grep, read_file with offset/limit) instead of piping to a POSIX utility.",
 		}
 	}
 	return nil

--- a/internal/tools/shell_runtime.go
+++ b/internal/tools/shell_runtime.go
@@ -24,7 +24,7 @@ var (
 	// family commands cmd.exe has no equivalent for (unlike `dir`/`findstr`,
 	// which sound similar enough that a model might reach for the POSIX name
 	// instead) — most often seen piped in, e.g. `git log ... | head`.
-	windowsPosixUtilityPattern = regexp.MustCompile(`(?i)(^|[&|;]\s*)(head|tail|grep|wc|awk|sed|cut|xargs|tr)\b`)
+	windowsPosixUtilityPattern = regexp.MustCompile(`(?i)(^|[&|;]\s*)(head|tail|grep|wc|awk|sed|cut|xargs|tr)(?:\s+|$)`)
 )
 
 func detectShellRuntime(goos string) shellRuntime {


### PR DESCRIPTION
## Summary

Zero always runs the bash tool through native `cmd.exe` on Windows. The existing pre-flight Windows-syntax detector (`detectShellCommandIssue`) only caught bash-style `cd /...` and bare `ls`, not the broader family of common POSIX pipe utilities (`head`, `tail`, `grep`, `wc`, `awk`, `sed`, `cut`, `xargs`, `tr`) that cmd.exe has no equivalent for. Piping into any of these (e.g. `git log ... | head`, a `git blame ... | grep` pipeline) always failed, wasting a turn — reported in the wild.

This adds a `windowsPosixUtilityPattern` check alongside the existing `cd`/`ls` detectors in `internal/tools/shell_runtime.go`, blocking these pre-flight with the same "translate to cmd.exe / use Zero's native tools" guidance already used for `cd`/`ls`.

Scoped narrowly to the pre-flight command-text check (locale-independent, since it inspects the model-generated command rather than cmd.exe's own translated error output) rather than trying to also expand the post-hoc output-string matcher, which can never be locale-complete.

## Linked issue

Fixes #411

## Checklist

- [ ] The linked issue already has the `issue-approved` label.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] `gofmt` clean.
- [x] Tests added/updated for the change (and run under `-race` where relevant).
- [ ] UI changes include screenshots or a short recording where possible.

### Verification notes

- `go build ./...` / `go vet ./...` clean.
- Added `TestDetectShellCommandIssueFlagsPipedPosixUtilities` and `TestDetectShellCommandIssueAllowsUnrelatedCommands` (`internal/tools/bash_tool_test.go`); both pass alongside the existing `cd`/`ls` detector tests.
- `go test ./internal/tools/...` passes in full.
- `gofmt -l` on the touched files: pre-existing repo-wide CRLF flag (`core.autocrlf=true` on Windows), not introduced by this change — same as prior PRs against this repo.
- Verified false-positive safety by hand: `git grep foo` (real git subcommand, not a pipe target) and `findstr /r "..."` are unaffected since the pattern only matches at the start of a command or immediately after a `|`/`&`/`;` separator, not as a positional argument.
- Not a UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows shell command detection to flag pipelines that use common POSIX-style utilities (for example, `head`, `grep`, `wc`, `tail`) where they aren’t supported.
  * Reduced false positives by allowing unrelated Windows-appropriate commands (such as `git`, `dir`, `findstr`, and `echo`) to pass through unflagged.
* **Tests**
  * Added coverage to verify both the new Windows pipeline detection and the unchanged behavior for unrelated commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->