### PR TITLE
fix(tools): fix cmd.exe /S/C corrupting commands with embedded quotes

### DIFF
--- a/internal/sandbox/windows_process_windows.go
+++ b/internal/sandbox/windows_process_windows.go
@@ -87,11 +87,20 @@ func windowsCommandLine(args []string) (string, error) {
 	if len(args) == 0 {
 		return "", errorsNewWindowsProcess("missing command")
 	}
-	out := make([]string, 0, len(args))
 	for _, arg := range args {
 		if strings.ContainsRune(arg, 0) {
 			return "", errorsNewWindowsProcess("command argument contains NUL")
 		}
+	}
+	// Zero's cmd.exe shell invocation needs its final element (the shell
+	// command text) reaching cmd.exe raw, not escaped like a normal argv
+	// element: see WindowsShellCommandLine for why. Every other command this
+	// runner might launch is escaped normally below.
+	if commandLine, ok := windowsShellCommandLineFromArgs(args); ok {
+		return commandLine, nil
+	}
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
 		out = append(out, syscall.EscapeArg(arg))
 	}
 	return strings.Join(out, " "), nil

--- a/internal/sandbox/windows_runner.go
+++ b/internal/sandbox/windows_runner.go
@@ -105,6 +105,56 @@ const (
 	WindowsSandboxLevelDisabled   WindowsSandboxLevel = "disabled"
 )
 
+// WindowsShellArgs returns cmd.exe's argv (after the executable name) for
+// running commandText as a shell command on Windows: no wrapping quotes and
+// no /S, so commandText reaches cmd.exe's own /C remainder parsing exactly as
+// written. See WindowsShellCommandLine for why that matters. Used both as
+// CommandSpec.Args for the plain (unwrapped) path and, via
+// windowsShellCommandLineFromArgs, to recognize this same shape once it has
+// round-tripped through the sandboxed runner's CLI argv.
+func WindowsShellArgs(commandText string) []string {
+	return []string{"/d", "/c", commandText}
+}
+
+// WindowsShellCommandLine builds the raw command line a Windows CreateProcess
+// call should receive to run commandText as a shell command: "cmd.exe /d /c "
+// followed by commandText completely unescaped.
+//
+// cmd.exe's own /C remainder parsing is not CommandLineToArgvW-compatible: it
+// applies its own quote-stripping heuristic (documented in `cmd /?`) whenever
+// the remainder starts with a literal quote, and that heuristic does not
+// understand backslash-escaped inner quotes the way a normal argv consumer
+// would. A command like `python -c "print(15 / 3)"` passed through the
+// standard exec.Cmd Args mechanism gets wrapped in an outer pair of quotes
+// (because it contains spaces) with its own quotes escaped as \" — exactly
+// the shape that heuristic corrupts, stripping the outer quotes but leaving
+// the literal backslashes behind. Passing commandText through raw, exactly as
+// the model wrote it, means cmd.exe parses it the same way it would if typed
+// directly at an interactive prompt: a leading quoted executable path like
+// `"C:\Program Files\foo.exe" arg` is preserved correctly by cmd.exe's own
+// quote-preserving special case, and a command with no leading quote at all,
+// like the python example above, is never touched by the stripping heuristic
+// in the first place.
+func WindowsShellCommandLine(commandText string) string {
+	return "cmd.exe /d /c " + commandText
+}
+
+// windowsShellCommandLineFromArgs reports whether args is exactly
+// ["cmd.exe"]+WindowsShellArgs(text) for some text and, if so, returns
+// WindowsShellCommandLine's result for that text. The sandboxed runner path
+// only has the deserialized argv (WindowsSandboxCommandConfig.Command) to
+// work from, not the original commandText, so it recovers the raw command
+// line by recognizing the shape instead.
+func windowsShellCommandLineFromArgs(args []string) (string, bool) {
+	if len(args) != 4 {
+		return "", false
+	}
+	if !strings.EqualFold(args[0], "cmd.exe") || args[1] != "/d" || args[2] != "/c" {
+		return "", false
+	}
+	return WindowsShellCommandLine(args[3]), true
+}
+
 type WindowsSandboxCommandArgsOptions struct {
 	SandboxHome       string
 	CommandCWD        string

--- a/internal/sandbox/windows_runner_test.go
+++ b/internal/sandbox/windows_runner_test.go
@@ -147,3 +147,56 @@ func TestRunWindowsSandboxCommandRunnerRejectsInvalidArgs(t *testing.T) {
 		t.Fatalf("stderr = %q, want runner name", stderr.String())
 	}
 }
