### PR TITLE
fix(sandbox): self-heal a corrupt unelevated setup marker

### DIFF
--- a/internal/sandbox/windows_unelevated.go
+++ b/internal/sandbox/windows_unelevated.go
@@ -61,8 +61,10 @@ func buildWindowsUnelevatedAppliedPlan(config WindowsSandboxCommandConfig) (Wind
 
 // loadWindowsUnelevatedSetupMarker reads the marker; a missing file is the
 // common first-run state and returns an empty marker, not an error. A marker
-// with an unexpected schema version is treated as empty so the runner re-applies
-// (and rewrites) rather than failing.
+// with an unexpected schema version or a corrupt/truncated body is likewise
+// treated as empty so the runner re-applies (and rewrites) rather than failing:
+// the marker only memoizes idempotent ACL applies, so resetting it can only
+// cost redundant work, never skip enforcement.
 func loadWindowsUnelevatedSetupMarker(sandboxHome string) (WindowsUnelevatedSetupMarker, error) {
 	sandboxHome = strings.TrimSpace(sandboxHome)
 	if sandboxHome == "" {
@@ -78,7 +80,7 @@ func loadWindowsUnelevatedSetupMarker(sandboxHome string) (WindowsUnelevatedSetu
 	}
 	var marker WindowsUnelevatedSetupMarker
 	if err := json.Unmarshal(bytes, &marker); err != nil {
-		return WindowsUnelevatedSetupMarker{}, fmt.Errorf("parse windows unelevated setup marker %s: %w", path, err)
+		return WindowsUnelevatedSetupMarker{SchemaVersion: windowsUnelevatedSetupMarkerSchemaVersion}, nil
 	}
 	if marker.SchemaVersion != windowsUnelevatedSetupMarkerSchemaVersion {
 		return WindowsUnelevatedSetupMarker{SchemaVersion: windowsUnelevatedSetupMarkerSchemaVersion}, nil

--- a/internal/sandbox/windows_unelevated_test.go
+++ b/internal/sandbox/windows_unelevated_test.go
@@ -138,6 +138,38 @@ func TestWindowsUnelevatedSetupMarkerEvictsOldestPastCap(t *testing.T) {
 	}
 }
 
+func TestLoadWindowsUnelevatedSetupMarkerSelfHealsCorruptFile(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".zero-sandbox")
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatalf("mkdir sandbox home: %v", err)
+	}
+	path := WindowsUnelevatedSetupMarkerPath(home)
+	// A truncated body must reset like an unknown schema, not brick every
+	// unelevated command until the file is hand-deleted.
+	if err := os.WriteFile(path, []byte(`{"schemaVersion":1,"appliedPlans":[{"aclPlanHash":"h`), 0o600); err != nil {
+		t.Fatalf("write corrupt marker: %v", err)
+	}
+	marker, err := loadWindowsUnelevatedSetupMarker(home)
+	if err != nil {
+		t.Fatalf("corrupt marker must self-heal, got error: %v", err)
+	}
+	if len(marker.AppliedPlans) != 0 || marker.SchemaVersion != windowsUnelevatedSetupMarkerSchemaVersion {
+		t.Fatalf("corrupt marker must reset to empty current-schema marker, got %+v", marker)
+	}
+	// The healed marker must accept new recordings over the corrupt file.
+	applied := WindowsUnelevatedAppliedPlan{ACLPlanHash: "hash-heal", ACLPlanEntries: 2}
+	if err := recordWindowsUnelevatedAppliedPlan(home, applied); err != nil {
+		t.Fatalf("record over corrupt marker: %v", err)
+	}
+	marker, err = loadWindowsUnelevatedSetupMarker(home)
+	if err != nil {
+		t.Fatalf("reload healed marker: %v", err)
+	}
+	if !marker.contains(applied) {
+		t.Fatalf("healed marker = %+v, want the recorded plan", marker)
+	}
+}
+
 func TestLoadWindowsUnelevatedSetupMarkerResetsUnknownSchema(t *testing.T) {
 	home := filepath.Join(t.TempDir(), ".zero-sandbox")
 	if err := os.MkdirAll(home, 0o700); err != nil {


### PR DESCRIPTION
Follow-up addressing the review feedback from coderabbitai and @anandh8x on #427 (merged): a malformed or truncated `windows-unelevated-setup.json` returned a hard error from `loadWindowsUnelevatedSetupMarker`, bricking every unelevated command until the file was hand-deleted, while the unknown-schema path already self-healed by resetting to an empty marker.

## What

Treat corrupt JSON exactly like an unknown schema: reset to an empty current-schema marker so the runner re-applies the ACL plan and rewrites the file on the next command.

## Why it's safe

The marker only memoizes idempotent ACL applies. Resetting it can only cost redundant work (one extra apply); it can never skip enforcement, so failing open on the memoization is the fail-safe direction.

## Testing

- New `TestLoadWindowsUnelevatedSetupMarkerSelfHealsCorruptFile`: a truncated marker body loads as an empty marker without error, and a subsequent record over the corrupt file succeeds.
- `go test ./internal/sandbox/` green on Windows 11, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)