### PR TITLE
ci: add golangci-lint as an advisory check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # govulncheck and deadcode resolve a toolchain from their own modules, which
-      # can drop below the version go.mod requires and then fail to load our
-      # packages. Pin GOTOOLCHAIN to the go.mod toolchain so both run under it.
+      # govulncheck, deadcode, and golangci-lint each resolve a toolchain from
+      # their own modules, which can drop below the version go.mod requires and
+      # then fail to load our packages. Pin GOTOOLCHAIN to the go.mod toolchain
+      # so all three run under it.
       - name: Pin toolchain from go.mod
         run: |
           toolchain="$(awk '/^toolchain /{print $2}' go.mod)"
@@ -120,3 +121,13 @@ jobs:
       - name: deadcode (advisory)
         continue-on-error: true
         run: go run golang.org/x/tools/cmd/deadcode@v0.46.0 -test=false ./...
+
+      # Advisory: catches what deadcode's whole-program reachability analysis
+      # doesn't, unused private functions/assignments reachable within a
+      # package but never actually called, plus staticcheck-style correctness
+      # and readability issues. Scoped to a few linters rather than the full
+      # default battery, and non-blocking, while the existing findings across
+      # the repo are cleaned up incrementally (see #527).
+      - name: golangci-lint (advisory)
+        continue-on-error: true
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --enable-only unused,ineffassign,staticcheck ./...


### PR DESCRIPTION
## Summary

CI currently runs `go vet`, `gofmt -l`, tests, `govulncheck` (hard gate), and an advisory `deadcode` check (unreachable-from-cmd/* analysis). None of these catch unused private functions/assignments that are locally reachable but never called, or staticcheck-style correctness/readability issues.

Concretely: CodeRabbit's review on #476 flagged `truncateHeadTail` in `internal/tools/bash.go` as dead code that "would fail CI", but nothing in this repo actually runs golangci-lint, so it wouldn't have. Running it locally turned up the same finding plus several more that had been sitting on `main` uncaught, fixed in #527, plus more elsewhere in the repo (`internal/sandbox`, `internal/tui`, `internal/update`) that #527 didn't touch.

`deadcode` didn't catch any of these because it's a different kind of analysis: whole-program reachability from `cmd/*` entrypoints, not per-package unused-function detection.

## Changes

Add a `golangci-lint (advisory)` step to the `security` job, right after `deadcode`:

- Scoped to `unused`, `ineffassign`, and `staticcheck` rather than the full default battery, so this doesn't immediately dump the entire default linter set's noise into CI.
- `continue-on-error: true` (same as `deadcode`), so it's visible but non-blocking while the existing findings across the repo get cleaned up incrementally instead of all landing as a wall of failures on unrelated in-flight PRs.
- Pinned to `v2.12.2`, invoked via `go run` the same way `govulncheck`/`deadcode` already are, and added to the toolchain-pin comment/step for the same reason (its own module's toolchain resolution can drop below what go.mod requires).

## Test plan

- Ran the exact command locally against `main`: `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --enable-only unused,ineffassign,staticcheck ./...`, confirms it resolves and runs cleanly (42 pre-existing findings surfaced, which is expected and why this lands advisory first).
- Workflow YAML structure/indentation matches the existing `deadcode` step exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI security and code-quality checks with clearer toolchain guidance.
  * Added an advisory lint pass to surface additional issues without blocking merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->