### PR TITLE
fix(tui): show an M suffix for million-scale token counts

### DIFF
--- a/internal/tui/human_count_test.go
+++ b/internal/tui/human_count_test.go
@@ -1,0 +1,28 @@
+package tui
+
+import "testing"
+
+func TestHumanCount(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1K"},
+		{12400, "12.4K"},
+		{200000, "200K"},
+		{999999, "1000K"},
+		// The bug: a million-scale count must switch to an M suffix instead
+		// of continuing to render as "1000K", "1200K", etc.
+		{1_000_000, "1M"},
+		{1_048_576, "1M"},
+		{1_200_000, "1.2M"},
+		{-5, "0"},
+	}
+	for _, c := range cases {
+		if got := humanCount(c.n); got != c.want {
+			t.Errorf("humanCount(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -386,17 +386,24 @@ func (m model) contextWindowSegment() string {
 }
 
 // humanCount renders a token count the way the status line wants it: 999,
-// 12.4K, 200K.
+// 12.4K, 200K, 1M, 1.2M.
 func humanCount(n int) string {
 	if n < 0 {
 		n = 0
 	}
-	if n < 1000 {
+	switch {
+	case n < 1000:
 		return strconv.Itoa(n)
+	case n < 1_000_000:
+		return humanCountScaled(float64(n)/1000, "K")
+	default:
+		return humanCountScaled(float64(n)/1_000_000, "M")
 	}
-	value := float64(n) / 1000
-	text := fmt.Sprintf("%.1fK", value)
-	return strings.Replace(text, ".0K", "K", 1)
+}
+
+func humanCountScaled(value float64, suffix string) string {
+	text := fmt.Sprintf("%.1f%s", value, suffix)
+	return strings.Replace(text, ".0"+suffix, suffix, 1)
 }
 
 // formatContextWindow renders a model's context window for the title bar


### PR DESCRIPTION
## What

The status line and sidebar context gauge ("used/window · NN%") render token counts through humanCount, which only ever produces a K suffix. A million-scale count (e.g. a 1,000,000-token context window, as advertised by 1M-context models) renders as "1000K" instead of "1M". Its sibling formatContextWindow (used for the title bar and other context-window displays) already switches to an M suffix above a million; humanCount never got the same treatment.

## Fix

Generalize humanCount to scale into M above 1,000,000, keeping the same trailing-".0" trim convention already used for K. Kept as its own implementation rather than reusing formatContextWindow's logic: that function's M-switch is a round-number heuristic tailored for context-window sizes (near-multiples of a million), while humanCount also renders live, arbitrary "used" token counts that are essentially never round.

## Testing

New TestHumanCount covers the boundary explicitly (999999 stays "1000K", matching pre-existing rounding at that boundary; 1,000,000 now renders "1M"; 1,048,576 rounds to "1M"; 1,200,000 to "1.2M") plus the pre-existing K-scale and edge cases (0, 999, negative). go vet clean, go build clean. Full internal/tui suite passes, excluding two failures pre-existing and identical on unmodified main in my environment (unrelated path-assumption issues under a deeply nested working directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token counts now display in a more readable format, including `K` and `M` suffixes for larger values.
  * Large numbers are rounded to one decimal place where needed for cleaner display.

* **Bug Fixes**
  * Fixed count formatting so values at and above one million now use an `M` suffix instead of continuing to show `K`.
  * Negative counts continue to display as `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->