### PR TITLE
fix(config): let a gateway ANTHROPIC_BASE_URL resolve as anthropic-compatible

### DIFF
--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -590,8 +590,16 @@ func applyProviderEnv(cfg *FileConfig, providerKind ProviderKind, env envProfile
 	if profile.Name == "" {
 		profile.Name = string(providerKind)
 	}
+	// A non-official baseURL from the environment signals a proxy/gateway, so promote
+	// the first-party kind to its -compatible transport (which accepts a custom URL).
+	// Env-only by design: a custom baseURL in a project config.json is left as-is and
+	// rejected by Resolve, so an untrusted project can't redirect a first-party key to
+	// another host.
 	if providerKind == ProviderKindOpenAI && baseURL != "" && !isOfficialOpenAIBaseURL(baseURL) {
 		profile.ProviderKind = ProviderKindOpenAICompatible
+	}
+	if providerKind == ProviderKindAnthropic && baseURL != "" && !isOfficialAnthropicBaseURL(baseURL) {
+		profile.ProviderKind = ProviderKindAnthropicCompat
 	}
 	// When the env supplies only credentials (no baseURL) for a provider name that
 	// already exists, don't force the standard transport kind — a same-named

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -617,6 +617,35 @@ func TestResolveUsesOpenAIEnvFallback(t *testing.T) {
 	}
 }
 
+func TestResolveUsesAnthropicEnvBaseURLAsCompatible(t *testing.T) {
+	// ANTHROPIC_BASE_URL pointing at a proxy/gateway must resolve to an
+	// anthropic-compatible provider (mirroring OPENAI_BASE_URL), not the "requires
+	// official baseURL" rejection — issue #479. The env is user-controlled, so a
+	// custom URL there is a deliberate gateway choice, unlike a project config.json.
+	resolved, err := Resolve(ResolveOptions{
+		Env: map[string]string{
+			"ANTHROPIC_API_KEY":  "sk-ant-env",
+			"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic",
+			"ANTHROPIC_MODEL":    "claude-custom",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.ActiveProvider != "anthropic" {
+		t.Fatalf("ActiveProvider = %q, want anthropic", resolved.ActiveProvider)
+	}
+	if resolved.Provider.ProviderKind != ProviderKindAnthropicCompat {
+		t.Fatalf("ProviderKind = %q, want anthropic-compatible", resolved.Provider.ProviderKind)
+	}
+	if resolved.Provider.BaseURL != "https://gateway.example/anthropic" {
+		t.Fatalf("BaseURL = %q, want gateway URL", resolved.Provider.BaseURL)
+	}
+	if resolved.Provider.APIKey != "sk-ant-env" || resolved.Provider.Model != "claude-custom" {
+		t.Fatalf("Provider = %#v, want env credentials/model", resolved.Provider)
+	}
+}
+
 func TestResolveUsesOpenAIAPIKeyOnlyWithDefaultModel(t *testing.T) {
 	resolved, err := Resolve(ResolveOptions{
 		Env: map[string]string{


### PR DESCRIPTION
Fixes #479.

Setting `ANTHROPIC_BASE_URL` to a local gateway/proxy blows up setup with `anthropic provider anthropic requires official baseURL https://api.anthropic.com`. Turns out `OPENAI_BASE_URL` already handles this — a non-official URL from the env auto-promotes to the `openai-compatible` kind — but Anthropic never got the same treatment, so the standard `ANTHROPIC_BASE_URL` proxy convention just gets rejected.

This mirrors the OpenAI behavior for Anthropic: a non-official `ANTHROPIC_BASE_URL` in the environment resolves to `anthropic-compatible` instead of the pinned first-party kind.

Kept it env-only on purpose. A custom baseURL in a project's `config.json` is still rejected — that pin is a security control (a cloned repo shouldn't be able to point your real Anthropic key at another host), and `TestResolveRejectsAnthropicOfficialProviderCustomBaseURL` still passes to prove it. The environment is the user's own shell, so a gateway URL there is a deliberate choice.

Verified with a resolver test that runs the exact reported env through `Resolve()` and checks it lands on `anthropic-compatible` with the gateway URL and no error.

One gap left out on purpose: `GEMINI_BASE_URL`/`GOOGLE_BASE_URL` has the same limitation, but there's no `google-compatible` kind to promote to, so fixing that is a separate, larger change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment-based configuration so Anthropic-compatible gateways and proxies are recognized correctly when a custom base URL is provided.
  * Resolved provider selection to keep the configured base URL and use the expected Anthropic credentials and model settings in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->