### PR TITLE
fix(sandbox): gate /tmp test assertions on GOOS, not path existence

### DIFF
--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -72,6 +72,9 @@ func TestPermissionProfileFromPolicyIncludesDefaultTempWriteRoots(t *testing.T) 
 	if !writeRootsContain(profile.FileSystem.WriteRoots, tmpdir) {
 		t.Fatalf("write roots = %#v, want temp root %q", profile.FileSystem.WriteRoots, tmpdir)
 	}
+	// /tmp is a default temp write root on POSIX only (see
+	// defaultTempWriteRootCandidatesForGOOS); on Windows the bare path resolves
+	// against the current drive, so a stray C:\tmp must not turn this on.
 	if runtime.GOOS != "windows" && pathExists("/tmp") && !writeRootsContain(profile.FileSystem.WriteRoots, "/tmp") {
 		t.Fatalf("write roots = %#v, want /tmp", profile.FileSystem.WriteRoots)
 	}

--- a/internal/sandbox/scope_test.go
+++ b/internal/sandbox/scope_test.go
@@ -129,6 +129,9 @@ func TestNewScopeNormalizesAndValidatesExtraRoots(t *testing.T) {
 	if !stringSliceContains(roots, normalizeWorkspaceRootBestEffort(extra)) {
 		t.Fatalf("Roots()=%v want extra root %q", roots, normalizeWorkspaceRootBestEffort(extra))
 	}
+	// /tmp is a default temp write root on POSIX only (see
+	// defaultTempWriteRootCandidatesForGOOS); on Windows the bare path resolves
+	// against the current drive, so a stray C:\tmp must not turn this on.
 	if runtime.GOOS != "windows" && pathExists("/tmp") && !stringSliceContains(roots, normalizeWorkspaceRootBestEffort("/tmp")) {
 		t.Fatalf("Roots()=%v want default /tmp write root", roots)
 	}


### PR DESCRIPTION
Update after rebase: main picked up the same functional guard fix via #378 while this PR was open, so this now only adds the explanatory comment for why the guard needs the GOOS check. Merge for the comment or close as superseded, either is fine.

## What

Adds a comment to the /tmp assertions in `TestPermissionProfileFromPolicyIncludesDefaultTempWriteRoots` and `TestNewScopeNormalizesAndValidatesExtraRoots` explaining why `runtime.GOOS != "windows"` is required in addition to `pathExists("/tmp")`: Go resolves the bare path `/tmp` against the current drive on Windows, so a stray `C:\tmp` used to satisfy the old guard while the product code (correctly, see `defaultTempWriteRootCandidatesForGOOS` in `internal/sandbox/scope.go`) never adds `/tmp` as a Windows default temp root. The comment keeps the check from being "simplified" away later.

## Testing

Full `internal/sandbox` suite passes on Windows 11 after the rebase. POSIX behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)