### PR TITLE
fix(acp): log session persistence failures instead of discarding them

### DIFF
--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -388,15 +390,21 @@ func (a *Agent) modeState(s *acpSession) *SessionModeState {
 
 func (a *Agent) persistTurn(sess *acpSession, user, assistant string) {
 	if a.deps.Store != nil {
-		_, _ = a.deps.Store.AppendEvent(sess.id, sessions.AppendEventInput{
+		if _, err := a.deps.Store.AppendEvent(sess.id, sessions.AppendEventInput{
 			Type:    sessions.EventMessage,
 			Payload: map[string]any{"role": "user", "content": user},
-		})
+		}); err != nil {
+			// best-effort; log at least so we notice history loss
+			// (real fix would surface to transcript / user)
+			fmt.Fprintf(os.Stderr, "warning: failed to persist user turn: %v\n", err)
+		}
 		if assistant != "" {
-			_, _ = a.deps.Store.AppendEvent(sess.id, sessions.AppendEventInput{
+			if _, err := a.deps.Store.AppendEvent(sess.id, sessions.AppendEventInput{
 				Type:    sessions.EventMessage,
 				Payload: map[string]any{"role": "assistant", "content": assistant},
-			})
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to persist assistant turn: %v\n", err)
+			}
 		}
 	}
 	sess.appendHistory(turnRecord{user: user, assistant: assistant})

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -162,6 +163,41 @@ func TestACPUnknownSessionPromptErrors(t *testing.T) {
 	err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{SessionID: "nope", Prompt: []ContentBlock{TextBlock("x")}}, &PromptResult{})
 	if err == nil {
 		t.Fatal("expected error for unknown session")
+	}
+}
+
+// TestPersistTurnLogsAppendEventFailures proves that a persistence failure
+// (previously silently discarded via `_, _ = ...AppendEvent(...)`) now gets
+// logged instead of vanishing without a trace. An invalid session id makes
+// AppendEvent fail deterministically without needing to break the store.
+func TestPersistTurnLogsAppendEventFailures(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	a := &Agent{deps: Deps{Store: store}}
+	sess := &acpSession{id: "not a valid session id!!"}
+
+	origStderr := os.Stderr
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = write
+
+	a.persistTurn(sess, "hello", "world")
+
+	if err := write.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	os.Stderr = origStderr
+
+	captured, err := io.ReadAll(read)
+	if err != nil {
+		t.Fatalf("read captured stderr: %v", err)
+	}
+	output := string(captured)
+	for _, want := range []string{"failed to persist user turn", "failed to persist assistant turn"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected stderr to contain %q, got %q", want, output)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`Agent.persistTurn` silently discarded errors from `Store.AppendEvent` for both the user and assistant turn (`_, _ = a.deps.Store.AppendEvent(...)`). A store failure (disk full, permission error, backend error) could corrupt or lose conversation history with the agent continuing as if nothing happened, breaking `/rewind`, checkpoints, and continuity between runs.

Closes #471

## Changes

- `internal/acp/agent.go`: `persistTurn` now checks the error returned by each `AppendEvent` call and logs a warning to stderr (`warning: failed to persist user turn: ...` / `warning: failed to persist assistant turn: ...`) instead of discarding it.
- This is a minimum, best-effort fix (log at least). Surfacing the failure to the transcript or user is left as future work, per the issue's suggested fix list.

## Test plan

- Added `TestPersistTurnLogsAppendEventFailures` in `internal/acp/agent_test.go`: forces `AppendEvent` to fail deterministically with an invalid session id, captures stderr via a pipe, and asserts both warning messages are logged.
- `go build ./internal/acp/...`
- `go vet ./internal/acp/...`
- `go test ./internal/acp/... -count=1` (all pass)

This was split out of #468 at reviewer request (Vasanthdev2004 asked for the bundled fixes to be split into independent PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved turn-saving behavior so message persistence issues are now reported instead of being silently ignored.
  * Added visible warnings when user or assistant message writes fail, while continuing best-effort processing.
  * Expanded test coverage to verify persistence failures are surfaced correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->