### PR TITLE
fix: preserve conversation context in exec prompts

### DIFF
--- a/internal/sessions/exec_session.go
+++ b/internal/sessions/exec_session.go
@@ -161,9 +161,6 @@ func FormatExecPrompt(prompt string, prepared PreparedExec) string {
 		return prompt
 	}
 	events := promptContextEvents(prepared.ContextEvents)
-	if len(events) == 0 {
-		return prompt
-	}
 
 	lines := []string{}
 	for _, event := range events {

--- a/internal/sessions/exec_session.go
+++ b/internal/sessions/exec_session.go
@@ -160,9 +160,9 @@ func FormatExecPrompt(prompt string, prepared PreparedExec) string {
 	if prepared.Mode == ModeNew || len(prepared.ContextEvents) == 0 {
 		return prompt
 	}
-	events := prepared.ContextEvents
-	if len(events) > 20 {
-		events = events[len(events)-20:]
+	events := promptContextEvents(prepared.ContextEvents)
+	if len(events) == 0 {
+		return prompt
 	}
 
 	lines := []string{}
@@ -185,6 +185,25 @@ func FormatExecPrompt(prompt string, prepared PreparedExec) string {
 		"Current user request:",
 		prompt,
 	}, "\n")
+}
+
+func promptContextEvents(events []Event) []Event {
+	const maxPromptContextEvents = 80
+
+	filtered := make([]Event, 0, len(events))
+	for _, event := range events {
+		switch event.Type {
+		case EventMessage, EventCompaction, EventSessionFork, EventSessionChild, EventSpecialistStart, EventSpecialistStop, EventError:
+			filtered = append(filtered, event)
+		}
+	}
+	if len(filtered) == 0 {
+		filtered = append(filtered, events...)
+	}
+	if len(filtered) > maxPromptContextEvents {
+		filtered = filtered[len(filtered)-maxPromptContextEvents:]
+	}
+	return filtered
 }
 
 func forkTitle(title string) string {

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -555,6 +555,32 @@ func TestPrepareExecSessionResolvesResumeAndFork(t *testing.T) {
 	}
 }
 
+func TestFormatExecPromptKeepsConversationMessagesWhenNoisyEventsFollow(t *testing.T) {
+	events := []Event{
+		{Sequence: 1, Type: EventMessage, Payload: json.RawMessage(`{"role":"user","content":"first user request"}`)},
+		{Sequence: 2, Type: EventMessage, Payload: json.RawMessage(`{"role":"assistant","content":"first assistant answer"}`)},
+	}
+	for sequence := 3; sequence <= 45; sequence++ {
+		events = append(events, Event{Sequence: sequence, Type: EventToolResult, Payload: json.RawMessage(`{"name":"read_file","output":"noisy tool result"}`)})
+	}
+	events = append(events, Event{Sequence: 46, Type: EventMessage, Payload: json.RawMessage(`{"role":"user","content":"latest user request"}`)})
+
+	prompt := FormatExecPrompt("continue", PreparedExec{
+		Mode:          ModeResume,
+		Session:       Metadata{SessionID: "session-with-noise"},
+		ContextEvents: events,
+	})
+
+	for _, want := range []string{"first user request", "first assistant answer", "latest user request", "Current user request:", "continue"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("expected prompt to contain %q, got %q", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "noisy tool result") {
+		t.Fatalf("expected prompt to omit noisy non-conversation events, got %q", prompt)
+	}
+}
+
 func TestPrepareExecPersistsSpecialistMetadataForNewSession(t *testing.T) {
 	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T14:30:00Z")})
 

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -581,6 +581,65 @@ func TestFormatExecPromptKeepsConversationMessagesWhenNoisyEventsFollow(t *testi
 	}
 }
 
+func TestFormatExecPromptTruncatesConversationMessagesAfterFilteringNoise(t *testing.T) {
+	events := make([]Event, 0, 100)
+	for sequence := 1; sequence <= 85; sequence++ {
+		events = append(events, Event{
+			Sequence: sequence,
+			Type:     EventMessage,
+			Payload:  json.RawMessage(fmt.Sprintf(`{"role":"user","content":"conversation message %03d"}`, sequence)),
+		})
+		if sequence%10 == 0 {
+			events = append(events, Event{
+				Sequence: 1000 + sequence,
+				Type:     EventToolResult,
+				Payload:  json.RawMessage(fmt.Sprintf(`{"name":"read_file","output":"noisy tool result %03d"}`, sequence)),
+			})
+		}
+	}
+	events = append(events, Event{
+		Sequence: 2000,
+		Type:     EventToolResult,
+		Payload:  json.RawMessage(`{"name":"bash","output":"trailing noisy tool result"}`),
+	})
+
+	contextEvents := promptContextEvents(events)
+	if len(contextEvents) != 80 {
+		t.Fatalf("expected prompt context to keep 80 events, got %d", len(contextEvents))
+	}
+	if contextEvents[0].Sequence != 6 || contextEvents[len(contextEvents)-1].Sequence != 85 {
+		t.Fatalf("expected prompt context to keep message sequences 6-85, got first=%d last=%d", contextEvents[0].Sequence, contextEvents[len(contextEvents)-1].Sequence)
+	}
+
+	prompt := FormatExecPrompt("continue", PreparedExec{
+		Mode:          ModeResume,
+		Session:       Metadata{SessionID: "long-session-with-noise"},
+		ContextEvents: events,
+	})
+
+	if got, want := strings.Count(prompt, "- #"), len(contextEvents); got != want {
+		t.Fatalf("expected prompt to contain %d context event lines, got %d in %q", want, got, prompt)
+	}
+	for _, want := range []string{"conversation message 006", "conversation message 085", "Current user request:", "continue"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("expected prompt to contain %q, got %q", want, prompt)
+		}
+	}
+	for _, unwanted := range []string{
+		"conversation message 001",
+		"conversation message 002",
+		"conversation message 003",
+		"conversation message 004",
+		"conversation message 005",
+		"noisy tool result",
+		"trailing noisy tool result",
+	} {
+		if strings.Contains(prompt, unwanted) {
+			t.Fatalf("expected prompt to omit %q, got %q", unwanted, prompt)
+		}
+	}
+}
+
 func TestPrepareExecPersistsSpecialistMetadataForNewSession(t *testing.T) {
 	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T14:30:00Z")})
 


### PR DESCRIPTION
## Summary
Fixes exec/session prompt formatting so older conversation turns are preserved instead of being dropped when many later context events exist.

## What changed
- Preserve the latest event window.
- Prepend earlier conversation events when available.
- Add regression coverage for long exec/session histories.

## Tests
- go test ./internal/sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resumed session prompts to keep the most relevant conversation messages, even when unrelated/noisy events appear afterward.
  * Reduced prompt noise by filtering retained context to allowed event types and capping the context to a larger, recent window.

* **Tests**
  * Added tests to verify resume-mode prompt generation preserves conversation content while omitting noisy tool/result outputs, including correct truncation behavior with many events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->