### PR TITLE
feat(agent): inject per-user config.UserConfigDir()/zero/ZERO.md guidelines into system prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,12 @@ Tips:
 - In a monorepo, drop a narrower `AGENTS.md` in each sub-tree (e.g. `services/api/AGENTS.md`). Zero picks those up automatically when you launch from inside the sub-tree.
 - A YAML frontmatter block (`---\n...\n---`) at the top is preserved verbatim in the injected prompt but is not parsed for `globs:` or `alwaysApply:` scoping today — keep the body self-contained.
 
+### Personal guidelines, across every project
+
+For preferences that follow *you*, not a specific repo (tone, tooling habits, workflow), drop a `ZERO.md` in your user config directory: `~/.config/zero/ZERO.md` on Linux/macOS, `%AppData%\Roaming\zero\ZERO.md` on Windows — the same directory as `config.json` and your personal specialists. Same format and 8 KiB cap as the project files above, and the same case-insensitive basename match.
+
+This file is injected as its own `## User guidelines` section, before the project's `AGENTS.md`/`ZERO.md`, and is labeled as personal preference in the prompt: project guidelines are the later, more specific instruction and take precedence over it when the two conflict.
+
 ## 2. Custom specialists
 
 Specialists are Zero's sub-agents. Three scopes, in priority order:
@@ -307,6 +313,7 @@ A team that wants every contributor's Zero to behave the same way commits:
 Each contributor adds only:
 
 - `~/.config/zero/config.json` — their personal API keys, theme, default mode.
+- `~/.config/zero/ZERO.md` — personal preferences that follow them across every project (see section 1).
 - `~/.local/share/zero/skills/` — personal skills they keep across projects.
 
 That's it. Run `zero` from the repo root and the agent has the team's full instruction set, every contributor's personal setup, and nothing else.

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -37,6 +37,13 @@ const fallbackSystemPrompt = "You are Zero, a terminal coding agent. Help with t
 // general-to-specific order.
 var projectContextFiles = []string{"AGENTS.md", "ZERO.md", ".zero/AGENTS.md"}
 
+// userContextFile is the per-user instruction file. It intentionally lives next
+// to the legacy ~/.zero config location so users can keep personal guidance out
+// of individual repositories.
+const userContextFile = ".zero/ZERO.md"
+
+var userHomeDirForPrompt = os.UserHomeDir
+
 // maxProjectContextBytes caps how much of a single project doc is injected so
 // a large guidelines file can't blow the context budget.
 const maxProjectContextBytes = 8 << 10 // 8 KiB per file
@@ -82,6 +89,9 @@ func buildSystemPrompt(options Options) string {
 	}
 	if ws := workspaceContext(options.Cwd); ws != "" {
 		sections = append(sections, ws)
+	}
+	if user := userGuidelines(); user != "" {
+		sections = append(sections, user)
 	}
 	if delegation := specialistDelegationContext(options); delegation != "" {
 		sections = append(sections, delegation)
@@ -262,6 +272,34 @@ func projectGuidelines(cwd, gitRoot string) string {
 		totalUsed += len(content)
 	}
 	return b.String()
+}
+
+// userGuidelines returns the per-user ZERO.md instructions block, if present.
+func userGuidelines() string {
+	home, err := userHomeDirForPrompt()
+	if err != nil {
+		return ""
+	}
+	home = strings.TrimSpace(home)
+	if home == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, filepath.FromSlash(userContextFile)))
+	if err != nil {
+		return ""
+	}
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return ""
+	}
+	if len(content) > maxProjectContextBytes {
+		cut := maxProjectContextBytes
+		for cut > 0 && !utf8.RuneStart(content[cut]) {
+			cut--
+		}
+		content = content[:cut] + "\n… (truncated)"
+	}
+	return "## User guidelines (" + userContextFile + ")\n\n" + content
 }
 
 // projectGuidelineDirs returns the directory chain from gitRoot to cwd

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/repomap"
 	"github.com/Gitlawb/zero/internal/workspaceseed"
 )
