### PR TITLE
Batch session event persistence

### DIFF
--- a/internal/sessions/append_events_test.go
+++ b/internal/sessions/append_events_test.go
@@ -1,0 +1,233 @@
+package sessions
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStoreAppendEventsBatchesSequencesAndMetadata(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: sequenceClock([]time.Time{
+		time.Date(2026, 6, 4, 15, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 4, 15, 0, 1, 0, time.UTC),
+		time.Date(2026, 6, 4, 15, 0, 2, 0, time.UTC),
+		time.Date(2026, 6, 4, 15, 0, 3, 0, time.UTC),
+	})})
+	session, err := store.Create(CreateInput{SessionID: "batch"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	appended, err := store.AppendEvents(session.SessionID, []AppendEventInput{
+		{Type: EventMessage, Payload: map[string]any{"role": "user", "content": "one"}},
+		{Type: EventToolCall, Payload: map[string]any{"id": "call_1", "name": "read_file"}},
+		{Type: EventToolResult, Payload: map[string]any{"toolCallId": "call_1", "status": "ok"}},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvents returned error: %v", err)
+	}
+	if len(appended) != 3 {
+		t.Fatalf("expected 3 appended events, got %#v", appended)
+	}
+	for index, event := range appended {
+		wantSequence := index + 1
+		if event.Sequence != wantSequence || event.ID != fmt.Sprintf("batch:%d", wantSequence) {
+			t.Fatalf("event identity mismatch at %d: %#v", index, event)
+		}
+	}
+	if appended[0].CreatedAt != "2026-06-04T15:00:01Z" || appended[2].CreatedAt != "2026-06-04T15:00:03Z" {
+		t.Fatalf("unexpected event timestamps: %#v", appended)
+	}
+
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if loaded == nil || loaded.EventCount != 3 || loaded.LastEventType != EventToolResult || loaded.UpdatedAt != appended[2].CreatedAt {
+		t.Fatalf("metadata not updated from final batch event: %#v", loaded)
+	}
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if !reflect.DeepEqual(eventTypesForTest(events), []EventType{EventMessage, EventToolCall, EventToolResult}) {
+		t.Fatalf("unexpected event types: %#v", events)
+	}
+}
+
+func TestStoreAppendEventsEmptyBatchDoesNotRewriteMetadata(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T15:10:00Z")})
+	session, err := store.Create(CreateInput{SessionID: "empty_batch", Title: "unchanged"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	appended, err := store.AppendEvents(session.SessionID, nil)
+	if err != nil {
+		t.Fatalf("AppendEvents empty returned error: %v", err)
+	}
+	if len(appended) != 0 {
+		t.Fatalf("empty AppendEvents returned %#v", appended)
+	}
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if loaded == nil || !reflect.DeepEqual(*loaded, session) {
+		t.Fatalf("empty AppendEvents rewrote metadata: before=%#v after=%#v", session, loaded)
+	}
+}
+
+func TestStoreAppendEventsInvalidPayloadDoesNotPartiallyAppend(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T15:20:00Z")})
+	session, err := store.Create(CreateInput{SessionID: "invalid_batch"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	_, err = store.AppendEvents(session.SessionID, []AppendEventInput{
+		{Type: EventMessage, Payload: map[string]any{"content": "valid first"}},
+		{Type: EventMessage, Payload: json.RawMessage(`{"broken"`)},
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid raw JSON payload") {
+		t.Fatalf("expected invalid raw payload error, got %v", err)
+	}
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("invalid batch should not append partial events: %#v", events)
+	}
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if loaded == nil || loaded.EventCount != 0 || loaded.LastEventType != "" {
+		t.Fatalf("invalid batch should not update metadata: %#v", loaded)
+	}
+}
+
+func TestStoreAppendEventsSequencesAfterMetadataLag(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T15:30:00Z")})
+	session, err := store.Create(CreateInput{SessionID: "lagging"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": "already durable"}}); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+	lagging, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	lagging.EventCount = 0
+	lagging.LastEventType = ""
+	if err := store.writeMetadata(*lagging); err != nil {
+		t.Fatalf("writeMetadata returned error: %v", err)
+	}
+
+	appended, err := store.AppendEvents(session.SessionID, []AppendEventInput{
+		{Type: EventToolCall, Payload: map[string]any{"id": "call"}},
+		{Type: EventToolResult, Payload: map[string]any{"toolCallId": "call"}},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvents returned error: %v", err)
+	}
+	if len(appended) != 2 || appended[0].Sequence != 2 || appended[1].Sequence != 3 {
+		t.Fatalf("batch did not sequence after durable log tail: %#v", appended)
+	}
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if loaded == nil || loaded.EventCount != 3 || loaded.LastEventType != EventToolResult {
+		t.Fatalf("metadata not repaired by batch append: %#v", loaded)
+	}
+}
+
+func TestStoreAppendEventsSerializesConcurrentBatches(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T15:40:00Z")})
+	session, err := store.Create(CreateInput{SessionID: "concurrent_batches"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	const writers = 8
+	const perBatch = 3
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for writer := 0; writer < writers; writer++ {
+		wg.Add(1)
+		go func(writer int) {
+			defer wg.Done()
+			appended, err := store.AppendEvents(session.SessionID, []AppendEventInput{
+				{Type: EventMessage, Payload: map[string]int{"writer": writer, "index": 0}},
+				{Type: EventMessage, Payload: map[string]int{"writer": writer, "index": 1}},
+				{Type: EventMessage, Payload: map[string]int{"writer": writer, "index": 2}},
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			if len(appended) != perBatch {
+				errs <- fmt.Errorf("writer %d appended %d events", writer, len(appended))
+				return
+			}
+			for index := 1; index < len(appended); index++ {
+				if appended[index].Sequence != appended[index-1].Sequence+1 {
+					errs <- fmt.Errorf("writer %d batch was interleaved: %#v", writer, appended)
+					return
+				}
+			}
+			errs <- nil
+		}(writer)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("AppendEvents returned error: %v", err)
+		}
+	}
+
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	total := writers * perBatch
+	if len(events) != total {
+		t.Fatalf("expected %d events, got %d", total, len(events))
+	}
+	seen := map[int]bool{}
+	for _, event := range events {
+		if seen[event.Sequence] {
+			t.Fatalf("duplicate sequence %d in %#v", event.Sequence, events)
+		}
+		seen[event.Sequence] = true
+	}
+	for sequence := 1; sequence <= total; sequence++ {
+		if !seen[sequence] {
+			t.Fatalf("missing sequence %d in %#v", sequence, events)
+		}
+	}
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if loaded == nil || loaded.EventCount != total || loaded.LastEventType != EventMessage {
+		t.Fatalf("metadata not updated after concurrent batches: %#v", loaded)
+	}
+}
+
+func eventTypesForTest(events []Event) []EventType {
+	types := make([]EventType, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.Type)
+	}
+	return types
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -153,6 +153,11 @@ type AppendEventInput struct {
 	Payload any
 }
 
+type preparedAppendEvent struct {
+	Type    EventType
+	Payload json.RawMessage
+}
+
 type RecordSpecInput struct {
 	SpecID              string
 	SpecFilePath        string
@@ -426,7 +431,7 @@ func (store *Store) Fork(parentSessionID string, input ForkInput) (Metadata, err
 	if err != nil {
 		return Metadata{}, err
 	}
-	copied := 0
+	copyInputs := []AppendEventInput{}
 	for _, event := range events {
 		// Do NOT copy usage accounting into the fork. It already counted against the
 		// parent, and a usage report that aggregates the parent and the fork would
@@ -435,11 +440,12 @@ func (store *Store) Fork(parentSessionID string, input ForkInput) (Metadata, err
 		if event.Type == EventUsage {
 			continue
 		}
-		if _, err := store.AppendEvent(fork.SessionID, AppendEventInput{Type: event.Type, Payload: event.Payload}); err != nil {
-			return Metadata{}, err
-		}
-		copied++
+		copyInputs = append(copyInputs, AppendEventInput{Type: event.Type, Payload: event.Payload})
 	}
+	if _, err := store.AppendEvents(fork.SessionID, copyInputs); err != nil {
+		return Metadata{}, err
+	}
+	copied := len(copyInputs)
 	// Copy the parent's content-addressed checkpoint blobs into the fork so the
 	// copied EventSessionCheckpoint events resolve to real blobs and a rewind on
 	// the fork can restore file content (otherwise rewind reads missing blobs
@@ -513,19 +519,34 @@ func (store *Store) RecordSpec(sessionID string, input RecordSpecInput) (Metadat
 }
 
 func (store *Store) AppendEvent(sessionID string, input AppendEventInput) (Event, error) {
-	if !ValidSessionID(sessionID) {
-		return Event{}, fmt.Errorf("invalid zero session id %q", sessionID)
-	}
-	if strings.TrimSpace(string(input.Type)) == "" {
-		return Event{}, fmt.Errorf("zero session event type is required")
-	}
-	unlock, err := store.lockSession(sessionID)
+	events, err := store.AppendEvents(sessionID, []AppendEventInput{input})
 	if err != nil {
 		return Event{}, err
 	}
+	return events[0], nil
+}
+
+// AppendEvents appends a batch of events atomically under one session lock and
+// durability pass. The returned events have contiguous sequences in input order.
+// An empty batch is a no-op and does not rewrite metadata.
+func (store *Store) AppendEvents(sessionID string, inputs []AppendEventInput) ([]Event, error) {
+	if !ValidSessionID(sessionID) {
+		return nil, fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	prepared, err := prepareAppendEventInputs(inputs)
+	if err != nil {
+		return nil, err
+	}
+	if len(prepared) == 0 {
+		return []Event{}, nil
+	}
+	unlock, err := store.lockSession(sessionID)
+	if err != nil {
+		return nil, err
+	}
 	defer unlock()
 
-	return store.appendEventLocked(sessionID, input)
+	return store.appendPreparedEventsLocked(sessionID, prepared)
 }
 
 // AppendEventUnlessExists appends input only when exists(currentEvents) is false,
@@ -572,13 +593,26 @@ func (store *Store) AppendEventUnlessExists(sessionID string, input AppendEventI
 // the single lock they already hold, instead of re-locking (which would deadlock
 // on the non-reentrant in-process mutex).
 func (store *Store) appendEventLocked(sessionID string, input AppendEventInput) (Event, error) {
-	session, err := store.readMetadata(sessionID)
+	prepared, err := prepareAppendEventInputs([]AppendEventInput{input})
 	if err != nil {
 		return Event{}, err
 	}
-	payload, err := rawPayload(input.Payload)
+	events, err := store.appendPreparedEventsLocked(sessionID, prepared)
 	if err != nil {
 		return Event{}, err
+	}
+	return events[0], nil
+}
+
+// appendPreparedEventsLocked appends pre-validated events WITHOUT acquiring the
+// session lock. The caller MUST already hold store.lockSession(sessionID).
+func (store *Store) appendPreparedEventsLocked(sessionID string, inputs []preparedAppendEvent) ([]Event, error) {
+	if len(inputs) == 0 {
+		return []Event{}, nil
+	}
+	session, err := store.readMetadata(sessionID)
+	if err != nil {
+		return nil, err
 	}
 	sequence := session.EventCount + 1
 	// The events log is the source of truth for sequencing. metadata.EventCount is
@@ -590,46 +624,54 @@ func (store *Store) appendEventLocked(sessionID string, input AppendEventInput) 
 	if logSeq, err := store.lastEventSequence(sessionID); err == nil && logSeq >= sequence {
 		sequence = logSeq + 1
 	}
-	timestamp := store.timestamp()
-	event := Event{
-		ID:        fmt.Sprintf("%s:%d", sessionID, sequence),
-		SessionID: sessionID,
-		Sequence:  sequence,
-		Type:      input.Type,
-		CreatedAt: timestamp,
-		Payload:   payload,
-	}
-	data, err := json.Marshal(event)
-	if err != nil {
-		return Event{}, fmt.Errorf("encode zero session event: %w", err)
+	events := make([]Event, 0, len(inputs))
+	var batch bytes.Buffer
+	for index, input := range inputs {
+		timestamp := store.timestamp()
+		event := Event{
+			ID:        fmt.Sprintf("%s:%d", sessionID, sequence+index),
+			SessionID: sessionID,
+			Sequence:  sequence + index,
+			Type:      input.Type,
+			CreatedAt: timestamp,
+			Payload:   input.Payload,
+		}
+		data, err := json.Marshal(event)
+		if err != nil {
+			return nil, fmt.Errorf("encode zero session event: %w", err)
+		}
+		batch.Write(data)
+		batch.WriteByte('\n')
+		events = append(events, event)
 	}
 	file, err := os.OpenFile(store.eventsPath(sessionID), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
 	if err != nil {
-		return Event{}, fmt.Errorf("append zero session event: %w", err)
+		return nil, fmt.Errorf("append zero session event: %w", err)
 	}
-	if _, err := file.Write(append(data, '\n')); err != nil {
+	if _, err := file.Write(batch.Bytes()); err != nil {
 		_ = file.Close()
-		return Event{}, fmt.Errorf("append zero session event: %w", err)
+		return nil, fmt.Errorf("append zero session event: %w", err)
 	}
-	// fsync the event before reporting success: the derived metadata.json IS
+	// fsync the events before reporting success: the derived metadata.json IS
 	// fsync'd (writeMetadata), so without this a crash after the metadata flush
 	// but before the events.jsonl page reaches disk leaves EventCount ahead of the
-	// durable log — silently losing the just-appended event (incl. the checkpoint
+	// durable log — silently losing just-appended events (incl. checkpoints
 	// that /rewind targets). Make the log at least as durable as its metadata. (AUDIT-M12)
 	if err := file.Sync(); err != nil {
 		_ = file.Close()
-		return Event{}, fmt.Errorf("sync zero session event: %w", err)
+		return nil, fmt.Errorf("sync zero session event: %w", err)
 	}
 	if err := file.Close(); err != nil {
-		return Event{}, fmt.Errorf("close zero session event file: %w", err)
+		return nil, fmt.Errorf("close zero session event file: %w", err)
 	}
-	session.UpdatedAt = timestamp
-	session.EventCount = sequence
-	session.LastEventType = input.Type
+	last := events[len(events)-1]
+	session.UpdatedAt = last.CreatedAt
+	session.EventCount = last.Sequence
+	session.LastEventType = last.Type
 	if err := store.writeMetadata(session); err != nil {
-		return Event{}, err
+		return nil, err
 	}
-	return event, nil
+	return events, nil
 }
 
 // UpdateTitle replaces a session's Title and returns the updated metadata. It is
@@ -962,6 +1004,24 @@ func rawPayload(payload any) (json.RawMessage, error) {
 		return nil, fmt.Errorf("encode zero session payload: %w", err)
 	}
 	return data, nil
+}
+
+func prepareAppendEventInputs(inputs []AppendEventInput) ([]preparedAppendEvent, error) {
+	prepared := make([]preparedAppendEvent, 0, len(inputs))
+	for _, input := range inputs {
+		if strings.TrimSpace(string(input.Type)) == "" {
+			return nil, fmt.Errorf("zero session event type is required")
+		}
+		payload, err := rawPayload(input.Payload)
+		if err != nil {
+			return nil, err
+		}
+		prepared = append(prepared, preparedAppendEvent{
+			Type:    input.Type,
+			Payload: payload,
+		})
+	}
+	return prepared, nil
 }
 
 func envValue(env map[string]string, key string) string {

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -123,13 +123,24 @@ func (m model) appendSessionEvent(eventType sessions.EventType, payload any) (mo
 
 func (m model) appendSessionEvents(events []pendingSessionEvent) (model, []transcriptRow) {
 	rows := []transcriptRow{}
+	if m.activeSession.SessionID == "" || len(events) == 0 {
+		return m, rows
+	}
+	inputs := make([]sessions.AppendEventInput, 0, len(events))
 	for _, event := range events {
-		next, err := m.appendSessionEvent(event.Type, event.Payload)
-		if err != nil {
-			rows = append(rows, transcriptRow{kind: rowError, text: "session record error: " + err.Error()})
-			continue
-		}
-		m = next
+		inputs = append(inputs, sessions.AppendEventInput{Type: event.Type, Payload: event.Payload})
+	}
+	appended, err := m.sessionStore.AppendEvents(m.activeSession.SessionID, inputs)
+	if err != nil {
+		rows = append(rows, transcriptRow{kind: rowError, text: "session record error: " + err.Error()})
+		return m, rows
+	}
+	if len(appended) > 0 {
+		last := appended[len(appended)-1]
+		m.activeSession.UpdatedAt = last.CreatedAt
+		m.activeSession.EventCount = last.Sequence
+		m.activeSession.LastEventType = last.Type
+		m.sessionEvents = append(m.sessionEvents, appended...)
 	}
 	return m, rows
 }
@@ -142,13 +153,12 @@ func (m model) appendSessionEventsTo(sessionID string, events []pendingSessionEv
 	if m.sessionStore == nil || sessionID == "" {
 		return rows
 	}
+	inputs := make([]sessions.AppendEventInput, 0, len(events))
 	for _, event := range events {
-		if _, err := m.sessionStore.AppendEvent(sessionID, sessions.AppendEventInput{
-			Type:    event.Type,
-			Payload: event.Payload,
-		}); err != nil {
-			rows = append(rows, transcriptRow{kind: rowError, text: "session record error: " + err.Error()})
-		}
+		inputs = append(inputs, sessions.AppendEventInput{Type: event.Type, Payload: event.Payload})
+	}
+	if _, err := m.sessionStore.AppendEvents(sessionID, inputs); err != nil {
+		rows = append(rows, transcriptRow{kind: rowError, text: "session record error: " + err.Error()})
 	}
 	return rows
 }

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -108,6 +108,46 @@ func TestPromptSubmitPersistsTUISessionEvents(t *testing.T) {
 	}
 }
 
+func TestAppendSessionEventsBatchesAndUpdatesActiveSession(t *testing.T) {
+	store := testSessionStore(t)
+	session, err := store.Create(sessions.CreateInput{SessionID: "tui_batch", Title: "batch"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	m := model{
+		sessionStore:  store,
+		activeSession: session,
+	}
+
+	next, rows := m.appendSessionEvents([]pendingSessionEvent{
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "assistant", "content": "done"}},
+		{Type: sessions.EventUsage, Payload: map[string]any{"totalTokens": 3}},
+	})
+	if len(rows) != 0 {
+		t.Fatalf("appendSessionEvents returned error rows: %#v", rows)
+	}
+	if next.activeSession.EventCount != 2 || next.activeSession.LastEventType != sessions.EventUsage {
+		t.Fatalf("active session metadata not updated from batch: %#v", next.activeSession)
+	}
+	if len(next.sessionEvents) != 2 || next.sessionEvents[0].Sequence != 1 || next.sessionEvents[1].Sequence != 2 {
+		t.Fatalf("in-memory session events not updated from batch: %#v", next.sessionEvents)
+	}
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{sessions.EventMessage, sessions.EventUsage}) {
+		t.Fatalf("unexpected persisted event types: %#v", got)
+	}
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if loaded == nil || loaded.EventCount != next.activeSession.EventCount || loaded.LastEventType != next.activeSession.LastEventType {
+		t.Fatalf("store metadata diverged from active session: store=%#v active=%#v", loaded, next.activeSession)
+	}
+}
+
 func TestPromptWithoutProviderDoesNotCreateSession(t *testing.T) {
 	store := testSessionStore(t)
 	m := newModel(context.Background(), Options{SessionStore: store})


### PR DESCRIPTION
Fixes #525

## Summary
- Add batched session event append API.
- Persist batch with one session lock, log write/sync, metadata update.
- Wire TUI session persistence and fork event copying to batch append.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session events are now saved in batches more reliably, reducing the chance of partial writes or duplicate ordering.
  * Active session details stay in sync after event updates, including event count, last event type, and timestamps.
  * Empty event submissions no longer rewrite session data, and invalid event data is rejected cleanly without affecting saved history.
  * Concurrent session updates are now handled in a stable, ordered way.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->