### PR TITLE
feat(providers): add Meituan LongCat (LongCat-2.0) catalog preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ the key in the wizard:
 export OPENAI_API_KEY=sk-...
 export ANTHROPIC_API_KEY=...
 export GEMINI_API_KEY=...
+export LONGCAT_API_KEY=...
+```
+
+To configure Meituan LongCat (LongCat-2.0) directly, run:
+
+```bash
+zero providers setup longcat --set-active
 ```
 
 For local models, run Ollama or LM Studio and then use `zero setup` or

--- a/internal/cli/provider_catalog_onboarding_test.go
+++ b/internal/cli/provider_catalog_onboarding_test.go
@@ -18,6 +18,7 @@ func TestProviderCatalogRuntimeProvidersShowOnboardingSetupHints(t *testing.T) {
 	}{
 		{id: "openai", name: "OpenAI", transport: "openai", defaultModel: "gpt-4.1"},
 		{id: "groq", name: "Groq", transport: "openai-compatible", defaultModel: "llama-3.3-70b-versatile"},
+		{id: "longcat", name: "LongCat", transport: "openai-compatible", defaultModel: "LongCat-2.0"},
 		{id: "ollama-cloud", name: "Ollama Cloud", transport: "openai-compatible", defaultModel: "qwen3-coder:480b"},
 		{id: "ollama", name: "Ollama Local", transport: "openai-compatible", defaultModel: "llama3.1"},
 	}
@@ -43,6 +44,21 @@ func TestProviderCatalogRuntimeProvidersShowOnboardingSetupHints(t *testing.T) {
 				t.Fatalf("runtime-supported provider %s should not show unsupported reason, got:\n%s", tt.id, block)
 			}
 		})
+	}
+}
+
+func TestProviderCatalogLongCatRequiresAPIKey(t *testing.T) {
+	output := runProviderCatalogOnboarding(t)
+	block := providerCatalogOnboardingBlock(t, output, "longcat")
+
+	for _, want := range []string{
+		"requiresAuth=true",
+		"authEnvVars=LONGCAT_API_KEY",
+		"setup: zero providers setup longcat --set-active",
+	} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("expected LongCat catalog block to contain %q, got:\n%s", want, block)
+		}
 	}
 }
 

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -123,6 +123,7 @@ var descriptors = []Descriptor{
 	openAICompat("together", "Together AI", "https://api.together.xyz/v1", "meta-llama/Llama-3.3-70B-Instruct-Turbo", []string{"TOGETHER_API_KEY"}),
 	openAICompat("dashscope", "DashScope", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "qwen-plus", []string{"DASHSCOPE_API_KEY", "QWEN_API_KEY"}, "qwen"),
 	openAICompat("moonshot", "Moonshot AI", "https://api.moonshot.ai/v1", "kimi-k2-0905-preview", []string{"MOONSHOT_API_KEY"}, "kimi"),
+	openAICompat("longcat", "LongCat", "https://api.longcat.chat/openai", "LongCat-2.0", []string{"LONGCAT_API_KEY"}, "meituan longcat", "meituan", "longcat-2.0"),
 	openAICompat("nvidia-nim", "NVIDIA NIM", "https://integrate.api.nvidia.com/v1", "nvidia/llama-3.1-nemotron-70b-instruct", []string{"NVIDIA_API_KEY"}, "nvidia nim"),
 	anthropicCompat("minimax", "MiniMax", "https://api.minimax.io/anthropic", "MiniMax-M3", []string{"MINIMAX_API_KEY"}, "mini-max", "mini_max"),
 	openAICompat("mistral", "Mistral", "https://api.mistral.ai/v1", "mistral-large-latest", []string{"MISTRAL_API_KEY"}),

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -23,6 +23,7 @@ var expectedCatalogIDs = []string{
 	"together",
 	"dashscope",
 	"moonshot",
+	"longcat",
 	"nvidia-nim",
 	"minimax",
 	"mistral",
@@ -96,6 +97,28 @@ func TestRecommendedProviderEndpoint(t *testing.T) {
 	}
 	if descriptor.Transport != TransportOpenAICompatible {
 		t.Fatalf("OpenGateway transport = %q, want %q", descriptor.Transport, TransportOpenAICompatible)
+	}
+}
+
+func TestLongCatDescriptor(t *testing.T) {
+	descriptor, err := Require("longcat")
+	if err != nil {
+		t.Fatalf("Require(longcat) error = %v", err)
+	}
+	if descriptor.Name != "LongCat" {
+		t.Fatalf("Name = %q, want LongCat", descriptor.Name)
+	}
+	if descriptor.DefaultBaseURL != "https://api.longcat.chat/openai" {
+		t.Fatalf("DefaultBaseURL = %q, want LongCat OpenAI-compatible endpoint", descriptor.DefaultBaseURL)
+	}
+	if descriptor.DefaultModel != "LongCat-2.0" {
+		t.Fatalf("DefaultModel = %q, want LongCat-2.0", descriptor.DefaultModel)
+	}
+	if descriptor.Transport != TransportOpenAICompatible {
+		t.Fatalf("Transport = %q, want %q", descriptor.Transport, TransportOpenAICompatible)
+	}
+	if !reflect.DeepEqual(descriptor.AuthEnvVars, []string{"LONGCAT_API_KEY"}) {
+		t.Fatalf("AuthEnvVars = %#v, want LONGCAT_API_KEY", descriptor.AuthEnvVars)
 	}
 }
 
@@ -267,7 +290,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
 		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
-		TransportOpenAICompat:    {"gitlawb-opengateway", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "kilocode", "opencode", "opencode-go", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
+		TransportOpenAICompat:    {"gitlawb-opengateway", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "longcat", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "kilocode", "opencode", "opencode-go", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 
 	for transport, wantIDs := range cases {


### PR DESCRIPTION
## Summary

Adds **Meituan LongCat** (`LongCat-2.0`) as a first-class OpenAI-compatible provider preset, so it can be picked by name in the setup wizard / `zero providers setup longcat` instead of hand-entering a custom endpoint.

LongCat-2.0 is Meituan's open, OpenAI- and Anthropic-compatible model. This wires the OpenAI-compatible transport:

| Field | Value |
|---|---|
| Base URL | `https://api.longcat.chat/openai` (Zero appends `/chat/completions`) |
| Model | `LongCat-2.0` |
| Auth | `Bearer` via `LONGCAT_API_KEY` |

