### PR TITLE
fix(specialist): cap max specialist nesting depth

### DIFF
--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -219,8 +219,12 @@ func (executor Executor) Run(ctx context.Context, params TaskParameters, options
 	if options.CurrentDepth < 0 {
 		return ExecResult{}, fmt.Errorf("current depth cannot be negative")
 	}
-	if options.CurrentDepth > maxSpecialistDepth {
-		return ExecResult{}, fmt.Errorf("specialist nesting depth %d exceeds maximum %d", options.CurrentDepth, maxSpecialistDepth)
+	// >= (not >): this Run call spawns a CHILD at options.CurrentDepth+1, so a
+	// parent already AT the cap must still be rejected here rather than being
+	// allowed to launch one more level before the child's own next call trips
+	// the guard.
+	if options.CurrentDepth >= maxSpecialistDepth {
+		return ExecResult{}, fmt.Errorf("spawning a specialist at depth %d would exceed maximum nesting depth %d", options.CurrentDepth+1, maxSpecialistDepth)
 	}
 	if strings.TrimSpace(params.Prompt) == "" {
 		return ExecResult{}, fmt.Errorf("specialist prompt is required")

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -25,6 +25,7 @@ import (
 const (
 	sessionTagSpecialist     = "specialist"
 	promptFileThresholdBytes = 4 * 1024
+	maxSpecialistDepth       = 8 // hard cap to prevent infinite recursion/resource exhaustion via Task
 )
 
 const SessionTagSpecialist = sessionTagSpecialist
@@ -217,6 +218,9 @@ func (executor Executor) Run(ctx context.Context, params TaskParameters, options
 	}
 	if options.CurrentDepth < 0 {
 		return ExecResult{}, fmt.Errorf("current depth cannot be negative")
+	}
+	if options.CurrentDepth > maxSpecialistDepth {
+		return ExecResult{}, fmt.Errorf("specialist nesting depth %d exceeds maximum %d", options.CurrentDepth, maxSpecialistDepth)
 	}
 	if strings.TrimSpace(params.Prompt) == "" {
 		return ExecResult{}, fmt.Errorf("specialist prompt is required")

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -349,13 +349,24 @@ func TestRunRejectsDepthExceedingMax(t *testing.T) {
 // TestRunRejectsDepthAtMax covers the boundary: a parent already AT the cap
 // must be rejected too, since this Run call would launch a child one level
 // past it (--depth CurrentDepth+1). Only checking ">" here would let that
-// child start before the guard ever caught it.
+// child start before the guard ever caught it. The guard sits before the
+// fresh/resume branch in Run, so both call shapes must be proven to reject
+// here rather than falling through to runFresh/runResume.
 func TestRunRejectsDepthAtMax(t *testing.T) {
-	_, err := (Executor{}).Run(context.Background(), TaskParameters{
-		Prompt: "hi",
-	}, TaskRunOptions{CurrentDepth: maxSpecialistDepth})
-	if err == nil || !strings.Contains(err.Error(), "depth") {
-		t.Fatalf("Run error = %v, want depth error", err)
+	tests := []struct {
+		name   string
+		params TaskParameters
+	}{
+		{name: "fresh", params: TaskParameters{Prompt: "hi"}},
+		{name: "resume", params: TaskParameters{Prompt: "hi", Resume: "child_session"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := (Executor{}).Run(context.Background(), tc.params, TaskRunOptions{CurrentDepth: maxSpecialistDepth})
+			if err == nil || !strings.Contains(err.Error(), "depth") {
+				t.Fatalf("Run error = %v, want depth error", err)
+			}
+		})
 	}
 }
 

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -1,6 +1,7 @@
 package specialist
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -333,6 +334,15 @@ func TestBuildArgsRejectsInvalidInputs(t *testing.T) {
 				t.Fatalf("BuildArgs error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestRunRejectsDepthExceedingMax(t *testing.T) {
+	_, err := (Executor{}).Run(context.Background(), TaskParameters{
+		Prompt: "hi",
+	}, TaskRunOptions{CurrentDepth: maxSpecialistDepth + 1})
+	if err == nil || !strings.Contains(err.Error(), "depth") {
+		t.Fatalf("Run error = %v, want depth error", err)
 	}
 }
 

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -346,6 +346,19 @@ func TestRunRejectsDepthExceedingMax(t *testing.T) {
 	}
 }
 
+// TestRunRejectsDepthAtMax covers the boundary: a parent already AT the cap
+// must be rejected too, since this Run call would launch a child one level
+// past it (--depth CurrentDepth+1). Only checking ">" here would let that
+// child start before the guard ever caught it.
+func TestRunRejectsDepthAtMax(t *testing.T) {
+	_, err := (Executor{}).Run(context.Background(), TaskParameters{
+		Prompt: "hi",
+	}, TaskRunOptions{CurrentDepth: maxSpecialistDepth})
+	if err == nil || !strings.Contains(err.Error(), "depth") {
+		t.Fatalf("Run error = %v, want depth error", err)
+	}
+}
+
 func TestBuildArgsRejectsInvalidSessionIDs(t *testing.T) {
 	_, err := (Executor{NewSessionID: func() (string, error) { return "../escape", nil }}).BuildArgs(BuildArgsInput{
 		Prompt: "hi",


### PR DESCRIPTION
## Summary

Adds a hard cap on specialist (Task tool) nesting depth, as a defense-in-depth safeguard.

Related to #470. Not closing it: as explained below, today's normal specialist/swarm path can't actually reach this recursively, so this cap is a future-proof guard rather than a fix for an active exploit of the recursive chain #470 describes.

## Changes

- Add `maxSpecialistDepth = 8` in `internal/specialist/exec.go`.
- `Executor.Run` now rejects a call whose `CurrentDepth` is already at or past the cap with a clear error, before any specialist work starts. (Fixed from an earlier off-by-one: the check must trigger at `CurrentDepth >= maxSpecialistDepth`, not `>`, since this call is what launches the child at `CurrentDepth+1` — checking only `>` let a parent already at the cap start one more level before the guard caught it.)

## Why this is defense-in-depth, not an active-exploit fix

Per jatmn's review: today, a specialist (or swarm member) can't actually reach this code path recursively. Every specialist/swarm child is launched with `--tag specialist` (`internal/specialist/exec.go`, the only place `--tag` is set on a spawned child), and `shouldRegisterExecSpecialistTools` (`internal/cli/app.go`) refuses to register the Task tool whenever `tag == "specialist"`, regardless of `--auto high` — already covered by the existing `exec_test.go` case asserting a specialist child does not get the Task tool. So a specialist cannot itself call Task to spawn a grandchild, and `CurrentDepth` can't structurally exceed 1 through today's normal flow.

The cap is still worth having: it's cheap, matches the issue's suggested fix (hard `MaxDepth` with a clear error), and protects against a future change to that tag-gating logic silently reopening the recursive path. It is not closing an actively exploitable bug today.

## Test plan

- `TestRunRejectsDepthExceedingMax` and `TestRunRejectsDepthAtMax` in `internal/specialist/exec_test.go`, covering both the already-past-cap case and the exact-boundary case the off-by-one fix addresses. `TestRunRejectsDepthAtMax` is now a table covering both a fresh call and a `Resume` call, since the guard sits before the fresh/resume split in `Run`.
- `go build ./...`
- `go vet ./internal/specialist/...`
- `go test ./internal/specialist/... -count=1` (all pass)

This was split out of #468 at reviewer request (Vasanthdev2004 asked for the bundled fixes to be split into independent PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a maximum cap on nested specialist execution depth to prevent overly deep task chains.
  * Runs with a current depth at or beyond the limit now fail fast with a clear, depth-related error.
* **Tests**
  * Extended coverage to verify rejection when depth exceeds the maximum.
  * Added boundary tests for both fresh runs and resume runs when depth equals the maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

