### PR TITLE
feat(update): add zero upgrade command to apply self-updates

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -80,6 +80,7 @@ type appDeps struct {
 	runTUI                 func(context.Context, tui.Options) int
 	runEditor              func(string) error
 	checkUpdate            func(context.Context, update.Options) (update.Result, error)
+	applyUpdate            func(context.Context, update.Options) (update.ApplyResult, error)
 	now                    func() time.Time
 }
 
@@ -180,6 +181,7 @@ func defaultAppDeps() appDeps {
 		runTUI:           tui.Run,
 		runEditor:        openEditor,
 		checkUpdate:      update.Check,
+		applyUpdate:      update.Apply,
 		now:              time.Now,
 	}
 }
@@ -383,6 +385,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runSandbox(args[1:], stdout, stderr, deps)
 	case "update":
 		return runUpdate(args[1:], stdout, stderr, deps)
+	case "upgrade":
+		return runUpgrade(args[1:], stdout, stderr, deps)
 	case "worktrees", "worktree":
 		return runWorktrees(args[1:], stdout, stderr, deps)
 	case "verify":
@@ -514,6 +518,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.checkUpdate == nil {
 		deps.checkUpdate = defaults.checkUpdate
+	}
+	if deps.applyUpdate == nil {
+		deps.applyUpdate = defaults.applyUpdate
 	}
 	if deps.now == nil {
 		deps.now = defaults.now

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1370,6 +1370,32 @@ func TestRunUpdateRejectsCheckAndApplyTogether(t *testing.T) {
 	}
 }
 
+func TestRunUpdateRejectsTargetWithApply(t *testing.T) {
+	for _, args := range [][]string{
+		{"update", "--apply", "--target", "linux-arm64"},
+		{"upgrade", "--target", "linux-arm64"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			exitCode := runWithDeps(args, &stdout, &stderr, appDeps{
+				applyUpdate: func(context.Context, update.Options) (update.ApplyResult, error) {
+					t.Fatal("applyUpdate should not run when --target is combined with --apply")
+					return update.ApplyResult{}, nil
+				},
+			})
+
+			if exitCode != exitUsage {
+				t.Fatalf("expected usage exit code, got %d", exitCode)
+			}
+			if got := stderr.String(); !strings.Contains(got, "--target cannot be combined with --apply") {
+				t.Fatalf("expected --target/--apply usage error, got %q", got)
+			}
+		})
+	}
+}
+
 func TestRunUpdateReportsApplyError(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1267,6 +1267,127 @@ func TestRunUpdateReportsUpToDate(t *testing.T) {
 	}
 }
 
