### PR TITLE
docs(plugins): add Toshi as a concrete community plugin example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,8 @@ Plugin commands run with the plugin directory as their working directory. Use re
 
 > **Roadmap.** An in-UI plugins manager (browse, install, enable / disable) is on the backlog. Today you use the `zero plugins` CLI subcommands above. Skills declared inside a plugin's `plugin.json` are not yet merged into the `skill` tool's discovery (see section 3).
 
+> **Example (community).** [`toshi`](https://github.com/philpof102-svg/toshi) is a small community plugin that follows this exact format — a terminal-companion mascot (a stdio MCP + a side WebView) you can `zero plugins add` to see the plugin system end to end. GPL-3.0.
+
 ## 7. Configuration locations
 
 Three layers, applied in order (later layers override earlier ones):


### PR DESCRIPTION
Small docs-only addition to **§6 Plugins**: a one-line, real-world example so readers can see the plugin format in practice.

[`toshi`](https://github.com/philpof102-svg/toshi) is a community plugin that follows the documented `plugin.json` format exactly — a terminal-companion mascot delivered as a **stdio MCP server + a side WebView**. It can be `zero plugins add`-ed to exercise the plugin system end to end, and it's GPL-3.0.

No code changes — just a concrete pointer next to the existing plugin docs. Happy to adjust wording or drop it if you'd rather keep AGENTS.md example-free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a community plugin example in the Plugins section, including a link and short description for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->