### PR TITLE
feat(sandbox): unelevated Windows fallback tier instead of prompts-only degrade

### DIFF
--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -19,6 +19,13 @@ var errWindowsSandboxNotInitialized = errors.New(
 const windowsSetupDowngradeReason = "Windows OS sandbox inactive — commands run with workspace path-confinement and " +
 	"per-command approval only. Run `zero sandbox setup` from an elevated (Administrator) terminal for full filesystem and network isolation."
 
+// windowsUnelevatedDowngradeReason is surfaced when Windows runs the sandbox in
+// the unelevated tier: the restricted-token write-jail is enforced (the command
+// runner applies the workspace ACLs itself, which needs no Administrator
+// rights), but the WFP network filters are Administrator-only and absent.
+const windowsUnelevatedDowngradeReason = "Windows sandbox running unelevated — the filesystem write-jail is enforced, but network " +
+	"isolation still relies on per-command approval. Run `zero sandbox setup` from an elevated (Administrator) terminal for OS-level network enforcement."
+
 // windowsSandboxInitialized reports whether the per-host Windows sandbox setup
 // marker exists. A missing marker is the common fresh-install state, so the
 // caller degrades rather than bricking the command. Indirected through a var so
@@ -174,19 +181,28 @@ func (manager SandboxManager) BuildExecutionRequest(request SandboxManagerReques
 	if request.ValidateExecution && preference == SandboxPreferenceRequire && backend.SupportLevel() != BackendSupportNative {
 		return SandboxExecutionRequest{}, nativeSandboxUnavailableError(backend)
 	}
-	// Windows: the OS sandbox needs a one-time elevated `zero sandbox setup` (it
-	// applies WFP network filters + workspace ACLs and writes a marker). Without
-	// it the command runner hard-fails — so on the default preference, DEGRADE to
-	// the in-process policy gate + per-command approval (matching Linux/macOS when
-	// their sandbox is unavailable) instead of bricking every command. A strict
-	// caller (--sandbox require) still gets a clear error pointing at setup.
+	// Windows: the FULL OS sandbox needs a one-time elevated `zero sandbox setup`
+	// (it applies WFP network filters + workspace ACLs and writes a marker).
+	// Without it, a restricted-filesystem profile can still run in the UNELEVATED
+	// tier: the command runner applies the workspace ACL plan itself (DACL edits
+	// on user-owned roots need no Administrator rights) and wraps the command in
+	// the write-restricted token, so the filesystem write-jail holds. Only the
+	// WFP network filters are Administrator-only, so network stays with the
+	// in-process approval gate at that tier. A profile that needs the sandbox
+	// solely for network isolation gains nothing from the unelevated tier and
+	// DEGRADES to the policy gate as before. A strict caller (--sandbox require)
+	// still gets a clear error pointing at setup.
 	windowsNeedsSetup := false
 	if manager.goos == "windows" && requiresPlatformSandbox && enforcementLevel == EnforcementNative && !windowsSandboxInitialized() {
 		if preference == SandboxPreferenceRequire {
 			return SandboxExecutionRequest{}, errWindowsSandboxNotInitialized
 		}
-		enforcementLevel = EnforcementDegraded
 		windowsNeedsSetup = true
+		if profile.FileSystem.Kind == FileSystemRestricted {
+			enforcementLevel = EnforcementUnelevated
+		} else {
+			enforcementLevel = EnforcementDegraded
+		}
 	}
 	targetBackend := manager.targetBackend(preference, policy, requiresPlatformSandbox)
 	downgradeReason := ""
@@ -196,7 +212,11 @@ func (manager SandboxManager) BuildExecutionRequest(request SandboxManagerReques
 			downgradeReason = windowsSetupDowngradeReason
 		}
 	}
-	wrapped := backend.CommandWrapping && backend.Available && enforcementLevel == EnforcementNative
+	if enforcementLevel == EnforcementUnelevated {
+		downgradeReason = windowsUnelevatedDowngradeReason
+	}
+	wrapped := backend.CommandWrapping && backend.Available &&
+		(enforcementLevel == EnforcementNative || enforcementLevel == EnforcementUnelevated)
 	markers := backend.SandboxEnvMarkers(policy)
 	if !wrapped && backend.Name != BackendWSL {
 		markers = nil

--- a/internal/sandbox/runner_windows_integration_test.go
+++ b/internal/sandbox/runner_windows_integration_test.go
@@ -132,6 +132,64 @@ exit 0
 	}
 }
 
