### PR TITLE
chore: fix golangci-lint findings (dead code, ineffassign, staticcheck)

### DIFF
--- a/internal/agent/command_prefix.go
+++ b/internal/agent/command_prefix.go
@@ -168,10 +168,6 @@ func cleanPrefixRule(prefix []string) []string {
 	return cleaned
 }
 
-func safeRequestedPrefix(prefix []string, command []string) bool {
-	return safeRequestedPrefixForSegments(prefix, [][]string{command})
-}
-
 func safeRequestedPrefixForSegments(prefix []string, segments [][]string) bool {
 	if len(prefix) == 0 || !sandbox.ValidCommandPrefix(prefix) {
 		return false
@@ -194,14 +190,6 @@ func safeRequestedPrefixForSegments(prefix []string, segments [][]string) bool {
 		return false
 	}
 	return matched
-}
-
-func safeShellCommandTokens(command string) ([]string, bool) {
-	segments, ok := safeShellCommandSegments(command)
-	if !ok || len(segments) != 1 {
-		return nil, false
-	}
-	return segments[0], true
 }
 
 func safeShellCommandSegments(command string) ([][]string, bool) {

--- a/internal/agent/partition_cache_stable_test.go
+++ b/internal/agent/partition_cache_stable_test.go
@@ -34,7 +34,7 @@ func TestPartitionToolsActiveAppendsLoadedToolAfterEagerBlock(t *testing.T) {
 		t.Fatalf("expected read_file, tool_search and loaded alpha all exposed, got %#v", exposed)
 	}
 	// The eager tools must precede the loaded deferred tool (appended, not inserted).
-	if !(readPos < alphaPos && searchPos < alphaPos) {
+	if readPos >= alphaPos || searchPos >= alphaPos {
 		t.Fatalf("loaded deferred tool must be appended after the eager block; got read=%d search=%d alpha=%d", readPos, searchPos, alphaPos)
 	}
 	// beta was never loaded — it stays hidden.

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -520,14 +520,6 @@ func (b *boundedBuffer) retained() string {
 	return string(b.head) + string(b.tail)
 }
 
-// truncateHeadTail keeps the first and last halves of value when it exceeds
-// maxBytes, dropping the middle behind a marker. Returns the possibly-truncated
-// text, the raw byte length, and whether truncation happened.
-func truncateHeadTail(value string, maxBytes int) (string, int, bool) {
-	// value holds the whole stream, so its length is the true raw size.
-	return truncateHeadTailWithTotal(value, len(value), maxBytes)
-}
-
 // truncateHeadTailWithTotal head+tail-truncates value to maxBytes, using total —
 // the full original byte count — for the "N bytes omitted" marker and the raw
 // count. total may exceed len(value) when the middle was already discarded during

--- a/internal/tools/edit_replacers.go
+++ b/internal/tools/edit_replacers.go
@@ -58,7 +58,7 @@ func fuzzyEditMatch(content, find string, replaceAll bool) (string, error) {
 				continue
 			}
 			seen[search] = true
-			if strings.Index(content, search) < 0 {
+			if !strings.Contains(content, search) {
 				continue
 			}
 			candidates = append(candidates, search)

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -28,7 +28,7 @@ const (
 	webFetchTimeout         = 30 * time.Second
 	webFetchRedirectLimit   = 5
 	webFetchErrorBodyLimit  = 4 * 1024
-	webFetchPublicOnlyHint  = "web_fetch only supports public remote HTTP/HTTPS URLs. For localhost or private network URLs, use bash with curl so sandbox network permission can apply."
+	webFetchPublicOnlyHint  = "web_fetch only supports public remote HTTP/HTTPS URLs. For localhost or private network URLs, use bash with curl so sandbox network permission can apply"
 )
 
 type webFetchTool struct {
@@ -348,7 +348,7 @@ func webFetchRedirectPolicy(previous func(*http.Request, []*http.Request) error,
 			return fmt.Errorf("too many redirects: maximum is %d", webFetchRedirectLimit)
 		}
 		if err := validateParsedWebFetchURL(request.Context(), request.URL, resolver); err != nil {
-			return fmt.Errorf("Unsafe redirect URL: %w", err)
+			return fmt.Errorf("unsafe redirect URL: %w", err)
 		}
 		if previous != nil {
 			return previous(request, via)

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -405,7 +405,7 @@ func TestWebFetchToolRejectsUnsafeRedirects(t *testing.T) {
 			if result.Status != StatusError {
 				t.Fatalf("expected redirect safety error, got %s: %s", result.Status, result.Output)
 			}
-			if !strings.Contains(result.Output, "Unsafe redirect URL") {
+			if !strings.Contains(result.Output, "unsafe redirect URL") {
 				t.Fatalf("expected unsafe redirect message, got %q", result.Output)
 			}
 		})

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -426,7 +426,6 @@ func stringListArgWebSearch(args map[string]any, key string) (domains []string, 
 	if !ok || value == nil {
 		return nil, false, nil
 	}
-	provided = true
 	raw, ok := value.([]any)
 	if !ok {
 		if asString, ok2 := value.([]string); ok2 {


### PR DESCRIPTION
## Summary

Small cleanup pass from running `golangci-lint` locally (installed it after CodeRabbit's `truncateHeadTail` nitpick on #476 turned out to have no equivalent check in this repo's actual CI, which only runs `go vet`).

## Changes

- Remove three unused functions found by the `unused` linter: `safeRequestedPrefix`, `safeShellCommandTokens` (`internal/agent/command_prefix.go`), and `truncateHeadTail` (`internal/tools/bash.go`). Each was a thin wrapper with no remaining callers.
- Drop an ineffectual assignment in `stringListArgWebSearch` (`internal/tools/web_search.go`): every return path after it already sets the named return explicitly, so the assignment never took effect.
- Simplify a negated-and condition in `partition_cache_stable_test.go` via De Morgan's law.
- Use `strings.Contains` instead of `strings.Index(...) < 0` in `edit_replacers.go`.
- Fix error string style (staticcheck ST1005): lowercase `"unsafe redirect URL"` and drop the trailing period from `webFetchPublicOnlyHint` in `web_fetch.go`, updating the one test that asserted on the old casing.

Deliberately left the `errcheck` findings (unchecked `defer file.Close()` / `response.Body.Close()` / `Write()` errors) alone. Those are stylistic, not correctness bugs, and this repo's CI doesn't run golangci-lint at all, so there's no actual gate to satisfy there.

## Test plan

- `go build ./...`
- `go vet ./...` (clean, matches actual CI)
- `go test ./internal/agent/... ./internal/tools/...` (pass)
- `golangci-lint run ./internal/agent/... ./internal/tools/... --enable-only unused,ineffassign,staticcheck` (0 issues, down from 6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the wording and consistency of a few error messages shown during unsafe redirect handling and web fetch prompts.
  * Tightened validation and matching behavior in some command and edit workflows for more reliable results.

* **Refactor**
  * Simplified several internal code paths and cleanup logic without changing expected user-facing behavior.
  * Updated test assertions to better reflect the current output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->