+func TestRunUpdateApplyTextAndJSON(t *testing.T) {
+	applyResult := update.ApplyResult{
+		Result: update.Result{
+			CurrentVersion:  "dev",
+			LatestVersion:   "0.2.0",
+			UpdateAvailable: true,
+		},
+		Applied:       true,
+		InstallMethod: update.InstallMethodStandalone,
+		BinaryPath:    "/usr/local/bin/zero",
+		Message:       "updated to 0.2.0",
+	}
+	var gotOptions update.Options
+	deps := appDeps{
+		applyUpdate: func(_ context.Context, options update.Options) (update.ApplyResult, error) {
+			gotOptions = options
+			return applyResult, nil
+		},
+		checkUpdate: func(context.Context, update.Options) (update.Result, error) {
+			t.Fatal("checkUpdate should not run for --apply")
+			return update.Result{}, nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"update", "--apply"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "updated to 0.2.0") {
+		t.Fatalf("unexpected apply text: %q", stdout.String())
+	}
+	if gotOptions.CurrentVersion != "dev" {
+		t.Fatalf("unexpected options passed to applyUpdate: %#v", gotOptions)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"update", "--apply", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var payload struct {
+		Applied       bool   `json:"applied"`
+		InstallMethod string `json:"installMethod"`
+		BinaryPath    string `json:"binaryPath"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("apply JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if !payload.Applied || payload.InstallMethod != string(update.InstallMethodStandalone) || payload.BinaryPath != applyResult.BinaryPath {
+		t.Fatalf("unexpected apply JSON: %#v", payload)
+	}
+}
+
+func TestRunUpgradeDefaultsToApply(t *testing.T) {
+	var applyCalled bool
+	deps := appDeps{
+		applyUpdate: func(context.Context, update.Options) (update.ApplyResult, error) {
+			applyCalled = true
+			return update.ApplyResult{Message: "already up to date"}, nil
+		},
+		checkUpdate: func(context.Context, update.Options) (update.Result, error) {
+			t.Fatal("checkUpdate should not run for `zero upgrade`")
+			return update.Result{}, nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"upgrade"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !applyCalled {
+		t.Fatal("expected `zero upgrade` to call applyUpdate")
+	}
+}
+
+func TestRunUpdateRejectsCheckAndApplyTogether(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"update", "--check", "--apply"}, &stdout, &stderr, appDeps{
+		checkUpdate: func(context.Context, update.Options) (update.Result, error) {
+			t.Fatal("checkUpdate should not run")
+			return update.Result{}, nil
+		},
+		applyUpdate: func(context.Context, update.Options) (update.ApplyResult, error) {
+			t.Fatal("applyUpdate should not run")
+			return update.ApplyResult{}, nil
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit code, got %d", exitCode)
+	}
+	if got := stderr.String(); !strings.Contains(got, "only one of --check or --apply") {
+		t.Fatalf("expected --check/--apply usage error, got %q", got)
+	}
+}
+
+func TestRunUpdateReportsApplyError(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"update", "--apply"}, &stdout, &stderr, appDeps{
+		applyUpdate: func(context.Context, update.Options) (update.ApplyResult, error) {
+			return update.ApplyResult{}, errors.New("download failed")
+		},
+	})
+
+	if exitCode == exitSuccess {
+		t.Fatalf("expected non-success exit code, got %d", exitCode)
+	}
+	if got := stderr.String(); !strings.Contains(got, "download failed") {
+		t.Fatalf("expected apply error, got %q", got)
+	}
+}
+
 func assertHelpOutput(t *testing.T, args []string) {
 	t.Helper()
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -12,6 +12,7 @@ import (
 
 type updateOptions struct {
 	check      bool
+	apply      bool
 	json       bool
 	repository string
 	endpoint   string
@@ -20,6 +21,18 @@ type updateOptions struct {
 }
 
 func runUpdate(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	return runUpdateCommand(args, stdout, stderr, deps, false)
+}
+
+func runUpgrade(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	return runUpdateCommand(args, stdout, stderr, deps, true)
+}
+
+// runUpdateCommand backs both `zero update` and `zero upgrade`. defaultApply
+// makes `--apply` the implicit behavior for `zero upgrade` when neither
+// `--check` nor `--apply` is passed explicitly; `zero update` keeps requiring
+// one of the two so existing scripts around `zero update --check` don't change.
+func runUpdateCommand(args []string, stdout io.Writer, stderr io.Writer, deps appDeps, defaultApply bool) int {
 	options, help, err := parseUpdateArgs(args)
 	if err != nil {
 		return writeUsageError(stderr, err.Error())
@@ -30,10 +43,16 @@ func runUpdate(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 		}
 		return exitSuccess
 	}
-	if !options.check {
-		return writeUsageError(stderr, "Only `zero update --check` is available right now.")
+	if options.check && options.apply {
+		return writeUsageError(stderr, "Pass only one of --check or --apply.")
 	}
-	checkOptions := update.Options{
+	if !options.check && !options.apply {
+		if !defaultApply {
+			return writeUsageError(stderr, "Pass --check to check for updates or --apply to install one (or use `zero upgrade`).")
+		}
+		options.apply = true
+	}
+	updateOptions := update.Options{
 		CurrentVersion: version,
 		Repository:     options.repository,
 		Endpoint:       options.endpoint,
@@ -44,10 +63,26 @@ func runUpdate(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 		if err != nil {
 			return writeUsageError(stderr, err.Error())
 		}
-		checkOptions.GOOS = target.GOOS
-		checkOptions.GOARCH = target.GOARCH
+		updateOptions.GOOS = target.GOOS
+		updateOptions.GOARCH = target.GOARCH
 	}
-	result, err := deps.checkUpdate(context.Background(), checkOptions)
+	if options.apply {
+		result, err := deps.applyUpdate(context.Background(), updateOptions)
+		if err != nil {
+			return writeAppError(stderr, "Could not install update: "+err.Error(), exitCrash)
+		}
+		if options.json {
+			if err := writePrettyJSON(stdout, result); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		if _, err := fmt.Fprintln(stdout, update.FormatApply(result)); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	result, err := deps.checkUpdate(context.Background(), updateOptions)
 	if err != nil {
 		return writeAppError(stderr, "Could not check for updates: "+err.Error(), exitCrash)
 	}
@@ -72,6 +107,8 @@ func parseUpdateArgs(args []string) (updateOptions, bool, error) {
 			return options, true, nil
 		case arg == "--check":
 			options.check = true
+		case arg == "--apply":
+			options.apply = true
 		case arg == "--json":
 			options.json = true
 		case arg == "--repo":
@@ -155,10 +192,13 @@ func parseUpdateTarget(value string) (string, error) {
 func writeUpdateHelp(w io.Writer) error {
 	_, err := fmt.Fprint(w, `Usage:
   zero update --check [flags]
+  zero update --apply [flags]
+  zero upgrade [flags]
 
 Flags:
       --check                 Check the latest GitHub release without installing
-      --json                  Print the update check result as JSON
+      --apply                 Download, verify, and install the latest release
+      --json                  Print the update result as JSON
       --repo <owner/repo>     Repository to check when no endpoint is provided
       --endpoint <url|repo>   Release API URL or owner/repo slug to check
       --timeout <duration>    Release check timeout (default 5s)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -52,6 +52,9 @@ func runUpdateCommand(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		}
 		options.apply = true
 	}
+	if options.apply && options.target != "" {
+		return writeUsageError(stderr, "--target cannot be combined with --apply; it only verifies release assets for --check.")
+	}
 	updateOptions := update.Options{
 		CurrentVersion: version,
 		Repository:     options.repository,
@@ -202,7 +205,7 @@ Flags:
       --repo <owner/repo>     Repository to check when no endpoint is provided
       --endpoint <url|repo>   Release API URL or owner/repo slug to check
       --timeout <duration>    Release check timeout (default 5s)
-      --target <platform>     Release target to verify (for example windows-x64)
+      --target <platform>     Release target to verify with --check (for example windows-x64); not valid with --apply
   -h, --help                  Show this help
 `)
 	return err

--- a/internal/oauth/encrypt.go
+++ b/internal/oauth/encrypt.go
@@ -114,7 +114,12 @@ func createSecretFile(path string) ([]byte, error) {
 			}
 			return writeNewSecretFile(path)
 		}
-		if !errors.Is(err, os.ErrExist) {
+		// On Windows a concurrent holder's os.Remove leaves the lock file in a
+		// "delete pending" state, so an O_EXCL create races it with
+		// ERROR_ACCESS_DENIED (os.ErrPermission) rather than ErrExist. Treat that
+		// as contention and retry too — mirroring acquireFileLock in lock.go —
+		// otherwise concurrent secret creation spuriously fails on Windows.
+		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("oauth: create token secret lock: %w", err)
 		}
 		if data, rerr := readSecretFileRetry(path); rerr == nil {

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -9,9 +9,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/release"
 )
+
+// DefaultDownloadTimeout bounds the archive/checksum download phase of a
+// standalone Apply, separately from Options.Timeout (which only covers the
+// small release-metadata check), so a stalled connection can't hang forever.
+const DefaultDownloadTimeout = 5 * time.Minute
 
 // ApplyResult reports the outcome of Apply.
 type ApplyResult struct {
@@ -20,6 +27,7 @@ type ApplyResult struct {
 	InstallMethod InstallMethod `json:"installMethod,omitempty"`
 	BinaryPath    string        `json:"binaryPath,omitempty"`
 	Message       string        `json:"message,omitempty"`
+	Warnings      []string      `json:"warnings,omitempty"`
 }
 
 // windowsOptionalBinaries/linuxOptionalBinaries mirror the helper binary
@@ -38,9 +46,6 @@ func Apply(ctx context.Context, options Options) (ApplyResult, error) {
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	if !checkResult.UpdateAvailable {
-		return ApplyResult{Result: checkResult, Message: "already up to date"}, nil
-	}
 
 	executablePath, err := os.Executable()
 	if err != nil {
@@ -51,8 +56,14 @@ func Apply(ctx context.Context, options Options) (ApplyResult, error) {
 	}
 	// Best-effort: remove a "<binary>.old" left behind by a previous Windows
 	// replaceBinary call now that enough time (a whole separate invocation)
-	// has passed for the old process to have released the file.
+	// has passed for the old process to have released the file. Runs
+	// regardless of whether an update is available, so it isn't stuck waiting
+	// on a future upgrade that may never come.
 	CleanupStaleBinary(executablePath)
+
+	if !checkResult.UpdateAvailable {
+		return ApplyResult{Result: checkResult, Message: "already up to date"}, nil
+	}
 
 	method := DetectInstallMethod(executablePath)
 	switch method {
@@ -68,7 +79,8 @@ func Apply(ctx context.Context, options Options) (ApplyResult, error) {
 			Message:       fmt.Sprintf("updated via npm to %s", checkResult.LatestVersion),
 		}, nil
 	default:
-		if err := applyStandaloneUpdate(ctx, checkResult, executablePath); err != nil {
+		warnings, err := applyStandaloneUpdate(ctx, checkResult, executablePath)
+		if err != nil {
 			return ApplyResult{}, err
 		}
 		return ApplyResult{
@@ -77,6 +89,7 @@ func Apply(ctx context.Context, options Options) (ApplyResult, error) {
 			InstallMethod: method,
 			BinaryPath:    executablePath,
 			Message:       fmt.Sprintf("updated to %s", checkResult.LatestVersion),
+			Warnings:      warnings,
 		}, nil
 	}
 }
@@ -86,7 +99,14 @@ func FormatApply(result ApplyResult) string {
 	if !result.Applied {
 		return Format(result.Result)
 	}
-	return fmt.Sprintf("[zero] %s (%s -> %s)\nBinary: %s", result.Message, result.CurrentVersion, result.LatestVersion, result.BinaryPath)
+	lines := []string{
+		fmt.Sprintf("[zero] %s (%s -> %s)", result.Message, result.CurrentVersion, result.LatestVersion),
+		"Binary: " + result.BinaryPath,
+	}
+	for _, warning := range result.Warnings {
+		lines = append(lines, "Warning: "+warning)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func applyNpmUpdate(ctx context.Context) error {
@@ -103,38 +123,41 @@ func applyNpmUpdate(ctx context.Context) error {
 	return nil
 }
 
-func applyStandaloneUpdate(ctx context.Context, result Result, executablePath string) error {
+func applyStandaloneUpdate(ctx context.Context, result Result, executablePath string) ([]string, error) {
 	asset := result.ReleaseAsset
 	if !asset.Verified {
-		return fmt.Errorf("release asset for %s-%s could not be verified", asset.Platform, asset.Arch)
+		return nil, fmt.Errorf("release asset for %s-%s could not be verified", asset.Platform, asset.Arch)
 	}
 
 	tempDir, err := os.MkdirTemp("", "zero-update-*")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		_ = os.RemoveAll(tempDir)
 	}()
 
+	downloadCtx, cancel := context.WithTimeout(ctx, DefaultDownloadTimeout)
+	defer cancel()
+
 	archivePath := filepath.Join(tempDir, asset.ArchiveName)
-	if err := downloadFile(ctx, asset.ArchiveURL, archivePath); err != nil {
-		return fmt.Errorf("download release archive: %w", err)
+	if err := downloadFile(downloadCtx, asset.ArchiveURL, archivePath); err != nil {
+		return nil, fmt.Errorf("download release archive: %w", err)
 	}
 	checksumPath := filepath.Join(tempDir, asset.ChecksumName)
-	if err := downloadFile(ctx, asset.ChecksumURL, checksumPath); err != nil {
-		return fmt.Errorf("download release checksum: %w", err)
+	if err := downloadFile(downloadCtx, asset.ChecksumURL, checksumPath); err != nil {
+		return nil, fmt.Errorf("download release checksum: %w", err)
 	}
 	if _, err := release.VerifySHA256Checksum(checksumPath); err != nil {
-		return fmt.Errorf("verify release checksum: %w", err)
+		return nil, fmt.Errorf("verify release checksum: %w", err)
 	}
 
 	extractDir := filepath.Join(tempDir, "extracted")
 	if err := os.MkdirAll(extractDir, 0o755); err != nil {
-		return err
+		return nil, err
 	}
 	if err := extractArchive(archivePath, extractDir); err != nil {
-		return fmt.Errorf("extract release archive: %w", err)
+		return nil, fmt.Errorf("extract release archive: %w", err)
 	}
 
 	binaryName := "zero"
@@ -148,17 +171,18 @@ func applyStandaloneUpdate(ctx context.Context, result Result, executablePath st
 
 	newBinaryPath, err := findByBasename(extractDir, binaryName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if newBinaryPath == "" {
-		return fmt.Errorf("release archive did not contain %s", binaryName)
+		return nil, fmt.Errorf("release archive did not contain %s", binaryName)
 	}
 
 	targetDir := filepath.Dir(executablePath)
 	if err := installBinary(newBinaryPath, executablePath); err != nil {
-		return err
+		return nil, err
 	}
 
+	var warnings []string
 	for _, name := range optionalBinaries {
 		source, err := findByBasename(extractDir, name)
 		if err != nil || source == "" {
@@ -168,10 +192,12 @@ func applyStandaloneUpdate(ctx context.Context, result Result, executablePath st
 		if _, err := os.Stat(destPath); err != nil {
 			continue // only refresh helpers this install already has
 		}
-		_ = installBinary(source, destPath)
+		if err := installBinary(source, destPath); err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to update helper %s: %v", name, err))
+		}
 	}
 
-	return nil
+	return warnings, nil
 }
 
 // installBinary stages sourcePath next to targetPath (same directory, so the

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -1,0 +1,243 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/Gitlawb/zero/internal/release"
+)
+
+// ApplyResult reports the outcome of Apply.
+type ApplyResult struct {
+	Result
+	Applied       bool          `json:"applied"`
+	InstallMethod InstallMethod `json:"installMethod,omitempty"`
+	BinaryPath    string        `json:"binaryPath,omitempty"`
+	Message       string        `json:"message,omitempty"`
+}
+
+// windowsOptionalBinaries/linuxOptionalBinaries mirror the helper binary
+// names scripts/postinstall.mjs copies alongside the main binary when
+// present, so `zero upgrade` refreshes them too instead of leaving them stale.
+var (
+	windowsOptionalBinaries = []string{"zero-windows-command-runner.exe", "zero-windows-sandbox-setup.exe"}
+	linuxOptionalBinaries   = []string{"zero-linux-sandbox", "zero-seccomp"}
+)
+
+// Apply checks for an update and, if one is available, installs it: via
+// `npm install -g` for npm-managed installs, or by downloading, verifying,
+// and atomically replacing the binary for standalone installs.
+func Apply(ctx context.Context, options Options) (ApplyResult, error) {
+	checkResult, err := Check(ctx, options)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if !checkResult.UpdateAvailable {
+		return ApplyResult{Result: checkResult, Message: "already up to date"}, nil
+	}
+
+	executablePath, err := os.Executable()
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("resolve current executable: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(executablePath); err == nil {
+		executablePath = resolved
+	}
+	// Best-effort: remove a "<binary>.old" left behind by a previous Windows
+	// replaceBinary call now that enough time (a whole separate invocation)
+	// has passed for the old process to have released the file.
+	CleanupStaleBinary(executablePath)
+
+	method := DetectInstallMethod(executablePath)
+	switch method {
+	case InstallMethodNpm:
+		if err := applyNpmUpdate(ctx); err != nil {
+			return ApplyResult{}, err
+		}
+		return ApplyResult{
+			Result:        checkResult,
+			Applied:       true,
+			InstallMethod: method,
+			BinaryPath:    executablePath,
+			Message:       fmt.Sprintf("updated via npm to %s", checkResult.LatestVersion),
+		}, nil
+	default:
+		if err := applyStandaloneUpdate(ctx, checkResult, executablePath); err != nil {
+			return ApplyResult{}, err
+		}
+		return ApplyResult{
+			Result:        checkResult,
+			Applied:       true,
+			InstallMethod: method,
+			BinaryPath:    executablePath,
+			Message:       fmt.Sprintf("updated to %s", checkResult.LatestVersion),
+		}, nil
+	}
+}
+
+// FormatApply renders an ApplyResult as human-readable text.
+func FormatApply(result ApplyResult) string {
+	if !result.Applied {
+		return Format(result.Result)
+	}
+	return fmt.Sprintf("[zero] %s (%s -> %s)\nBinary: %s", result.Message, result.CurrentVersion, result.LatestVersion, result.BinaryPath)
+}
+
+func applyNpmUpdate(ctx context.Context) error {
+	npmPath, err := exec.LookPath("npm")
+	if err != nil {
+		return fmt.Errorf("npm not found on PATH: reinstall with `npm install -g %s@latest`", npmPackageName)
+	}
+	command := exec.CommandContext(ctx, npmPath, "install", "-g", npmPackageName+"@latest")
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("npm install -g %s@latest: %w", npmPackageName, err)
+	}
+	return nil
+}
+
+func applyStandaloneUpdate(ctx context.Context, result Result, executablePath string) error {
+	asset := result.ReleaseAsset
+	if !asset.Verified {
+		return fmt.Errorf("release asset for %s-%s could not be verified", asset.Platform, asset.Arch)
+	}
+
+	tempDir, err := os.MkdirTemp("", "zero-update-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	archivePath := filepath.Join(tempDir, asset.ArchiveName)
+	if err := downloadFile(ctx, asset.ArchiveURL, archivePath); err != nil {
+		return fmt.Errorf("download release archive: %w", err)
+	}
+	checksumPath := filepath.Join(tempDir, asset.ChecksumName)
+	if err := downloadFile(ctx, asset.ChecksumURL, checksumPath); err != nil {
+		return fmt.Errorf("download release checksum: %w", err)
+	}
+	if _, err := release.VerifySHA256Checksum(checksumPath); err != nil {
+		return fmt.Errorf("verify release checksum: %w", err)
+	}
+
+	extractDir := filepath.Join(tempDir, "extracted")
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		return err
+	}
+	if err := extractArchive(archivePath, extractDir); err != nil {
+		return fmt.Errorf("extract release archive: %w", err)
+	}
+
+	binaryName := "zero"
+	optionalBinaries := linuxOptionalBinaries
+	if runtime.GOOS == "windows" {
+		binaryName = "zero.exe"
+		optionalBinaries = windowsOptionalBinaries
+	} else if runtime.GOOS == "darwin" {
+		optionalBinaries = nil
+	}
+
+	newBinaryPath, err := findByBasename(extractDir, binaryName)
+	if err != nil {
+		return err
+	}
+	if newBinaryPath == "" {
+		return fmt.Errorf("release archive did not contain %s", binaryName)
+	}
+
+	targetDir := filepath.Dir(executablePath)
+	if err := installBinary(newBinaryPath, executablePath); err != nil {
+		return err
+	}
+
+	for _, name := range optionalBinaries {
+		source, err := findByBasename(extractDir, name)
+		if err != nil || source == "" {
+			continue // optional: the sandbox degrades gracefully without it
+		}
+		destPath := filepath.Join(targetDir, name)
+		if _, err := os.Stat(destPath); err != nil {
+			continue // only refresh helpers this install already has
+		}
+		_ = installBinary(source, destPath)
+	}
+
+	return nil
+}
+
+// installBinary stages sourcePath next to targetPath (same directory, so the
+// final rename is atomic/same-filesystem) and then swaps it into place.
+func installBinary(sourcePath string, targetPath string) error {
+	stagedPath := targetPath + ".new"
+	if err := copyFile(sourcePath, stagedPath); err != nil {
+		return fmt.Errorf("stage %s: %w", filepath.Base(targetPath), err)
+	}
+	defer func() {
+		_ = os.Remove(stagedPath)
+	}()
+	if err := replaceBinary(targetPath, stagedPath); err != nil {
+		return fmt.Errorf("install %s: %w", filepath.Base(targetPath), err)
+	}
+	return nil
+}
+
+func copyFile(sourcePath string, destPath string) (retErr error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = source.Close()
+	}()
+	dest, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := dest.Close(); closeErr != nil && retErr == nil {
+			retErr = closeErr
+		}
+	}()
+	_, retErr = io.Copy(dest, source)
+	return retErr
+}
+
+func downloadFile(ctx context.Context, url string, destPath string) error {
+	if url == "" {
+		return fmt.Errorf("missing download URL")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("User-Agent", "zero/update")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("download failed (%s): %s", response.Status, url)
+	}
+	out, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, response.Body)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -1,0 +1,197 @@
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/release"
+)
+
+func TestApplyReturnsNoopWhenUpToDate(t *testing.T) {
+	result, err := Apply(context.Background(), Options{
+		CurrentVersion: "0.2.0",
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Fetch: func(_ context.Context, endpoint string) (Release, error) {
+			return releaseForTarget(t, "v0.2.0", "linux", "amd64"), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if result.Applied {
+		t.Fatalf("expected Applied=false when already up to date, got %#v", result)
+	}
+}
+
+func TestApplyStandaloneUpdateReplacesBinary(t *testing.T) {
+	binaryName := "zero"
+	optionalName := "zero-seccomp"
+	if runtime.GOOS == "windows" {
+		binaryName = "zero.exe"
+		optionalName = "zero-windows-command-runner.exe"
+	}
+
+	installDir := t.TempDir()
+	executablePath := filepath.Join(installDir, binaryName)
+	if err := os.WriteFile(executablePath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatalf("WriteFile executable: %v", err)
+	}
+	// Only pre-existing optional helpers should be refreshed; an absent one
+	// (e.g. the platform's other optional helper) must not be introduced.
+	existingHelperPath := filepath.Join(installDir, optionalName)
+	if err := os.WriteFile(existingHelperPath, []byte("old-helper"), 0o755); err != nil {
+		t.Fatalf("WriteFile helper: %v", err)
+	}
+
+	archiveName := "zero-v0.2.0-linux-x64.tar.gz"
+	archiveDir := t.TempDir()
+	archivePath := filepath.Join(archiveDir, archiveName)
+	writeTestTarGz(t, archivePath, map[string]string{
+		"zero":                            "new-binary",
+		"zero.exe":                        "new-binary-exe",
+		"zero-seccomp":                    "new-helper",
+		"zero-windows-command-runner.exe": "new-helper-exe",
+	})
+	checksum, err := release.SHA256File(archivePath)
+	if err != nil {
+		t.Fatalf("SHA256File: %v", err)
+	}
+	checksumText, err := release.FormatSHA256Checksum(checksum, archiveName)
+	if err != nil {
+		t.Fatalf("FormatSHA256Checksum: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + archiveName:
+			http.ServeFile(w, r, archivePath)
+		case "/" + archiveName + ".sha256":
+			_, _ = w.Write([]byte(checksumText))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	result := Result{
+		LatestVersion: "0.2.0",
+		ReleaseAsset: AssetCheck{
+			Platform:      "linux",
+			Arch:          "x64",
+			ArchiveName:   archiveName,
+			ArchiveURL:    server.URL + "/" + archiveName,
+			ChecksumName:  archiveName + ".sha256",
+			ChecksumURL:   server.URL + "/" + archiveName + ".sha256",
+			ArchiveFound:  true,
+			ChecksumFound: true,
+			Verified:      true,
+		},
+	}
+
+	if err := applyStandaloneUpdate(context.Background(), result, executablePath); err != nil {
+		t.Fatalf("applyStandaloneUpdate returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(executablePath)
+	if err != nil {
+		t.Fatalf("ReadFile executable: %v", err)
+	}
+	wantBinary := "new-binary"
+	if runtime.GOOS == "windows" {
+		wantBinary = "new-binary-exe"
+	}
+	if string(data) != wantBinary {
+		t.Fatalf("executable content = %q, want %q", data, wantBinary)
+	}
+
+	helperData, err := os.ReadFile(existingHelperPath)
+	if err != nil {
+		t.Fatalf("ReadFile helper: %v", err)
+	}
+	wantHelper := "new-helper"
+	if runtime.GOOS == "windows" {
+		wantHelper = "new-helper-exe"
+	}
+	if string(helperData) != wantHelper {
+		t.Fatalf("helper content = %q, want %q", helperData, wantHelper)
+	}
+
+	if entries, err := os.ReadDir(installDir); err == nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			// On Windows, replaceBinary leaves "<name>.old" behind (the running
+			// binary is renamed aside, not deleted) for later best-effort cleanup.
+			if name == binaryName || name == optionalName || name == binaryName+".old" || name == optionalName+".old" {
+				continue
+			}
+			t.Fatalf("unexpected extra file left in install dir: %s", name)
+		}
+	}
+}
+
+func TestApplyStandaloneUpdateRejectsChecksumMismatch(t *testing.T) {
+	binaryName := "zero"
+	if runtime.GOOS == "windows" {
+		binaryName = "zero.exe"
+	}
+
+	installDir := t.TempDir()
+	executablePath := filepath.Join(installDir, binaryName)
+	if err := os.WriteFile(executablePath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatalf("WriteFile executable: %v", err)
+	}
+
+	archiveName := "zero-v0.2.0-linux-x64.tar.gz"
+	archiveDir := t.TempDir()
+	archivePath := filepath.Join(archiveDir, archiveName)
+	writeTestTarGz(t, archivePath, map[string]string{"zero": "new-binary", "zero.exe": "new-binary-exe"})
+
+	badChecksumText, err := release.FormatSHA256Checksum("0000000000000000000000000000000000000000000000000000000000000000"[:64], archiveName)
+	if err != nil {
+		t.Fatalf("FormatSHA256Checksum: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + archiveName:
+			http.ServeFile(w, r, archivePath)
+		case "/" + archiveName + ".sha256":
+			_, _ = w.Write([]byte(badChecksumText))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	result := Result{
+		ReleaseAsset: AssetCheck{
+			Platform:      "linux",
+			Arch:          "x64",
+			ArchiveName:   archiveName,
+			ArchiveURL:    server.URL + "/" + archiveName,
+			ChecksumName:  archiveName + ".sha256",
+			ChecksumURL:   server.URL + "/" + archiveName + ".sha256",
+			ArchiveFound:  true,
+			ChecksumFound: true,
+			Verified:      true,
+		},
+	}
+
+	if err := applyStandaloneUpdate(context.Background(), result, executablePath); err == nil {
+		t.Fatal("expected checksum mismatch error")
+	}
+
+	data, err := os.ReadFile(executablePath)
+	if err != nil {
+		t.Fatalf("ReadFile executable: %v", err)
+	}
+	if string(data) != "old-binary" {
+		t.Fatalf("executable should be untouched after checksum failure, got %q", data)
+	}
+}

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/release"
@@ -102,8 +103,10 @@ func TestApplyStandaloneUpdateReplacesBinary(t *testing.T) {
 		},
 	}
 
-	if err := applyStandaloneUpdate(context.Background(), result, executablePath); err != nil {
+	if warnings, err := applyStandaloneUpdate(context.Background(), result, executablePath); err != nil {
 		t.Fatalf("applyStandaloneUpdate returned error: %v", err)
+	} else if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
 	}
 
 	data, err := os.ReadFile(executablePath)
@@ -142,6 +145,98 @@ func TestApplyStandaloneUpdateReplacesBinary(t *testing.T) {
 			}
 			t.Fatalf("unexpected extra file left in install dir: %s", name)
 		}
+	}
+}
+
+func TestApplyStandaloneUpdateWarnsWhenHelperRefreshFails(t *testing.T) {
+	binaryName := "zero"
+	optionalName := "zero-seccomp"
+	if runtime.GOOS == "windows" {
+		binaryName = "zero.exe"
+		optionalName = "zero-windows-command-runner.exe"
+	} else if runtime.GOOS == "darwin" {
+		t.Skip("macOS ships no optional helper binaries to refresh")
+	}
+
+	installDir := t.TempDir()
+	executablePath := filepath.Join(installDir, binaryName)
+	if err := os.WriteFile(executablePath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatalf("WriteFile executable: %v", err)
+	}
+	// The helper must already exist for a refresh to be attempted at all.
+	existingHelperPath := filepath.Join(installDir, optionalName)
+	if err := os.WriteFile(existingHelperPath, []byte("old-helper"), 0o755); err != nil {
+		t.Fatalf("WriteFile helper: %v", err)
+	}
+	// Force installBinary's staging copy to fail by occupying its staged
+	// "<helper>.new" path with a directory instead of a file.
+	if err := os.MkdirAll(existingHelperPath+".new", 0o755); err != nil {
+		t.Fatalf("MkdirAll staged path: %v", err)
+	}
+
+	archiveName := "zero-v0.2.0-linux-x64.tar.gz"
+	archiveDir := t.TempDir()
+	archivePath := filepath.Join(archiveDir, archiveName)
+	writeTestTarGz(t, archivePath, map[string]string{
+		"zero":                            "new-binary",
+		"zero.exe":                        "new-binary-exe",
+		"zero-seccomp":                    "new-helper",
+		"zero-windows-command-runner.exe": "new-helper-exe",
+	})
+	checksum, err := release.SHA256File(archivePath)
+	if err != nil {
+		t.Fatalf("SHA256File: %v", err)
+	}
+	checksumText, err := release.FormatSHA256Checksum(checksum, archiveName)
+	if err != nil {
+		t.Fatalf("FormatSHA256Checksum: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + archiveName:
+			http.ServeFile(w, r, archivePath)
+		case "/" + archiveName + ".sha256":
+			_, _ = w.Write([]byte(checksumText))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	result := Result{
+		LatestVersion: "0.2.0",
+		ReleaseAsset: AssetCheck{
+			Platform:      "linux",
+			Arch:          "x64",
+			ArchiveName:   archiveName,
+			ArchiveURL:    server.URL + "/" + archiveName,
+			ChecksumName:  archiveName + ".sha256",
+			ChecksumURL:   server.URL + "/" + archiveName + ".sha256",
+			ArchiveFound:  true,
+			ChecksumFound: true,
+			Verified:      true,
+		},
+	}
+
+	warnings, err := applyStandaloneUpdate(context.Background(), result, executablePath)
+	if err != nil {
+		t.Fatalf("applyStandaloneUpdate returned error: %v", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], optionalName) {
+		t.Fatalf("expected one warning mentioning %s, got %v", optionalName, warnings)
+	}
+
+	data, err := os.ReadFile(executablePath)
+	if err != nil {
+		t.Fatalf("ReadFile executable: %v", err)
+	}
+	wantBinary := "new-binary"
+	if runtime.GOOS == "windows" {
+		wantBinary = "new-binary-exe"
+	}
+	if string(data) != wantBinary {
+		t.Fatalf("main binary should still be updated despite helper failure: got %q, want %q", data, wantBinary)
 	}
 }
 
@@ -193,7 +288,7 @@ func TestApplyStandaloneUpdateRejectsChecksumMismatch(t *testing.T) {
 		},
 	}
 
-	if err := applyStandaloneUpdate(context.Background(), result, executablePath); err == nil {
+	if _, err := applyStandaloneUpdate(context.Background(), result, executablePath); err == nil {
 		t.Fatal("expected checksum mismatch error")
 	}
 

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -31,10 +31,15 @@ func TestApplyReturnsNoopWhenUpToDate(t *testing.T) {
 
 func TestApplyStandaloneUpdateReplacesBinary(t *testing.T) {
 	binaryName := "zero"
-	optionalName := "zero-seccomp"
-	if runtime.GOOS == "windows" {
+	// macOS ships no optional helper binaries (matching scripts/postinstall.mjs),
+	// so there's nothing to refresh there; only linux/windows have one to check.
+	optionalName := ""
+	switch runtime.GOOS {
+	case "windows":
 		binaryName = "zero.exe"
 		optionalName = "zero-windows-command-runner.exe"
+	case "linux":
+		optionalName = "zero-seccomp"
 	}
 
 	installDir := t.TempDir()
@@ -44,9 +49,12 @@ func TestApplyStandaloneUpdateReplacesBinary(t *testing.T) {
 	}
 	// Only pre-existing optional helpers should be refreshed; an absent one
 	// (e.g. the platform's other optional helper) must not be introduced.
-	existingHelperPath := filepath.Join(installDir, optionalName)
-	if err := os.WriteFile(existingHelperPath, []byte("old-helper"), 0o755); err != nil {
-		t.Fatalf("WriteFile helper: %v", err)
+	var existingHelperPath string
+	if optionalName != "" {
+		existingHelperPath = filepath.Join(installDir, optionalName)
+		if err := os.WriteFile(existingHelperPath, []byte("old-helper"), 0o755); err != nil {
+			t.Fatalf("WriteFile helper: %v", err)
+		}
 	}
 
 	archiveName := "zero-v0.2.0-linux-x64.tar.gz"
@@ -110,16 +118,18 @@ func TestApplyStandaloneUpdateReplacesBinary(t *testing.T) {
 		t.Fatalf("executable content = %q, want %q", data, wantBinary)
 	}
 
-	helperData, err := os.ReadFile(existingHelperPath)
-	if err != nil {
-		t.Fatalf("ReadFile helper: %v", err)
-	}
-	wantHelper := "new-helper"
-	if runtime.GOOS == "windows" {
-		wantHelper = "new-helper-exe"
-	}
-	if string(helperData) != wantHelper {
-		t.Fatalf("helper content = %q, want %q", helperData, wantHelper)
+	if optionalName != "" {
+		helperData, err := os.ReadFile(existingHelperPath)
+		if err != nil {
+			t.Fatalf("ReadFile helper: %v", err)
+		}
+		wantHelper := "new-helper"
+		if runtime.GOOS == "windows" {
+			wantHelper = "new-helper-exe"
+		}
+		if string(helperData) != wantHelper {
+			t.Fatalf("helper content = %q, want %q", helperData, wantHelper)
+		}
 	}
 
 	if entries, err := os.ReadDir(installDir); err == nil {
@@ -127,7 +137,7 @@ func TestApplyStandaloneUpdateReplacesBinary(t *testing.T) {
 			name := entry.Name()
 			// On Windows, replaceBinary leaves "<name>.old" behind (the running
 			// binary is renamed aside, not deleted) for later best-effort cleanup.
-			if name == binaryName || name == optionalName || name == binaryName+".old" || name == optionalName+".old" {
+			if name == binaryName || (optionalName != "" && name == optionalName) || name == binaryName+".old" || (optionalName != "" && name == optionalName+".old") {
 				continue
 			}
 			t.Fatalf("unexpected extra file left in install dir: %s", name)

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -1,0 +1,165 @@
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// extractArchive extracts a .tar.gz or .zip release archive into destDir.
+func extractArchive(archivePath string, destDir string) error {
+	if strings.HasSuffix(archivePath, ".zip") {
+		return extractZip(archivePath, destDir)
+	}
+	return extractTarGz(archivePath, destDir)
+}
+
+func extractTarGz(archivePath string, destDir string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = gzipReader.Close()
+	}()
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		target, err := safeExtractPath(destDir, header.Name)
+		if err != nil {
+			return err
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			if err := writeExtractedFile(target, tarReader, fs.FileMode(header.Mode)); err != nil {
+				return err
+			}
+		default:
+			// Release archives only ever contain regular files and directories;
+			// reject anything else (symlinks, devices) rather than silently skip it.
+			return fmt.Errorf("unsupported archive entry type for %s", header.Name)
+		}
+	}
+}
+
+func extractZip(archivePath string, destDir string) error {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+	for _, entry := range reader.File {
+		target, err := safeExtractPath(destDir, entry.Name)
+		if err != nil {
+			return err
+		}
+		if entry.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := func() error {
+			entryReader, err := entry.Open()
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = entryReader.Close()
+			}()
+			return writeExtractedFile(target, entryReader, entry.Mode())
+		}(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeExtractedFile(target string, source io.Reader, mode fs.FileMode) error {
+	if mode == 0 {
+		mode = 0o644
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, source)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+// safeExtractPath resolves an archive entry name against destDir, rejecting
+// absolute paths or entries that would escape destDir via "..".
+func safeExtractPath(destDir string, name string) (string, error) {
+	cleanName := filepath.Clean(strings.ReplaceAll(name, "\\", "/"))
+	if cleanName == "." {
+		return destDir, nil
+	}
+	if filepath.IsAbs(cleanName) || cleanName == ".." || strings.HasPrefix(cleanName, "../") {
+		return "", fmt.Errorf("archive entry escapes destination: %s", name)
+	}
+	target := filepath.Join(destDir, cleanName)
+	destDirClean := filepath.Clean(destDir)
+	if target != destDirClean && !strings.HasPrefix(target, destDirClean+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive entry escapes destination: %s", name)
+	}
+	return target, nil
+}
+
+// findByBasename recursively searches root for the first regular file whose
+// basename matches name, mirroring scripts/postinstall.mjs's lookup so
+// helper binaries nested under archive subdirectories (e.g. helpers/) are
+// still found.
+func findByBasename(root string, name string) (string, error) {
+	var found string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if found != "" {
+			return fs.SkipAll
+		}
+		if !entry.IsDir() && entry.Name() == name {
+			found = path
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return found, nil
+}

--- a/internal/update/extract_test.go
+++ b/internal/update/extract_test.go
@@ -1,0 +1,177 @@
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestTarGz(t *testing.T, archivePath string, entries map[string]string) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("Create archive: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	gzipWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for name, content := range entries {
+		header := &tar.Header{Name: name, Mode: 0o755, Size: int64(len(content))}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("WriteHeader %s: %v", name, err)
+		}
+		if _, err := tarWriter.Write([]byte(content)); err != nil {
+			t.Fatalf("Write %s: %v", name, err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+}
+
+func writeTestZip(t *testing.T, archivePath string, entries map[string]string) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("Create archive: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	zipWriter := zip.NewWriter(file)
+	for name, content := range entries {
+		writer, err := zipWriter.Create(name)
+		if err != nil {
+			t.Fatalf("Create entry %s: %v", name, err)
+		}
+		if _, err := writer.Write([]byte(content)); err != nil {
+			t.Fatalf("Write %s: %v", name, err)
+		}
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatalf("close zip writer: %v", err)
+	}
+}
+
+func TestExtractTarGzRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "archive.tar.gz")
+	writeTestTarGz(t, archivePath, map[string]string{
+		"zero":                 "main-binary",
+		"helpers/zero-seccomp": "helper-binary",
+	})
+
+	destDir := filepath.Join(dir, "extracted")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := extractArchive(archivePath, destDir); err != nil {
+		t.Fatalf("extractArchive: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destDir, "zero"))
+	if err != nil {
+		t.Fatalf("ReadFile zero: %v", err)
+	}
+	if string(data) != "main-binary" {
+		t.Fatalf("zero content = %q", data)
+	}
+	data, err = os.ReadFile(filepath.Join(destDir, "helpers", "zero-seccomp"))
+	if err != nil {
+		t.Fatalf("ReadFile helpers/zero-seccomp: %v", err)
+	}
+	if string(data) != "helper-binary" {
+		t.Fatalf("helpers/zero-seccomp content = %q", data)
+	}
+}
+
+func TestExtractZipRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "archive.zip")
+	writeTestZip(t, archivePath, map[string]string{
+		"zero.exe": "main-binary",
+	})
+
+	destDir := filepath.Join(dir, "extracted")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := extractArchive(archivePath, destDir); err != nil {
+		t.Fatalf("extractArchive: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destDir, "zero.exe"))
+	if err != nil {
+		t.Fatalf("ReadFile zero.exe: %v", err)
+	}
+	if string(data) != "main-binary" {
+		t.Fatalf("zero.exe content = %q", data)
+	}
+}
+
+func TestExtractTarGzRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "archive.tar.gz")
+	writeTestTarGz(t, archivePath, map[string]string{
+		"../escape": "malicious",
+	})
+
+	destDir := filepath.Join(dir, "extracted")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := extractArchive(archivePath, destDir); err == nil {
+		t.Fatal("expected extractArchive to reject a path-traversal entry")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "escape")); err == nil {
+		t.Fatal("path traversal entry was written outside the destination directory")
+	}
+}
+
+func TestExtractZipRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "archive.zip")
+	writeTestZip(t, archivePath, map[string]string{
+		"../../escape.exe": "malicious",
+	})
+
+	destDir := filepath.Join(dir, "extracted")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := extractArchive(archivePath, destDir); err == nil {
+		t.Fatal("expected extractArchive to reject a path-traversal entry")
+	}
+}
+
+func TestFindByBasenameSearchesRecursively(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "helpers")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	wantPath := filepath.Join(nested, "zero-seccomp")
+	if err := os.WriteFile(wantPath, []byte("helper"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	found, err := findByBasename(dir, "zero-seccomp")
+	if err != nil {
+		t.Fatalf("findByBasename: %v", err)
+	}
+	if found != wantPath {
+		t.Fatalf("findByBasename = %q, want %q", found, wantPath)
+	}
+
+	notFound, err := findByBasename(dir, "does-not-exist")
+	if err != nil {
+		t.Fatalf("findByBasename: %v", err)
+	}
+	if notFound != "" {
+		t.Fatalf("findByBasename = %q, want empty", notFound)
+	}
+}

--- a/internal/update/installmethod.go
+++ b/internal/update/installmethod.go
@@ -1,0 +1,45 @@
+package update
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// npmPackageName is the published package name for the npm distribution of
+// zero (see package.json). scripts/postinstall.mjs downloads the native
+// binary into the same directory as package.json and leaves a
+// ".zero-binary-version" marker file next to it — both are reliable signals
+// that a given executable came from an npm install.
+const npmPackageName = "@gitlawb/zero"
+
+// InstallMethod identifies how the running zero binary was installed.
+type InstallMethod string
+
+const (
+	InstallMethodNpm        InstallMethod = "npm"
+	InstallMethodStandalone InstallMethod = "standalone"
+)
+
+// DetectInstallMethod inspects the directory containing executablePath for
+// npm-install markers left by scripts/postinstall.mjs.
+func DetectInstallMethod(executablePath string) InstallMethod {
+	dir := filepath.Dir(executablePath)
+	if _, err := os.Stat(filepath.Join(dir, ".zero-binary-version")); err == nil {
+		return InstallMethodNpm
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return InstallMethodStandalone
+	}
+	var pkg struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return InstallMethodStandalone
+	}
+	if pkg.Name == npmPackageName {
+		return InstallMethodNpm
+	}
+	return InstallMethodStandalone
+}

--- a/internal/update/installmethod_test.go
+++ b/internal/update/installmethod_test.go
@@ -1,0 +1,60 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectInstallMethodStandaloneByDefault(t *testing.T) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "zero")
+	if err := os.WriteFile(exePath, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if method := DetectInstallMethod(exePath); method != InstallMethodStandalone {
+		t.Fatalf("DetectInstallMethod = %q, want standalone", method)
+	}
+}
+
+func TestDetectInstallMethodNpmViaMarkerFile(t *testing.T) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "zero")
+	if err := os.WriteFile(exePath, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".zero-binary-version"), []byte("0.1.0\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile marker: %v", err)
+	}
+	if method := DetectInstallMethod(exePath); method != InstallMethodNpm {
+		t.Fatalf("DetectInstallMethod = %q, want npm", method)
+	}
+}
+
+func TestDetectInstallMethodNpmViaPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "zero")
+	if err := os.WriteFile(exePath, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"@gitlawb/zero"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile package.json: %v", err)
+	}
+	if method := DetectInstallMethod(exePath); method != InstallMethodNpm {
+		t.Fatalf("DetectInstallMethod = %q, want npm", method)
+	}
+}
+
+func TestDetectInstallMethodIgnoresUnrelatedPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "zero")
+	if err := os.WriteFile(exePath, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"some-other-package"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile package.json: %v", err)
+	}
+	if method := DetectInstallMethod(exePath); method != InstallMethodStandalone {
+		t.Fatalf("DetectInstallMethod = %q, want standalone", method)
+	}
+}

--- a/internal/update/replace_other.go
+++ b/internal/update/replace_other.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package update
+
+import "os"
+
+// replaceBinary installs newPath over targetPath. On POSIX systems renaming
+// over a running executable is safe: the process currently executing it keeps
+// its open inode, and the rename is atomic within the same filesystem.
+func replaceBinary(targetPath string, newPath string) error {
+	if err := os.Chmod(newPath, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(newPath, targetPath)
+}
+
+// CleanupStaleBinary is a no-op outside Windows, which is the only platform
+// that requires renaming a running binary aside instead of replacing it directly.
+func CleanupStaleBinary(targetPath string) {}

--- a/internal/update/replace_windows.go
+++ b/internal/update/replace_windows.go
@@ -18,7 +18,9 @@ func replaceBinary(targetPath string, newPath string) error {
 		return fmt.Errorf("rename running binary aside: %w", err)
 	}
 	if err := os.Rename(newPath, targetPath); err != nil {
-		_ = os.Rename(oldPath, targetPath)
+		if restoreErr := os.Rename(oldPath, targetPath); restoreErr != nil {
+			return fmt.Errorf("install new binary: %w; additionally failed to restore the original binary: %v (original preserved at %s)", err, restoreErr, oldPath)
+		}
 		return fmt.Errorf("install new binary: %w", err)
 	}
 	return nil

--- a/internal/update/replace_windows.go
+++ b/internal/update/replace_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package update
+
+import (
+	"fmt"
+	"os"
+)
+
+// replaceBinary installs newPath over targetPath. Windows will not let a
+// running executable be overwritten or deleted directly, but NTFS does allow
+// renaming it aside — the same trick already used for locked config files in
+// internal/cli/mcp_config.go's replaceMCPWritableConfigFile.
+func replaceBinary(targetPath string, newPath string) error {
+	oldPath := targetPath + ".old"
+	_ = os.Remove(oldPath) // best-effort cleanup of a leftover from a previous upgrade
+	if err := os.Rename(targetPath, oldPath); err != nil {
+		return fmt.Errorf("rename running binary aside: %w", err)
+	}
+	if err := os.Rename(newPath, targetPath); err != nil {
+		_ = os.Rename(oldPath, targetPath)
+		return fmt.Errorf("install new binary: %w", err)
+	}
+	return nil
+}
+
+// CleanupStaleBinary best-effort removes a "<path>.old" file left behind by a
+// previous replaceBinary call once the old process holding it has exited.
+// Callers should invoke this once at startup for the current executable.
+func CleanupStaleBinary(targetPath string) {
+	_ = os.Remove(targetPath + ".old")
+}


### PR DESCRIPTION
## Summary

Closes #459. Extends the existing `zero update --check` (check-only) with an actual apply/install step:

- `zero update --apply` / `zero upgrade` download, sha256-verify, and install the latest release.
- npm installs delegate to `npm install -g @gitlawb/zero@latest`.
- Standalone installs download the release archive, verify its checksum, extract it (zip-slip guarded), and atomically replace the running binary plus any pre-existing optional sandbox helper binaries.
- On Windows, the running exe is renamed aside (NTFS allows this even while it's executing) since it can't be overwritten directly; the leftover `.old` file is cleaned up on a later invocation.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./internal/update/... ./internal/cli/...` passes, including new tests for archive extraction (incl. zip-slip rejection), install-method detection, checksum-mismatch rejection, and CLI wiring (`--apply`, `--check`+`--apply` conflict, `upgrade` alias)
- [x] Manual end-to-end on Windows: built the binary, pointed it at a local fake GitHub-releases server, ran `zero update --check` then `zero upgrade`, confirmed the binary was downloaded, checksum-verified, and swapped in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `upgrade` command that installs available updates by default.
  * Added `update --apply` to install updates, with improved messaging and richer `--json` output.
* **Bug Fixes**
  * Improved CLI validation and exit codes (disallowing incompatible flag combinations and reporting apply/check failures correctly).
  * Safer update installation: checksum verification, secure archive extraction, and atomic binary replacement (including best-effort handling of optional helpers).
  * Improved concurrent secret creation reliability on Windows to reduce spurious permission errors.
* **Tests**
  * Expanded coverage for apply/upgrade behavior, CLI validation, install failure handling, and extraction security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->