### PR TITLE
Make shortcuts reconfigurable via the config file.

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -743,6 +743,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		},
 		PermissionMode: permissionMode,
 		Notify:         resolved.Notify,
+		KeyBindings:    resolved.KeyBindings,
 		Setup: tui.SetupOptions{
 			Visible:    setupVisible,
 			Required:   needsSetup,

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -144,6 +144,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		Tools:          cfg.Tools,
 		Swarm:          cfg.Swarm,
 		Preferences:    cfg.Preferences,
+		KeyBindings:    cfg.KeyBindings,
 		LocalControl:   cfg.LocalControl,
 	}, nil
 }
@@ -225,6 +226,7 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 		dst.Preferences.Theme = strings.TrimSpace(src.Preferences.Theme)
 	}
 	mergeLocalControlConfig(&dst.LocalControl, src.LocalControl)
+	mergeKeyBindings(&dst.KeyBindings, src.KeyBindings)
 }
 
 func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
@@ -277,6 +279,7 @@ func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
 	if src.Swarm.MaxTeamSize != 0 {
 		dst.Swarm.MaxTeamSize = src.Swarm.MaxTeamSize
 	}
+	mergeKeyBindings(&dst.KeyBindings, src.KeyBindings)
 	// Local control is intentionally user-config/override only. A cloned project
 	// must not be able to make browser, desktop, or terminal automation tools
 	// appear in the model's tool surface.
@@ -665,6 +668,7 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 		cfg.Tools.deferThresholdSet = true
 	}
 	mergeLocalControlConfig(&cfg.LocalControl, overrides.LocalControl)
+	mergeKeyBindings(&cfg.KeyBindings, overrides.KeyBindings)
 	for _, provider := range overrides.Providers {
 		mergeProvider(cfg, provider)
 	}
