### PR TITLE
fix(oauth): retry secret-lock on Windows ERROR_ACCESS_DENIED (delete-pending race)

### DIFF
--- a/internal/oauth/encrypt.go
+++ b/internal/oauth/encrypt.go
@@ -114,7 +114,12 @@ func createSecretFile(path string) ([]byte, error) {
 			}
 			return writeNewSecretFile(path)
 		}
-		if !errors.Is(err, os.ErrExist) {
+		// On Windows a concurrent holder's os.Remove leaves the lock file in a
+		// "delete pending" state, so an O_EXCL create races it with
+		// ERROR_ACCESS_DENIED (os.ErrPermission) rather than ErrExist. Treat that
+		// as contention and retry too — mirroring acquireFileLock in lock.go —
+		// otherwise concurrent secret creation spuriously fails on Windows.
+		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("oauth: create token secret lock: %w", err)
 		}
 		if data, rerr := readSecretFileRetry(path); rerr == nil {


### PR DESCRIPTION
## Summary

`createSecretFile` (`internal/oauth/encrypt.go`) takes a `<secret>.lock` with `O_CREATE|O_EXCL` and retries on contention — but it only treated **`os.ErrExist`** as contention. On Windows, when a concurrent holder's `defer os.Remove(lockPath)` leaves the lock file in a **"delete pending"** state, a racer's `O_EXCL` create returns **`ERROR_ACCESS_DENIED` (`os.ErrPermission`)**, not `ErrExist` — so it fell through to a hard `oauth: create token secret lock: Access is denied` error instead of retrying.

This treats `os.ErrPermission` as retryable contention too, mirroring the **identical handling already present in `acquireFileLock` (`lock.go`, from #261)** for the exact same OS quirk. That sibling lock got the fix; this second lock loop was missed.

**Impact:** fixes the intermittently-failing Windows CI test `TestLoadOrCreateSecretConcurrentConverges` that has been red-flagging the Windows smoke job on unrelated PRs — and fixes a real Windows bug where concurrent token-secret creation (parallel logins/refreshes) could spuriously fail.

## Verification

- macOS: `go build ./...`, `go vet`, `gofmt` clean; `go test ./internal/oauth/` green; the concurrent-converge test passes under `-race` (5×).
- ⚠️ The Windows delete-pending `ERROR_ACCESS_DENIED` path **can't be reproduced off Windows** — the definitive confirmation is this PR's **Windows smoke** job going green (it was failing on that exact test before this change).

## Linked issue

Team / internal-cycle PR — no separate issue; fixes a CI-blocking Windows flake surfaced across recent PRs.

## Checklist

- [x] `go build ./...`, `go vet ./...`, `go test ./internal/oauth/` pass locally (non-Windows).
- [x] `gofmt` clean.
- [x] Fix mirrors the existing `lock.go` handling; explanatory comment added.
- [ ] Windows CI green — the real proof; watch this PR's Windows smoke job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret file creation on Windows by handling a permission-related lock contention case correctly.
  * Reduced spurious failures when multiple processes try to create secrets at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->