**Scope — deliberately minimal.** One catalog descriptor plus its catalog/onboarding tests and a README env-var line. No shared plumbing is touched, so existing providers are byte-for-byte unaffected (no attribution-header machinery needed, unlike the AI/ML API preset, so the diff stays small). Because onboarding (`setupProviderOptions`), the setup wizard (`providerWizardProviders`), and the model picker all derive their list from `providercatalog.All()` filtered by `RuntimeSupported`, the single descriptor surfaces in all three automatically — no separate lists to update. Placed with the other OpenAI-compatible third parties (after `moonshot`), below the first-party providers.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green (73 packages, 0 failures); `gofmt` clean.
- New tests: `TestLongCatDescriptor`, the `expectedCatalogIDs` / transport-order guards, `TestProviderCatalogRuntimeProvidersShowOnboardingSetupHints/longcat`, and `TestProviderCatalogLongCatRequiresAPIKey`.
- Live binary — `zero providers catalog` lists it correctly:

  ```
  id=longcat name=LongCat
    transport=openai-compatible defaultModel=LongCat-2.0
    defaultBaseURL=https://api.longcat.chat/openai
    authEnvVars=LONGCAT_API_KEY
    requiresAuth=true local=false runtimeSupported=true
    setup: zero providers setup longcat --set-active
  ```

- Caveat: the endpoint is wired **by-spec from LongCat's published docs** (base `.../openai` + Zero's `/chat/completions` append matches their documented `base_url`). A live completion still needs a real `LONGCAT_API_KEY`; `zero providers models longcat` will probe their live `/models` endpoint once a key is available.

## Linked issue

Team / internal development-cycle PR — per CONTRIBUTING.md, team members may open PRs outside the community `issue-approved` flow. Prompted by a community request to run LongCat-2.0 in Zero. Happy to file a tracking issue if preferred.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] `gofmt` clean.
- [x] Tests added/updated for the change.
- [x] No new UI code — LongCat renders in the existing provider picker automatically; `zero providers catalog` output included above in lieu of a screenshot.
- [ ] The linked issue already has the `issue-approved` label — N/A for a team internal-cycle PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the LongCat provider in the provider catalog.
  * Users can now configure LongCat with the `LONGCAT_API_KEY` environment variable.
  * Updated onboarding and setup guidance to include LongCat activation steps.

* **Tests**
  * Expanded provider catalog coverage to verify LongCat appears in supported provider lists.
  * Added checks for LongCat’s authentication requirement, API key setting, and provider details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->