### PR TITLE
feat: support Shift+Enter for composer newlines

### DIFF
--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -306,7 +306,7 @@ func (m model) composerPositionAtVisualCell(x int, y int, width int) (int, bool)
 func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 	state := m.currentComposerState()
 	switch {
-	case keyIs(msg, tea.KeyEnter) && keyAlt(msg):
+	case keyIs(msg, tea.KeyEnter) && (keyAlt(msg) || keyShift(msg)):
 		m = m.insertComposerTextWithPastePreview(state, "\n", "")
 	case keyCtrl(msg, 'j'):
 		m = m.insertComposerTextWithPastePreview(state, "\n", "")

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -299,7 +299,8 @@ func TestModifiedEnterInsertsNewlineWithoutSubmitting(t *testing.T) {
 		key  tea.Msg
 	}{
 		{name: "alt enter", key: testKeyAlt(tea.KeyEnter)},
-		{name: "shift enter", key: testKeyCtrl('j')},
+		{name: "shift enter", key: testKeyShift(tea.KeyEnter)},
+		{name: "ctrl j", key: testKeyCtrl('j')},
 	}
 
 	for _, tc := range tests {

--- a/internal/tui/keybinding_help.go
+++ b/internal/tui/keybinding_help.go
@@ -36,7 +36,7 @@ func (m model) buildKeybindingGroups() []keybindingGroup {
 			title: "Chat",
 			bindings: []keybinding{
 				{"Enter", "send the message"},
-				{"Alt+Enter", "insert a newline (multi-line compose)"},
+				{"Shift+Enter / Alt+Enter", "insert a newline (multi-line compose)"},
 				{"Esc (\u00d72)", "cancel the run / dismiss a popup / clear the input"},
 				{"Ctrl+C", "cancel the run, then quit"},
 				{"?", "show this help (on an empty input)"},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1239,7 +1239,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.picker != nil {
 				return m.choosePicker()
 			}
-			if keyAlt(msg) {
+			if keyAlt(msg) || keyShift(msg) {
 				if next, ok := m.applyComposerKey(msg); ok {
 					return next, nil
 				}


### PR DESCRIPTION
## Summary

Adds Shift+Enter as an additional composer shortcut for inserting a newline.

## What changed

- Keeps Enter behavior unchanged: submits the prompt.
- Keeps existing newline shortcuts unchanged: Alt+Enter and Ctrl+J.
- Adds Shift+Enter as another newline shortcut.
- Updates keybinding help/tests.

## Tests

- go test ./internal/tui

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated composer Enter handling so **Shift+Enter** and **Alt+Enter** both insert a newline instead of submitting.
  * Ensured multi-line compose shortcuts behave consistently with the new Enter behavior.
  * Updated shortcut help text to display **Shift+Enter / Alt+Enter** for multi-line compose.
* **Tests**
  * Improved automated coverage for modified Enter cases (including Shift and Ctrl variants).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->