### PR TITLE
docs: document AGENTS.md/ZERO.md and plugin manifest format

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,32 @@ zero cron             scheduled agent jobs
 zero update           check for newer releases
 ```
 
+## Extending Zero
+
+### Project instructions
+
+Zero appends project-specific guidance to the system prompt from the first
+`AGENTS.md`, `ZERO.md`, or `.zero/AGENTS.md` file found in each directory from
+the git root down to your current working directory (checked in that order
+per directory). Files are injected general-to-specific, capped at 8 KiB per
+file and 32 KiB total.
+
+### Plugins
+
+Plugins are discovered from `~/.config/zero/plugins/<name>/plugin.json`
+(user scope) and `<repo>/.zero/plugins/<name>/plugin.json` (project scope),
+and managed with `zero plugins`. A manifest can declare:
+
+- `tools` — custom tools (`command`, `args`, `inputSchema`, and a
+  `permission` of `allow`, `prompt`, or `deny`)
+- `hooks` — commands run on `beforeTool`, `afterTool`, `sessionStart`, or
+  `sessionEnd`
+- `prompts` and `skills` — additional prompt/skill files
+
+MCP servers (`zero mcp`) and standalone markdown skills (`zero skills`) use
+the same extension points and can also be wired up outside of a plugin
+manifest.
+
 ## Appearance And Accessibility
 
 | Control | Effect |

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ Plugins are discovered from `~/.config/zero/plugins/<name>/plugin.json`
 and managed with `zero plugins`. A manifest can declare:
 
 - `tools` — custom tools (`command`, `args`, `inputSchema`, and a
-  `permission` of `allow`, `prompt`, or `deny`)
+  `permission` of `prompt` or `deny`; `allow` is honored only when manifest tool
+  auto-approval is enabled)
 - `hooks` — commands run on `beforeTool`, `afterTool`, `sessionStart`, or
   `sessionEnd`
 - `prompts` and `skills` — additional prompt/skill files

--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ per directory). Files are injected general-to-specific, capped at 8 KiB per
 file and 32 KiB total.
 
 A personal `ZERO.md` under `config.UserConfigDir()/zero/ZERO.md`
-(`~/.config/zero/ZERO.md` on Linux/macOS, `%AppData%\Roaming\zero\ZERO.md` on
-Windows) applies across every workspace, ahead of any project guidelines.
+(`$XDG_CONFIG_HOME/zero/ZERO.md` or `~/.config/zero/ZERO.md` on Linux/macOS,
+`%AppData%\Roaming\zero\ZERO.md` on Windows) applies across every workspace, ahead of any project guidelines.
 
 ### Plugins
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ zero update           check for newer releases
 
 ## Extending Zero
 
-### Project instructions
+### Project and personal instructions
 
 Zero appends project-specific guidance to the system prompt from the first
 `AGENTS.md`, `ZERO.md`, or `.zero/AGENTS.md` file found in each directory from
@@ -293,11 +293,17 @@ the git root down to your current working directory (checked in that order
 per directory). Files are injected general-to-specific, capped at 8 KiB per
 file and 32 KiB total.
 
+A personal `ZERO.md` under `config.UserConfigDir()/zero/ZERO.md`
+(`~/.config/zero/ZERO.md` on Linux/macOS, `%AppData%\Roaming\zero\ZERO.md` on
+Windows) applies across every workspace, ahead of any project guidelines.
+
 ### Plugins
 
-Plugins are discovered from `~/.config/zero/plugins/<name>/plugin.json`
-(user scope) and `<repo>/.zero/plugins/<name>/plugin.json` (project scope),
-and managed with `zero plugins`. A manifest can declare:
+Plugins are discovered from `~/.config/zero/plugins/<name>/plugin.json` (user
+scope — `$XDG_CONFIG_HOME` or `~/.config` on every OS, independent of the
+`config.UserConfigDir()` path used above) and `<cwd>/.zero/plugins/<name>/plugin.json`
+(project scope — resolved from the current working directory, not the repo
+root), and managed with `zero plugins`. A manifest can declare:
 
 - `tools` — custom tools (`command`, `args`, `inputSchema`, and a
   `permission` of `prompt` or `deny`; `allow` is honored only when manifest tool


### PR DESCRIPTION
## Summary
- Adds an "Extending Zero" section to `README.md` documenting the `AGENTS.md`/`ZERO.md`/`.zero/AGENTS.md` project-instructions lookup chain (git root → cwd, 8 KiB/file, 32 KiB total)
- Documents the `plugin.json` manifest fields (`tools`, `hooks`, `prompts`, `skills`) and the two discovery paths (`~/.config/zero/plugins/*/plugin.json`, `<repo>/.zero/plugins/*/plugin.json`)
- Notes that MCP servers and standalone skills share the same extension points

Closes #521

## Test plan
- [x] Read through the rendered README section for accuracy against `internal/agent/system_prompt.go` and `internal/plugins/plugins.go`
- [ ] Maintainer review for tone/placement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an **“Extending Zero”** section explaining how project instructions are discovered and appended from local configuration files (general-to-specific order, with per-file and total size limits).
  * Documented support for a global personal `ZERO.md` that applies across workspaces.
  * Expanded plugin discovery/management guidance for user-scope and project-scope manifests, including declared capabilities, and clarified how MCP servers and standalone markdown skills reuse the same extension points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->