@@ -37,12 +38,13 @@ const fallbackSystemPrompt = "You are Zero, a terminal coding agent. Help with t
 // general-to-specific order.
 var projectContextFiles = []string{"AGENTS.md", "ZERO.md", ".zero/AGENTS.md"}
 
-// userContextFile is the per-user instruction file. It intentionally lives next
-// to the legacy ~/.zero config location so users can keep personal guidance out
+// userContextFile is the per-user instruction file, resolved under
+// config.UserConfigDir()/zero/ alongside the rest of Zero's per-user config
+// (config.json, commands, specialists) so users can keep personal guidance out
 // of individual repositories.
-const userContextFile = ".zero/ZERO.md"
+const userContextFile = "ZERO.md"
 
-var userHomeDirForPrompt = os.UserHomeDir
+var userConfigDirForPrompt = config.UserConfigDir
 
 // maxProjectContextBytes caps how much of a single project doc is injected so
 // a large guidelines file can't blow the context budget.
@@ -275,16 +277,24 @@ func projectGuidelines(cwd, gitRoot string) string {
 }
 
 // userGuidelines returns the per-user ZERO.md instructions block, if present.
+// The file lives in config.UserConfigDir()/zero/ next to Zero's other
+// per-user config; the basename match is case-insensitive so a file saved as
+// zero.md still resolves on case-sensitive filesystems, mirroring the project
+// guideline loader.
 func userGuidelines() string {
-	home, err := userHomeDirForPrompt()
+	configDir, err := userConfigDirForPrompt()
 	if err != nil {
 		return ""
 	}
-	home = strings.TrimSpace(home)
-	if home == "" {
+	configDir = strings.TrimSpace(configDir)
+	if configDir == "" {
 		return ""
 	}
-	data, err := os.ReadFile(filepath.Join(home, filepath.FromSlash(userContextFile)))
+	match := findUserContextFile(filepath.Join(configDir, "zero"))
+	if match == "" {
+		return ""
+	}
+	data, err := os.ReadFile(match)
 	if err != nil {
 		return ""
 	}
@@ -299,7 +309,22 @@ func userGuidelines() string {
 		}
 		content = content[:cut] + "\n… (truncated)"
 	}
-	return "## User guidelines (" + userContextFile + ")\n\n" + content
+	return "## User guidelines (" + filepath.Base(match) + ")\n\n" + content
+}
+
+// findUserContextFile returns the on-disk path of the user guideline file in
+// dir, matching the basename case-insensitively, or "" when absent.
+func findUserContextFile(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.EqualFold(e.Name(), userContextFile) {
+			return filepath.Join(dir, e.Name())
+		}
+	}
+	return ""
 }
 
 // projectGuidelineDirs returns the directory chain from gitRoot to cwd

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -300,17 +300,25 @@ func userGuidelines() string {
 	return "## User guidelines (" + filepath.Base(match) + ")\n\n" + content
 }
 
+// truncationMarker is appended to guideline content that was cut short.
+const truncationMarker = "\n… (truncated)"
+
 // truncateGuidelineContent caps content at limit bytes without splitting a