+
+func TestWindowsShellArgsHasNoSAndKeepsCommandTextWhole(t *testing.T) {
+	args := WindowsShellArgs(`python -c "print(15 / 3)"`)
+	want := []string{"/d", "/c", `python -c "print(15 / 3)"`}
+	if len(args) != len(want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+	for index := range want {
+		if args[index] != want[index] {
+			t.Fatalf("args = %#v, want %#v", args, want)
+		}
+	}
+}
+
+func TestWindowsShellCommandLineLeavesCommandTextUnescaped(t *testing.T) {
+	// The whole point of this function: commandText's own quotes must reach
+	// cmd.exe exactly as written, not re-quoted or backslash-escaped the way
+	// a normal argv-escaping function (like syscall.EscapeArg) would treat an
+	// argument containing spaces and embedded quotes.
+	commandText := `python -c "print(15 / 3)"`
+	got := WindowsShellCommandLine(commandText)
+	want := `cmd.exe /d /c python -c "print(15 / 3)"`
+	if got != want {
+		t.Fatalf("WindowsShellCommandLine = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsShellCommandLineFromArgsRecognizesTheShellShape(t *testing.T) {
+	commandLine, ok := windowsShellCommandLineFromArgs([]string{"cmd.exe", "/d", "/c", `echo "hi"`})
+	if !ok {
+		t.Fatal("windowsShellCommandLineFromArgs did not recognize the shell shape")
+	}
+	if want := `cmd.exe /d /c echo "hi"`; commandLine != want {
+		t.Fatalf("commandLine = %q, want %q", commandLine, want)
+	}
+}
+
+func TestWindowsShellCommandLineFromArgsRejectsOtherShapes(t *testing.T) {
+	cases := [][]string{
+		nil,
+		{"cmd.exe"},
+		{"cmd.exe", "/d", "/c"},
+		{"cmd.exe", "/d", "/c", "echo hi", "extra"},
+		{"git.exe", "/d", "/c", "echo hi"},
+		{"cmd.exe", "/s", "/c", "echo hi"},
+		{"cmd.exe", "/d", "/k", "echo hi"},
+	}
+	for _, args := range cases {
+		if _, ok := windowsShellCommandLineFromArgs(args); ok {
+			t.Fatalf("windowsShellCommandLineFromArgs(%#v) matched, want no match", args)
+		}
+	}
+}

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -112,7 +111,7 @@ func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroS
 	if commandEngine == nil && sandboxPermissions == SandboxPermissionsRequireEscalated {
 		meta["sandbox_permissions"] = string(SandboxPermissionsRequireEscalated)
 	}
-	command, plan, cleanup, err := buildBashCommand(commandCtx, commandText, absoluteCwd, commandEngine)
+	command, plan, err := buildBashCommand(commandCtx, commandText, absoluteCwd, commandEngine)
 	if err != nil {
 		meta["exit_code"] = "-1"
 		return Result{
@@ -121,10 +120,6 @@ func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroS
 			Meta:   meta,
 		}
 	}
-	// Release any plan-scoped resources, and any resources buildBashCommand
-	// itself allocated (e.g. a Windows temp script file), once the command has
-	// finished running.
-	defer cleanup()
 	defer plan.Cleanup()
 	addSandboxMeta(meta, plan)
 
@@ -225,29 +220,26 @@ func shellIssueBlockResult(issue shellIssue) Result {
 	}
 }
 
-// buildBashCommand returns the exec.Cmd, the sandbox plan, and a cleanup func
-// the caller must run once the command has finished (in addition to
-// plan.Cleanup()) to release any resources this function allocated outside
-// the plan itself, such as the Windows temp script file below.
-func buildBashCommand(ctx context.Context, commandText string, absoluteCwd string, engine *zeroSandbox.Engine) (*exec.Cmd, zeroSandbox.CommandPlan, func(), error) {
-	name := shellExecutable()
-	args := shellArguments(commandText)
-	cleanup := func() {}
-	if runtime.GOOS == "windows" {
-		scriptName, scriptArgs, scriptCleanup, err := windowsShellCommandSpec(commandText)
-		if err != nil {
-			return nil, zeroSandbox.CommandPlan{}, func() {}, err
-		}
-		name, args, cleanup = scriptName, scriptArgs, scriptCleanup
-	}
+// buildBashCommand returns the exec.Cmd and the sandbox plan for running
+// commandText. On Windows, when the command is not wrapped by the sandbox
+// engine (plan.Wrapped == false), it also overrides the child's raw command
+// line so commandText reaches cmd.exe unescaped; see
+// zeroSandbox.WindowsShellCommandLine for why that matters. The wrapped case
+// gets the same treatment inside the sandboxed runner process itself
+// (internal/sandbox/windows_process_windows.go), since that command line is
+// built there, not here.
+func buildBashCommand(ctx context.Context, commandText string, absoluteCwd string, engine *zeroSandbox.Engine) (*exec.Cmd, zeroSandbox.CommandPlan, error) {
 	spec := zeroSandbox.CommandSpec{
-		Name: name,
-		Args: args,
+		Name: shellExecutable(),
+		Args: shellArguments(commandText),
 		Dir:  absoluteCwd,
 	}
 	if engine != nil {
 		command, plan, err := engine.CommandContext(ctx, spec)
-		return command, plan, cleanup, err
+		if err == nil {
+			applyWindowsShellCommandLine(command, commandText, plan.Wrapped)
+		}
+		return command, plan, err
 	}
 	plan := zeroSandbox.CommandPlan{
 		Backend: zeroSandbox.Backend{
@@ -261,48 +253,8 @@ func buildBashCommand(ctx context.Context, commandText string, absoluteCwd strin
 	}
 	command := exec.CommandContext(ctx, spec.Name, spec.Args...)
 	command.Dir = spec.Dir
-	return command, plan, cleanup, nil
-}
-
-// windowsShellCommandSpec builds the Name/Args for running commandText on
-// Windows by writing it to a temp .cmd file and pointing cmd.exe /c at the
-// file's path, instead of passing commandText itself as the /c argument.
-//
-// cmd.exe's own /S/C remainder parsing does not follow standard
-// CommandLineToArgvW argv-escaping rules: per its documented behavior, WITH
-// /S present it strips the FIRST and LAST literal quote character in the
-// entire remainder (not a matched pair), regardless of how those quotes were
-// escaped for the outer argv. A command with embedded double quotes -
-// `python -c "print(15 / 3)"`, `git commit -m "message"`, `node -e "..."` -
-// gets its quoting corrupted by that stripping before the target program
-// ever sees it: the child ends up with a truncated, mis-quoted argument
-// instead of the original text. Pointing /c at a plain file path sidesteps
-// this entirely, since the /c remainder is then just a path with no quotes
-// to strip.
-func windowsShellCommandSpec(commandText string) (string, []string, func(), error) {
-	script, err := os.CreateTemp("", "zero-bash-*.cmd")
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("create temp shell script: %w", err)
-	}
-	scriptPath := script.Name()
-	cleanup := func() { _ = os.Remove(scriptPath) }
-	// @echo off: cmd.exe treats a /c target ending in .cmd as a batch file, and
-	// batch files echo each line they run (the "C:\path>command" prompt+command
-	// noise) before executing it, unless echo is turned off first. Without
-	// this, that echoed line pollutes captured stdout that callers parse.
-	// CRLF: cmd.exe's script reader is line-oriented, and a bare LF can leave a
-	// stray \r artifact from Windows text-mode line semantics; CRLF matches a
-	// real .cmd file written by a Windows text editor.
-	if _, err := script.WriteString("@echo off\r\n" + commandText + "\r\n"); err != nil {
-		_ = script.Close()
-		cleanup()
-		return "", nil, nil, fmt.Errorf("write temp shell script: %w", err)
-	}
-	if err := script.Close(); err != nil {
-		cleanup()
-		return "", nil, nil, fmt.Errorf("close temp shell script: %w", err)
-	}
-	return "cmd.exe", []string{"/d", "/s", "/c", scriptPath}, cleanup, nil
+	applyWindowsShellCommandLine(command, commandText, plan.Wrapped)
+	return command, plan, nil
 }
 
 func addSandboxMeta(meta map[string]string, plan zeroSandbox.CommandPlan) {
@@ -362,7 +314,7 @@ func shellExecutable() string {
 
 func shellArguments(command string) []string {
 	if runtime.GOOS == "windows" {
-		return []string{"/d", "/s", "/c", command}
+		return zeroSandbox.WindowsShellArgs(command)
 	}
 	return []string{"-c", command}
 }

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -111,7 +112,7 @@ func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroS
 	if commandEngine == nil && sandboxPermissions == SandboxPermissionsRequireEscalated {
 		meta["sandbox_permissions"] = string(SandboxPermissionsRequireEscalated)
 	}
-	command, plan, err := buildBashCommand(commandCtx, commandText, absoluteCwd, commandEngine)
+	command, plan, cleanup, err := buildBashCommand(commandCtx, commandText, absoluteCwd, commandEngine)
 	if err != nil {
 		meta["exit_code"] = "-1"
 		return Result{
@@ -120,7 +121,10 @@ func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroS
 			Meta:   meta,
 		}
 	}
-	// Release any plan-scoped resources once the command has finished running.
+	// Release any plan-scoped resources, and any resources buildBashCommand
+	// itself allocated (e.g. a Windows temp script file), once the command has
+	// finished running.
+	defer cleanup()
 	defer plan.Cleanup()
 	addSandboxMeta(meta, plan)
 
@@ -221,14 +225,29 @@ func shellIssueBlockResult(issue shellIssue) Result {
 	}
 }
 
-func buildBashCommand(ctx context.Context, commandText string, absoluteCwd string, engine *zeroSandbox.Engine) (*exec.Cmd, zeroSandbox.CommandPlan, error) {
+// buildBashCommand returns the exec.Cmd, the sandbox plan, and a cleanup func
+// the caller must run once the command has finished (in addition to
+// plan.Cleanup()) to release any resources this function allocated outside
+// the plan itself, such as the Windows temp script file below.
+func buildBashCommand(ctx context.Context, commandText string, absoluteCwd string, engine *zeroSandbox.Engine) (*exec.Cmd, zeroSandbox.CommandPlan, func(), error) {
+	name := shellExecutable()
+	args := shellArguments(commandText)
+	cleanup := func() {}
+	if runtime.GOOS == "windows" {
+		scriptName, scriptArgs, scriptCleanup, err := windowsShellCommandSpec(commandText)
+		if err != nil {
+			return nil, zeroSandbox.CommandPlan{}, func() {}, err
+		}
+		name, args, cleanup = scriptName, scriptArgs, scriptCleanup
+	}
 	spec := zeroSandbox.CommandSpec{
-		Name: shellExecutable(),
-		Args: shellArguments(commandText),
+		Name: name,
+		Args: args,
 		Dir:  absoluteCwd,
 	}
 	if engine != nil {
-		return engine.CommandContext(ctx, spec)
+		command, plan, err := engine.CommandContext(ctx, spec)
+		return command, plan, cleanup, err
 	}
 	plan := zeroSandbox.CommandPlan{
 		Backend: zeroSandbox.Backend{
@@ -242,7 +261,48 @@ func buildBashCommand(ctx context.Context, commandText string, absoluteCwd strin
 	}
 	command := exec.CommandContext(ctx, spec.Name, spec.Args...)
 	command.Dir = spec.Dir
-	return command, plan, nil
+	return command, plan, cleanup, nil
+}
+
+// windowsShellCommandSpec builds the Name/Args for running commandText on
+// Windows by writing it to a temp .cmd file and pointing cmd.exe /c at the
+// file's path, instead of passing commandText itself as the /c argument.
+//
+// cmd.exe's own /S/C remainder parsing does not follow standard
+// CommandLineToArgvW argv-escaping rules: per its documented behavior, WITH
+// /S present it strips the FIRST and LAST literal quote character in the
+// entire remainder (not a matched pair), regardless of how those quotes were
+// escaped for the outer argv. A command with embedded double quotes -
+// `python -c "print(15 / 3)"`, `git commit -m "message"`, `node -e "..."` -
+// gets its quoting corrupted by that stripping before the target program
+// ever sees it: the child ends up with a truncated, mis-quoted argument
+// instead of the original text. Pointing /c at a plain file path sidesteps
+// this entirely, since the /c remainder is then just a path with no quotes
+// to strip.
+func windowsShellCommandSpec(commandText string) (string, []string, func(), error) {
+	script, err := os.CreateTemp("", "zero-bash-*.cmd")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("create temp shell script: %w", err)
+	}
+	scriptPath := script.Name()
+	cleanup := func() { _ = os.Remove(scriptPath) }
+	// @echo off: cmd.exe treats a /c target ending in .cmd as a batch file, and
+	// batch files echo each line they run (the "C:\path>command" prompt+command
+	// noise) before executing it, unless echo is turned off first. Without
+	// this, that echoed line pollutes captured stdout that callers parse.
+	// CRLF: cmd.exe's script reader is line-oriented, and a bare LF can leave a
+	// stray \r artifact from Windows text-mode line semantics; CRLF matches a
+	// real .cmd file written by a Windows text editor.
+	if _, err := script.WriteString("@echo off\r\n" + commandText + "\r\n"); err != nil {
+		_ = script.Close()
+		cleanup()
+		return "", nil, nil, fmt.Errorf("write temp shell script: %w", err)
+	}
+	if err := script.Close(); err != nil {
+		cleanup()
+		return "", nil, nil, fmt.Errorf("close temp shell script: %w", err)
+	}
+	return "cmd.exe", []string{"/d", "/s", "/c", scriptPath}, cleanup, nil
 }
 
 func addSandboxMeta(meta map[string]string, plan zeroSandbox.CommandPlan) {

--- a/internal/tools/bash_proc_unix.go
+++ b/internal/tools/bash_proc_unix.go
@@ -42,3 +42,7 @@ func hardenProcessLifetime(command *exec.Cmd) {
 		return nil
 	}
 }
+
+// applyWindowsShellCommandLine is a no-op outside Windows; there is no
+// cmd.exe command-line-parsing quirk to work around here.
+func applyWindowsShellCommandLine(command *exec.Cmd, commandText string, wrapped bool) {}

--- a/internal/tools/bash_proc_windows.go
+++ b/internal/tools/bash_proc_windows.go
@@ -5,7 +5,10 @@ package tools
 import (
 	"os/exec"
 	"strconv"
+	"syscall"
 	"time"
+
+	zeroSandbox "github.com/Gitlawb/zero/internal/sandbox"
 )
 
 // bashWaitDelay bounds how long Wait blocks for the I/O pipes to drain after the
@@ -27,4 +30,18 @@ func hardenProcessLifetime(command *exec.Cmd) {
 		_ = exec.Command("taskkill.exe", "/T", "/F", "/PID", strconv.Itoa(command.Process.Pid)).Run()
 		return nil
 	}
+}
+
+// applyWindowsShellCommandLine overrides command's raw child command line so
+// commandText reaches cmd.exe unescaped instead of auto-quoted the way
+// exec.Cmd would normally encode a single Args element. Skipped when wrapped
+// is true: the sandbox engine then routes execution through a separate
+// zero-windows-command-runner process, which builds its own child command
+// line from scratch (internal/sandbox/windows_process_windows.go) rather than
+// inheriting whatever this outer exec.Cmd is configured with.
+func applyWindowsShellCommandLine(command *exec.Cmd, commandText string, wrapped bool) {
+	if wrapped {
+		return
+	}
+	command.SysProcAttr = &syscall.SysProcAttr{CmdLine: zeroSandbox.WindowsShellCommandLine(commandText)}
 }

--- a/internal/tools/bash_tool_test.go
+++ b/internal/tools/bash_tool_test.go
@@ -17,6 +17,18 @@ import (
 
 func TestMain(m *testing.M) {
 	if len(os.Args) >= 3 && os.Args[1] == "--zero-bash-helper" {
+		if os.Args[2] == "echo-arg" {
+			// Echoes back exactly the one argument it received, to verify a
+			// quoted, space-and-slash-containing argument (the same shape as
+			// `python -c "print(15 / 3)"`) survives the shell invocation
+			// intact instead of being truncated/corrupted.
+			if len(os.Args) < 4 {
+				fmt.Fprintln(os.Stderr, "echo-arg requires exactly one argument")
+				os.Exit(1)
+			}
+			fmt.Println(os.Args[3])
+			return
+		}
 		runBashToolHelper(os.Args[2])
 		return
 	}
@@ -394,10 +406,11 @@ func TestBashToolBuildsWrappedSandboxExecCommand(t *testing.T) {
 		},
 	})
 
-	command, plan, err := buildBashCommand(context.Background(), "pwd", root, engine)
+	command, plan, cleanup, err := buildBashCommand(context.Background(), "pwd", root, engine)
 	if err != nil {
 		t.Fatalf("buildBashCommand: %v", err)
 	}
+	t.Cleanup(cleanup)
 	if command.Path != "/usr/bin/sandbox-exec" || !plan.Wrapped {
 		t.Fatalf("command path = %q plan = %#v, want wrapped sandbox-exec", command.Path, plan)
 	}
@@ -503,6 +516,37 @@ func TestBashToolAllowsNonInteractiveCommand(t *testing.T) {
 	}
 	if result.Meta["safety_block"] != "" {
 		t.Fatalf("did not expect a safety block, got %#v", result.Meta)
+	}
+}
+
+// TestBashToolPreservesEmbeddedQuotesOnWindows pins a real, previously-broken
+// case: cmd.exe's own /S/C remainder parsing strips the first and last
+// literal quote character in the WHOLE remainder (not a matched pair) when
+// /S is present, corrupting a command whose own text contains embedded
+// double quotes - exactly the shape of `python -c "print(15 / 3)"`,
+// `git commit -m "message"`, `node -e "..."`. Before the fix, the helper
+// below received a truncated, mis-quoted argument (starting with a stray
+// literal `"`) instead of the text between the quotes.
+func TestBashToolPreservesEmbeddedQuotesOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("cmd.exe /S/C quote-remainder parsing is Windows-specific")
+	}
+	root := t.TempDir()
+	executable := shellQuote(os.Args[0])
+	// Space and a slash: the two characters whose position in the original
+	// bug report's SyntaxError ("print(15, truncated right before the /")
+	// showed exactly where the corruption happened.
+	commandText := executable + ` --zero-bash-helper echo-arg "hello / world"`
+
+	result := NewBashTool(root).Run(context.Background(), map[string]any{
+		"command": commandText,
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "hello / world") {
+		t.Fatalf("expected the embedded-quote argument to survive intact, got %q", result.Output)
 	}
 }
 

--- a/internal/tools/bash_tool_test.go
+++ b/internal/tools/bash_tool_test.go
@@ -406,11 +406,10 @@ func TestBashToolBuildsWrappedSandboxExecCommand(t *testing.T) {
 		},
 	})
 
-	command, plan, cleanup, err := buildBashCommand(context.Background(), "pwd", root, engine)
+	command, plan, err := buildBashCommand(context.Background(), "pwd", root, engine)
 	if err != nil {
 		t.Fatalf("buildBashCommand: %v", err)
 	}
-	t.Cleanup(cleanup)
 	if command.Path != "/usr/bin/sandbox-exec" || !plan.Wrapped {
 		t.Fatalf("command path = %q plan = %#v, want wrapped sandbox-exec", command.Path, plan)
 	}
@@ -520,13 +519,15 @@ func TestBashToolAllowsNonInteractiveCommand(t *testing.T) {
 }
 
 // TestBashToolPreservesEmbeddedQuotesOnWindows pins a real, previously-broken
-// case: cmd.exe's own /S/C remainder parsing strips the first and last
-// literal quote character in the WHOLE remainder (not a matched pair) when
-// /S is present, corrupting a command whose own text contains embedded
-// double quotes - exactly the shape of `python -c "print(15 / 3)"`,
-// `git commit -m "message"`, `node -e "..."`. Before the fix, the helper
-// below received a truncated, mis-quoted argument (starting with a stray
-// literal `"`) instead of the text between the quotes.
+// case: passing commandText as a normal exec.Cmd argument makes Go wrap it in
+// an outer pair of quotes (it contains spaces) with its own quotes escaped as
+// \", and cmd.exe's /C remainder parsing strips the first and last literal
+// quote character in that remainder without undoing the backslash-escaping -
+// corrupting a command whose own text contains embedded double quotes,
+// exactly the shape of `python -c "print(15 / 3)"`, `git commit -m
+// "message"`, `node -e "..."`. Before the fix, the helper below received a
+// truncated, mis-quoted argument (starting with a stray literal `"`) instead
+// of the text between the quotes.
 func TestBashToolPreservesEmbeddedQuotesOnWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("cmd.exe /S/C quote-remainder parsing is Windows-specific")
@@ -547,6 +548,35 @@ func TestBashToolPreservesEmbeddedQuotesOnWindows(t *testing.T) {
 	}
 	if !strings.Contains(result.Output, "hello / world") {
 		t.Fatalf("expected the embedded-quote argument to survive intact, got %q", result.Output)
+	}
+}
+
+// TestBashToolRunsCommandLineForLoopSyntax pins cmd.exe command-line syntax,
+// not batch-file syntax: a `for %i in (...) do ...` loop with a single
+// percent sign is valid typed directly at a cmd.exe prompt (or via
+// `cmd /C "..."`), but requires %%i inside an actual .bat/.cmd FILE, because
+// batch files perform an extra pass of percent-substitution before FOR ever
+// runs, consuming the single percent so the loop variable never binds. An
+// earlier version of this fix ran commandText from a temporary .cmd file
+// instead of passing it straight through to cmd.exe's /C remainder, which
+// silently broke single-percent syntax like this.
+func TestBashToolRunsCommandLineForLoopSyntax(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("cmd.exe command-line vs batch-file parsing is Windows-specific")
+	}
+	root := t.TempDir()
+
+	result := NewBashTool(root).Run(context.Background(), map[string]any{
+		"command": "for %i in (1 2 3) do echo %i",
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	for _, want := range []string{"1", "2", "3"} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("expected the for-loop to expand %%i to %q, got %q", want, result.Output)
+		}
 	}
 }
 

