### PR TITLE
fix(tui): keep the profile name on /model switch so the stored key resolves

### DIFF
--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -619,7 +619,15 @@ func (m model) normalizeProfileForProvider(provider providercatalog.Descriptor) 
 		strings.TrimSpace(profile.Name) == "" ||
 		strings.TrimSpace(profile.CatalogID) == ""
 	if normalizeIdentity {
-		profile.Name = provider.ID
+		// Only canonicalize an empty or generic placeholder name — never clobber a
+		// real user-provided profile name. The credential store is keyed by
+		// profile.Name (SecureProviderProfile stores under Name), so rewriting it
+		// here made the later profileWithCredential lookup miss the saved key and
+		// rebuild a keyless provider — a 401 on every /model switch for any profile
+		// named differently from its catalog id (e.g. "my-openai").
+		if strings.TrimSpace(profile.Name) == "" || genericProviderCatalogID(profile.Name) {
+			profile.Name = provider.ID
+		}
 		profile.CatalogID = provider.ID
 	}
 	if strings.TrimSpace(profile.BaseURL) == "" {

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -976,3 +976,49 @@ func TestSwitchProviderModelWarmsDiscoveryForTheNewProvider(t *testing.T) {
 		t.Fatal("switching to ollama should warm both the generic and ollama-specific discovery commands")
 	}
 }
+
+func TestNormalizeProfileForProviderPreservesCustomName(t *testing.T) {
+	openai, ok := providercatalog.Get("openai")
+	if !ok {
+		t.Fatal("openai descriptor missing from catalog")
+	}
+
+	// A first-party provider set up with a custom profile name and the baseURL at
+	// the catalog default. normalizeIdentity is true here (baseURL matches), but
+	// the real name must survive: it is the credential-store key, so clobbering it
+	// dropped the saved key and 401'd every /model switch (issue #440).
+	m := model{providerProfile: config.ProviderProfile{
+		Name:         "my-openai",
+		CatalogID:    "openai",
+		BaseURL:      openai.DefaultBaseURL,
+		APIKeyStored: true,
+	}}
+	got := m.normalizeProfileForProvider(openai)
+	if got.Name != "my-openai" {
+		t.Fatalf("Name = %q, want it preserved as %q (credential store is keyed by Name)", got.Name, "my-openai")
+	}
+	if got.CatalogID != "openai" {
+		t.Fatalf("CatalogID = %q, want it canonicalized to %q", got.CatalogID, "openai")
+	}
+}
+
+func TestNormalizeProfileForProviderCanonicalizesPlaceholderName(t *testing.T) {
+	openai, ok := providercatalog.Get("openai")
+	if !ok {
+		t.Fatal("openai descriptor missing from catalog")
+	}
+
+	// Empty and generic placeholder names still get canonicalized to the catalog
+	// id — those carry no meaningful credential-store key to preserve.
+	for _, name := range []string{"", "custom-openai-compatible"} {
+		m := model{providerProfile: config.ProviderProfile{
+			Name:      name,
+			BaseURL:   openai.DefaultBaseURL,
+			CatalogID: name,
+		}}
+		got := m.normalizeProfileForProvider(openai)
+		if got.Name != "openai" {
+			t.Fatalf("Name = %q for placeholder %q, want canonicalized to %q", got.Name, name, "openai")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`/model` switching threw a credential/auth error (401) for any provider whose saved profile name differed from its catalog id — e.g. a provider you set up as OpenAI but named `my-openai`. The provider worked before the switch; the switch itself dropped its credential.

## Root cause

`normalizeProfileForProvider` (`internal/tui/picker.go`) rewrote the profile identity when `normalizeIdentity` was true:

```go
if normalizeIdentity {
    profile.Name = provider.ID   // clobbers a real user name
    profile.CatalogID = provider.ID
}
```

`normalizeIdentity` is true whenever the saved `BaseURL` matches the catalog default — i.e. for essentially every first-party provider. The credential store is keyed by **`profile.Name`** (`SecureProviderProfile` → `store.Set(Name, key)`; `ApplyStoredAPIKey` → `store.Get(Name)`), and this normalization runs *before* `profileWithCredential`. So the key saved under `my-openai` was looked up under `openai`, missed, and the rebuilt provider went out with no key → 401.

## Fix

Only canonicalize an empty or generic `custom-*` placeholder name; never overwrite a real user-provided name. `CatalogID` canonicalization is unchanged (it is not the store key), so descriptor/metadata resolution is unaffected.

## Tests

- `TestNormalizeProfileForProviderPreservesCustomName` — a custom-named first-party profile (`my-openai`, baseURL at catalog default) keeps its `Name` through normalization while `CatalogID` is still canonicalized.
- `TestNormalizeProfileForProviderCanonicalizesPlaceholderName` — empty and generic placeholder names still canonicalize to the catalog id.
- Full `internal/tui` suite passes; `go build ./...`, `go vet ./...`, `gofmt` clean.

Fixes #440


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved custom profile names when selecting a provider, instead of replacing them with a generic provider name.
  * Continued to normalize placeholder or empty names to the expected provider name for consistent display.
* **Tests**
  * Added coverage for both custom-named and placeholder provider profiles to confirm the updated naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->