@@ -697,6 +701,24 @@ func mergeLocalControlDriverConfig(dst *LocalControlDriverConfig, src LocalContr
 	}
 	if driver := strings.TrimSpace(src.Driver); driver != "" {
 		dst.Driver = driver
+	}
+}
+
+func mergeKeyBindings(dst *KeyBindingsConfig, src KeyBindingsConfig) {
+	if src.ToggleDetailed != "" {
+		dst.ToggleDetailed = src.ToggleDetailed
+	}
+	if src.ToggleMouse != "" {
+		dst.ToggleMouse = src.ToggleMouse
+	}
+	if src.CycleReasoning != "" {
+		dst.CycleReasoning = src.CycleReasoning
+	}
+	if src.TogglePlan != "" {
+		dst.TogglePlan = src.TogglePlan
+	}
+	if src.ToggleSidebar != "" {
+		dst.ToggleSidebar = src.ToggleSidebar
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -112,6 +112,25 @@ func (p PreferencesConfig) RecapsEnabled() bool {
 	return p.Recaps == nil || *p.Recaps
 }
 
+// KeyBindingDef defines one key binding string (e.g. "ctrl+o") that the TUI
+// can remap. An empty string means "use the built-in default" for that action.
+type KeyBindingDef string
+
+// KeyBindingsConfig holds the subset of TUI keybindings that users may remap
+// via config.json. Each field defaults to a sensible built-in when empty.
+type KeyBindingsConfig struct {
+	// ToggleDetailed toggles the detailed transcript view (default: ctrl+o).
+	ToggleDetailed KeyBindingDef `json:"toggleDetailed,omitempty"`
+	// ToggleMouse toggles mouse capture release (default: ctrl+e).
+	ToggleMouse KeyBindingDef `json:"toggleMouse,omitempty"`
+	// CycleReasoning cycles through reasoning effort levels (default: ctrl+t).
+	CycleReasoning KeyBindingDef `json:"cycleReasoning,omitempty"`
+	// TogglePlan toggles the plan panel expansion (default: ctrl+p).
+	TogglePlan KeyBindingDef `json:"togglePlan,omitempty"`
+	// ToggleSidebar toggles the right context sidebar (default: ctrl+b).
+	ToggleSidebar KeyBindingDef `json:"toggleSidebar,omitempty"`
+}
+
 // LocalControlConfig controls local browser/desktop/terminal automation helpers.
 // Helpers are discovered lazily by the tool that needs them; no setup command or
 // background probe is required during startup.
@@ -206,6 +225,7 @@ type FileConfig struct {
 	Tools          ToolsConfig        `json:"tools,omitempty"`
 	Swarm          SwarmConfig        `json:"swarm,omitempty"`
 	Preferences    PreferencesConfig  `json:"preferences,omitempty"`
+	KeyBindings    KeyBindingsConfig  `json:"keybindings,omitempty"`
 	LocalControl   LocalControlConfig `json:"localControl,omitempty"`
 }
 
@@ -220,6 +240,7 @@ func (cfg FileConfig) MarshalJSON() ([]byte, error) {
 		Tools          ToolsConfig         `json:"tools,omitempty"`
 		Swarm          SwarmConfig         `json:"swarm,omitempty"`
 		Preferences    PreferencesConfig   `json:"preferences,omitempty"`
+		KeyBindings    KeyBindingsConfig   `json:"keybindings,omitempty"`
 		LocalControl   *LocalControlConfig `json:"localControl,omitempty"`
 	}
 	raw := rawConfig{
@@ -232,6 +253,7 @@ func (cfg FileConfig) MarshalJSON() ([]byte, error) {
 		Tools:          cfg.Tools,
 		Swarm:          cfg.Swarm,
 		Preferences:    cfg.Preferences,
+		KeyBindings:    cfg.KeyBindings,
 	}
 	if !cfg.LocalControl.Empty() {
 		raw.LocalControl = &cfg.LocalControl
@@ -256,6 +278,7 @@ type Overrides struct {
 	Sandbox        SandboxConfig
 	Notify         NotifyConfig
 	Tools          ToolsConfig
+	KeyBindings    KeyBindingsConfig
 	LocalControl   LocalControlConfig
 }
 
@@ -270,6 +293,7 @@ type ResolvedConfig struct {
 	Tools          ToolsConfig
 	Swarm          SwarmConfig
 	Preferences    PreferencesConfig
+	KeyBindings    KeyBindingsConfig
 	LocalControl   LocalControlConfig
 }
 
@@ -316,6 +340,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		Tools           ToolsConfig                `json:"tools"`
 		Swarm           SwarmConfig                `json:"swarm"`
 		Preferences     PreferencesConfig          `json:"preferences"`
+		KeyBindings     KeyBindingsConfig          `json:"keybindings"`
 		LocalControl    LocalControlConfig         `json:"localControl"`
 		MCPServers      map[string]MCPServerConfig `json:"mcpServers"`
 		MCPServersSnake map[string]MCPServerConfig `json:"mcp_servers"`
@@ -342,6 +367,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	cfg.Tools = raw.Tools
 	cfg.Swarm = raw.Swarm
 	cfg.Preferences = raw.Preferences
+	cfg.KeyBindings = raw.KeyBindings
 	cfg.LocalControl = raw.LocalControl
 	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
 		cfg.MCP.Servers = map[string]MCPServerConfig{}

--- a/internal/tui/binding_test.go
+++ b/internal/tui/binding_test.go
@@ -161,5 +161,3 @@ func TestDispatchOptionO(t *testing.T) {
 		t.Errorf("model.keyMatch should NOT match ctrl+o when option+o is configured")
 	}
 }
-
-

--- a/internal/tui/binding_test.go
+++ b/internal/tui/binding_test.go
@@ -84,6 +84,134 @@ func TestCtrlEMatchesDefault(t *testing.T) {
 	}
 }
 
+func TestCtrlBindingRejectsSupersetModifiers(t *testing.T) {
+	// Configured ctrl+e must NOT match ctrl+alt+e or ctrl+shift+e
+	// (Mod.Contains superset correctness for the ctrl-letter fast path).
+	p := parseBinding("ctrl+e")
+	matcher := p.Matcher()
+
+	bad := []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{"ctrl+alt+e", tea.KeyPressMsg(tea.Key{Code: 'e', Mod: tea.ModCtrl | tea.ModAlt})},
+		{"ctrl+shift+e", tea.KeyPressMsg(tea.Key{Code: 'e', Mod: tea.ModCtrl | tea.ModShift})},
+		{"ctrl+alt+shift+e", tea.KeyPressMsg(tea.Key{Code: 'e', Mod: tea.ModCtrl | tea.ModAlt | tea.ModShift})},
+		{"ctrl+cmd+e", tea.KeyPressMsg(tea.Key{Code: 'e', Mod: tea.ModCtrl | tea.ModSuper})},
+	}
+
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if matcher(tt.msg) {
+				t.Errorf("ctrl+e matcher should NOT match %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestAltBindingRejectsSupersetModifiers(t *testing.T) {
+	// Configured alt+o must NOT match alt+shift+o (code path, exact mod).
+	p := parseBinding("alt+o")
+	matcher := p.Matcher()
+
+	bad := []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{"alt+shift+o", tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModAlt | tea.ModShift})},
+		{"alt+ctrl+o", tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModAlt | tea.ModCtrl})},
+		{"alt+cmd+o", tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModAlt | tea.ModSuper})},
+	}
+
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if matcher(tt.msg) {
+				t.Errorf("alt+o matcher should NOT match %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestPlainKeyBindingRejectsModifiers(t *testing.T) {
+	// A configured plain-key binding (no modifiers, e.g. "o") should only
+	// match when Mod is exactly 0, not when a modifier is held.
+	p := parseBinding("o")
+	matcher := p.Matcher()
+
+	plain := tea.KeyPressMsg(tea.Key{Code: 'o'})
+	if !matcher(plain) {
+		t.Errorf("'o' matcher should match {Code:'o'} with no modifiers")
+	}
+
+	bad := []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{"ctrl+o", tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModCtrl})},
+		{"alt+o", tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModAlt})},
+		{"shift+o", tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModShift})},
+	}
+
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if matcher(tt.msg) {
+				t.Errorf("'o' matcher should NOT match %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestParseBindingUTF8Character(t *testing.T) {
+	// A 2-byte UTF-8 key like é (U+00E9) should parse as a single character,
+	// not be rejected by a byte-length check.
+	p := parseBinding("é")
+	if p.isZero() {
+		t.Errorf("parseBinding('é') should not be zero — it's a valid single character")
+	}
+	if p.code != 'é' {
+		t.Errorf("parseBinding('é').code = %d (U+%04X), want %d (U+00E9)", p.code, p.code, 'é')
+	}
+	if p.text != "" {
+		t.Errorf("parseBinding('é').text = %q, want empty string", p.text)
+	}
+
+	// Also verify the matcher works
+	matcher := p.Matcher()
+	msg := tea.KeyPressMsg(tea.Key{Code: 'é', Text: "é"})
+	if !matcher(msg) {
+		t.Errorf("'é' matcher should match {Code:'é', Text:'é'}")
+	}
+
+	// Should not match with a modifier
+	msgAlt := tea.KeyPressMsg(tea.Key{Code: 'é', Text: "é", Mod: tea.ModAlt})
+	if matcher(msgAlt) {
+		t.Errorf("'é' matcher should NOT match with modifier")
+	}
+}
+
+func TestDispatchRejectsSupersetModifiers(t *testing.T) {
+	// Integration: model.keyMatch with a configured binding must reject
+	// modifier supersets.
+	cfg := config.KeyBindingsConfig{
+		ToggleDetailed: "ctrl+o",
+	}
+	bindings := resolveKeyBindings(cfg)
+	defaultFn := func(tea.KeyMsg) bool { return false }
+	m := model{keyBindings: bindings}
+
+	// Ctrl+O should match
+	msgCtrlO := tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModCtrl})
+	if !m.keyMatch(bindings.toggleDetailed, msgCtrlO, defaultFn) {
+		t.Errorf("keyMatch should match ctrl+o when configured")
+	}
+
+	// Ctrl+Alt+O should NOT match
+	msgCtrlAltO := tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModCtrl | tea.ModAlt})
+	if m.keyMatch(bindings.toggleDetailed, msgCtrlAltO, defaultFn) {
+		t.Errorf("keyMatch should NOT match ctrl+alt+o when ctrl+o is configured")
+	}
+}
+
 func TestConfigToBindingPipeline(t *testing.T) {
 	cfg := config.KeyBindingsConfig{
 		ToggleDetailed: "option+o",

--- a/internal/tui/binding_test.go
+++ b/internal/tui/binding_test.go
@@ -1,0 +1,165 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestParseBindingLabel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string // expected Label()
+	}{
+		{"option+o", "Alt+O"},
+		{"ctrl+o", "Ctrl+O"},
+		{"ctrl+e", "Ctrl+E"},
+		{"option+b", "Alt+B"},
+		{"option+O", "Alt+O"},
+		{"alt+o", "Alt+O"},
+		{"cmd+o", "Cmd+O"},
+		{"super+o", "Cmd+O"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			p := parseBinding(tt.input)
+			got := p.Label()
+			if got != tt.want {
+				t.Errorf("parseBinding(%q).Label() = %q, want %q", tt.input, got, tt.want)
+			}
+			if p.isZero() {
+				t.Errorf("parseBinding(%q).isZero() = true, want false", tt.input)
+			}
+		})
+	}
+}
+
+func TestOptionOMatchesOptionO(t *testing.T) {
+	p := parseBinding("option+o")
+	matcher := p.Matcher()
+
+	// Simulate iTerm2 with "Option as Meta" pressing Option+O
+	// Terminal sends ESC o → KeyPressEvent{Code: 'o', Mod: ModAlt}
+	msg := tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModAlt})
+
+	if !matcher(msg) {
+		t.Errorf("option+o matcher should match {Code:'o', Mod:ModAlt}")
+	}
+
+	// Should NOT match plain 'o'
+	msg2 := tea.KeyPressMsg(tea.Key{Code: 'o'})
+	if matcher(msg2) {
+		t.Errorf("option+o matcher should NOT match {Code:'o'} without ModAlt")
+	}
+
+	// Should NOT match ctrl+o
+	msg3 := tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModCtrl})
+	if matcher(msg3) {
+		t.Errorf("option+o matcher should NOT match {Code:'o', Mod:ModCtrl}")
+	}
+}
+
+func TestOptionOMatchesComposedCharacters(t *testing.T) {
+	p := parseBinding("option+o")
+	matcher := p.Matcher()
+
+	// On macOS without "Option as Meta", Option+O produces ø (U+00F8)
+	msg := tea.KeyPressMsg(tea.Key{Code: 0xF8, Text: "ø"})
+	if matcher(msg) {
+		t.Logf("NOTE: option+o matcher also matches option+ø (macOS compose behavior)")
+	}
+}
+
+func TestCtrlEMatchesDefault(t *testing.T) {
+	p := parseBinding("ctrl+e")
+	matcher := p.Matcher()
+
+	// Terminal sends Ctrl+E → byte 0x05 → KeyPressEvent{Code: 'e', Mod: ModCtrl}
+	msg := tea.KeyPressMsg(tea.Key{Code: 'e', Mod: tea.ModCtrl})
+
+	if !matcher(msg) {
+		t.Errorf("ctrl+e matcher should match {Code:'e', Mod:ModCtrl}")
+	}
+}
+
+func TestConfigToBindingPipeline(t *testing.T) {
+	cfg := config.KeyBindingsConfig{
+		ToggleDetailed: "option+o",
+		ToggleMouse:    "ctrl+e",
+		CycleReasoning: "ctrl+t",
+		TogglePlan:     "ctrl+p",
+		ToggleSidebar:  "option+b",
+	}
+
+	bindings := resolveKeyBindings(cfg)
+
+	tests := []struct {
+		name    string
+		binding parsedBinding
+		wantKey string
+	}{
+		{"toggleDetailed", bindings.toggleDetailed, "Alt+O"},
+		{"toggleMouse", bindings.toggleMouse, "Ctrl+E"},
+		{"cycleReasoning", bindings.cycleReasoning, "Ctrl+T"},
+		{"togglePlan", bindings.togglePlan, "Ctrl+P"},
+		{"toggleSidebar", bindings.toggleSidebar, "Alt+B"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.binding.isZero() {
+				t.Errorf("%s binding is zero (unset) — config not loaded", tt.name)
+			}
+			if got := tt.binding.Label(); got != tt.wantKey {
+				t.Errorf("%s.Label() = %q, want %q", tt.name, got, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestHelpBindingSubstitution(t *testing.T) {
+	// Verify that the help overlay correctly shows user-configured bindings
+	// by checking that Label() returns non-empty for config-sourced bindings.
+	cfg := config.KeyBindingsConfig{
+		ToggleDetailed: "option+o",
+		ToggleSidebar:  "option+b",
+	}
+
+	bindings := resolveKeyBindings(cfg)
+
+	if l := bindings.toggleDetailed.Label(); l != "Alt+O" {
+		t.Errorf("toggleDetailed.Label() = %q, want %q", l, "Alt+O")
+	}
+	if l := bindings.toggleSidebar.Label(); l != "Alt+B" {
+		t.Errorf("toggleSidebar.Label() = %q, want %q", l, "Alt+B")
+	}
+}
+
+// TestDispatchOptionO is an integration-style test: it verifies that pressing
+// Option+O dispatches as toggleDetailed when configured.
+func TestDispatchOptionO(t *testing.T) {
+	cfg := config.KeyBindingsConfig{
+		ToggleDetailed: "option+o",
+	}
+	bindings := resolveKeyBindings(cfg)
+
+	// Simulate Option+O in iTerm2 with "Option as Meta" → ESC o → {Code:'o', Mod:ModAlt}
+	msg := tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModAlt})
+	defaultFn := func(tea.KeyMsg) bool { return false }
+
+	// This is the dispatch check the model uses
+	m := model{keyBindings: bindings}
+	if !m.keyMatch(bindings.toggleDetailed, msg, defaultFn) {
+		t.Errorf("model.keyMatch should match option+o")
+	}
+
+	// Also verify default doesn't match
+	msgCtrlO := tea.KeyPressMsg(tea.Key{Code: 'o', Mod: tea.ModCtrl})
+	if m.keyMatch(bindings.toggleDetailed, msgCtrlO, defaultFn) {
+		t.Errorf("model.keyMatch should NOT match ctrl+o when option+o is configured")
+	}
+}
+
+

--- a/internal/tui/keybinding_help.go
+++ b/internal/tui/keybinding_help.go
@@ -5,6 +5,10 @@
 // lists them grouped, so the keymap is discoverable the way the reference TUIs
 // do it. The list is declarative and hand-curated to match the real handlers in
 // model.go's Update switch; keep them in sync when a binding changes.
+//
+// Configurable bindings (toggleDetailed, toggleMouse, cycleReasoning,
+// togglePlan, toggleSidebar) pull their key label from m.keyBindings so a user
+// who remaps them in config.json sees the actual chords, not the defaults.
 package tui
 
 import "strings"
@@ -21,63 +25,67 @@ type keybindingGroup struct {
 	bindings []keybinding
 }
 
-// keybindingGroups is the full, grouped shortcut list shown by the `?` overlay.
+// buildKeybindingGroups returns the full, grouped shortcut list shown by the
+// `?` overlay. Configurable bindings use the user's remapped labels (via
+// m.keyBindings) when present; unconfigured bindings get their built-in labels.
 // Sourced from the real key cases in model.go (Update) — not invented. When a
-// binding is added/changed there, update it here too (a test guards that the
-// data is non-empty and well-formed, but it can't verify the bindings exist).
-var keybindingGroups = []keybindingGroup{
-	{
-		title: "Chat",
-		bindings: []keybinding{
-			{"Enter", "send the message"},
-			{"Alt+Enter", "insert a newline (multi-line compose)"},
-			{"Esc (×2)", "cancel the run / dismiss a popup / clear the input"},
-			{"Ctrl+C", "cancel the run, then quit"},
-			{"?", "show this help (on an empty input)"},
+// binding is added/changed there, update this method too.
+func (m model) buildKeybindingGroups() []keybindingGroup {
+	return []keybindingGroup{
+		{
+			title: "Chat",
+			bindings: []keybinding{
+				{"Enter", "send the message"},
+				{"Alt+Enter", "insert a newline (multi-line compose)"},
+				{"Esc (\u00d72)", "cancel the run / dismiss a popup / clear the input"},
+				{"Ctrl+C", "cancel the run, then quit"},
+				{"?", "show this help (on an empty input)"},
+			},
 		},
-	},
-	{
-		title: "Model & run controls",
-		bindings: []keybinding{
-			{"Ctrl+T", "cycle reasoning effort (auto → low → medium → high)"},
-			{"Shift+Tab", "cycle permission mode (auto ↔ ask)"},
-			{"Ctrl+P", "expand / collapse the plan panel"},
+		{
+			title: "Model & run controls",
+			bindings: []keybinding{
+				{labelOr(m.keyBindings.cycleReasoning, "Ctrl+T"), "cycle reasoning effort (auto \u2192 low \u2192 medium \u2192 high)"},
+				{"Shift+Tab", "cycle permission mode (auto \u2194 ask)"},
+				{labelOr(m.keyBindings.togglePlan, "Ctrl+P"), "expand / collapse the plan panel"},
+			},
 		},
-	},
-	{
-		title: "Navigation & scrollback",
-		bindings: []keybinding{
-			{"PgUp / PgDn", "scroll the transcript by a page"},
-			{"↑ / ↓", "scroll, or move within a popup / multi-line input"},
-			{"Ctrl+O", "toggle the detailed (full-screen) transcript"},
-			{"Ctrl+B", "hide / show the right context sidebar"},
-			{"Ctrl+E", "release the mouse to drag-select & copy text"},
-			{"Tab", "accept the autocomplete / picker selection"},
+		{
+			title: "Navigation & scrollback",
+			bindings: []keybinding{
+				{"PgUp / PgDn", "scroll the transcript by a page"},
+				{"\u2191 / \u2193", "scroll, or move within a popup / multi-line input"},
+				{labelOr(m.keyBindings.toggleDetailed, "Ctrl+O"), "toggle the detailed (full-screen) transcript"},
+				{labelOr(m.keyBindings.toggleSidebar, "Ctrl+B"), "hide / show the right context sidebar"},
+				{labelOr(m.keyBindings.toggleMouse, "Ctrl+E"), "release the mouse to drag-select & copy text"},
+				{"Tab", "accept the autocomplete / picker selection"},
+			},
 		},
-	},
-	{
-		title: "Specialists & pickers",
-		bindings: []keybinding{
-			{"Click a specialist card", "drill into its sub-session"},
-			{"↑ / Esc (in a sub-session)", "return to the main chat"},
-			{"Ctrl+F (in /model)", "toggle the highlighted model as a favorite"},
-			{"Click a tool card", "expand / collapse its output"},
-			{"Right-click", "paste the clipboard"},
+		{
+			title: "Specialists & pickers",
+			bindings: []keybinding{
+				{"Click a specialist card", "drill into its sub-session"},
+				{"\u2191 / Esc (in a sub-session)", "return to the main chat"},
+				{"Ctrl+F (in /model)", "toggle the highlighted model as a favorite"},
+				{"Click a tool card", "expand / collapse its output"},
+				{"Right-click", "paste the clipboard"},
+			},
 		},
-	},
+	}
 }
 
 // keybindingHelpFooter is the dismiss hint shown at the bottom of the overlay.
-const keybindingHelpFooter = "? or Esc to close · /help for slash commands"
+const keybindingHelpFooter = "? or Esc to close \u00b7 /help for slash commands"
 
 // renderKeybindingHelpLines builds the overlay body lines (group titles +
 // aligned key/description rows + footer), wrapped to the inner width. Exposed
 // separately from the framed renderer so tests can assert on content without
 // the border chrome.
 func (m model) renderKeybindingHelpLines(innerWidth int) []string {
-	keyColumn := keybindingKeyColumnWidth()
+	groups := m.buildKeybindingGroups()
+	keyColumn := keybindingKeyColumnWidth(groups)
 	lines := make([]string, 0, 64)
-	for index, group := range keybindingGroups {
+	for index, group := range groups {
 		if index > 0 {
 			lines = append(lines, "")
 		}
@@ -93,9 +101,9 @@ func (m model) renderKeybindingHelpLines(innerWidth int) []string {
 
 // keybindingKeyColumnWidth returns the width of the key column: the widest key
 // chord across all groups, so the descriptions align in a clean second column.
-func keybindingKeyColumnWidth() int {
+func keybindingKeyColumnWidth(groups []keybindingGroup) int {
 	widest := 0
-	for _, group := range keybindingGroups {
+	for _, group := range groups {
 		for _, binding := range group.bindings {
 			if n := len([]rune(binding.keys)); n > widest {
 				widest = n

--- a/internal/tui/keybinding_help_test.go
+++ b/internal/tui/keybinding_help_test.go
@@ -87,11 +87,13 @@ func TestHelpOverlayViewRendersGroupsAndKeys(t *testing.T) {
 	}
 }
 
-func TestKeybindingGroupsAreWellFormed(t *testing.T) {
-	if len(keybindingGroups) == 0 {
-		t.Fatal("keybindingGroups must not be empty")
+func TestBuildKeybindingGroupsAreWellFormed(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	groups := m.buildKeybindingGroups()
+	if len(groups) == 0 {
+		t.Fatal("buildKeybindingGroups must not return empty")
 	}
-	for _, group := range keybindingGroups {
+	for _, group := range groups {
 		if strings.TrimSpace(group.title) == "" {
 			t.Fatal("every keybinding group needs a title")
 		}

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -229,11 +229,11 @@ func labelOr(b parsedBinding, defaultLabel string) string {
 // dispatch time. When a binding's parsedBinding is zero, the built-in default
 // check in model.go's updateModel should be used.
 type keyBindings struct {
-	toggleDetailed  parsedBinding
-	toggleMouse     parsedBinding
-	cycleReasoning  parsedBinding
-	togglePlan      parsedBinding
-	toggleSidebar   parsedBinding
+	toggleDetailed parsedBinding
+	toggleMouse    parsedBinding
+	cycleReasoning parsedBinding
+	togglePlan     parsedBinding
+	toggleSidebar  parsedBinding
 }
 
 // resolveKeyBindings converts a user-facing KeyBindingsConfig into the

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -112,23 +113,28 @@ func (p parsedBinding) Matcher() func(tea.KeyMsg) bool {
 		mod |= tea.ModSuper // ⌘ Command on macOS, ⊞ Win on Windows
 	}
 
-	// ctrl+letter fast path — the terminal may report this as a control
-	// character code (e.g. ctrl+o → 0x0F), so use keyCtrl which handles
-	// both the code and ModCtrl representations.
+	// ctrl+letter fast path — use exact modifier equality so that a
+	// configured ctrl+o does NOT fire on ctrl+alt+o or ctrl+shift+o.
+	// Note: in raw terminal mode Bubble Tea may report ctrl+letter as
+	// {Code:letter, Mod:ModCtrl} (handled below), or as a control char
+	// code (e.g. 0x0F) without a modifier flag.  The latter is handled by
+	// the text-based fallback in model.go for default bindings; for
+	// configured bindings the code+mod path below is what the user
+	// expressed.
 	if mod == tea.ModCtrl && p.code >= 'a' && p.code <= 'z' {
 		return func(msg tea.KeyMsg) bool {
-			return keyCtrl(msg, p.code)
+			return msg.Key().Code == p.code && msg.Key().Mod == mod
 		}
 	}
 
 	if p.text != "" {
 		return func(msg tea.KeyMsg) bool {
-			return msg.Key().Text == p.text && msg.Key().Mod.Contains(mod)
+			return msg.Key().Text == p.text && msg.Key().Mod == mod
 		}
 	}
 
 	return func(msg tea.KeyMsg) bool {
-		return msg.Key().Code == p.code && msg.Key().Mod.Contains(mod)
+		return msg.Key().Code == p.code && msg.Key().Mod == mod
 	}
 }
 
@@ -205,7 +211,7 @@ func parseBinding(s string) parsedBinding {
 		p.code = 0
 	default:
 		// Single character, any modifier context
-		if len(keyPart) == 1 {
+		if utf8.RuneCountInString(keyPart) == 1 {
 			p.code = []rune(keyPart)[0]
 		}
 		// else unrecognised — leave zero so it falls through to default
@@ -246,14 +252,6 @@ func resolveKeyBindings(cfg config.KeyBindingsConfig) keyBindings {
 		togglePlan:     parseBinding(string(cfg.TogglePlan)),
 		toggleSidebar:  parseBinding(string(cfg.ToggleSidebar)),
 	}
-}
-
-// builtinBindings holds the default hardcoded bindings. keybinding config
-// overrides the built-in on a per-action basis when the field is non-empty.
-var builtinBindings = keyBindings{
-	// All zero: the model.go dispatch uses hardcoded key-case comparisons.
-	// These are the canonical defaults and are never matched through the
-	// parsedBinding.Matcher path — the config-override path is separate.
 }
 
 // keyMatch returns true when msg matches either the user-configured binding b

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -1,0 +1,267 @@
+package tui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+// parsedBinding is the parsed representation of a keybinding string such as
+// "ctrl+o" or "alt+enter". The zero value is a sentinel meaning "use default".
+type parsedBinding struct {
+	ctrl  bool
+	alt   bool
+	shift bool
+	cmd   bool   // ⌘ Command (macOS) / ⊞ Win → ModSuper
+	code  rune   // tea.KeyCode or 0 for text-based matching
+	text  string // for text-based matching (e.g. "?")
+}
+
+// isZero returns true when p is the nil sentinel (no binding configured).
+func (p parsedBinding) isZero() bool {
+	return p.code == 0 && p.text == ""
+}
+
+// Label returns a human-readable representation of the binding, e.g. "Ctrl+O"
+// or "Cmd+Shift+Enter". Used in the help overlay. Returns empty string for
+// zero (unset) bindings.
+func (p parsedBinding) Label() string {
+	if p.isZero() {
+		return ""
+	}
+	var b strings.Builder
+	if p.ctrl {
+		b.WriteString("Ctrl+")
+	}
+	if p.alt {
+		b.WriteString("Alt+")
+	}
+	if p.shift {
+		b.WriteString("Shift+")
+	}
+	if p.cmd {
+		b.WriteString("Cmd+")
+	}
+	if p.text != "" {
+		b.WriteString(p.text)
+	} else if p.code != 0 {
+		switch p.code {
+		case tea.KeyEnter:
+			b.WriteString("Enter")
+		case tea.KeyTab:
+			b.WriteString("Tab")
+		case tea.KeyEsc:
+			b.WriteString("Esc")
+		case tea.KeySpace:
+			b.WriteString("Space")
+		case tea.KeyBackspace:
+			b.WriteString("Backspace")
+		case tea.KeyDelete:
+			b.WriteString("Delete")
+		case tea.KeyUp:
+			b.WriteString("↑")
+		case tea.KeyDown:
+			b.WriteString("↓")
+		case tea.KeyLeft:
+			b.WriteString("←")
+		case tea.KeyRight:
+			b.WriteString("→")
+		case tea.KeyHome:
+			b.WriteString("Home")
+		case tea.KeyEnd:
+			b.WriteString("End")
+		case tea.KeyPgUp:
+			b.WriteString("PgUp")
+		case tea.KeyPgDown:
+			b.WriteString("PgDn")
+		default:
+			// Printable character — uppercase for display
+			if p.code >= 'a' && p.code <= 'z' {
+				b.WriteRune(p.code - 32)
+			} else {
+				b.WriteRune(p.code)
+			}
+		}
+	}
+	return b.String()
+}
+
+// Matcher returns a function that matches a tea.KeyMsg against this binding.
+// It is the hot path for the key dispatch — kept cheap intentionally.
+func (p parsedBinding) Matcher() func(tea.KeyMsg) bool {
+	if p.isZero() {
+		// A zero binding should never be matched — the caller is expected to
+		// check useDefault() first and fall through to the built-in check.
+		return func(tea.KeyMsg) bool { return false }
+	}
+
+	// Build the required modifier mask from the parsed flags.
+	var mod tea.KeyMod
+	if p.ctrl {
+		mod |= tea.ModCtrl
+	}
+	if p.alt {
+		mod |= tea.ModAlt
+	}
+	if p.shift {
+		mod |= tea.ModShift
+	}
+	if p.cmd {
+		mod |= tea.ModSuper // ⌘ Command on macOS, ⊞ Win on Windows
+	}
+
+	// ctrl+letter fast path — the terminal may report this as a control
+	// character code (e.g. ctrl+o → 0x0F), so use keyCtrl which handles
+	// both the code and ModCtrl representations.
+	if mod == tea.ModCtrl && p.code >= 'a' && p.code <= 'z' {
+		return func(msg tea.KeyMsg) bool {
+			return keyCtrl(msg, p.code)
+		}
+	}
+
+	if p.text != "" {
+		return func(msg tea.KeyMsg) bool {
+			return msg.Key().Text == p.text && msg.Key().Mod.Contains(mod)
+		}
+	}
+
+	return func(msg tea.KeyMsg) bool {
+		return msg.Key().Code == p.code && msg.Key().Mod.Contains(mod)
+	}
+}
+
+// parseBinding converts a user-written keybinding string (e.g. "ctrl+o") into
+// a parsedBinding. The empty string returns zero parsedBinding (the "use
+// default" sentinel).
+func parseBinding(s string) parsedBinding {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return parsedBinding{}
+	}
+
+	parts := strings.Split(strings.ToLower(s), "+")
+	var p parsedBinding
+	var keyPart string
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		switch part {
+		case "ctrl", "control":
+			p.ctrl = true
+		case "alt", "option":
+			p.alt = true
+		case "shift":
+			p.shift = true
+		case "cmd", "command":
+			p.cmd = true
+		case "super":
+			// "super" matches the Bubble Tea naming; on macOS this is ⌘
+			p.cmd = true
+		default:
+			keyPart = part
+		}
+	}
+
+	if p.ctrl && len(keyPart) == 1 && keyPart[0] >= 'a' && keyPart[0] <= 'z' {
+		// ctrl+<letter> — store the code so the match is exact
+		p.code = []rune(keyPart)[0]
+		p.text = ""
+		return p
+	}
+
+	// Map named keys to their tea.KeyCode
+	switch keyPart {
+	case "enter", "return":
+		p.code = tea.KeyEnter
+	case "tab":
+		p.code = tea.KeyTab
+	case "esc", "escape":
+		p.code = tea.KeyEsc
+	case "space":
+		p.code = tea.KeySpace
+	case "backspace":
+		p.code = tea.KeyBackspace
+	case "delete":
+		p.code = tea.KeyDelete
+	case "up":
+		p.code = tea.KeyUp
+	case "down":
+		p.code = tea.KeyDown
+	case "left":
+		p.code = tea.KeyLeft
+	case "right":
+		p.code = tea.KeyRight
+	case "home":
+		p.code = tea.KeyHome
+	case "end":
+		p.code = tea.KeyEnd
+	case "pgup", "pageup":
+		p.code = tea.KeyPgUp
+	case "pgdown", "pagedown":
+		p.code = tea.KeyPgDown
+	case "?":
+		p.text = "?"
+		p.code = 0
+	default:
+		// Single character, any modifier context
+		if len(keyPart) == 1 {
+			p.code = []rune(keyPart)[0]
+		}
+		// else unrecognised — leave zero so it falls through to default
+	}
+
+	return p
+}
+
+// labelOr returns b.Label() when b is configured (non-zero), otherwise it
+// returns the caller-supplied default label string.  This is the display-layer
+// counterpart to keyMatch — dispatch falls through to the hardcoded default
+// function, so the label displayed in help / hints must match that fallback.
+func labelOr(b parsedBinding, defaultLabel string) string {
+	if !b.isZero() {
+		return b.Label()
+	}
+	return defaultLabel
+}
+
+// keyBindings holds the parsed, resolved key bindings the model uses at
+// dispatch time. When a binding's parsedBinding is zero, the built-in default
+// check in model.go's updateModel should be used.
+type keyBindings struct {
+	toggleDetailed  parsedBinding
+	toggleMouse     parsedBinding
+	cycleReasoning  parsedBinding
+	togglePlan      parsedBinding
+	toggleSidebar   parsedBinding
+}
+
+// resolveKeyBindings converts a user-facing KeyBindingsConfig into the
+// dispatch-ready parsed form, using empty-is-default semantics.
+func resolveKeyBindings(cfg config.KeyBindingsConfig) keyBindings {
+	return keyBindings{
+		toggleDetailed: parseBinding(string(cfg.ToggleDetailed)),
+		toggleMouse:    parseBinding(string(cfg.ToggleMouse)),
+		cycleReasoning: parseBinding(string(cfg.CycleReasoning)),
+		togglePlan:     parseBinding(string(cfg.TogglePlan)),
+		toggleSidebar:  parseBinding(string(cfg.ToggleSidebar)),
+	}
+}
+
+// builtinBindings holds the default hardcoded bindings. keybinding config
+// overrides the built-in on a per-action basis when the field is non-empty.
+var builtinBindings = keyBindings{
+	// All zero: the model.go dispatch uses hardcoded key-case comparisons.
+	// These are the canonical defaults and are never matched through the
+	// parsedBinding.Matcher path — the config-override path is separate.
+}
+
+// keyMatch returns true when msg matches either the user-configured binding b
+// or (when b is zero/unset) the built-in default matcher defaultFn. This is
+// the bridge between the config surface and the hot dispatch path in model.go.
+func (m model) keyMatch(b parsedBinding, msg tea.KeyMsg, defaultFn func(tea.KeyMsg) bool) bool {
+	if !b.isZero() {
+		return b.Matcher()(msg)
+	}
+	return defaultFn(msg)
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -117,6 +117,7 @@ type model struct {
 	selfCorrectTests      bool
 	reasoningEffort       modelregistry.ReasoningEffort
 	responseStyle         string
+	keyBindings           keyBindings
 	themeMode             themeMode // palette preference: auto (default), dark, light
 	hasDarkBg             bool      // last terminal background-detection result (auto mode)
 	userAgent             string
@@ -726,6 +727,7 @@ func newModel(ctx context.Context, options Options) model {
 		permissionMode:              permissionMode,
 		reasoningEffort:             options.ReasoningEffort,
 		responseStyle:               defaultedResponseStyle(options.ResponseStyle),
+		keyBindings:                 resolveKeyBindings(options.KeyBindings),
 		themeMode:                   resolveThemeMode(options.Theme, os.Getenv("ZERO_THEME"), options.SavedTheme),
 		hasDarkBg:                   true,
 		userAgent:                   options.UserAgent,
@@ -1078,7 +1080,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case keyCtrl(msg, 'c'):
 			return m.handleCtrlC()
-		case keyCtrl(msg, 'o'):
+		case m.keyMatch(m.keyBindings.toggleDetailed, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'o') }):
 			return m.toggleDetailedTranscript(), nil
 		case m.fileView.active && m.noBlockingModal() && m.composerValue() == "" && (keyText(msg) == "d" || keyText(msg) == "f"):
 			// Mode toggle for the file drill-in, only while the composer is empty
@@ -1088,12 +1090,13 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.setFileViewMode(fileViewFull), nil
 			}
 			return m.setFileViewMode(fileViewDiff), nil
-		case keyCtrl(msg, 'e'):
+		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }):
 			// Release/recapture the mouse so the user can drag-select and copy text
 			// natively (mouse capture otherwise intercepts terminal selection).
 			m.mouseReleased = !m.mouseReleased
 			if m.mouseReleased {
-				return m.appendSystemNotice("Mouse released — drag to select and copy text. Press Ctrl+E again to re-enable mouse interaction (clicks, right-click paste)."), nil
+				mouseKey := labelOr(m.keyBindings.toggleMouse, "Ctrl+E")
+			return m.appendSystemNotice(fmt.Sprintf("Mouse released — drag to select and copy text. Press %s again to re-enable mouse interaction (clicks, right-click paste).", mouseKey)), nil
 			}
 			return m.appendSystemNotice("Mouse interaction re-enabled."), nil
 		case keyIs(msg, tea.KeyEsc):
@@ -1268,7 +1271,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.permissionMode = nextPermissionMode(m.permissionMode)
 				return m, nil
 			}
-		case keyCtrl(msg, 't'):
+		case m.keyMatch(m.keyBindings.cycleReasoning, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 't') }):
 			if m.transcriptDetailed {
 				return m, nil
 			}
@@ -1281,14 +1284,14 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.noBlockingModal() {
 				return m.cycleReasoningEffort()
 			}
-		case keyCtrl(msg, 'p'):
+		case m.keyMatch(m.keyBindings.togglePlan, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'p') }):
 			// Ctrl+P toggles the plan panel expansion (collapse/expand step list).
 			if m.noBlockingModal() && !m.plan.isEmpty() {
 				m.plan.expanded = !m.plan.expanded
 				return m, nil
 			}
-		case keyCtrl(msg, 'b'):
-			// Ctrl+B collapses / restores the right context sidebar. Only acts when
+		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }):
+			// Ctrl+B / Ctrl+U collapses / restores the right context sidebar. Only acts when
 			// the sidebar would otherwise be on screen (managed mode, wide enough,
 			// real conversation) so it's a no-op — not a confusing notice — on the
 			// home screen or a narrow terminal. Hiding reflows the chat to full
@@ -2331,6 +2334,10 @@ func (m model) composerIdleHint() string {
 		m.subchat.active || m.suggestionsActive() || m.transcriptDetailed {
 		return ""
 	}
+	sidebarKey := labelOr(m.keyBindings.toggleSidebar, "Ctrl+B")
+	detailKey := labelOr(m.keyBindings.toggleDetailed, "Ctrl+O")
+	mouseKey := labelOr(m.keyBindings.toggleMouse, "Ctrl+E")
+
 	var hint string
 	switch widthTier(m.width) {
 	case tierTiny:
@@ -2338,9 +2345,9 @@ func (m model) composerIdleHint() string {
 	case tierNarrow:
 		hint = "? shortcuts"
 	case tierMedium:
-		hint = "? shortcuts · Ctrl+B sidebar · Ctrl+E copy"
+		hint = fmt.Sprintf("? shortcuts · %s sidebar · %s copy", sidebarKey, mouseKey)
 	default:
-		hint = "? shortcuts · Ctrl+B sidebar · Ctrl+O detail · Ctrl+E copy · Shift+Tab mode"
+		hint = fmt.Sprintf("? shortcuts · %s sidebar · %s detail · %s copy · Shift+Tab mode", sidebarKey, detailKey, mouseKey)
 	}
 	return zeroTheme.faint.Render(hint)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1096,7 +1096,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.mouseReleased = !m.mouseReleased
 			if m.mouseReleased {
 				mouseKey := labelOr(m.keyBindings.toggleMouse, "Ctrl+E")
-			return m.appendSystemNotice(fmt.Sprintf("Mouse released — drag to select and copy text. Press %s again to re-enable mouse interaction (clicks, right-click paste).", mouseKey)), nil
+				return m.appendSystemNotice(fmt.Sprintf("Mouse released — drag to select and copy text. Press %s again to re-enable mouse interaction (clicks, right-click paste).", mouseKey)), nil
 			}
 			return m.appendSystemNotice("Mouse interaction re-enabled."), nil
 		case keyIs(msg, tea.KeyEsc):
@@ -1297,7 +1297,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// home screen or a narrow terminal. Hiding reflows the chat to full
 			// width, so mirror the width-change bookkeeping (re-wrap the streaming
 			// fade, resize the composer) the WindowSizeMsg path does.
-			if m.noBlockingModal() && m.sidebarAvailable() {
+			if m.noBlockingModal() && m.sidebarToggleAllowed() {
 				// Just show/hide — no transcript notice. The reflow IS the feedback,
 				// and emitting a line every toggle piled up noise in the chat.
 				m.sidebarHidden = !m.sidebarHidden

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1291,7 +1291,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }):
-			// Ctrl+B / Ctrl+U collapses / restores the right context sidebar. Only acts when
+			// Ctrl+B collapses / restores the right context sidebar. Only acts when
 			// the sidebar would otherwise be on screen (managed mode, wide enough,
 			// real conversation) so it's a no-op — not a confusing notice — on the
 			// home screen or a narrow terminal. Hiding reflows the chat to full

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -64,6 +64,10 @@ type Options struct {
 	// Notify configures completion / awaiting-input notifications.
 	Notify config.NotifyConfig
 
+	// KeyBindings configures remappable TUI keybindings. An empty/zero
+	// KeyBindingsConfig means "use built-in defaults" for each action.
+	KeyBindings config.KeyBindingsConfig
+
 	// AltScreen tells the model it is running inside Bubble Tea's alternate
 	// screen. Run sets this for the interactive app; tests can leave it false
 	// to exercise the native scrollback renderer.

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -47,6 +47,34 @@ func (m model) sidebarActive() bool {
 	return !m.sidebarHidden && m.sidebarAvailable()
 }
 
+// sidebarToggleAllowed reports whether the toggle-sidebar keybinding should
+// respond. Unlike sidebarAvailable it OMITS the content check
+// (sidebarHasContent) so the user can toggle their show/hide preference even
+// when the sidebar auto-hid due to having nothing to show. The content gate
+// is still applied at render time (sidebarActive chains sidebarAvailable), so
+// toggling on when there's no content just records the preference for when
+// content arrives — the sidebar stays hidden until then.
+func (m model) sidebarToggleAllowed() bool {
+	if !m.altScreen || m.height <= 0 || m.subchat.active {
+		return false
+	}
+	if sidebarWidth(m.width) <= 0 {
+		return false
+	}
+	if widthTier(m.width) < tierMedium {
+		return false
+	}
+	if m.setup.visible || m.providerWizard != nil || m.mcpAddWizard != nil ||
+		m.mcpManager != nil || m.picker != nil || m.suggestionsActive() {
+		return false
+	}
+	// Home/welcome screen: stay single-column until there's real conversation.
+	if m.transcriptEmpty() {
+		return false
+	}
+	return true
+}
+
 // sidebarAvailable reports whether the two-column layout CAN render: only in
 // alt-screen managed mode, with a measured height, on a wide-enough terminal,
 // outside subchat/overlays, with real conversation. It ignores the user's Ctrl+B


### PR DESCRIPTION
## Summary

Allows to configure keyboard shortcuts mapping to prevent conflicts with terminal/shell.

Example `config.json`

```
  "keybindings": {
    "toggleDetailed": "ctrl+y",
    "toggleMouse": "ctrl+e",
    "cycleReasoning": "ctrl+m",
    "togglePlan": "ctrl+k",
    "toggleSidebar": "ctrl+u"
  }
```
<img width="652" height="654" alt="Screenshot 2026-07-03 at 11 08 58" src="https://github.com/user-attachments/assets/a13b35ed-40d8-4b9e-98b2-512123d31078" />



## Linked issue

https://github.com/Gitlawb/zero/issues/416


## Checklist

- [ ] The linked issue already has the `issue-approved` label.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] `gofmt` clean.
- [x] Tests added/updated for the change (and run under `-race` where relevant).
- [x] UI changes include screenshots or a short recording where possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added configurable TUI keyboard shortcuts for transcript details, mouse capture, reasoning cycling, plan/context expansion, and sidebar visibility.
  * Updated the `? shortcuts` overlay and on-screen hints to display your configured keys.

* **Bug Fixes**
  * Custom shortcut settings now consistently drive both key handling and displayed labels.

* **Bug Fixes / Behavior**
  * Improved sidebar show/hide handling to better respect saved preference even when the sidebar auto-hides.

* **Tests**
  * Added broader coverage for shortcut parsing, matching, and help-overlay substitution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->