### PR TITLE
fix(agent): reject a malformed additional_permissions payload before prompting

### DIFF
--- a/internal/agent/additional_permissions_validation_test.go
+++ b/internal/agent/additional_permissions_validation_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/tools"
@@ -77,6 +78,37 @@ func TestExecuteToolCallRejectsAdditionalPermissionsWithoutFlagBeforePrompt(t *t
 	}
 	if promptCalls != 0 {
 		t.Fatalf("OnPermissionRequest called %d times, want 0 (must reject before prompting)", promptCalls)
+	}
+}
+
+// The rejection message must show a concrete, correctly-shaped example: a
+// model that gets this wrong once (attaching sandbox_permissions out of habit
+// from an earlier call, without a valid payload) needs enough in the error to
+// self-correct on retry instead of repeating the identical mistake.
+func TestExecuteToolCallMissingAdditionalPermissionsErrorIsActionable(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewBashTool(root))
+
+	result, err := executeToolCall(
+		context.Background(),
+		registry,
+		ToolCall{
+			ID:        "c1",
+			Name:      "bash",
+			Arguments: `{"command":"ping example.com","sandbox_permissions":"with_additional_permissions"}`,
+		},
+		PermissionModeAuto,
+		Options{},
+	)
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if !strings.Contains(result.Output, `{"network": {"enabled": true}}`) {
+		t.Fatalf("output = %q, want a concrete additional_permissions example", result.Output)
+	}
+	if !strings.Contains(result.Output, "omit sandbox_permissions") {
+		t.Fatalf("output = %q, want guidance that the flag can simply be omitted", result.Output)
 	}
 }
 

