### PR TITLE
feat(agent): guard against over-engineering the solution in the editing discipline

### DIFF
--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -63,6 +63,10 @@ work.
   targeted diffs. Match the existing indentation, imports, and idioms. Match the
   file's comment density: do not add explanatory comments unless the user asks or
   the code is already comment-dense.
+- Solve the problem as posed, not a more general version of it. Add no
+  speculative abstraction, configurability, or handling for cases that cannot
+  occur, and nothing the user did not ask for. A small diff can still be
+  over-built; if a 200-line solution could be 50, rewrite it.
 - Preserve behavior you were not asked to change. Do not delete or rewrite code
   you did not author unless the task requires it; if you must, say so.
 


### PR DESCRIPTION
## Summary

Adds one bullet to the Editing discipline section of the core system prompt to curb over-engineering the **solution**, not just the diff.

Zero already tells the agent to prefer the smallest change and avoid unrelated rewrites — that caps the *diff*. But a small diff can still be over-built: speculative abstraction, unrequested configurability, error handling for cases that can't occur. That specific pitfall wasn't guarded anywhere. The new bullet closes it:

> Solve the problem as posed, not a more general version of it. Add no speculative abstraction, configurability, or handling for cases that cannot occur, and nothing the user did not ask for. A small diff can still be over-built; if a 200-line solution could be 50, rewrite it.

## Validation

Before/after eval on five over-engineering-prone tasks (config loader, memoize cache, JSON POST, dict validator, CSV reader), each solved under the current editing rules vs the current rules + this guardrail, then judged for simplicity **and** correctness:

- **3/5** treatment solutions simpler, **0** more complex, **0** correctness regressions (avg **9 vs 11** non-blank lines).
- The baseline gold-plated on two: an unrequested `wrapper.cache` introspection attribute on the cache, and unrequested header-merge config on the POST. The guardrail versions dropped both and stayed correct.
- On trivial tasks (word count, leap year) it's a no-op — the baseline is already minimal there, so there's nothing to trim.

## Scope

One file, four lines, in `internal/agent/system_prompt.md`. `go build` + `go test ./internal/agent/...` green. Closes #516.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal editing guidance to encourage more focused, scoped changes and avoid unnecessary extra work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->