-// UTF-8 rune, appending a truncation marker when anything was cut.
+// UTF-8 rune, appending a truncation marker when anything was cut. Space for
+// the marker is reserved before choosing the cut point, so the returned
+// string never exceeds limit (assuming limit is larger than the marker).
 func truncateGuidelineContent(content string, limit int) string {
 	if len(content) <= limit {
 		return content
 	}
-	cut := limit
+	cut := limit - len(truncationMarker)
+	if cut < 0 {
+		cut = 0
+	}
 	for cut > 0 && !utf8.RuneStart(content[cut]) {
 		cut--
 	}
-	return content[:cut] + "\n… (truncated)"
+	return content[:cut] + truncationMarker
 }
 
 // findCaseInsensitiveFile returns the on-disk path of the regular file in dir

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -262,13 +262,7 @@ func projectGuidelines(cwd, gitRoot string) string {
 		if remaining := maxProjectContextTotalBytes - totalUsed; remaining < limit {
 			limit = remaining
 		}
-		if len(content) > limit {
-			cut := limit
-			for cut > 0 && !utf8.RuneStart(content[cut]) {
-				cut--
-			}
-			content = content[:cut] + "\n… (truncated)"
-		}
+		content = truncateGuidelineContent(content, limit)
 		label := projectGuidelineLabel(match, gitRoot)
 		b.WriteString("\n\n## Project guidelines (" + label + ")\n\n" + content)
 		totalUsed += len(content)
@@ -290,7 +284,7 @@ func userGuidelines() string {
 	if configDir == "" {
 		return ""
 	}
-	match := findUserContextFile(filepath.Join(configDir, "zero"))
+	match := findCaseInsensitiveFile(filepath.Join(configDir, "zero"), userContextFile)
 	if match == "" {
 		return ""
 	}
@@ -302,25 +296,32 @@ func userGuidelines() string {
 	if content == "" {
 		return ""
 	}
-	if len(content) > maxProjectContextBytes {
-		cut := maxProjectContextBytes
-		for cut > 0 && !utf8.RuneStart(content[cut]) {
-			cut--
-		}
-		content = content[:cut] + "\n… (truncated)"
-	}
+	content = truncateGuidelineContent(content, maxProjectContextBytes)
 	return "## User guidelines (" + filepath.Base(match) + ")\n\n" + content
 }
 
-// findUserContextFile returns the on-disk path of the user guideline file in
-// dir, matching the basename case-insensitively, or "" when absent.
-func findUserContextFile(dir string) string {
+// truncateGuidelineContent caps content at limit bytes without splitting a
+// UTF-8 rune, appending a truncation marker when anything was cut.
+func truncateGuidelineContent(content string, limit int) string {
+	if len(content) <= limit {
+		return content
+	}
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(content[cut]) {
+		cut--
+	}
+	return content[:cut] + "\n… (truncated)"
+}
+
+// findCaseInsensitiveFile returns the on-disk path of the regular file in dir
+// whose name matches basename case-insensitively, or "" when absent.
+func findCaseInsensitiveFile(dir, basename string) string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return ""
 	}
 	for _, e := range entries {
-		if !e.IsDir() && strings.EqualFold(e.Name(), userContextFile) {
+		if !e.IsDir() && strings.EqualFold(e.Name(), basename) {
 			return filepath.Join(dir, e.Name())
 		}
 	}
@@ -379,23 +380,16 @@ func projectGuidelineLabel(match, gitRoot string) string {
 // Returns "" when nothing matches.
 func findProjectContextFile(dir string) string {
 	for _, name := range projectContextFiles {
-		baseLower := strings.ToLower(filepath.Base(name))
 		// Walk to the file's parent through dir with case-insensitive segment
-		// matching, then find a regular file with the same lowercased
-		// basename. This works on both case-sensitive and case-insensitive
-		// filesystems and always returns the on-disk filename.
+		// matching, then find a regular file with the same basename. This works
+		// on both case-sensitive and case-insensitive filesystems and always
+		// returns the on-disk filename.
 		parent, ok := resolveDirCaseInsensitive(filepath.Dir(filepath.Join(dir, name)), dir)
 		if !ok {
 			continue
 		}
-		entries, err := os.ReadDir(parent)
-		if err != nil {
-			continue
-		}
-		for _, e := range entries {
-			if !e.IsDir() && strings.ToLower(e.Name()) == baseLower {
-				return filepath.Join(parent, e.Name())
-			}
+		if match := findCaseInsensitiveFile(parent, filepath.Base(name)); match != "" {
+			return match
 		}
 	}
 	return ""

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -89,11 +89,15 @@ func buildSystemPrompt(options Options) string {
 	if seed := workspaceSeedContext(options.Cwd); seed != "" {
 		sections = append(sections, seed)
 	}
-	if ws := workspaceContext(options.Cwd); ws != "" {
-		sections = append(sections, ws)
-	}
+	// User guidelines are injected before workspace/project guidelines so the
+	// project's AGENTS.md/ZERO.md is the later, more specific instruction
+	// block. See userGuidelines for the explicit precedence note carried in
+	// the section text itself.
 	if user := userGuidelines(); user != "" {
 		sections = append(sections, user)
+	}
+	if ws := workspaceContext(options.Cwd); ws != "" {
+		sections = append(sections, ws)
 	}
 	if delegation := specialistDelegationContext(options); delegation != "" {
 		sections = append(sections, delegation)
@@ -274,7 +278,11 @@ func projectGuidelines(cwd, gitRoot string) string {
 // The file lives in config.UserConfigDir()/zero/ next to Zero's other
 // per-user config; the basename match is case-insensitive so a file saved as
 // zero.md still resolves on case-sensitive filesystems, mirroring the project
-// guideline loader.
+// guideline loader. The section carries an explicit precedence note because
+// this is a global, personal preferences file: it is injected earlier in the
+// prompt than the project's AGENTS.md/ZERO.md (see buildSystemPrompt), and
+// the note keeps that precedence unambiguous even if a model weighs later
+// context more heavily than section order alone implies.
 func userGuidelines() string {
 	configDir, err := userConfigDirForPrompt()
 	if err != nil {
@@ -297,7 +305,10 @@ func userGuidelines() string {
 		return ""
 	}
 	content = truncateGuidelineContent(content, maxProjectContextBytes)
-	return "## User guidelines (" + filepath.Base(match) + ")\n\n" + content
+	return "## User guidelines (" + filepath.Base(match) + ")\n\n" +
+		"These are the operator's personal preferences, not project policy. " +
+		"Where they conflict with a repository's project guidelines below (AGENTS.md/ZERO.md), the project guidelines take precedence.\n\n" +
+		content
 }
 
 // truncationMarker is appended to guideline content that was cut short.
@@ -305,11 +316,15 @@ const truncationMarker = "\n… (truncated)"
 
 // truncateGuidelineContent caps content at limit bytes without splitting a
 // UTF-8 rune, appending a truncation marker when anything was cut. Space for
-// the marker is reserved before choosing the cut point, so the returned
-// string never exceeds limit (assuming limit is larger than the marker).
+// the marker is reserved before choosing the cut point. When limit is too
+// small to fit the marker itself, the marker is dropped instead, so the
+// returned string never exceeds limit for any non-negative limit.
 func truncateGuidelineContent(content string, limit int) string {
 	if len(content) <= limit {
 		return content
+	}
+	if limit <= 0 {
+		return ""
 	}
 	cut := limit - len(truncationMarker)
 	if cut < 0 {
@@ -318,7 +333,16 @@ func truncateGuidelineContent(content string, limit int) string {
 	for cut > 0 && !utf8.RuneStart(content[cut]) {
 		cut--
 	}
-	return content[:cut] + truncationMarker
+	if truncated := content[:cut] + truncationMarker; len(truncated) <= limit {
+		return truncated
+	}
+	// limit is smaller than the marker itself: fall back to a hard,
+	// rune-safe cut at limit bytes with no marker rather than exceeding it.
+	end := limit
+	for end > 0 && !utf8.RuneStart(content[end]) {
+		end--
+	}
+	return content[:end]
 }
 
 // findCaseInsensitiveFile returns the on-disk path of the regular file in dir

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -127,6 +127,46 @@ func systemPromptTestBlock(t *testing.T, prompt, start, end string) string {
 	return body
 }
 
+func TestBuildSystemPromptIncludesUserGuidelines(t *testing.T) {
+	home := t.TempDir()
+	writeSystemPromptTestFile(t, home, userContextFile, "  Prefer concise summaries.  \n")
+	t.Cleanup(withSystemPromptTestHome(t, home))
+
+	prompt := buildSystemPrompt(Options{})
+	if !strings.Contains(prompt, "## User guidelines (.zero/ZERO.md)") {
+		t.Fatalf("expected user guidelines header, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Prefer concise summaries.") {
+		t.Fatalf("expected user guidelines content, got:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "  Prefer concise summaries.  ") {
+		t.Fatalf("expected user guidelines content to be trimmed, got:\n%s", prompt)
+	}
+}
+
+func TestBuildSystemPromptOmitsUserGuidelinesWithoutHome(t *testing.T) {
+	t.Cleanup(withSystemPromptTestHomeFunc(t, func() (string, error) { return "", os.ErrNotExist }))
+
+	prompt := buildSystemPrompt(Options{})
+	if strings.Contains(prompt, "## User guidelines") {
+		t.Fatalf("expected user guidelines to be omitted without a home directory, got:\n%s", prompt)
+	}
+}
+
+func withSystemPromptTestHome(t *testing.T, home string) func() {
+	t.Helper()
+	return withSystemPromptTestHomeFunc(t, func() (string, error) { return home, nil })
+}
+
+func withSystemPromptTestHomeFunc(t *testing.T, fn func() (string, error)) func() {
+	t.Helper()
+	old := userHomeDirForPrompt
+	userHomeDirForPrompt = fn
+	return func() {
+		userHomeDirForPrompt = old
+	}
+}
+
 func TestBuildSystemPromptInjectsProjectGuidelinesCaseInsensitive(t *testing.T) {
 	// Git tracks AGENTS.md on a case-sensitive filesystem; the
 	// loader must still resolve it when the cwd lookup uses lowercase.

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -128,12 +128,12 @@ func systemPromptTestBlock(t *testing.T, prompt, start, end string) string {
 }
 
 func TestBuildSystemPromptIncludesUserGuidelines(t *testing.T) {
-	home := t.TempDir()
-	writeSystemPromptTestFile(t, home, userContextFile, "  Prefer concise summaries.  \n")
-	t.Cleanup(withSystemPromptTestHome(t, home))
+	configDir := t.TempDir()
+	writeSystemPromptTestFile(t, configDir, "zero/ZERO.md", "  Prefer concise summaries.  \n")
+	t.Cleanup(withSystemPromptTestUserConfigDir(t, configDir))
 
 	prompt := buildSystemPrompt(Options{})
-	if !strings.Contains(prompt, "## User guidelines (.zero/ZERO.md)") {
+	if !strings.Contains(prompt, "## User guidelines (ZERO.md)") {
 		t.Fatalf("expected user guidelines header, got:\n%s", prompt)
 	}
 	if !strings.Contains(prompt, "Prefer concise summaries.") {
@@ -144,26 +144,40 @@ func TestBuildSystemPromptIncludesUserGuidelines(t *testing.T) {
 	}
 }
 
-func TestBuildSystemPromptOmitsUserGuidelinesWithoutHome(t *testing.T) {
-	t.Cleanup(withSystemPromptTestHomeFunc(t, func() (string, error) { return "", os.ErrNotExist }))
+func TestBuildSystemPromptIncludesUserGuidelinesCaseInsensitive(t *testing.T) {
+	configDir := t.TempDir()
+	writeSystemPromptTestFile(t, configDir, "zero/zero.md", "Prefer concise summaries.\n")
+	t.Cleanup(withSystemPromptTestUserConfigDir(t, configDir))
 
 	prompt := buildSystemPrompt(Options{})
-	if strings.Contains(prompt, "## User guidelines") {
-		t.Fatalf("expected user guidelines to be omitted without a home directory, got:\n%s", prompt)
+	if !strings.Contains(prompt, "## User guidelines (zero.md)") {
+		t.Fatalf("expected case-insensitive zero.md resolution, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Prefer concise summaries.") {
+		t.Fatalf("expected user guidelines content, got:\n%s", prompt)
 	}
 }
 
-func withSystemPromptTestHome(t *testing.T, home string) func() {
-	t.Helper()
-	return withSystemPromptTestHomeFunc(t, func() (string, error) { return home, nil })
+func TestBuildSystemPromptOmitsUserGuidelinesWithoutConfigDir(t *testing.T) {
+	t.Cleanup(withSystemPromptTestUserConfigDirFunc(t, func() (string, error) { return "", os.ErrNotExist }))
+
+	prompt := buildSystemPrompt(Options{})
+	if strings.Contains(prompt, "## User guidelines") {
+		t.Fatalf("expected user guidelines to be omitted without a config directory, got:\n%s", prompt)
+	}
 }
 
-func withSystemPromptTestHomeFunc(t *testing.T, fn func() (string, error)) func() {
+func withSystemPromptTestUserConfigDir(t *testing.T, dir string) func() {
 	t.Helper()
-	old := userHomeDirForPrompt
-	userHomeDirForPrompt = fn
+	return withSystemPromptTestUserConfigDirFunc(t, func() (string, error) { return dir, nil })
+}
+
+func withSystemPromptTestUserConfigDirFunc(t *testing.T, fn func() (string, error)) func() {
+	t.Helper()
+	old := userConfigDirForPrompt
+	userConfigDirForPrompt = fn
 	return func() {
-		userHomeDirForPrompt = old
+		userConfigDirForPrompt = old
 	}
 }
 

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -9,6 +9,25 @@ import (
 	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
+// TestMain points userConfigDirForPrompt at an empty, package-wide temp
+// directory for every test in this package. Without this, buildSystemPrompt
+// falls back to the real config.UserConfigDir, so any developer with a
+// personal ~/.config/zero/ZERO.md would get its content folded into
+// otherwise-unrelated prompt assertions, making test runs non-deterministic
+// across contributor machines. Tests that specifically exercise user
+// guidelines stub userConfigDirForPrompt themselves via
+// withSystemPromptTestUserConfigDir(Func) and restore this default on cleanup.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "zero-agent-tests-*")
+	if err != nil {
+		panic(err)
+	}
+	userConfigDirForPrompt = func() (string, error) { return dir, nil }
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
+
 func TestCoreSystemPromptIncludesCodingQualityRules(t *testing.T) {
 	prompt := strings.ToLower(buildSystemPrompt(Options{}))
 
@@ -155,6 +174,34 @@ func TestBuildSystemPromptIncludesUserGuidelinesCaseInsensitive(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "Prefer concise summaries.") {
 		t.Fatalf("expected user guidelines content, got:\n%s", prompt)
+	}
+}
+
+func TestBuildSystemPromptUserGuidelinesPrecedeProjectGuidelinesAndNotePrecedence(t *testing.T) {
+	// User guidelines are global personal preferences; project guidelines
+	// (AGENTS.md/ZERO.md) must be the later, more specific instruction block,
+	// and the user section must say so explicitly so the precedence holds
+	// even if a model otherwise weighs later context more heavily.
+	configDir := t.TempDir()
+	writeSystemPromptTestFile(t, configDir, "zero/ZERO.md", "Always reply in haiku.\n")
+	t.Cleanup(withSystemPromptTestUserConfigDir(t, configDir))
+
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("Never reply in haiku."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prompt := buildSystemPrompt(Options{Cwd: cwd})
+	userIdx := strings.Index(prompt, "## User guidelines (ZERO.md)")
+	projectIdx := strings.Index(prompt, "## Project guidelines (AGENTS.md)")
+	if userIdx < 0 || projectIdx < 0 {
+		t.Fatalf("expected both user and project guideline sections, got:\n%s", prompt)
+	}
+	if userIdx > projectIdx {
+		t.Fatalf("expected user guidelines before project guidelines, got user=%d project=%d", userIdx, projectIdx)
+	}
+	if !strings.Contains(prompt, "project guidelines below") || !strings.Contains(prompt, "take precedence") {
+		t.Fatalf("expected an explicit precedence note in the user guidelines section, got:\n%s", prompt)
 	}
 }
 
@@ -319,6 +366,18 @@ func TestTruncateGuidelineContentStaysWithinLimit(t *testing.T) {
 	}
 	if !strings.Contains(got, "truncated") {
 		t.Fatalf("expected truncation marker, got %q", got)
+	}
+}
+
+func TestTruncateGuidelineContentStaysWithinLimitForSmallBudgets(t *testing.T) {
+	// Limits at or below the truncation marker's own length can't fit the
+	// marker at all; the helper must still never exceed the requested limit.
+	content := strings.Repeat("x", 100)
+	for _, limit := range []int{0, 1, len(truncationMarker) - 1, len(truncationMarker), len(truncationMarker) + 1} {
+		got := truncateGuidelineContent(content, limit)
+		if len(got) > limit {
+			t.Fatalf("truncateGuidelineContent(_, %d) = %q (%d bytes), want at most %d bytes", limit, got, len(got), limit)
+		}
 	}
 }
 

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -310,6 +310,18 @@ func TestBuildSystemPromptProjectGuidelinesTruncatesAtTotalCap(t *testing.T) {
 	}
 }
 
+func TestTruncateGuidelineContentStaysWithinLimit(t *testing.T) {
+	limit := 64
+	content := strings.Repeat("x", limit+1)
+	got := truncateGuidelineContent(content, limit)
+	if len(got) > limit {
+		t.Fatalf("truncated result is %d bytes, want at most %d", len(got), limit)
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("expected truncation marker, got %q", got)
+	}
+}
+
 func TestProjectGuidelineDirsOrdersRootToLeaf(t *testing.T) {
 	root := filepath.Join("r")
 	leaf := filepath.Join(root, "a", "b")


### PR DESCRIPTION
## Summary

Inject per-user instructions from `ZERO.md` in the user config directory (`config.UserConfigDir()/zero/ZERO.md`) into the system prompt, alongside existing project-level guideline files (`AGENTS.md`, `ZERO.md`, `.zero/AGENTS.md`). This lets operators keep personal preferences (tone, tooling, workflow) outside individual repositories while still having them apply to every Zero session.

The file resolves to `~/.config/zero/ZERO.md` on Linux and macOS and `%AppData%\Roaming\zero\ZERO.md` on Windows, next to the rest of Zero's per-user config (`config.json`, commands, specialists).

## Linked issue

No linked issue yet. Per CONTRIBUTING.md, this PR may need a parent issue with the `issue-approved` label before merge.

## Changes

**`internal/agent/system_prompt.go`**
- Add `userContextFile` constant (`ZERO.md`) resolved under `config.UserConfigDir()/zero/`, with a `userConfigDirForPrompt` hook for tests.
- Add `userGuidelines()` to read, trim, and cap user instructions (8 KiB, same per-file limit as project docs). The basename match is case-insensitive, mirroring the project guideline loader.
- Inject the user guidelines section into `buildSystemPrompt` after workspace context.

**`internal/agent/system_prompt_test.go`**
- Add tests for including user guidelines when the file exists, including a case-insensitive `zero.md` variant.
- Add a test for omitting user guidelines when the config directory is unavailable.
- Add test helpers to stub `userConfigDirForPrompt`.

## Test plan

- [x] `go test ./internal/agent/... -run "UserGuidelines|BuildSystemPrompt" -count=1`
- [x] Rebased onto latest `upstream/main` cleanly.
- [ ] Manual: create `ZERO.md` under the user config dir with a short preference, start a session, confirm `## User guidelines (ZERO.md)` appears in the injected system prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-user “personal guidelines” loaded from `~/.config/zero/ZERO.md` (case-insensitive), injected as a dedicated **User guidelines** section.
  * When present, user guidelines appear before project guidelines and include a clear precedence note.

* **Bug Fixes**
  * Trims and safely truncates injected guideline content to the configured byte budget, including a truncation marker when cut off.
  * Leaves the prompt unchanged if the config directory or guideline file can’t be accessed.

* **Documentation**
  * Updated `AGENTS.md` to document personal guidelines discovery and precedence, and refreshed the example file list.

* **Tests**
  * Added deterministic tests for injection behavior, omission behavior, case-insensitive matching, and truncation invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