--- a/internal/tools/exec_command.go
+++ b/internal/tools/exec_command.go
@@ -561,31 +561,19 @@ func (tool execCommandTool) startSession(commandText string, absoluteCwd string,
 	id := tool.manager.allocateID()
 	commandCtx, cancel := context.WithCancel(context.Background())
 	commandEngine := commandEngineForSandboxPermissions(engine, sandboxPermissions)
-	command, plan, scriptCleanup, err := buildBashCommand(commandCtx, commandText, absoluteCwd, commandEngine)
+	command, plan, err := buildBashCommand(commandCtx, commandText, absoluteCwd, commandEngine)
 	if err != nil {
 		cancel()
 		return nil, err
 	}
 	output := newExecOutputBuffer()
 	monitor := zeroSandbox.StartDenialMonitor(context.Background(), plan.MonitorTag)
-	stdin, tty, processCleanup, err := startExecProcess(command, output, ttyRequested)
+	stdin, tty, cleanup, err := startExecProcess(command, output, ttyRequested)
 	if err != nil {
 		_ = monitor.Stop()
 		plan.Cleanup()
-		scriptCleanup()
 		cancel()
 		return nil, err
-	}
-	// The session outlives this function (its process keeps running in the
-	// background goroutine below), so buildBashCommand's script cleanup (e.g. a
-	// Windows temp script file) must run alongside startExecProcess's own
-	// cleanup, not be dropped - and not before the process that reads the
-	// script has actually exited.
-	sessionCleanup := func() {
-		if processCleanup != nil {
-			processCleanup()
-		}
-		scriptCleanup()
 	}
 	session := &execSession{
 		id:          id,
@@ -599,7 +587,7 @@ func (tool execCommandTool) startSession(commandText string, absoluteCwd string,
 		plan:        plan,
 		cancel:      cancel,
 		stdin:       stdin,
-		cleanup:     sessionCleanup,
+		cleanup:     cleanup,
 		output:      output,
 		done:        make(chan struct{}),
 	}

--- a/internal/tools/exec_command.go
+++ b/internal/tools/exec_command.go
@@ -561,19 +561,31 @@ func (tool execCommandTool) startSession(commandText string, absoluteCwd string,
 	id := tool.manager.allocateID()
 	commandCtx, cancel := context.WithCancel(context.Background())
 	commandEngine := commandEngineForSandboxPermissions(engine, sandboxPermissions)
-	command, plan, err := buildBashCommand(commandCtx, commandText, absoluteCwd, commandEngine)
+	command, plan, scriptCleanup, err := buildBashCommand(commandCtx, commandText, absoluteCwd, commandEngine)
 	if err != nil {
 		cancel()
 		return nil, err
 	}
 	output := newExecOutputBuffer()
 	monitor := zeroSandbox.StartDenialMonitor(context.Background(), plan.MonitorTag)
-	stdin, tty, cleanup, err := startExecProcess(command, output, ttyRequested)
+	stdin, tty, processCleanup, err := startExecProcess(command, output, ttyRequested)
 	if err != nil {
 		_ = monitor.Stop()
 		plan.Cleanup()
+		scriptCleanup()
 		cancel()
 		return nil, err
+	}
+	// The session outlives this function (its process keeps running in the
+	// background goroutine below), so buildBashCommand's script cleanup (e.g. a
+	// Windows temp script file) must run alongside startExecProcess's own
+	// cleanup, not be dropped - and not before the process that reads the
+	// script has actually exited.
+	sessionCleanup := func() {
+		if processCleanup != nil {
+			processCleanup()
+		}
+		scriptCleanup()
 	}
 	session := &execSession{
 		id:          id,
@@ -587,7 +599,7 @@ func (tool execCommandTool) startSession(commandText string, absoluteCwd string,
 		plan:        plan,
 		cancel:      cancel,
 		stdin:       stdin,
-		cleanup:     cleanup,
+		cleanup:     sessionCleanup,
 		output:      output,
 		done:        make(chan struct{}),
 	}


### PR DESCRIPTION
## What

Any shell command whose own text contains embedded double quotes (`python -c "print(15 / 3)"`, `git commit -m "message"`, `node -e "..."`) was silently corrupted on Windows before reaching the target program. Reported live: a model ran `python -c "print(15 / 3)"` and got back `SyntaxError: unterminated string literal`, with the code Python actually received shown as literally `"print(15`, truncated right before the `/`.

## Root cause

`bash.go` passes the full command text as one argv element to `cmd.exe /d /s /c`. Go's `os/exec` escapes it correctly for a standard `CommandLineToArgvW`-style parser: wrapping the whole thing in quotes and backslash-escaping the embedded ones. But `cmd.exe`'s own `/C` remainder parsing does not follow those rules once `/S` is present. Per its documented behavior, it strips the first and last literal quote character in the whole remainder (not a matched pair) before handing the now-corrupted text along to be re-tokenized. The escaping was correct for one layer of parsing; the command line actually goes through two.

## Fix (updated after review)

The original version of this PR worked around the corruption by writing `commandText` to a temp `.cmd` file and pointing `/c` at the file's path. Review found that traded one bug for others: it silently reinterpreted the command as batch-file syntax instead of command-line syntax (`for %i in (...) do ...` needs `%%i` only inside an actual `.bat`/`.cmd` file, not typed at a prompt or passed via `/C`), `/s` was still corrupting the *script path itself* if it ever contained spaces, and the temp file leaked on sandbox planning errors.

Fixed at the actual source instead, with no temp file at all: `commandText` now reaches `cmd.exe` completely unescaped, exactly as if it had been typed at an interactive prompt.

- On the unwrapped path, `internal/tools/bash_proc_windows.go` sets `exec.Cmd.SysProcAttr.CmdLine` directly, bypassing Go's normal per-argument escaping (the thing that was wrapping `commandText` in an outer pair of quotes in the first place).
- On the sandboxed path, the command is serialized as CLI argv and reconstructed inside a separate `zero-windows-command-runner` process, so the same fix has to happen again where *that* process actually builds its `CreateProcessAsUser` command line (`internal/sandbox/windows_process_windows.go`'s `windowsCommandLine`): it now recognizes Zero's shell-invocation shape and leaves the final element (the command text) unescaped instead of running it through `syscall.EscapeArg` like every other argument.
- Both call sites for "what shape is Zero's shell invocation" (the argv-building side and the raw-command-line-building side) now go through two shared functions in `internal/sandbox/windows_runner.go` (`WindowsShellArgs`, `WindowsShellCommandLine`), instead of the `/d /c` literals living in three separate places that could drift out of sync.
- `/s` is dropped entirely, not just avoided on one path. It forced the more aggressive of cmd.exe's two documented stripping behaviors; without it, a command that legitimately starts with a quoted executable path (`"C:\Program Files\foo.exe" arg`) gets cmd.exe's own careful quote-preserving special case for that exact shape, instead of also being blindly stripped.

No temp file means nothing to leak on a sandbox planning error, and no batch-file reinterpretation of the command text, so this also resolves the batch-vs-command-line and cleanup-leak review findings as a consequence of removing the mechanism they were about, not as separate patches.

`buildBashCommand` is back to its original 3-value return (`*exec.Cmd`, `CommandPlan`, `error`); the cleanup-func threading through `bash.go` and `exec_command.go` from the temp-file version is gone.

## Testing

- `TestBashToolPreservesEmbeddedQuotesOnWindows` (kept from the original PR): pins the original corruption shape via a self-dispatch test helper.
- `TestBashToolRunsCommandLineForLoopSyntax` (new): runs `for %i in (1 2 3) do echo %i` (single percent) through the tool and asserts it expands correctly. This is the test that would have failed under the temp-`.cmd`-file version of this fix and passes now.
- `TestWindowsShellArgsHasNoSAndKeepsCommandTextWhole`, `TestWindowsShellCommandLineLeavesCommandTextUnescaped`, `TestWindowsShellCommandLineFromArgsRecognizes/RejectsOtherShapes` (new, `internal/sandbox`): unit-test the shared shape/escaping logic directly, cross-platform (no Windows-only build tag needed for these, since they're pure string logic).

All of the above run and pass on an actual Windows machine, not just cross-compiled. `go build ./...` and `go vet ./internal/tools/... ./internal/sandbox/...` clean on windows/linux/darwin cross-compiles. Full `internal/tools` and `internal/sandbox` suites green, excluding failures pre-existing and identical on unmodified `main` in my environment (unrelated path-assumption issues under a deeply nested working directory, not touched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command handling so quoted arguments and loop syntax are preserved more reliably.
  * Made Windows command-line parsing more consistent across sandboxed and non-sandboxed execution paths.
  * Added stricter validation to reject invalid command arguments consistently.

* **Tests**
  * Added regression coverage for embedded quotes, `cmd.exe` loop syntax, and Windows shell command-line shape handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->