### PR TITLE
fix(auth): route zero auth login chatgpt to the dedicated ChatGPT flow

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -301,12 +301,24 @@ func runAuthLogin(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 	if len(parsed.positional) != 1 {
 		return writeExecUsageError(stderr, "usage: zero auth login <provider> [--device] [--scope <scope>]")
 	}
+	provider := parsed.positional[0]
+	// ChatGPT (Codex) requires a fixed redirect_uri (http://localhost:1455/
+	// auth/callback) and mandatory authorize params (id_token_add_organizations,
+	// codex_cli_simplified_flow, originator) that the generic loopback flow
+	// cannot supply. Route it to the dedicated ChatGPT login so
+	// `zero auth login chatgpt` behaves identically to `zero auth chatgpt`.
+	if strings.EqualFold(provider, "chatgpt") {
+		if parsed.device {
+			return writeExecUsageError(stderr, "ChatGPT login does not support --device (it is loopback-only)")
+		}
+		return runAuthChatGPT(nil, stdout, stderr, deps)
+	}
 	manager, err := newAuthManager(deps, stdout)
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
 	status, err := manager.Login(context.Background(), oauth.LoginOptions{
-		Provider:    parsed.positional[0],
+		Provider:    provider,
 		Device:      parsed.device,
 		ExtraScopes: parsed.scopes,
 	})
@@ -489,8 +501,9 @@ Commands:
 A provider is any OAuth 2.0 / OIDC server. "openrouter" ('zero auth openrouter')
 works out of the box. "xai" ('zero auth login xai') uses a built-in preset that is
 off by default — enable it with ZERO_OAUTH_ALLOW_PRESETS=1, or set the
-ZERO_OAUTH_XAI_* vars yourself. Any preset field is overridable via the env vars
-below. For a custom provider named <name>, set:
+ZERO_OAUTH_XAI_* vars yourself. "chatgpt" ('zero auth login chatgpt' or
+'zero auth chatgpt') uses a fixed-port loopback flow against the Codex backend.
+Any preset field is overridable via the env vars below. For a custom provider named <name>, set:
   ZERO_OAUTH_<NAME>_CLIENT_ID       (required)
   ZERO_OAUTH_<NAME>_CLIENT_SECRET   (optional)
   ZERO_OAUTH_<NAME>_AUTHORIZE_URL   ZERO_OAUTH_<NAME>_TOKEN_URL

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -311,6 +311,9 @@ func runAuthLogin(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 		if parsed.device {
 			return writeExecUsageError(stderr, "ChatGPT login does not support --device (it is loopback-only)")
 		}
+		if len(parsed.scopes) > 0 {
+			return writeExecUsageError(stderr, "ChatGPT login does not support --scope (the required scopes are fixed by the Codex client registration)")
+		}
 		return runAuthChatGPT(nil, stdout, stderr, deps)
 	}
 	manager, err := newAuthManager(deps, stdout)

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -182,3 +182,18 @@ func TestRunAuthLoginChatGPTRoutesToDedicatedFlow(t *testing.T) {
 		t.Fatalf("stderr = %q, want the ChatGPT-specific rejection (case-insensitive)", stderr.String())
 	}
 }
+
+// TestRunAuthLoginChatGPTRejectsScope mirrors the --device rejection: --scope
+// must not be silently dropped on the ChatGPT path. The Codex client
+// registration pins a fixed scope set (incl. api.connectors.*), so custom
+// scopes are rejected up front rather than plumbed through.
+func TestRunAuthLoginChatGPTRejectsScope(t *testing.T) {
+	withAuthStore(t)
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "login", "chatgpt", "--scope", "custom-scope"}, &stdout, &stderr, appDeps{}); code == exitSuccess {
+		t.Fatal("auth login chatgpt --scope should be rejected")
+	}
+	if !strings.Contains(stderr.String(), "ChatGPT login does not support --scope") {
+		t.Fatalf("stderr = %q, want the ChatGPT-specific --scope rejection", stderr.String())
+	}
+}

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -156,3 +156,29 @@ func TestRunAuthHelp(t *testing.T) {
 		}
 	}
 }
+
+// TestRunAuthLoginChatGPTRoutesToDedicatedFlow verifies `zero auth login
+// chatgpt` reaches the dedicated ChatGPT login (fixed-port loopback + mandatory
+// authorize params), not the generic manager path. The generic login accepts
+// --device, so a ChatGPT-specific rejection proves the routing took effect.
+// See issue #430: the generic path built a random-port 127.0.0.1 redirect_uri
+// without the required extra params, so OpenAI's authorize endpoint rejected it.
+func TestRunAuthLoginChatGPTRoutesToDedicatedFlow(t *testing.T) {
+	withAuthStore(t)
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "login", "chatgpt", "--device"}, &stdout, &stderr, appDeps{}); code == exitSuccess {
+		t.Fatal("auth login chatgpt --device should be rejected (ChatGPT is loopback-only)")
+	}
+	if !strings.Contains(stderr.String(), "ChatGPT login does not support --device") {
+		t.Fatalf("stderr = %q, want the ChatGPT-specific --device rejection", stderr.String())
+	}
+	// Case-insensitive provider name should still route.
+	stdout.Reset()
+	stderr.Reset()
+	if code := runWithDeps([]string{"auth", "login", "ChatGPT", "--device"}, &stdout, &stderr, appDeps{}); code == exitSuccess {
+		t.Fatal("auth login ChatGPT --device should be rejected")
+	}
+	if !strings.Contains(stderr.String(), "ChatGPT login does not support --device") {
+		t.Fatalf("stderr = %q, want the ChatGPT-specific rejection (case-insensitive)", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

`zero auth login chatgpt` failed with an "Authentication Error" because it went through the generic OAuth loopback path, which builds a random-port `http://127.0.0.1:<port>/callback` redirect_uri with no extra authorize params. OpenAI's ChatGPT client registration requires exactly `http://localhost:1455/auth/callback` plus the `id_token_add_organizations`, `codex_cli_simplified_flow`, and `originator` params, so the authorize endpoint rejected the request before any browser interaction.

This routes the `chatgpt` provider to the existing dedicated ChatGPT login flow (`provideroauth.ChatGPTLogin`), which already binds the fixed port 1455, uses the `localhost` host, the `/auth/callback` path, and sends the required params. `zero auth login chatgpt` now behaves identically to `zero auth chatgpt`.

## Changes

- `runAuthLogin` delegates to `runAuthChatGPT` when the provider is `chatgpt` (case-insensitive), instead of the generic `manager.Login` path.
- `--device` is rejected with a clear message for `chatgpt` since the flow is loopback-only (no device-code path).
- Help text updated to mention `zero auth login chatgpt`.

## Root cause

The generic loopback flow (`loginLoopback` in the OAuth manager) cannot satisfy ChatGPT's requirements:

1. **Wrong redirect_uri** — random port, `127.0.0.1` host, `/callback` path vs the required `localhost:1455/auth/callback`.
2. **Missing mandatory params** — `id_token_add_organizations`, `codex_cli_simplified_flow`, `originator` are not sent (the generic path passes `nil` extra params).

These are per-provider details the generic engine doesn't know about, so routing to the dedicated flow is the correct fix rather than special-casing the generic path.

Fixes #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `zero auth login` now handles ChatGPT sign-in through the dedicated browser-based flow, including a clear error when `--device` is used with ChatGPT.
  * Other authentication providers continue to use the standard login experience.

* **Documentation**
  * Updated the auth help text to better explain ChatGPT and related OAuth environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->