### PR TITLE
docs(install): document Bun install and improve missing-binary error

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ The npm package installs a small wrapper plus the matching Zero binary for your
 platform from GitHub Releases. It supports Linux, macOS, and Windows on x64 and
 arm64.
 
+### Bun
+
+Bun does not run dependency lifecycle scripts by default, so the `postinstall`
+that fetches the Zero binary is skipped and the first run fails with
+`No native binary found next to the npm wrapper`.
+
+Install with Bun, then fetch the binary in one of two ways:
+
+```bash
+# Option A: run the installer manually
+bun add @gitlawb/zero
+node node_modules/@gitlawb/zero/scripts/postinstall.mjs
+
+# Option B: allow the postinstall to run on install
+# add to your package.json:  "trustedDependencies": ["@gitlawb/zero"]
+bun add @gitlawb/zero
+```
+
+For global installs (`bun add -g @gitlawb/zero`), use Option A against the
+global install path, or prefer the install scripts below.
+
 ### Install scripts
 
 Linux/macOS:

--- a/bin/zero.js
+++ b/bin/zero.js
@@ -54,8 +54,26 @@ const nativePath = join(packageRoot, zeroBinaryName());
 const localControlHelpers = localControlHelperManifest(packageRoot);
 
 if (!existsSync(nativePath)) {
+  const postinstallScript = join(packageRoot, 'scripts', 'postinstall.mjs');
+  const ranByBun = process.execPath.includes('bun') || !!process.versions?.bun;
   console.error(
-    '[zero] No native binary found next to the npm wrapper. Reinstall the zero package or run `go run ./cmd/zero-release build` from the repository.'
+    '[zero] No native binary found next to the npm wrapper.\n' +
+      'The platform binary is fetched at install time by a postinstall script,\n' +
+      'which did not run (or was skipped) for this install.\n' +
+      '\n' +
+      'Fix it now by running the installer manually:\n' +
+      `  node "${postinstallScript}"\n` +
+      '\n' +
+      (ranByBun
+        ? 'You installed with Bun, which does not run dependency lifecycle scripts\n' +
+          'by default. To let it run on future installs, add zero to your\n' +
+          'project\'s trustedDependencies:\n' +
+          '  "trustedDependencies": ["@gitlawb/zero"]\n' +
+          'then reinstall.\n' +
+          '\n'
+        : '') +
+      'If that fails, build from source: https://github.com/Gitlawb/zero\n' +
+      '(go run ./cmd/zero, requires Go 1.25+).',
   );
   process.exit(1);
 }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -24,6 +24,38 @@ Requirements:
 - Node.js 18+
 - network access to npm and GitHub Releases
 
+## Bun
+
+Bun is "default-secure" and does not run lifecycle scripts of installed
+dependencies (only the installing project's own scripts), so the `postinstall`
+that fetches the Zero binary is silently skipped. The first run then fails with
+`No native binary found next to the npm wrapper`.
+
+To install with Bun, either run the installer manually after installing:
+
+```bash
+bun add @gitlawb/zero
+node node_modules/@gitlawb/zero/scripts/postinstall.mjs
+```
+
+Or allow the postinstall to run by adding the package to your project's
+`trustedDependencies` before installing:
+
+```json
+{
+  "trustedDependencies": ["@gitlawb/zero"]
+}
+```
+
+```bash
+bun add @gitlawb/zero
+```
+
+For global installs (`bun add -g @gitlawb/zero`), run the installer manually
+against the global install path, or use the install scripts below.
+
+Reference: <https://bun.sh/docs/pm/lifecycle>
+
 ## Linux And macOS Script
 
 Install the latest release:


### PR DESCRIPTION
## Summary

Installing `@gitlawb/zero` with **Bun** silently skips the wrapper's `postinstall`, so the native binary is never fetched and the first run fails with:

```
[zero] No native binary found next to the npm wrapper. Reinstall the zero
package or run `go run ./cmd/zero-release build` from the repository.
```

That message only helps someone with a source checkout — a Bun user who just ran `bun add` is left stuck. This PR makes Bun a documented install path and makes the error actionable for everyone.

## Why this happens

Bun is "default-secure" and **does not run lifecycle scripts of installed dependencies** by default — only the installing project's own scripts. `@gitlawb/zero` isn't on Bun's built-in `trustedDependencies` list, so the `postinstall` in `scripts/postinstall.mjs` (which downloads the platform binary from GitHub Releases) is skipped with no warning. `npm`/`yarn` run it, so the documented `npm install -g @gitlawb/zero` flow works; only Bun users hit this.

Refs: [bun.sh/docs/cli/install](https://bun.sh/docs/cli/install), [bun.sh/docs/pm/lifecycle](https://bun.sh/docs/pm/lifecycle)

## Changes

- **`README.md`** — new `### Bun` subsection under **Install** with the two working install paths.
- **`docs/INSTALL.md`** — new `## Bun` section with the same, plus a link to Bun's lifecycle docs.
- **`bin/zero.js`** — rewrote the missing-binary error to:
  - keep the existing `No native binary found next to the npm wrapper` lead line (so the Go wrapper test at `internal/npmwrapper/npmwrapper_test.go:259` still passes),
  - tell the user to run `scripts/postinstall.mjs` manually (concrete fix that works for any package manager), and
  - when launched under Bun (`process.versions.bun` / `bun` in `execPath`), append a Bun-specific note pointing at `trustedDependencies`.
  - The source-build fallback now points at `go run ./cmd/zero` rather than `go run ./cmd/zero-release build` (the latter only makes sense inside a release checkout).

## Verification

- `node --check bin/zero.js` ✓
- Previewed the error under `node` (generic path) and under `bun` (Bun-specific hint appears) ✓
- `go test ./internal/npmwrapper/ ./internal/release/` ✓ (all pass, including `TestNodeWrapperReportsMissingNativeBinary`)

```
ok  github.com/Gitlawb/zero/internal/npmwrapper  0.544s
ok  github.com/Gitlawb/zero/internal/release     0.024s
```

## Notes / possible follow-ups

- A more permanent fix would be to ship the binary via per-platform `optionalDependencies` packages (esbuild/sharp style), which removes the reliance on a `postinstall` entirely and works under Bun without `trustedDependencies`. That's a bigger change and out of scope here; this PR is the minimal docs + error-message fix.
- Happy to trim/adjust wording if you'd prefer a shorter README note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Bun-specific installation guidance, including how to handle packages that skip lifecycle scripts by default.
  * Documented two setup options: run the post-install step manually or allow it via trusted dependencies.
  * Expanded install docs with notes for global installs and related lifecycle behavior.

* **Bug Fixes**
  * Improved the missing-native-binary error message with clearer, step-by-step recovery instructions.
  * Added clearer guidance for Bun users and a fallback path for rebuilding from source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->