+// TestWindowsUnelevatedRealSandboxSmoke exercises the unelevated tier end to
+// end WITHOUT running the elevated setup helper: the command runner applies
+// the workspace ACLs itself, a write inside the workspace succeeds under the
+// restricted token, and a write outside every granted root is denied. Unlike
+// the elevated smoke above it needs no Administrator terminal.
+func TestWindowsUnelevatedRealSandboxSmoke(t *testing.T) {
+	if os.Getenv("ZERO_SANDBOX_REAL_SMOKE") != "1" {
+		t.Skip("set ZERO_SANDBOX_REAL_SMOKE=1 to run real Windows sandbox smoke tests")
+	}
+	runnerExe := realSmokeExecutable(t, "ZERO_WINDOWS_COMMAND_RUNNER_EXE", WindowsSandboxCommandRunnerName)
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	sandboxHome := filepath.Join(root, ".zero-sandbox")
+	profile := PermissionProfile{
+		FileSystem: FileSystemPolicy{
+			Kind:                 FileSystemRestricted,
+			ReadRoots:            []string{root},
+			WriteRoots:           []WritableRoot{{Root: root, ProtectedMetadataNames: []string{".git", ".zero", ".agents"}}},
+			IncludePlatformRoots: true,
+			AllowTemp:            true,
+		},
+		Network: NetworkPolicy{Mode: NetworkDeny},
+	}
+	config := WindowsSandboxCommandArgsOptions{
+		SandboxHome:       sandboxHome,
+		CommandCWD:        root,
+		WorkspaceRoots:    []string{root},
+		PermissionProfile: profile,
+		SandboxLevel:      WindowsSandboxLevelUnelevated,
+	}
+
+	// cmd.exe rather than powershell.exe: managed PowerShell cannot initialize
+	// its crypto provider under a write-restricted token on some hosts
+	// (0x8009001d, the same restricted-token limitation the runner documents for
+	// Schannel), and the write-jail assertion only needs a native shell.
+	insideMarker := filepath.Join(root, "unelevated-write-ok.txt")
+	runWindowsRealSmokeCommand(t, runnerExe, config, []string{
+		"cmd.exe", "/d", "/s", "/c", "echo ok>" + insideMarker,
+	}, 0)
+	if bytes, err := os.ReadFile(insideMarker); err != nil || strings.TrimSpace(string(bytes)) != "ok" {
+		t.Fatalf("unelevated sandboxed write marker = %q, %v; want ok", bytes, err)
+	}
+	if _, err := os.Stat(WindowsUnelevatedSetupMarkerPath(sandboxHome)); err != nil {
+		t.Fatalf("expected the unelevated setup marker to be recorded: %v", err)
+	}
+
+	outsideMarker := filepath.Join(outside, "unelevated-write-denied.txt")
+	runWindowsRealSmokeCommand(t, runnerExe, config, []string{
+		"cmd.exe", "/d", "/s", "/c", "echo leaked>" + outsideMarker,
+	}, 1)
+	if _, err := os.Stat(outsideMarker); err == nil {
+		t.Fatalf("unelevated sandbox allowed a write outside every granted root")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat outside marker: %v", err)
+	}
+}
+
 func realSmokeExecutable(t *testing.T, envKey string, fallbackName string) string {
 	t.Helper()
 	if path := os.Getenv(envKey); path != "" {

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -143,9 +143,16 @@ const (
 )
 
 const (
-	EnforcementNative   EnforcementLevel = "native"
-	EnforcementDegraded EnforcementLevel = "degraded"
-	EnforcementDisabled EnforcementLevel = "disabled"
+	EnforcementNative EnforcementLevel = "native"
+	// EnforcementUnelevated is the Windows-only middle tier used when the
+	// elevated `zero sandbox setup` has not run: commands still wrap through the
+	// command runner with a write-restricted token and workspace ACLs (which the
+	// runner can apply without Administrator rights), but the WFP network
+	// filters are absent, so network isolation stays with the in-process
+	// approval gate.
+	EnforcementUnelevated EnforcementLevel = "unelevated"
+	EnforcementDegraded   EnforcementLevel = "degraded"
+	EnforcementDisabled   EnforcementLevel = "disabled"
 )
 
 type Policy struct {

--- a/internal/sandbox/windows_command_runner_windows.go
+++ b/internal/sandbox/windows_command_runner_windows.go
@@ -8,12 +8,19 @@ import (
 )
 
 func runWindowsSandboxCommand(config WindowsSandboxCommandConfig, stderr io.Writer) int {
-	if config.SandboxLevel != WindowsSandboxLevelRestrictedToken {
+	switch config.SandboxLevel {
+	case WindowsSandboxLevelRestrictedToken:
+		if err := ValidateWindowsSandboxSetupMarker(WindowsSandboxSetupConfigFromCommand(config)); err != nil {
+			fmt.Fprintln(stderr, WindowsSandboxCommandRunnerName+": "+err.Error())
+			return 1
+		}
+	case WindowsSandboxLevelUnelevated:
+		if err := ensureWindowsUnelevatedSetup(config); err != nil {
+			fmt.Fprintln(stderr, WindowsSandboxCommandRunnerName+": "+err.Error())
+			return 1
+		}
+	default:
 		fmt.Fprintf(stderr, "%s: unsupported Windows sandbox level %q\n", WindowsSandboxCommandRunnerName, config.SandboxLevel)
-		return 1
-	}
-	if err := ValidateWindowsSandboxSetupMarker(WindowsSandboxSetupConfigFromCommand(config)); err != nil {
-		fmt.Fprintln(stderr, WindowsSandboxCommandRunnerName+": "+err.Error())
 		return 1
 	}
 	if err := ValidateWindowsNetworkPolicy(config.PermissionProfile.Network); err != nil {
@@ -56,4 +63,33 @@ func runWindowsSandboxCommand(config WindowsSandboxCommandConfig, stderr io.Writ
 		return 1
 	}
 	return exitCode
+}
+
+// ensureWindowsUnelevatedSetup applies the workspace ACL plan from the current
+// (non-elevated) process so the write-restricted token has somewhere its
+// capability SIDs are granted. DACL edits on user-owned workspace and temp
+// roots need no Administrator rights; the WFP network filters DO, so this tier
+// provisions no network enforcement — the offline-marker SID composed into the
+// token stays inert until an elevated `zero sandbox setup` installs the block
+// filters. Applied plans are recorded by hash so repeat commands skip the
+// re-apply; like the elevated setup, grants are left in place (the rollback is
+// deliberately discarded) because they only name synthetic capability SIDs
+// that no other token carries.
+func ensureWindowsUnelevatedSetup(config WindowsSandboxCommandConfig) error {
+	applied, plan, err := buildWindowsUnelevatedAppliedPlan(config)
+	if err != nil {
+		return err
+	}
+	marker, err := loadWindowsUnelevatedSetupMarker(config.SandboxHome)
+	if err != nil {
+		return err
+	}
+	if marker.contains(applied) {
+		return nil
+	}
+	if _, err := applyWindowsACLPlan(plan); err != nil {
+		return fmt.Errorf("apply unelevated workspace ACLs: %w — the workspace may be on a filesystem the current user does not own; "+
+			"run `zero sandbox setup` from an elevated (Administrator) terminal, or re-run with `--sandbox forbid` to skip OS sandboxing", err)
+	}
+	return recordWindowsUnelevatedAppliedPlan(config.SandboxHome, applied)
 }

--- a/internal/sandbox/windows_degrade_test.go
+++ b/internal/sandbox/windows_degrade_test.go
@@ -2,14 +2,16 @@ package sandbox
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
-// On Windows, a not-yet-set-up sandbox must DEGRADE (run unwrapped with a
-// downgrade reason) on the default preference — never brick the command — while
-// a strict --sandbox require still errors with a setup hint. Once the marker
-// exists, enforcement is native and the command wraps.
-func TestWindowsDegradesWhenSandboxNotInitialized(t *testing.T) {
+// On Windows, a not-yet-set-up sandbox must fall back to the UNELEVATED tier
+// (wrapped through the runner with the write-restricted token, network left to
+// the approval gate) on the default preference — never brick the command —
+// while a strict --sandbox require still errors with a setup hint. Once the
+// marker exists, enforcement is native and the command wraps.
+func TestWindowsFallsBackUnelevatedWhenSandboxNotInitialized(t *testing.T) {
 	restore := windowsSandboxInitialized
 	t.Cleanup(func() { windowsSandboxInitialized = restore })
 
@@ -24,22 +26,23 @@ func TestWindowsDegradesWhenSandboxNotInitialized(t *testing.T) {
 		ValidateExecution: true,
 	}
 
-	// Marker missing + auto -> degrade (unwrapped, with a reason), no error.
+	// Marker missing + auto -> unelevated tier: still wrapped, with a reason
+	// documenting the missing network enforcement, no error.
 	windowsSandboxInitialized = func() bool { return false }
 	auto := base
 	auto.Preference = SandboxPreferenceAuto
 	req, err := mgr.BuildExecutionRequest(auto)
 	if err != nil {
-		t.Fatalf("auto must degrade, not error: %v", err)
+		t.Fatalf("auto must fall back, not error: %v", err)
 	}
-	if req.EnforcementLevel != EnforcementDegraded {
-		t.Fatalf("enforcement = %v, want degraded", req.EnforcementLevel)
+	if req.EnforcementLevel != EnforcementUnelevated {
+		t.Fatalf("enforcement = %v, want unelevated", req.EnforcementLevel)
 	}
-	if req.CommandWrapped {
-		t.Fatal("degraded command must NOT be wrapped through the sandbox runner")
+	if !req.CommandWrapped {
+		t.Fatal("unelevated command must still be wrapped through the sandbox runner")
 	}
-	if req.DowngradeReason == "" {
-		t.Fatal("expected a downgrade reason explaining the missing setup")
+	if req.DowngradeReason == "" || !strings.Contains(req.DowngradeReason, "network") {
+		t.Fatalf("downgrade reason = %q, want an explanation of the missing network enforcement", req.DowngradeReason)
 	}
 
 	// Marker missing + require -> hard error pointing at setup.
@@ -49,7 +52,7 @@ func TestWindowsDegradesWhenSandboxNotInitialized(t *testing.T) {
 		t.Fatalf("require must error with the setup hint, got %v", err)
 	}
 
-	// Marker present -> native, wrapped.
+	// Marker present -> native, wrapped, no downgrade reason.
 	windowsSandboxInitialized = func() bool { return true }
 	req, err = mgr.BuildExecutionRequest(auto)
 	if err != nil {
@@ -57,5 +60,44 @@ func TestWindowsDegradesWhenSandboxNotInitialized(t *testing.T) {
 	}
 	if req.EnforcementLevel != EnforcementNative || !req.CommandWrapped {
 		t.Fatalf("initialized -> native wrapped, got enforcement=%v wrapped=%v", req.EnforcementLevel, req.CommandWrapped)
+	}
+	if req.DowngradeReason != "" {
+		t.Fatalf("native downgrade reason = %q, want empty", req.DowngradeReason)
+	}
+}
+
+// A profile that needs the platform sandbox ONLY for network isolation gains
+// nothing from the unelevated tier (which cannot enforce network), so it must
+// keep the old degrade-to-policy-gate behavior.
+func TestWindowsNetworkOnlyProfileStillDegradesWhenNotInitialized(t *testing.T) {
+	restore := windowsSandboxInitialized
+	t.Cleanup(func() { windowsSandboxInitialized = restore })
+	windowsSandboxInitialized = func() bool { return false }
+
+	mgr := NewSandboxManager(SandboxManagerOptions{
+		GOOS:    "windows",
+		Backend: Backend{Name: BackendWindowsRestrictedToken, Available: true, Executable: "zero.exe", Platform: "windows"},
+	})
+	req, err := mgr.BuildExecutionRequest(SandboxManagerRequest{
+		WorkspaceRoot: `C:\ws`,
+		Command:       CommandSpec{Name: "bash", Args: []string{"-c", "echo hi"}},
+		Policy:        DefaultPolicy(),
+		Profile: PermissionProfile{
+			FileSystem: FileSystemPolicy{Kind: FileSystemUnrestricted, IncludePlatformRoots: true, AllowTemp: true},
+			Network:    NetworkPolicy{Mode: NetworkDeny},
+		},
+		Preference: SandboxPreferenceAuto,
+	})
+	if err != nil {
+		t.Fatalf("network-only profile must degrade, not error: %v", err)
+	}
+	if req.EnforcementLevel != EnforcementDegraded {
+		t.Fatalf("enforcement = %v, want degraded", req.EnforcementLevel)
+	}
+	if req.CommandWrapped {
+		t.Fatal("degraded command must NOT be wrapped through the sandbox runner")
+	}
+	if req.DowngradeReason == "" {
+		t.Fatal("expected a downgrade reason explaining the missing setup")
 	}
 }

--- a/internal/sandbox/windows_runner.go
+++ b/internal/sandbox/windows_runner.go
@@ -95,8 +95,14 @@ type WindowsSandboxLevel string
 
 const (
 	WindowsSandboxLevelRestrictedToken WindowsSandboxLevel = "restricted-token"
-	WindowsSandboxLevelElevated        WindowsSandboxLevel = "elevated"
-	WindowsSandboxLevelDisabled        WindowsSandboxLevel = "disabled"
+	// WindowsSandboxLevelUnelevated is the restricted-token tier without the
+	// elevated setup: the runner applies the workspace ACL plan itself before
+	// launching (no Administrator rights needed) and skips the elevated setup
+	// marker check. Network is NOT enforced at this level — the WFP filters need
+	// the elevated setup — so callers must keep network behind the approval gate.
+	WindowsSandboxLevelUnelevated WindowsSandboxLevel = "unelevated"
+	WindowsSandboxLevelElevated   WindowsSandboxLevel = "elevated"
+	WindowsSandboxLevelDisabled   WindowsSandboxLevel = "disabled"
 )
 
 type WindowsSandboxCommandArgsOptions struct {
@@ -271,13 +277,20 @@ func windowsRestrictedTokenCommandPlan(execRequest SandboxExecutionRequest, poli
 		return CommandPlan{}, err
 	}
 	childEnv := windowsSandboxChildEnv(spec.Env, policy, execRequest.WorkspaceRoot)
+	// The unelevated enforcement tier maps to the runner's unelevated level: same
+	// restricted token, but the runner applies the workspace ACLs itself instead
+	// of requiring the elevated setup marker.
+	level := WindowsSandboxLevelRestrictedToken
+	if execRequest.EnforcementLevel == EnforcementUnelevated {
+		level = WindowsSandboxLevelUnelevated
+	}
 	args, err := BuildWindowsSandboxCommandArgs(WindowsSandboxCommandArgsOptions{
 		SandboxHome:       sandboxHome,
 		CommandCWD:        spec.Dir,
 		WorkspaceRoots:    []string{execRequest.WorkspaceRoot},
 		PermissionProfile: execRequest.PermissionProfile,
 		Env:               childEnv,
-		SandboxLevel:      WindowsSandboxLevelRestrictedToken,
+		SandboxLevel:      level,
 		Command:           append([]string{spec.Name}, spec.Args...),
 	})
 	if err != nil {
@@ -381,7 +394,7 @@ func nextWindowsSandboxFlagValue(args []string, index int) (string, int, error) 
 
 func validWindowsSandboxLevel(level WindowsSandboxLevel) bool {
 	switch level {
-	case WindowsSandboxLevelRestrictedToken, WindowsSandboxLevelElevated, WindowsSandboxLevelDisabled:
+	case WindowsSandboxLevelRestrictedToken, WindowsSandboxLevelUnelevated, WindowsSandboxLevelElevated, WindowsSandboxLevelDisabled:
 		return true
 	default:
 		return false

--- a/internal/sandbox/windows_unelevated.go
+++ b/internal/sandbox/windows_unelevated.go
@@ -1,0 +1,144 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const windowsUnelevatedSetupMarkerSchemaVersion = 1
+
+// windowsUnelevatedSetupMarkerMaxPlans bounds the applied-plan history so the
+// marker cannot grow without limit when a user hops between many workspaces.
+// Oldest entries are dropped first; re-applying an already-granted plan is
+// harmless, so eviction only costs a redundant ACL apply.
+const windowsUnelevatedSetupMarkerMaxPlans = 64
+
+// WindowsUnelevatedAppliedPlan fingerprints one workspace ACL plan the
+// unelevated tier has applied. Unlike the elevated setup marker it carries no
+// network infrastructure hash: the unelevated tier never provisions WFP
+// filters, so there is nothing network-side to fingerprint.
+type WindowsUnelevatedAppliedPlan struct {
+	ACLPlanHash    string `json:"aclPlanHash"`
+	ACLPlanEntries int    `json:"aclPlanEntries"`
+}
+
+// WindowsUnelevatedSetupMarker records which workspace ACL plans the command
+// runner has applied without elevation, keyed by plan hash, so repeat commands
+// in a known workspace skip the re-apply. One file serves every workspace under
+// a sandbox home (the elevated marker is instead a single-plan snapshot,
+// because its WFP half genuinely is machine-global).
+type WindowsUnelevatedSetupMarker struct {
+	SchemaVersion int                            `json:"schemaVersion"`
+	AppliedPlans  []WindowsUnelevatedAppliedPlan `json:"appliedPlans,omitempty"`
+}
+
+func WindowsUnelevatedSetupMarkerPath(sandboxHome string) string {
+	return filepath.Join(filepath.Clean(sandboxHome), "windows-unelevated-setup.json")
+}
+
+// buildWindowsUnelevatedAppliedPlan derives the ACL plan for the command's
+// permission profile plus its marker fingerprint. The same BuildWindowsACLPlan
+// output later feeds the apply step, so the fingerprint and the applied grants
+// can never drift apart.
+func buildWindowsUnelevatedAppliedPlan(config WindowsSandboxCommandConfig) (WindowsUnelevatedAppliedPlan, WindowsACLPlan, error) {
+	plan, err := BuildWindowsACLPlan(config)
+	if err != nil {
+		return WindowsUnelevatedAppliedPlan{}, WindowsACLPlan{}, err
+	}
+	hash, err := WindowsACLPlanHash(plan)
+	if err != nil {
+		return WindowsUnelevatedAppliedPlan{}, WindowsACLPlan{}, err
+	}
+	return WindowsUnelevatedAppliedPlan{
+		ACLPlanHash:    hash,
+		ACLPlanEntries: len(plan.Entries),
+	}, plan, nil
+}
+
+// loadWindowsUnelevatedSetupMarker reads the marker; a missing file is the
+// common first-run state and returns an empty marker, not an error. A marker
+// with an unexpected schema version is treated as empty so the runner re-applies
+// (and rewrites) rather than failing.
+func loadWindowsUnelevatedSetupMarker(sandboxHome string) (WindowsUnelevatedSetupMarker, error) {
+	sandboxHome = strings.TrimSpace(sandboxHome)
+	if sandboxHome == "" {
+		return WindowsUnelevatedSetupMarker{}, errors.New("windows sandbox home is required")
+	}
+	path := WindowsUnelevatedSetupMarkerPath(sandboxHome)
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return WindowsUnelevatedSetupMarker{SchemaVersion: windowsUnelevatedSetupMarkerSchemaVersion}, nil
+		}
+		return WindowsUnelevatedSetupMarker{}, fmt.Errorf("read windows unelevated setup marker: %w", err)
+	}
+	var marker WindowsUnelevatedSetupMarker
+	if err := json.Unmarshal(bytes, &marker); err != nil {
+		return WindowsUnelevatedSetupMarker{}, fmt.Errorf("parse windows unelevated setup marker %s: %w", path, err)
+	}
+	if marker.SchemaVersion != windowsUnelevatedSetupMarkerSchemaVersion {
+		return WindowsUnelevatedSetupMarker{SchemaVersion: windowsUnelevatedSetupMarkerSchemaVersion}, nil
+	}
+	return marker, nil
+}
+
+func (marker WindowsUnelevatedSetupMarker) contains(applied WindowsUnelevatedAppliedPlan) bool {
+	if strings.TrimSpace(applied.ACLPlanHash) == "" {
+		return false
+	}
+	for _, plan := range marker.AppliedPlans {
+		if plan.ACLPlanHash == applied.ACLPlanHash && plan.ACLPlanEntries == applied.ACLPlanEntries {
+			return true
+		}
+	}
+	return false
+}
+
+// recordWindowsUnelevatedAppliedPlan appends the plan to the marker (dropping
+// the oldest entries past the cap) and writes it atomically, following the
+// temp-file-then-rename pattern of the sibling marker writers.
+func recordWindowsUnelevatedAppliedPlan(sandboxHome string, applied WindowsUnelevatedAppliedPlan) error {
+	marker, err := loadWindowsUnelevatedSetupMarker(sandboxHome)
+	if err != nil {
+		return err
+	}
+	if marker.contains(applied) {
+		return nil
+	}
+	marker.SchemaVersion = windowsUnelevatedSetupMarkerSchemaVersion
+	marker.AppliedPlans = append(marker.AppliedPlans, applied)
+	if overflow := len(marker.AppliedPlans) - windowsUnelevatedSetupMarkerMaxPlans; overflow > 0 {
+		marker.AppliedPlans = append([]WindowsUnelevatedAppliedPlan(nil), marker.AppliedPlans[overflow:]...)
+	}
+	path := WindowsUnelevatedSetupMarkerPath(sandboxHome)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create windows unelevated setup marker dir: %w", err)
+	}
+	bytes, err := json.MarshalIndent(marker, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal windows unelevated setup marker: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".windows-unelevated-setup-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create windows unelevated setup marker temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(bytes); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write windows unelevated setup marker temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close windows unelevated setup marker temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace windows unelevated setup marker: %w", err)
+	}
+	return nil
+}

--- a/internal/sandbox/windows_unelevated_test.go
+++ b/internal/sandbox/windows_unelevated_test.go
@@ -1,0 +1,157 @@
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func testWindowsUnelevatedCommandConfig(t *testing.T) WindowsSandboxCommandConfig {
+	t.Helper()
+	root := t.TempDir()
+	return WindowsSandboxCommandConfig{
+		SandboxHome:    filepath.Join(root, ".zero-sandbox"),
+		CommandCWD:     root,
+		WorkspaceRoots: []string{root},
+		PermissionProfile: PermissionProfile{
+			FileSystem: FileSystemPolicy{
+				Kind:       FileSystemRestricted,
+				ReadRoots:  []string{root},
+				WriteRoots: []WritableRoot{{Root: root, ProtectedMetadataNames: []string{".git", ".zero", ".agents"}}},
+				AllowTemp:  true,
+			},
+			Network: NetworkPolicy{Mode: NetworkDeny},
+		},
+		SandboxLevel: WindowsSandboxLevelUnelevated,
+		Command:      []string{"cmd.exe", "/c", "echo hi"},
+	}
+}
+
+func TestWindowsSandboxCommandArgsRoundTripUnelevatedLevel(t *testing.T) {
+	config := testWindowsUnelevatedCommandConfig(t)
+	args, err := BuildWindowsSandboxCommandArgs(WindowsSandboxCommandArgsOptions{
+		SandboxHome:       config.SandboxHome,
+		CommandCWD:        config.CommandCWD,
+		WorkspaceRoots:    config.WorkspaceRoots,
+		PermissionProfile: config.PermissionProfile,
+		SandboxLevel:      WindowsSandboxLevelUnelevated,
+		Command:           config.Command,
+	})
+	if err != nil {
+		t.Fatalf("BuildWindowsSandboxCommandArgs: %v", err)
+	}
+	parsed, err := ParseWindowsSandboxCommandArgs(args)
+	if err != nil {
+		t.Fatalf("ParseWindowsSandboxCommandArgs: %v", err)
+	}
+	if parsed.SandboxLevel != WindowsSandboxLevelUnelevated {
+		t.Fatalf("round-tripped sandbox level = %q, want %q", parsed.SandboxLevel, WindowsSandboxLevelUnelevated)
+	}
+}
+
+func TestBuildWindowsUnelevatedAppliedPlanFingerprint(t *testing.T) {
+	config := testWindowsUnelevatedCommandConfig(t)
+	applied, plan, err := buildWindowsUnelevatedAppliedPlan(config)
+	if err != nil {
+		t.Fatalf("buildWindowsUnelevatedAppliedPlan: %v", err)
+	}
+	if applied.ACLPlanHash == "" || applied.ACLPlanEntries == 0 || applied.ACLPlanEntries != len(plan.Entries) {
+		t.Fatalf("applied plan = %+v with %d plan entries, want a non-empty consistent fingerprint", applied, len(plan.Entries))
+	}
+	// Same config -> same fingerprint (the marker's dedupe key).
+	again, _, err := buildWindowsUnelevatedAppliedPlan(config)
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if again != applied {
+		t.Fatalf("fingerprint not stable: %+v then %+v", applied, again)
+	}
+	// An unrestricted profile has no ACL plan to apply and must error.
+	config.PermissionProfile.FileSystem.Kind = FileSystemUnrestricted
+	if _, _, err := buildWindowsUnelevatedAppliedPlan(config); err == nil {
+		t.Fatal("expected an error for an unrestricted filesystem profile")
+	}
+}
+
+func TestWindowsUnelevatedSetupMarkerRecordAndLoad(t *testing.T) {
+	config := testWindowsUnelevatedCommandConfig(t)
+	applied, _, err := buildWindowsUnelevatedAppliedPlan(config)
+	if err != nil {
+		t.Fatalf("buildWindowsUnelevatedAppliedPlan: %v", err)
+	}
+
+	// Missing marker file is the fresh-install state: empty, no error, no match.
+	marker, err := loadWindowsUnelevatedSetupMarker(config.SandboxHome)
+	if err != nil {
+		t.Fatalf("load missing marker: %v", err)
+	}
+	if marker.contains(applied) {
+		t.Fatal("empty marker must not contain the plan")
+	}
+
+	if err := recordWindowsUnelevatedAppliedPlan(config.SandboxHome, applied); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	marker, err = loadWindowsUnelevatedSetupMarker(config.SandboxHome)
+	if err != nil {
+		t.Fatalf("load recorded marker: %v", err)
+	}
+	if !marker.contains(applied) || len(marker.AppliedPlans) != 1 {
+		t.Fatalf("marker = %+v, want exactly the recorded plan", marker)
+	}
+
+	// Recording the same plan again must not duplicate it.
+	if err := recordWindowsUnelevatedAppliedPlan(config.SandboxHome, applied); err != nil {
+		t.Fatalf("re-record: %v", err)
+	}
+	marker, err = loadWindowsUnelevatedSetupMarker(config.SandboxHome)
+	if err != nil {
+		t.Fatalf("reload marker: %v", err)
+	}
+	if len(marker.AppliedPlans) != 1 {
+		t.Fatalf("marker has %d plans after duplicate record, want 1", len(marker.AppliedPlans))
+	}
+}
+
+func TestWindowsUnelevatedSetupMarkerEvictsOldestPastCap(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".zero-sandbox")
+	first := WindowsUnelevatedAppliedPlan{ACLPlanHash: "hash-0", ACLPlanEntries: 1}
+	if err := recordWindowsUnelevatedAppliedPlan(home, first); err != nil {
+		t.Fatalf("record first: %v", err)
+	}
+	for index := 1; index <= windowsUnelevatedSetupMarkerMaxPlans; index++ {
+		plan := WindowsUnelevatedAppliedPlan{ACLPlanHash: fmt.Sprintf("hash-%d", index), ACLPlanEntries: index}
+		if err := recordWindowsUnelevatedAppliedPlan(home, plan); err != nil {
+			t.Fatalf("record %d: %v", index, err)
+		}
+	}
+	marker, err := loadWindowsUnelevatedSetupMarker(home)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(marker.AppliedPlans) != windowsUnelevatedSetupMarkerMaxPlans {
+		t.Fatalf("marker has %d plans, want the cap of %d", len(marker.AppliedPlans), windowsUnelevatedSetupMarkerMaxPlans)
+	}
+	if marker.contains(first) {
+		t.Fatal("oldest plan should have been evicted past the cap")
+	}
+}
+
+func TestLoadWindowsUnelevatedSetupMarkerResetsUnknownSchema(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".zero-sandbox")
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatalf("mkdir sandbox home: %v", err)
+	}
+	path := WindowsUnelevatedSetupMarkerPath(home)
+	if err := os.WriteFile(path, []byte(`{"schemaVersion":99,"appliedPlans":[{"aclPlanHash":"h","aclPlanEntries":1}]}`), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	marker, err := loadWindowsUnelevatedSetupMarker(home)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(marker.AppliedPlans) != 0 || marker.SchemaVersion != windowsUnelevatedSetupMarkerSchemaVersion {
+		t.Fatalf("unknown schema must reset to empty current-schema marker, got %+v", marker)
+	}
+}


### PR DESCRIPTION
> Note on process: I know CONTRIBUTING asks for an approved issue first, happy to convert this to an issue and resubmit if you prefer. Opening as a PR directly because the full working, Windows-verified implementation exists and is easier to evaluate than a proposal. Related (but separate, scoped) PR: #426, the `/tmp` test-guard fix, which makes the sandbox suite green on Windows so this branch can be validated there.

## What

Adds an `unelevated` enforcement tier to the Windows sandbox: when the elevated `zero sandbox setup` has not run, commands with a restricted-filesystem profile still wrap through the command runner under the write-restricted token, with the runner applying the workspace ACL plan itself (no Administrator rights needed). Previously this state dropped to the in-process policy gate with no OS enforcement.

## Why

Only the WFP network filters actually require elevation. The write-restricted token (`CreateRestrictedToken(WRITE_RESTRICTED)`) and the workspace ACL grants (DACL edits on user-owned roots) work from a normal process, so the filesystem write-jail can and should hold on fresh installs and non-admin machines. Same elevated/unelevated split Codex ships on Windows.

## How

- `EnforcementUnelevated` between `native` and `degraded` (`types.go`); the manager selects it when the elevated marker is missing, the preference is `auto`, and the profile restricts the filesystem (`manager.go`). Network-only profiles keep the old degrade; `--sandbox require` still errors with the setup hint.
- New `WindowsSandboxLevelUnelevated` runner level (`windows_runner.go`): same restricted-token launch path, but instead of validating the elevated setup marker, the runner applies the ACL plan via the existing `applyWindowsACLPlan` and records it (keyed by `WindowsACLPlanHash`) in `windows-unelevated-setup.json` so repeat commands skip the apply (`windows_command_runner_windows.go`, `windows_unelevated.go`). Grants are left in place like the elevated setup's; they only name synthetic capability SIDs no other token carries.
- The downgrade reason at this tier states explicitly that the write-jail is enforced while network isolation still relies on per-command approval.

## Testing

- `go test ./internal/sandbox/`: green (two pre-existing failures on Windows hosts, `TestPermissionProfileFromPolicyIncludesDefaultTempWriteRoots` and `TestNewScopeNormalizesAndValidatesExtraRoots`, fail identically on `main`; they assume POSIX `/tmp`).
- New portable unit tests: manager tier selection, args round-trip, marker record/dedupe/eviction/schema-reset.
- New `TestWindowsUnelevatedRealSandboxSmoke` (gated by `ZERO_SANDBOX_REAL_SMOKE=1`), **verified on real Windows 11 without elevation**: write inside the workspace succeeds under the restricted token; write outside every granted root is denied by the OS; marker recorded. Uses `cmd.exe` because managed PowerShell cannot initialize its crypto provider under a write-restricted token on some hosts (0x8009001d, same restricted-token family as the Schannel limitation already documented in the runner).
- `go build ./...`, `go vet ./internal/sandbox/...`, gofmt clean.

## Limitations (by design, stated in the downgrade reason)

- No network enforcement at this tier: WFP filters require the elevated setup; network stays behind the approval gate.
- ACL apply fails closed on filesystems the user does not own (e.g. some network shares), with an actionable error pointing at the elevated setup or `--sandbox forbid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Windows sandbox mode for running with limited privileges when full setup isn't available.
  * Expanded command handling so more Windows sandbox requests can still run with appropriate restrictions.
  * Added support for remembering applied workspace permissions to avoid repeating setup work.

* **Bug Fixes**
  * Improved fallback behavior on Windows when sandbox initialization is missing.
  * Added clearer guidance when sandbox permissions can't be applied.
  * Strengthened Windows sandbox behavior with additional validation and smoke coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->