### PR TITLE
fix: add android platform support for Termux npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "os": [
     "linux",
     "darwin",
-    "win32"
+    "win32",
+    "android"
   ],
   "cpu": [
     "x64",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -14,7 +14,7 @@
 // Env overrides (testing / mirrors / locked-down installs):
 //   ZERO_SKIP_DOWNLOAD=1      skip entirely, exit 0 (wrapper will guide if run)
 //   ZERO_INSTALL_DRY_RUN=1    print the resolved plan as JSON, no network, exit 0
-//   ZERO_INSTALL_PLATFORM=…   override process.platform (linux|darwin|win32)
+//   ZERO_INSTALL_PLATFORM=…   override process.platform (linux|darwin|win32|android)
 //   ZERO_INSTALL_ARCH=…       override process.arch (x64|arm64)
 //   ZERO_REPO=owner/name      override the GitHub repo (default Gitlawb/zero)
 //   ZERO_GITHUB_BASE_URL=…    override the download host (default https://github.com)
@@ -65,6 +65,7 @@ function warnSkip(message) {
 function resolvePlatform(p) {
   switch (p) {
     case 'linux':
+    case 'android':
       return 'linux';
     case 'darwin':
       return 'macos';


### PR DESCRIPTION
## Summary

`npm install -g @gitlawb/zero` failed on Android/Termux with `EBADPLATFORM` because `package.json`'s `os` array did not include `"android"`. Termux provides a Linux userspace on the Linux kernel — the existing `linux-arm64` binary works natively.

## Changes

1. **`package.json`** — Added `"android"` to the `os` array.
2. **`scripts/postinstall.mjs`** — Mapped `android` to `linux` in `resolvePlatform()`, so the postinstall downloads the correct `linux-arm64` binary.

Verified by the reporter on Termux (Unihertz Titan 2, Android 11, aarch64): postinstall succeeds and `zero --help` runs correctly.

Fixes #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Android as a recognized platform, improving compatibility for Android-based environments.
  * Android now uses the Linux prebuilt binary path, helping the app install and run more reliably on that platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->