### PR TITLE
Cache TUI model registry

### DIFF
--- a/internal/tui/image_attach.go
+++ b/internal/tui/image_attach.go
@@ -98,16 +98,9 @@ func (m model) modelSupportsVisionTUI() bool {
 	if trimmed == "" {
 		return false
 	}
-	// Check the curated registry first.
-	registry, err := modelregistry.DefaultRegistry()
-	if err == nil {
-		if modelregistry.SupportsVision(registry, trimmed) {
-			return true
-		}
-		// Catalog knows this model and it lacks vision — trust that.
-		if _, known := registry.Get(trimmed); known {
-			return false
-		}
+	// The curated catalog is authoritative only when it knows the model.
+	if entry, known := m.modelCatalog.Resolve(trimmed); known {
+		return entry.Supports(modelregistry.ModelCapabilityVision)
 	}
 	// Check the discovered model list (from models.dev) for InputModalities
 	// containing "image". This covers custom/ollama/cloud models not in the

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -67,6 +67,7 @@ type model struct {
 	gitBranch                   string
 	providerName                string
 	modelName                   string
+	modelCatalog                modelregistry.Registry
 	providerProfile             config.ProviderProfile
 	savedProviders              []config.ProviderProfile
 	provider                    zeroruntime.Provider
@@ -661,9 +662,13 @@ func newModel(ctx context.Context, options Options) model {
 		sessionStore = sessions.NewStore(sessions.StoreOptions{})
 	}
 	sandboxStore := options.SandboxStore
+	modelCatalog, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		panic(err)
+	}
 	usageTracker := options.UsageTracker
 	if usageTracker == nil {
-		usageTracker = usage.NewTracker(usage.TrackerOptions{})
+		usageTracker = usage.NewTracker(usage.TrackerOptions{Registry: &modelCatalog})
 	}
 	prService := options.PrService
 	if prService == nil {
@@ -715,6 +720,7 @@ func newModel(ctx context.Context, options Options) model {
 		gitBranch:                   gitBranch(cwd),
 		providerName:                options.ProviderName,
 		modelName:                   options.ModelName,
+		modelCatalog:                modelCatalog,
 		providerProfile:             options.ProviderProfile,
 		favoriteModels:              favoriteModelSet(options.FavoriteModels),
 		recapsEnabled:               options.RecapsEnabled,

--- a/internal/tui/model_catalog.go
+++ b/internal/tui/model_catalog.go
@@ -66,10 +66,8 @@ func (m model) modelContextWindow(modelName string) int {
 	if trimmed == "" {
 		return 0
 	}
-	if registry, err := modelregistry.DefaultRegistry(); err == nil {
-		if entry, ok := registry.Resolve(trimmed); ok && entry.ContextLimits.ContextWindow > 0 {
-			return entry.ContextLimits.ContextWindow
-		}
+	if entry, ok := m.modelCatalog.Resolve(trimmed); ok && entry.ContextLimits.ContextWindow > 0 {
+		return entry.ContextLimits.ContextWindow
 	}
 	// Live-discovered window, preferring the ACTIVE provider's models so a model ID
 	// shared across providers resolves to the provider actually in use; only then

--- a/internal/tui/model_catalog_test.go
+++ b/internal/tui/model_catalog_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
+)
+
+func TestModelContextWindowUsesCachedCatalog(t *testing.T) {
+	registry := mustTestModelRegistry(t, testModelEntry("custom-long-context", 12345, []modelregistry.ModelCapability{
+		modelregistry.ModelCapabilityChat,
+	}))
+	m := model{modelCatalog: registry}
+
+	if got := m.modelContextWindow("custom-long-context"); got != 12345 {
+		t.Fatalf("modelContextWindow = %d, want 12345", got)
+	}
+}
+
+func TestModelSupportsVisionTUITrustsCachedCatalog(t *testing.T) {
+	registry := mustTestModelRegistry(t, testModelEntry("gpt-5-text-only", 12345, []modelregistry.ModelCapability{
+		modelregistry.ModelCapabilityChat,
+	}))
+	m := model{modelName: "gpt-5-text-only", modelCatalog: registry}
+
+	if m.modelSupportsVisionTUI() {
+		t.Fatal("catalog-known text-only model must not fall through to vision name heuristic")
+	}
+}
+
+func TestModelSupportsVisionTUIChecksDiscoveredBeforeHeuristic(t *testing.T) {
+	registry := mustTestModelRegistry(t, testModelEntry("custom-known", 12345, []modelregistry.ModelCapability{
+		modelregistry.ModelCapabilityChat,
+	}))
+	m := model{
+		modelName:    "gpt-5-text-only",
+		modelCatalog: registry,
+		modelPickerLiveByProvider: map[string][]providermodeldiscovery.Model{
+			"custom": {{ID: "gpt-5-text-only", InputModalities: []string{"text"}}},
+		},
+	}
+
+	if m.modelSupportsVisionTUI() {
+		t.Fatal("discovered text-only model must not fall through to vision name heuristic")
+	}
+}
+
+func BenchmarkModelContextWindowLookup(b *testing.B) {
+	cachedRegistry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		b.Fatalf("load default registry: %v", err)
+	}
+
+	b.Run("default_registry_each_call", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			registry, err := modelregistry.DefaultRegistry()
+			if err != nil {
+				b.Fatalf("load default registry: %v", err)
+			}
+			entry, ok := registry.Resolve("gpt-4.1")
+			if !ok || entry.ContextLimits.ContextWindow <= 0 {
+				b.Fatal("expected gpt-4.1 context window")
+			}
+		}
+	})
+
+	b.Run("cached_registry", func(b *testing.B) {
+		m := model{modelName: "gpt-4.1", modelCatalog: cachedRegistry}
+		b.ReportAllocs()
+		for b.Loop() {
+			if got := m.modelContextWindow(m.modelName); got <= 0 {
+				b.Fatal("expected gpt-4.1 context window")
+			}
+		}
+	})
+}
+
+func mustTestModelRegistry(t *testing.T, entries ...modelregistry.ModelEntry) modelregistry.Registry {
+	t.Helper()
+	registry, err := modelregistry.NewRegistry(entries)
+	if err != nil {
+		t.Fatalf("create test model registry: %v", err)
+	}
+	return registry
+}
+
+func testModelEntry(id string, contextWindow int, capabilities []modelregistry.ModelCapability) modelregistry.ModelEntry {
+	return modelregistry.ModelEntry{
+		ID:            id,
+		DisplayName:   id,
+		APIModel:      id,
+		Provider:      modelregistry.ProviderOpenAI,
+		APIProviders:  []modelregistry.ProviderKind{modelregistry.ProviderOpenAI},
+		ContextLimits: modelregistry.ContextLimits{ContextWindow: contextWindow, MaxOutputTokens: 1024},
+		Capabilities:  capabilities,
+		Cost: modelregistry.ModelCost{
+			Currency:           "USD",
+			Unit:               "per_1m_tokens",
+			InputPerMillion:    1,
+			OutputPerMillion:   1,
+			Source:             "test",
+			SourceLastVerified: "2026-01-01",
+		},
+		Status:  modelregistry.ModelStatusActive,
+		Aliases: []string{id},
+	}
+}

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -846,13 +846,13 @@ func TestEffortPickerAutoSelectionKeepsEffortUnset(t *testing.T) {
 }
 
 func TestModelContextWindowResolution(t *testing.T) {
-	m := model{}
 	// Registered model → the exact registry window (compare to the registry value so
 	// this doesn't break on a benign catalog update).
 	registry, err := modelregistry.DefaultRegistry()
 	if err != nil {
 		t.Fatalf("load default registry: %v", err)
 	}
+	m := model{modelCatalog: registry}
 	entry, ok := registry.Resolve("gpt-4.1")
 	if !ok || entry.ContextLimits.ContextWindow <= 0 {
 		t.Fatalf("gpt-4.1 should resolve a positive window in the registry")


### PR DESCRIPTION
Fixes #494
## Summary
- cache the curated model registry once per TUI model\n- reuse it for context-window and vision checks
- add regression tests plus a lookup benchmark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced repeated model-registry lookups by reusing a cached model catalog during model checks.

* **Bug Fixes**
  * Improved how supported context windows and vision capability are determined for models.
  * Kept discovered-model handling and name-based fallback behavior intact when needed.

* **Tests**
  * Added coverage for cached catalog lookups, vision-capability checks, and discovery interactions.
  * Added a benchmark comparing repeated registry loading versus cached lookup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->