--- a/internal/agent/additional_permissions_validation_test.go
+++ b/internal/agent/additional_permissions_validation_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// A shell call that sets sandbox_permissions: with_additional_permissions but
+// omits (or malforms) additional_permissions can never succeed: the same
+// validation runs again at grant time regardless of the user's decision. It
+// must be rejected as a plain tool error BEFORE any permission prompt, not
+// surfaced as a confusing "approved but denied" prompt outcome.
+func TestExecuteToolCallRejectsMissingAdditionalPermissionsBeforePrompt(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewBashTool(root))
+
+	promptCalls := 0
+	result, err := executeToolCall(
+		context.Background(),
+		registry,
+		ToolCall{
+			ID:        "c1",
+			Name:      "bash",
+			Arguments: `{"command":"echo hi","sandbox_permissions":"with_additional_permissions"}`,
+		},
+		PermissionModeAuto,
+		Options{
+			OnPermissionRequest: func(ctx context.Context, request PermissionRequest) (PermissionDecision, error) {
+				promptCalls++
+				return PermissionDecision{Action: PermissionDecisionAllow}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if result.Status != tools.StatusError {
+		t.Fatalf("status = %q, want error", result.Status)
+	}
+	if promptCalls != 0 {
+		t.Fatalf("OnPermissionRequest called %d times, want 0 (must reject before prompting)", promptCalls)
+	}
+}
+
+// The mismatched-flag case (additional_permissions present without the
+// sandbox_permissions flag) must be rejected the same way.
+func TestExecuteToolCallRejectsAdditionalPermissionsWithoutFlagBeforePrompt(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewBashTool(root))
+
+	promptCalls := 0
+	result, err := executeToolCall(
+		context.Background(),
+		registry,
+		ToolCall{
+			ID:        "c1",
+			Name:      "bash",
+			Arguments: `{"command":"echo hi","additional_permissions":{"network":{"enabled":true}}}`,
+		},
+		PermissionModeAuto,
+		Options{
+			OnPermissionRequest: func(ctx context.Context, request PermissionRequest) (PermissionDecision, error) {
+				promptCalls++
+				return PermissionDecision{Action: PermissionDecisionAllow}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if result.Status != tools.StatusError {
+		t.Fatalf("status = %q, want error", result.Status)
+	}
+	if promptCalls != 0 {
+		t.Fatalf("OnPermissionRequest called %d times, want 0 (must reject before prompting)", promptCalls)
+	}
+}
+
+// A well-formed additional_permissions payload must still reach the normal
+// permission prompt: this fix only rejects malformed payloads.
+func TestExecuteToolCallStillPromptsForValidAdditionalPermissions(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewBashTool(root))
+
+	promptCalls := 0
+	_, err := executeToolCall(
+		context.Background(),
+		registry,
+		ToolCall{
+			ID:   "c1",
+			Name: "bash",
+			Arguments: `{"command":"echo hi","sandbox_permissions":"with_additional_permissions",` +
+				`"additional_permissions":{"network":{"enabled":true}}}`,
+		},
+		PermissionModeAuto,
+		Options{
+			OnPermissionRequest: func(ctx context.Context, request PermissionRequest) (PermissionDecision, error) {
+				promptCalls++
+				return PermissionDecision{Action: PermissionDecisionDeny}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if promptCalls != 1 {
+		t.Fatalf("OnPermissionRequest called %d times, want exactly 1 for a valid elevation request", promptCalls)
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -816,6 +816,25 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		}
 	}
 
+	// A shell command that sets sandbox_permissions: with_additional_permissions
+	// must carry a valid additional_permissions payload; inlineAdditionalPermissionsProfile
+	// is the single source of truth for that shape, and buildPermissionEvent (below)
+	// calls it again to render the prompt's scope text. Check it here, before any
+	// permission prompt is shown: a malformed payload can never be satisfied no
+	// matter what the user decides, so surfacing it as a plain tool error (which the
+	// model can see and retry) is both clearer and avoids presenting a normal-looking
+	// prompt whose "allow" path is guaranteed to fail with a confusing denial.
+	if toolFound && isShellCommandTool(call.Name) {
+		if _, _, err := inlineAdditionalPermissionsProfile(args, options.Cwd); err != nil {
+			return ToolResult{
+				ToolCallID: call.ID,
+				Name:       call.Name,
+				Status:     tools.StatusError,
+				Output:     "Error: " + err.Error(),
+			}, nil
+		}
+	}
+
 	// ask_user is intercepted in the loop (like permissions) so the question can
 	// be routed to an interactive front-end instead of blocking inside the tool.
 	// When no front-end is wired up it degrades to the tool's own graceful Run().

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2341,7 +2341,12 @@ func inlineAdditionalPermissionsProfile(args map[string]any, basePath string) (s
 	}
 	raw, ok := args["additional_permissions"]
 	if !ok || raw == nil {
-		return sandbox.RequestPermissionProfile{}, true, fmt.Errorf("missing additional_permissions; provide at least one of network or file_system")
+		return sandbox.RequestPermissionProfile{}, true, fmt.Errorf(
+			"sandbox_permissions was set to %q but no additional_permissions object was provided. "+
+				`Include one, for example additional_permissions: {"network": {"enabled": true}} or `+
+				`{"file_system": {"write": ["/path"]}}. If this command does not need elevated permissions, `+
+				"omit sandbox_permissions entirely and retry",
+			tools.SandboxPermissionsWithAdditionalPermissions)
 	}
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -2356,7 +2361,9 @@ func inlineAdditionalPermissionsProfile(args map[string]any, basePath string) (s
 		return sandbox.RequestPermissionProfile{}, true, err
 	}
 	if normalized.Empty() {
-		return sandbox.RequestPermissionProfile{}, true, fmt.Errorf("additional_permissions must include at least one requested permission in network or file_system")
+		return sandbox.RequestPermissionProfile{}, true, fmt.Errorf(
+			"additional_permissions must include at least one of network or file_system, for example " +
+				`{"network": {"enabled": true}} or {"file_system": {"write": ["/path"]}}`)
 	}
 	grantProfile, err := sandbox.RequestPermissionGrantProfile(normalized)
 	if err != nil {


### PR DESCRIPTION
## What

A shell tool call (`bash`/`exec_command`) that sets `sandbox_permissions: "with_additional_permissions"` but omits, or malforms, the `additional_permissions` payload was accepted into the normal permission-prompt flow. The user saw an ordinary-looking approval request, approved it, and only then hit a hard denial from the same validation running a second time at grant time, with the message `failed to grant session additional permissions: missing additional_permissions`.

## Why this happens

`buildPermissionEvent` (`internal/agent/loop.go`) calls `inlineAdditionalPermissionsProfile` to build the prompt's scope text, but only uses the result `if ok && err == nil`, silently discarding the exact validation error that later kills the grant in `grantInlineAdditionalPermissions`. So by the time the prompt is shown, the request is already known to be unsatisfiable, but nothing communicates that to the user.

This is most visible with models that set the `sandbox_permissions` flag inconsistently (I hit it repeatedly with a driving model that set the flag without ever including the `additional_permissions` object), producing a loop of approve-then-deny with no way to make progress on the shell command.

## Fix

`inlineAdditionalPermissionsProfile` is already the single source of truth for whether this payload is well-formed (it also catches the mismatched case: `additional_permissions` present without the flag). Run that same check up front, before any permission prompt is shown, and return a plain tool error immediately if it fails. A malformed payload can never succeed regardless of what the user decides, so:

- The user is never shown a prompt that cannot lead anywhere.
- The driving model gets a direct, actionable error it can see in the transcript and retry from with a corrected tool call.

The change is additive: one early-exit check before the existing `ask_user`/`request_permissions` interception, reusing existing validation logic with no changes to the successful path.

## Testing

Three new tests in `internal/agent/additional_permissions_validation_test.go`, all exercising `executeToolCall` directly and asserting on `OnPermissionRequest` call counts:

- Missing `additional_permissions` with the flag set: rejected, prompt never fires.
- `additional_permissions` present without the flag: rejected, prompt never fires.
- A valid payload: still reaches the prompt exactly once (confirms the fix is scoped to malformed input only).

`go build ./...`, `go vet ./internal/agent/...` clean. Full `internal/agent` suite passes; I confirmed the 4 unrelated failures in that suite (`TestRunPromptsAndAllowsOutsideWorkspaceWrite`, `TestRunSessionAllowsLaterOutsideWorkspaceWrite`, `TestRunAppliesSandboxEvenInUnsafeMode`, `TestRequestPermissionsTurnGrantAllowsLaterToolAndCleansUp`) are pre-existing on unmodified `main` in my environment and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added early validation for permission-related tool calls, so malformed `with_additional_permissions` requests fail immediately instead of showing the standard approval prompt.
  * Improved error messaging with clearer, actionable guidance (including correctly-shaped `additional_permissions` examples) when required fields are missing or normalize to an empty profile.
  * Verified that well-formed permission requests still follow the expected approval flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->