### PR TITLE
perf(agent): cheap compaction — dedicated summarizer model, input cap…

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -492,27 +492,29 @@ func (state *compactionState) switchModel(modelID string, window int) {
 	state.summarizerBroken = false
 }
 
-// summarizeProvider returns the provider summarization calls should use: the
-// dedicated summarizer when one applies to the current main model and is
-// healthy, else the main provider. The factory runs at most once per main
-// model; a build error marks the summarizer broken for that model.
-func (state *compactionState) summarizeProvider(ctx context.Context, main Provider) Provider {
+// summarizeProvider returns the provider summarization calls should use and
+// whether it is the dedicated summarizer: that one when it applies to the
+// current main model and is healthy, else the main provider. The factory runs
+// at most once per main model; a build error marks the summarizer broken for
+// that model. Callers branch on the boolean rather than comparing Provider
+// values — interface comparison panics on a non-comparable dynamic type.
+func (state *compactionState) summarizeProvider(ctx context.Context, main Provider) (Provider, bool) {
 	if state.summarizerFactory == nil || state.summarizerBroken {
-		return main
+		return main, false
 	}
 	if !state.summarizerResolved {
 		state.summarizerResolved = true
 		built, err := state.summarizerFactory(ctx, state.mainModel)
 		if err != nil {
 			state.summarizerBroken = true
-			return main
+			return main, false
 		}
 		state.summarizerProvider = built
 	}
 	if state.summarizerProvider == nil {
-		return main
+		return main, false
 	}
-	return state.summarizerProvider
+	return state.summarizerProvider, true
 }
 
 // fitsWindow reports whether a calibrated size is safely under the limit the
@@ -696,9 +698,9 @@ func (state *compactionState) summarizeClosure(ctx context.Context, provider Pro
 		state.planner = newContextPlanner(contextPlannerConfig{})
 	}
 	return func(toSummarize []zeroruntime.Message) (string, error) {
-		chosen := state.summarizeProvider(ctx, provider)
+		chosen, dedicated := state.summarizeProvider(ctx, provider)
 		summary, err := summarizeWithPlanner(ctx, chosen, toSummarize, state.onUsage, state.planner, state.trace)
-		if err == nil || chosen == provider {
+		if err == nil || !dedicated {
 			return summary, err
 		}
 		state.summarizerBroken = true

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Gitlawb/zero/internal/trace"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -390,6 +392,27 @@ type compactionState struct {
 	// starts at 1.0 and converges via an EMA as each turn reports actual usage, so
 	// later turns compact nearer to real capacity. Zero is treated as 1.0.
 	calibrationRatio float64
+
+	// summarizerFactory lazily builds the dedicated (cheap) summarizer provider
+	// (Options.Summarizer) for the current main model. summarizerProvider
+	// memoizes the built provider and summarizerResolved records that the
+	// factory ran (it may legitimately return no provider: the main model is
+	// already the cheap one). summarizerBroken is the sticky fallback: once a
+	// build or call fails, the run stays on the main provider until the next
+	// model switch — a misconfigured cheap model must never break (or
+	// repeatedly delay) compaction.
+	summarizerFactory  func(ctx context.Context, mainModelID string) (Provider, error)
+	summarizerProvider Provider
+	summarizerResolved bool
+	summarizerBroken   bool
+	// window is the context window the threshold was derived from. The
+	// reactive free-prune stage compares against it (the limit the provider
+	// enforces), not against the 70% proactive threshold — a pruned history
+	// between the two would still succeed on retry.
+	window int
+	// mainModel is the model the run currently streams on; the summarizer
+	// choice is made against it and remade after a mid-run switch.
+	mainModel string
 }
 
 // calibrate folds one turn's (rawEstimate, actualPromptTokens) sample into the
@@ -424,15 +447,84 @@ func (state *compactionState) calibratedTokens(raw int) int {
 
 func newCompactionState(options Options, task *taskState) *compactionState {
 	state := &compactionState{
-		enabled:      options.ContextWindow > 0,
-		threshold:    compactionThreshold(options.ContextWindow),
-		preserveLast: options.CompactionPreserveLast,
-		onUsage:      options.OnUsage,
-		task:         task,
-		planner:      newContextPlanner(contextPlannerConfig{contextWindow: options.ContextWindow, serviceTier: options.ServiceTier}),
-		trace:        options.Trace,
+		enabled:           options.ContextWindow > 0,
+		threshold:         compactionThreshold(options.ContextWindow),
+		window:            options.ContextWindow,
+		mainModel:         options.Model,
+		preserveLast:      options.CompactionPreserveLast,
+		onUsage:           options.OnUsage,
+		task:              task,
+		planner:           newContextPlanner(contextPlannerConfig{contextWindow: options.ContextWindow, serviceTier: options.ServiceTier}),
+		trace:             options.Trace,
+		summarizerFactory: options.Summarizer,
 	}
 	return state
+}
+
+// updateWindow re-derives the compaction threshold after a mid-run model
+// switch. The low-water mark is reset: it was measured against the old
+// threshold, and keeping it could suppress a compaction the smaller window
+// now requires. <= 0 (unknown model) leaves everything unchanged.
+func (state *compactionState) updateWindow(window int) {
+	if window <= 0 {
+		return
+	}
+	state.enabled = true
+	state.window = window
+	state.threshold = compactionThreshold(window)
+	state.lowWaterMark = 0
+	if state.planner != nil {
+		state.planner.config.contextWindow = window
+	}
+}
+
+// switchModel records a mid-run model switch: the window is re-derived
+// (window <= 0 keeps the old one) and the summarizer choice is forgotten so
+// the next compaction re-resolves it against the new main model. A run that
+// started on the cheap model (no dedicated summarizer) and escalated to an
+// expensive one therefore regains cheap summaries — the exact workflow a
+// dedicated summarizer exists for.
+func (state *compactionState) switchModel(modelID string, window int) {
+	state.mainModel = modelID
+	state.updateWindow(window)
+	state.summarizerProvider = nil
+	state.summarizerResolved = false
+	state.summarizerBroken = false
+}
+
+// summarizeProvider returns the provider summarization calls should use: the
+// dedicated summarizer when one applies to the current main model and is
+// healthy, else the main provider. The factory runs at most once per main
+// model; a build error marks the summarizer broken for that model.
+func (state *compactionState) summarizeProvider(ctx context.Context, main Provider) Provider {
+	if state.summarizerFactory == nil || state.summarizerBroken {
+		return main
+	}
+	if !state.summarizerResolved {
+		state.summarizerResolved = true
+		built, err := state.summarizerFactory(ctx, state.mainModel)
+		if err != nil {
+			state.summarizerBroken = true
+			return main
+		}
+		state.summarizerProvider = built
+	}
+	if state.summarizerProvider == nil {
+		return main
+	}
+	return state.summarizerProvider
+}
+
+// fitsWindow reports whether a calibrated size is safely under the limit the
+// provider enforces. The proactive threshold (70% of the window) is a trigger
+// for the paid summarizer, not the hard limit; the reactive path compares
+// against the window itself, with a small margin for estimate error, so a
+// history pruned to, say, 85% of the window takes the free retry.
+func (state *compactionState) fitsWindow(size int) bool {
+	if state.window <= 0 {
+		return size <= state.threshold
+	}
+	return size <= state.window-state.window/20
 }
 
 // maybeCompact runs proactive compaction at the top of a turn. It returns the
@@ -528,10 +620,34 @@ func (state *compactionState) recover(
 		// context-limit error never triggers an unexpected summarization call.
 		return messages, false, nil
 	}
-	if state.reactiveAttempted {
+	if !isContextLimitError(errorMessage) {
 		return messages, false, nil
 	}
-	if !isContextLimitError(errorMessage) {
+
+	// CHEAP FIRST STAGE (mirrors maybeCompact): a context-limit failure can
+	// often be fixed for free by dropping superseded reads and pruning old
+	// tool-result bodies. It runs regardless of the one-shot reactive budget
+	// (it costs nothing and cannot loop: a second pass finds nothing left to
+	// prune). The free retry is taken only when the pruned history fits the
+	// window the provider enforces — otherwise a retry would fail the same
+	// way, so fall through to the paid summarizer in this same call.
+	toolTokens := estimateToolDefTokens(tools)
+	prunedAny := false
+	if pruned, reclaimed := pruneSupersededReadResults(messages); reclaimed > 0 {
+		messages, prunedAny = pruned, true
+	}
+	if pruned, reclaimed := pruneStaleToolOutput(messages, state.preserveLast); reclaimed > 0 {
+		messages, prunedAny = pruned, true
+	}
+	if prunedAny {
+		size := state.calibratedTokens(estimateTokens(messages) + toolTokens)
+		if state.fitsWindow(size) {
+			state.lowWaterMark = size
+			return messages, true, nil
+		}
+	}
+
+	if state.reactiveAttempted {
 		return messages, false, nil
 	}
 
@@ -571,11 +687,21 @@ func (state *compactionState) recover(
 // provider call. The summary stream intentionally does NOT forward OnText (so
 // compaction stays invisible on the user-facing surface), but it DOES forward
 // OnUsage so the summarizer's token cost is still counted by usage/budgeting.
+// The call goes to the dedicated (cheap) summarizer when one applies; if that
+// call fails the summarizer is marked broken for the current model and the
+// same slice is retried once on the main provider, so the caller sees at most
+// one (main-provider-quality) error.
 func (state *compactionState) summarizeClosure(ctx context.Context, provider Provider) func([]zeroruntime.Message) (string, error) {
 	if state.planner == nil {
 		state.planner = newContextPlanner(contextPlannerConfig{})
 	}
 	return func(toSummarize []zeroruntime.Message) (string, error) {
+		chosen := state.summarizeProvider(ctx, provider)
+		summary, err := summarizeWithPlanner(ctx, chosen, toSummarize, state.onUsage, state.planner, state.trace)
+		if err == nil || chosen == provider {
+			return summary, err
+		}
+		state.summarizerBroken = true
 		return summarizeWithPlanner(ctx, provider, toSummarize, state.onUsage, state.planner, state.trace)
 	}
 }
@@ -659,8 +785,41 @@ func summarizeMessagesOnce(ctx context.Context, provider Provider, messages []ze
 	return summary, nil
 }
 
+// summaryToolResultClamp bounds each tool-result body in the summarizer input.
+// Tool outputs dominate the elided middle's bulk (build logs, file reads,
+// search results), yet the summary instructions only need their gist — the
+// model that ACTED on the full output already turned it into decisions the
+// surrounding messages record. 2,000 chars (~500 tokens) keeps the useful
+// head+tail of a result while cutting the summarizer input by 5-10x on
+// tool-heavy sessions; the summarizer's own cost is the price being cut.
+const summaryToolResultClamp = 2000
+
+// summaryToolArgsClamp bounds each tool-call argument blob in the transcript:
+// a write_file call carries the whole file body in its arguments.
+const summaryToolArgsClamp = 500
+
+// clampForSummary head+tail-truncates text for the summarizer transcript,
+// snapping to rune boundaries so the clamp never splits a UTF-8 sequence.
+func clampForSummary(text string, max int) string {
+	if max <= 0 || len(text) <= max {
+		return text
+	}
+	head := max * 3 / 4
+	tail := max - head
+	for head > 0 && !utf8.RuneStart(text[head]) {
+		head--
+	}
+	start := len(text) - tail
+	for start < len(text) && !utf8.RuneStart(text[start]) {
+		start++
+	}
+	return text[:head] + "\n…[" + strconv.Itoa(len(text)-head-(len(text)-start)) + " chars omitted for summarization]…\n" + text[start:]
+}
+
 // renderTranscript flattens messages into a plain-text transcript for the
 // summarizer. Secret scrubbing already happened upstream at the tool boundary.
+// Tool-result bodies and tool-call arguments are clamped (see the constants
+// above): the summary needs what was done and decided, not the raw payloads.
 func renderTranscript(messages []zeroruntime.Message) string {
 	lines := make([]string, 0, len(messages))
 	for _, message := range messages {
@@ -670,13 +829,13 @@ func renderTranscript(messages []zeroruntime.Message) string {
 			if len(message.ToolCalls) > 0 {
 				calls := make([]string, 0, len(message.ToolCalls))
 				for _, call := range message.ToolCalls {
-					calls = append(calls, call.Name+"("+call.Arguments+")")
+					calls = append(calls, call.Name+"("+clampForSummary(call.Arguments, summaryToolArgsClamp)+")")
 				}
 				line += "\n[tool calls: " + strings.Join(calls, "; ") + "]"
 			}
 			lines = append(lines, line)
 		case zeroruntime.MessageRoleTool:
-			lines = append(lines, "tool result: "+message.Content)
+			lines = append(lines, "tool result: "+clampForSummary(message.Content, summaryToolResultClamp))
 		default:
 			lines = append(lines, string(message.Role)+": "+message.Content)
 		}

--- a/internal/agent/compaction_cheap_test.go
+++ b/internal/agent/compaction_cheap_test.go
@@ -135,7 +135,7 @@ func TestSummarizerFactoryErrorFallsBack(t *testing.T) {
 	if factoryCalls != 1 {
 		t.Fatalf("factory calls = %d, want 1 (sticky failure)", factoryCalls)
 	}
-	if state.summarizeProvider(context.Background(), main) != Provider(main) {
+	if _, dedicated := state.summarizeProvider(context.Background(), main); dedicated {
 		t.Fatal("after a factory failure the run must stay on the main provider")
 	}
 	if factoryCalls != 1 {
@@ -338,10 +338,10 @@ func TestSwitchModelReresolvesSummarizer(t *testing.T) {
 		},
 	}, nil)
 
-	if got := state.summarizeProvider(context.Background(), main); got != Provider(main) {
+	if _, dedicated := state.summarizeProvider(context.Background(), main); dedicated {
 		t.Fatal("on the cheap model the main provider must summarize")
 	}
-	if got := state.summarizeProvider(context.Background(), main); got != Provider(main) || len(factoryModels) != 1 {
+	if _, dedicated := state.summarizeProvider(context.Background(), main); dedicated || len(factoryModels) != 1 {
 		t.Fatalf("factory must run once per main model, calls=%v", factoryModels)
 	}
 
@@ -349,7 +349,7 @@ func TestSwitchModelReresolvesSummarizer(t *testing.T) {
 	if state.threshold != compactionThreshold(400_000) || state.window != 400_000 {
 		t.Fatalf("switchModel must re-derive the window, got threshold=%d window=%d", state.threshold, state.window)
 	}
-	if got := state.summarizeProvider(context.Background(), main); got != Provider(cheap) {
+	if got, dedicated := state.summarizeProvider(context.Background(), main); !dedicated || got != Provider(cheap) {
 		t.Fatal("after escalating to an expensive model the dedicated cheap summarizer must be used")
 	}
 	if len(factoryModels) != 2 || factoryModels[1] != "big-model" {
@@ -358,11 +358,11 @@ func TestSwitchModelReresolvesSummarizer(t *testing.T) {
 
 	// A broken summarizer is retried after the next switch.
 	state.summarizerBroken = true
-	if got := state.summarizeProvider(context.Background(), main); got != Provider(main) {
+	if _, dedicated := state.summarizeProvider(context.Background(), main); dedicated {
 		t.Fatal("a broken summarizer must fall back to main")
 	}
 	state.switchModel("other-model", 0)
-	if got := state.summarizeProvider(context.Background(), main); got != Provider(cheap) {
+	if got, dedicated := state.summarizeProvider(context.Background(), main); !dedicated || got != Provider(cheap) {
 		t.Fatal("a model switch must clear the broken flag and rebuild the summarizer")
 	}
 }
@@ -433,5 +433,37 @@ func TestRunEscalationRederivesContextWindow(t *testing.T) {
 	}
 	if windows[len(windows)-1] != 400_000 {
 		t.Fatalf("post-escalation window = %d, want 400000", windows[len(windows)-1])
+	}
+}
+
+// nonComparableProvider has a slice field, so comparing two Provider interface
+// values holding it would panic; the summarizer path must never compare them.
+type nonComparableProvider struct {
+	inner *mockProvider
+	tags  []string
+}
+
+func (p nonComparableProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	return p.inner.StreamCompletion(ctx, request)
+}
+
+func TestSummarizeClosureNeverComparesProviderValues(t *testing.T) {
+	broken := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventError, Error: "boom: model not found"},
+	}}}
+	main := nonComparableProvider{inner: summaryProvider("MAIN SUMMARY"), tags: []string{"x"}}
+	state := newCompactionState(Options{
+		ContextWindow:          1000,
+		CompactionPreserveLast: 2,
+		Summarizer:             func(context.Context, string) (Provider, error) { return nonComparableProvider{inner: broken}, nil },
+	}, nil)
+	summary, err := state.summarizeClosure(context.Background(), main)([]zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "history"}})
+	if err != nil || summary != "MAIN SUMMARY" {
+		t.Fatalf("fallback with non-comparable providers must not panic and must use main, got %q err=%v", summary, err)
+	}
+	// And with no dedicated summarizer at all the closure still works.
+	state = newCompactionState(Options{ContextWindow: 1000, CompactionPreserveLast: 2}, nil)
+	if _, err := state.summarizeClosure(context.Background(), main)([]zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "history"}}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/agent/compaction_cheap_test.go
+++ b/internal/agent/compaction_cheap_test.go
@@ -1,0 +1,437 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// compactableHistory returns a history whose middle is large enough to trip
+// the proactive threshold for a 1000-token window.
+func compactableHistory() []zeroruntime.Message {
+	return []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "sys"},
+		{Role: zeroruntime.MessageRoleUser, Content: strings.Repeat("u", 4000)},
+		{Role: zeroruntime.MessageRoleAssistant, Content: strings.Repeat("a", 4000)},
+		{Role: zeroruntime.MessageRoleUser, Content: "u2"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "a2"},
+		{Role: zeroruntime.MessageRoleUser, Content: "u3"},
+	}
+}
+
+// Summarization must run on the dedicated (cheap) summarizer when one is
+// configured — the main provider sees no summarize traffic at all.
+func TestMaybeCompactUsesDedicatedSummarizer(t *testing.T) {
+	cheap := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventText, Content: "CHEAP SUMMARY"},
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+	main := &mockProvider{}
+	factoryCalls := 0
+	state := newCompactionState(Options{
+		ContextWindow:          1000,
+		CompactionPreserveLast: 2,
+		Summarizer: func(context.Context, string) (Provider, error) {
+			factoryCalls++
+			return cheap, nil
+		},
+	}, nil)
+
+	compacted := state.maybeCompact(context.Background(), main, compactableHistory(), nil)
+
+	if len(cheap.requests) == 0 {
+		t.Fatal("dedicated summarizer never received the summarize call")
+	}
+	if len(main.requests) != 0 {
+		t.Fatalf("main provider must see no summarize traffic, got %d requests", len(main.requests))
+	}
+	if factoryCalls != 1 {
+		t.Fatalf("summarizer factory calls = %d, want 1 (lazy, memoized)", factoryCalls)
+	}
+	if estimateTokens(compacted) >= estimateTokens(compactableHistory()) {
+		t.Fatal("compaction did not shrink the history")
+	}
+	found := false
+	for _, message := range compacted {
+		if strings.Contains(message.Content, "CHEAP SUMMARY") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("cheap summarizer's summary missing from the compacted history")
+	}
+}
+
+// A failing summarizer falls back to the main provider for the SAME slice and
+// stays broken for the rest of the run — no repeated failed cheap calls.
+func TestSummarizerFailureFallsBackToMainAndSticks(t *testing.T) {
+	broken := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventError, Error: "boom: model not found"},
+	}}}
+	main := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		{{Type: zeroruntime.StreamEventText, Content: "MAIN SUMMARY"}, {Type: zeroruntime.StreamEventDone}},
+		{{Type: zeroruntime.StreamEventText, Content: "MAIN SUMMARY 2"}, {Type: zeroruntime.StreamEventDone}},
+	}}
+	state := newCompactionState(Options{
+		ContextWindow:          1000,
+		CompactionPreserveLast: 2,
+		Summarizer:             func(context.Context, string) (Provider, error) { return broken, nil },
+	}, nil)
+	summarize := state.summarizeClosure(context.Background(), main)
+	input := []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "history"}}
+
+	summary, err := summarize(input)
+	if err != nil {
+		t.Fatalf("fallback must succeed via the main provider: %v", err)
+	}
+	if summary != "MAIN SUMMARY" {
+		t.Fatalf("summary = %q, want the main provider's", summary)
+	}
+	if len(broken.requests) != 1 {
+		t.Fatalf("broken summarizer requests = %d, want exactly 1", len(broken.requests))
+	}
+	if !state.summarizerBroken {
+		t.Fatal("a failed summarizer must be marked broken for the run")
+	}
+
+	// Second summarization: straight to main, no cheap retry.
+	if _, err := summarize(input); err != nil {
+		t.Fatal(err)
+	}
+	if len(broken.requests) != 1 {
+		t.Fatalf("broken summarizer was retried (%d requests)", len(broken.requests))
+	}
+	if len(main.requests) != 2 {
+		t.Fatalf("main provider requests = %d, want 2", len(main.requests))
+	}
+}
+
+// A factory that errors (misconfigured model) is equivalent to no summarizer:
+// main provider used, factory not retried.
+func TestSummarizerFactoryErrorFallsBack(t *testing.T) {
+	main := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventText, Content: "MAIN SUMMARY"},
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+	factoryCalls := 0
+	state := newCompactionState(Options{
+		ContextWindow:          1000,
+		CompactionPreserveLast: 2,
+		Summarizer: func(context.Context, string) (Provider, error) {
+			factoryCalls++
+			return nil, errors.New("unknown model")
+		},
+	}, nil)
+	summarize := state.summarizeClosure(context.Background(), main)
+
+	summary, err := summarize([]zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "history"}})
+	if err != nil || summary != "MAIN SUMMARY" {
+		t.Fatalf("summary = %q, err = %v; want main provider fallback", summary, err)
+	}
+	if factoryCalls != 1 {
+		t.Fatalf("factory calls = %d, want 1 (sticky failure)", factoryCalls)
+	}
+	if state.summarizeProvider(context.Background(), main) != Provider(main) {
+		t.Fatal("after a factory failure the run must stay on the main provider")
+	}
+	if factoryCalls != 1 {
+		t.Fatalf("factory retried after failure (%d calls)", factoryCalls)
+	}
+}
+
+// Tool payloads are clamped in the summarizer transcript: results to
+// summaryToolResultClamp, call arguments to summaryToolArgsClamp.
+func TestRenderTranscriptClampsToolPayloads(t *testing.T) {
+	bigResult := strings.Repeat("r", 50_000)
+	bigArgs := strings.Repeat("w", 20_000)
+	transcript := renderTranscript([]zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleAssistant, Content: "editing", ToolCalls: []zeroruntime.ToolCall{
+			{ID: "c1", Name: "write_file", Arguments: bigArgs},
+		}},
+		{Role: zeroruntime.MessageRoleTool, ToolCallID: "c1", Content: bigResult},
+		{Role: zeroruntime.MessageRoleUser, Content: "keep going"},
+	})
+
+	if len(transcript) > summaryToolResultClamp+summaryToolArgsClamp+1024 {
+		t.Fatalf("transcript is %d bytes; clamps did not apply", len(transcript))
+	}
+	if !strings.Contains(transcript, "chars omitted for summarization") {
+		t.Fatal("clamped transcript must carry the omission marker")
+	}
+	if !strings.Contains(transcript, "keep going") {
+		t.Fatal("non-tool content must survive unclamped")
+	}
+	// Head AND tail of the clamped payloads survive.
+	if !strings.HasPrefix(transcript[strings.Index(transcript, "tool result: ")+len("tool result: "):], "r") ||
+		!strings.Contains(transcript, "rrr\n\nuser: keep going") {
+		t.Fatalf("head/tail of the tool result lost:\n%s", transcript[:200])
+	}
+}
+
+// bigToolHistory returns a history with n large tool results (~40k estimated
+// tokens each): the trailing protection window keeps the newest verbatim,
+// the older ones are prunable.
+func bigToolHistory(n int) []zeroruntime.Message {
+	bigBody := strings.Repeat("x", 160_000)
+	messages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleSystem, Content: "sys"}}
+	for i := 0; i < n; i++ {
+		id := string(rune('a' + i))
+		messages = append(messages,
+			zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{ID: id, Name: "read_file", Arguments: "{\"path\":\"" + id + "\"}"}}},
+			zeroruntime.Message{Role: zeroruntime.MessageRoleTool, ToolCallID: id, Content: bigBody},
+		)
+	}
+	return append(messages, zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "go"})
+}
+
+func summaryProvider(text string) *mockProvider {
+	return &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		{{Type: zeroruntime.StreamEventText, Content: text}, {Type: zeroruntime.StreamEventDone}},
+		{{Type: zeroruntime.StreamEventText, Content: text}, {Type: zeroruntime.StreamEventDone}},
+	}}
+}
+
+// A context-limit error is first answered with the free prune stage; when the
+// pruned history fits the window the retry is free (no summarizer call) and
+// the one-shot reactive budget is untouched. The paid summarizer only runs
+// when a later error finds nothing left to prune.
+func TestRecoverPrunesBeforeSummarizing(t *testing.T) {
+	provider := summaryProvider("SUMMARY")
+	// The protected trailing tool output (~40k tokens) must fit the window.
+	state := newCompactionState(Options{ContextWindow: 200_000, CompactionPreserveLast: 2}, nil)
+	messages := bigToolHistory(5)
+
+	pruned, retried, err := state.recover(context.Background(), provider, messages, nil, "maximum context length exceeded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !retried {
+		t.Fatal("prunable history that fits must produce a free retry")
+	}
+	if len(provider.requests) != 0 {
+		t.Fatalf("free prune stage must not call the summarizer (%d requests)", len(provider.requests))
+	}
+	if state.reactiveAttempted {
+		t.Fatal("a free prune retry must not consume the reactive budget")
+	}
+	if estimateTokens(pruned) >= estimateTokens(messages) {
+		t.Fatal("prune did not shrink the history")
+	}
+
+	// Second context-limit error on the pruned history: nothing meaningfully
+	// prunable remains, so the paid summarizer fires and consumes the budget.
+	_, retried, err = state.recover(context.Background(), provider, pruned, nil, "maximum context length exceeded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !retried {
+		t.Fatal("second recover must compact and retry")
+	}
+	if len(provider.requests) == 0 {
+		t.Fatal("second recover must reach the summarizer")
+	}
+	if !state.reactiveAttempted {
+		t.Fatal("a paid recover must consume the reactive budget")
+	}
+}
+
+// When pruning reclaims something but the pruned history still exceeds the
+// window, recover falls through to the paid summarizer in the SAME call
+// instead of spending a retry that would fail the same way.
+func TestRecoverFallsThroughToSummarizerWhenPruneIsInsufficient(t *testing.T) {
+	provider := summaryProvider("SUMMARY")
+	// A 1,000-token window: even the protected trailing output overflows it.
+	state := newCompactionState(Options{ContextWindow: 1000, CompactionPreserveLast: 2}, nil)
+	messages := bigToolHistory(5)
+
+	compacted, retried, err := state.recover(context.Background(), provider, messages, nil, "maximum context length exceeded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !retried {
+		t.Fatal("insufficient prune must still end in a retry via summarization")
+	}
+	if len(provider.requests) == 0 {
+		t.Fatal("insufficient prune must reach the summarizer in the same recover call")
+	}
+	if !state.reactiveAttempted {
+		t.Fatal("the paid summarizer consumes the reactive budget")
+	}
+	if estimateTokens(compacted) >= estimateTokens(messages) {
+		t.Fatal("recover did not shrink the history")
+	}
+}
+
+// The free prune stage is not gated behind the one-shot budget: after a paid
+// reactive compaction, a later context-limit error still gets a free retry
+// when pruning makes the history fit.
+func TestRecoverFreePruneRunsAfterBudgetIsSpent(t *testing.T) {
+	provider := summaryProvider("SUMMARY")
+	state := newCompactionState(Options{ContextWindow: 200_000, CompactionPreserveLast: 2}, nil)
+	state.reactiveAttempted = true
+	messages := bigToolHistory(5)
+
+	pruned, retried, err := state.recover(context.Background(), provider, messages, nil, "maximum context length exceeded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !retried || len(provider.requests) != 0 {
+		t.Fatalf("free prune must retry without the summarizer even when the budget is spent (retried=%v, requests=%d)", retried, len(provider.requests))
+	}
+	if estimateTokens(pruned) >= estimateTokens(messages) {
+		t.Fatal("prune did not shrink the history")
+	}
+	// With nothing left to prune and the budget spent, the caller keeps its
+	// original error — recover neither loops nor summarizes.
+	_, retried, err = state.recover(context.Background(), provider, pruned, nil, "maximum context length exceeded")
+	if err != nil || retried || len(provider.requests) != 0 {
+		t.Fatalf("spent budget must not summarize again (retried=%v, requests=%d, err=%v)", retried, len(provider.requests), err)
+	}
+}
+
+// The free-retry gate compares against the window the provider enforces, not
+// the 70% proactive threshold: a history pruned to ~80% of the window still
+// takes the free retry.
+func TestRecoverFreeRetryGateUsesWindowNotThreshold(t *testing.T) {
+	provider := summaryProvider("SUMMARY")
+	messages := bigToolHistory(5)
+	pruned, _ := pruneStaleToolOutput(messages, 2)
+	prunedTokens := estimateTokens(pruned)
+	// Choose a window so the pruned size sits between 70% and 95% of it.
+	window := prunedTokens * 100 / 80
+	state := newCompactionState(Options{ContextWindow: window, CompactionPreserveLast: 2}, nil)
+	if prunedTokens <= state.threshold {
+		t.Fatalf("test setup: pruned size %d must exceed the proactive threshold %d", prunedTokens, state.threshold)
+	}
+
+	_, retried, err := state.recover(context.Background(), provider, messages, nil, "maximum context length exceeded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !retried || len(provider.requests) != 0 {
+		t.Fatalf("a history that fits the window must take the free retry (retried=%v, requests=%d)", retried, len(provider.requests))
+	}
+}
+
+// After a mid-run model switch the summarizer is re-resolved against the new
+// main model: a run that started on the cheap model (no dedicated summarizer)
+// and escalated gets a cheap summarizer, and a previously broken one is
+// retried for the new model.
+func TestSwitchModelReresolvesSummarizer(t *testing.T) {
+	cheap := summaryProvider("CHEAP SUMMARY")
+	main := summaryProvider("MAIN SUMMARY")
+	var factoryModels []string
+	state := newCompactionState(Options{
+		ContextWindow:          1000,
+		CompactionPreserveLast: 2,
+		Model:                  "cheap-model",
+		Summarizer: func(_ context.Context, mainModelID string) (Provider, error) {
+			factoryModels = append(factoryModels, mainModelID)
+			if mainModelID == "cheap-model" {
+				return nil, nil // main already is the cheap model
+			}
+			return cheap, nil
+		},
+	}, nil)
+
+	if got := state.summarizeProvider(context.Background(), main); got != Provider(main) {
+		t.Fatal("on the cheap model the main provider must summarize")
+	}
+	if got := state.summarizeProvider(context.Background(), main); got != Provider(main) || len(factoryModels) != 1 {
+		t.Fatalf("factory must run once per main model, calls=%v", factoryModels)
+	}
+
+	state.switchModel("big-model", 400_000)
+	if state.threshold != compactionThreshold(400_000) || state.window != 400_000 {
+		t.Fatalf("switchModel must re-derive the window, got threshold=%d window=%d", state.threshold, state.window)
+	}
+	if got := state.summarizeProvider(context.Background(), main); got != Provider(cheap) {
+		t.Fatal("after escalating to an expensive model the dedicated cheap summarizer must be used")
+	}
+	if len(factoryModels) != 2 || factoryModels[1] != "big-model" {
+		t.Fatalf("factory must be re-invoked with the new main model, calls=%v", factoryModels)
+	}
+
+	// A broken summarizer is retried after the next switch.
+	state.summarizerBroken = true
+	if got := state.summarizeProvider(context.Background(), main); got != Provider(main) {
+		t.Fatal("a broken summarizer must fall back to main")
+	}
+	state.switchModel("other-model", 0)
+	if got := state.summarizeProvider(context.Background(), main); got != Provider(cheap) {
+		t.Fatal("a model switch must clear the broken flag and rebuild the summarizer")
+	}
+}
+
+func TestCompactionUpdateWindow(t *testing.T) {
+	state := newCompactionState(Options{ContextWindow: 100_000, CompactionPreserveLast: 2}, nil)
+	state.lowWaterMark = 50_000
+	before := state.threshold
+
+	state.updateWindow(0) // unknown model: unchanged
+	if state.threshold != before || state.lowWaterMark != 50_000 {
+		t.Fatal("updateWindow(0) must be a no-op")
+	}
+
+	state.updateWindow(10_000)
+	if state.threshold >= before {
+		t.Fatalf("threshold = %d, want re-derived below %d", state.threshold, before)
+	}
+	if state.lowWaterMark != 0 {
+		t.Fatal("low-water mark must reset on a window change")
+	}
+	if !state.enabled {
+		t.Fatal("a positive window must keep compaction enabled")
+	}
+}
+
+// End-to-end: after escalate_model switches providers, the loop re-derives the
+// context window via ContextWindowFor, visible in the OnContext report.
+func TestRunEscalationRederivesContextWindow(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "big-model"})
+	switched := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "escalate"},
+		{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{}`},
+		{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+
+	var windows []int
+	result, err := Run(context.Background(), "go", provider, Options{
+		Registry:      registry,
+		ContextWindow: 100_000,
+		Model:         "small-model",
+		ModelSwitcher: func(context.Context, string) (Provider, error) { return switched, nil },
+		ContextWindowFor: func(modelID string) int {
+			if modelID == "big-model" {
+				return 400_000
+			}
+			return 0
+		},
+		OnContext: func(breakdown ContextBreakdown) { windows = append(windows, breakdown.ContextWindow) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("final answer = %q", result.FinalAnswer)
+	}
+	if len(windows) < 2 {
+		t.Fatalf("expected at least 2 OnContext reports, got %d", len(windows))
+	}
+	if windows[0] != 100_000 {
+		t.Fatalf("turn 1 window = %d, want the original 100000", windows[0])
+	}
+	if windows[len(windows)-1] != 400_000 {
+		t.Fatalf("post-escalation window = %d, want 400000", windows[len(windows)-1])
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -844,11 +844,21 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 					options.ServiceTier = ""
 					planner.config.serviceTier = ""
 					options.Trace.Counter(trace.CounterModelSwitches, 1)
-					// KNOWN LIMITATION (deferred): the compactor's context-window budget
-					// is fixed at run start from options.ContextWindow and is NOT updated
-					// here, so a switch to a model with a different window keeps compacting
-					// against the original budget. Fixing it needs the switcher to also
-					// report the new window — out of scope for this change.
+					// Re-derive the context window for the new model so compaction and
+					// the OnContext budget report track the model actually in force —
+					// without this a switch to a smaller-window model can overflow the
+					// target, and a switch to a larger one over-compacts. An unknown
+					// model (<= 0) keeps the original window. The compactor also
+					// re-resolves its dedicated summarizer against the new model.
+					window := 0
+					if options.ContextWindowFor != nil {
+						window = options.ContextWindowFor(turnRequestedModel)
+					}
+					if window > 0 {
+						options.ContextWindow = window
+						planner.config.contextWindow = window
+					}
+					compactor.switchModel(turnRequestedModel, window)
 				}
 			}
 		}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -348,10 +348,26 @@ type Options struct {
 	// CompactionPreserveLast is how many trailing messages compaction keeps
 	// verbatim. <= 0 falls back to defaultCompactionPreserveLast.
 	CompactionPreserveLast int
-	Registry               *tools.Registry
-	PermissionMode         PermissionMode
-	Autonomy               string
-	Sandbox                *sandbox.Engine
+	// Summarizer, when set, lazily builds the provider used for compaction
+	// summarization calls — typically a cheap/fast model, since summaries at
+	// main-model prices are the single most expensive recurring event in a
+	// long run. It receives the main model currently in force and may return
+	// (nil, nil) when no dedicated summarizer applies to it (the main model is
+	// already the cheap one). Built on the first paid compaction and again
+	// after a mid-run model switch. Any failure (build or call) falls back to
+	// the run's main provider until the next switch, so a misconfigured
+	// summarizer can never break compaction. nil keeps today's behavior.
+	Summarizer func(ctx context.Context, mainModelID string) (Provider, error)
+	// ContextWindowFor, when set, resolves a model ID to its context window so
+	// the compactor can re-derive its threshold after a mid-run model switch
+	// (escalate_model). Without it a switch keeps compacting against the
+	// original model's window — overflowing a smaller target or over-compacting
+	// a larger one. Return <= 0 when the model is unknown (window unchanged).
+	ContextWindowFor func(modelID string) int
+	Registry         *tools.Registry
+	PermissionMode   PermissionMode
+	Autonomy         string
+	Sandbox          *sandbox.Engine
 	// FileTracker records per-session file read/write versions so the write tools
 	// can detect a file changed on disk outside Zero since it was last read. nil
 	// disables the check. Created once per session and threaded into every tool run.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -948,6 +948,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		FavoriteModels:       resolved.Preferences.FavoriteModels,
 		RecentModels:         resolved.Preferences.RecentModels,
 		RecapsEnabled:        resolved.Preferences.RecapsEnabled(),
+		CompactionModel:      resolved.Preferences.CompactionModel,
 		Provider:             provider,
 		NewProvider:          deps.newProvider,
 		ProbeProviderHealth:  deps.probeProviderHealth,

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -682,16 +682,20 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		ModelSwitcher:        modelSwitcher,
 		TurnSessionProvider:  turnSessions,
 		ModelSessionSwitcher: modelSessionSwitcher,
-		ReasoningEffort:      forwardEffort,
-		Trace:                traceRecorder,
-		Cwd:                  workspaceRoot,
-		Images:               images,
-		Registry:             registry,
-		PermissionMode:       permissionMode,
-		Autonomy:             options.autonomy,
-		SelfCorrect:          selfCorrector,
-		FileDiagnostics:      fileDiagnostics,
-		Profile:              execProfile.Policy(displacedMaxTurns, execProfileFilledEffort),
+		Summarizer:           summarizerFactory(resolved, deps.newProvider),
+		ContextWindowFor: func(modelID string) int {
+			return modelregistry.AgentContextWindow(modelContextWindow(modelRegistry, modelID))
+		},
+		ReasoningEffort: forwardEffort,
+		Trace:           traceRecorder,
+		Cwd:             workspaceRoot,
+		Images:          images,
+		Registry:        registry,
+		PermissionMode:  permissionMode,
+		Autonomy:        options.autonomy,
+		SelfCorrect:     selfCorrector,
+		FileDiagnostics: fileDiagnostics,
+		Profile:         execProfile.Policy(displacedMaxTurns, execProfileFilledEffort),
 		// Headless exec: don't accept a no-tool-call turn as "done" while work
 		// clearly remains (pending plan items / a mid-step continuation cue) —
 		// nudge to continue, and finalize as INCOMPLETE rather than false success

--- a/internal/cli/summarizer.go
+++ b/internal/cli/summarizer.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providers"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// summarizerFactory adapts the resolved profile and the authenticated provider
+// builder into agent.Options.Summarizer; the selection rules live in
+// providers.CompactionSummarizerFactory, shared with the TUI.
+func summarizerFactory(resolved config.ResolvedConfig, newProvider func(config.ProviderProfile) (zeroruntime.Provider, error)) func(context.Context, string) (agent.Provider, error) {
+	return providers.CompactionSummarizerFactory(resolved.Provider, resolved.Preferences.CompactionModel, newProvider)
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -119,6 +119,12 @@ type PreferencesConfig struct {
 	// the user turned idle recaps off. A *bool is its own tri-state, so no
 	// custom unmarshal is needed (unlike ToolsConfig.DeferThreshold's int).
 	Recaps *bool `json:"recaps,omitempty"`
+	// CompactionModel routes compaction summarization calls to this model
+	// instead of the session's main model (summaries at main-model prices are
+	// the most expensive recurring event in long runs). Empty = automatic: a
+	// curated cheap model on official endpoints, the main model elsewhere.
+	// "main" forces the main model. ZERO_COMPACTION_MODEL overrides.
+	CompactionModel string `json:"compactionModel,omitempty"`
 }
 
 // RecentModelEntry is one provider-qualified model selection recorded in

--- a/internal/providers/compaction_model.go
+++ b/internal/providers/compaction_model.go
@@ -1,0 +1,108 @@
+package providers
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// Compaction summarization model selection.
+//
+// Compaction summaries used to run on the session's main model — near a 200k
+// window one summarization is a ~100k-token input call at full price, the
+// single most expensive recurring event in a long run. A cheap model handles
+// the "dense factual summary" task fine, so summarization is routed to one
+// whenever the target is knowable.
+//
+// Resolution order: ZERO_COMPACTION_MODEL env > preferences.compactionModel
+// config > a curated per-kind default (OFFICIAL endpoints only) > "" (use the
+// main model). The literal value "main" at any level forces the main model.
+// A wrong choice is never fatal: the agent falls back to the main provider on
+// the first summarizer failure for the rest of the run.
+
+// CompactionModelEnv overrides the compaction summarization model.
+const CompactionModelEnv = "ZERO_COMPACTION_MODEL"
+
+// compactionMainSentinel disables the dedicated summarizer explicitly.
+const compactionMainSentinel = "main"
+
+// Curated cheap summarizer defaults, applied only for provider kinds whose
+// model catalog is guaranteed (official endpoints). Custom / *-compatible
+// endpoints get NO default — their catalogs are unknowable, and a guaranteed
+// failed call per run is worse than main-model prices.
+const (
+	defaultAnthropicCompactionModel = "claude-haiku-4-5-20251001"
+	defaultGoogleCompactionModel    = "gemini-2.5-flash-lite"
+	defaultOpenAICompactionModel    = "gpt-4.1-mini"
+)
+
+// CompactionModelID returns the model that compaction summarization calls
+// should use for the given profile, or "" to use the session's main model.
+// preference is the resolved config value (preferences.compactionModel).
+func CompactionModelID(profile config.ProviderProfile, preference string) string {
+	value := strings.TrimSpace(os.Getenv(CompactionModelEnv))
+	if value == "" {
+		value = strings.TrimSpace(preference)
+	}
+	if value != "" {
+		if strings.EqualFold(value, compactionMainSentinel) {
+			return ""
+		}
+		return value
+	}
+	return defaultCompactionModel(profile)
+}
+
+func defaultCompactionModel(profile config.ProviderProfile) string {
+	metadata, err := ResolveRuntimeMetadata(profile, Options{})
+	if err != nil {
+		return ""
+	}
+	var candidate string
+	switch metadata.ProviderKind {
+	case config.ProviderKindAnthropic:
+		candidate = defaultAnthropicCompactionModel
+	case config.ProviderKindGoogle:
+		candidate = defaultGoogleCompactionModel
+	case config.ProviderKindOpenAI:
+		candidate = defaultOpenAICompactionModel
+	default:
+		return ""
+	}
+	// Session already runs on the cheap model: a dedicated summarizer buys
+	// nothing and would only add a second provider instance.
+	if strings.EqualFold(strings.TrimSpace(metadata.APIModel), candidate) {
+		return ""
+	}
+	return candidate
+}
+
+// CompactionSummarizerFactory returns the lazy constructor the agent loop
+// calls for its dedicated compaction summarizer (agent.Options.Summarizer).
+// The compactor passes the main model in force at that moment — on the first
+// paid compaction and again after a mid-run model switch — so the choice
+// tracks escalations: a run that starts on the cheap model gets no dedicated
+// summarizer, and gains one once it escalates to a pricier main model.
+// Returning (nil, nil) means "summarize on the main provider". The factory
+// itself is nil only when no provider builder exists. Shared by the exec and
+// TUI front ends so the selection rules cannot drift between them.
+func CompactionSummarizerFactory(base config.ProviderProfile, preference string, newProvider func(config.ProviderProfile) (zeroruntime.Provider, error)) func(context.Context, string) (zeroruntime.Provider, error) {
+	if newProvider == nil {
+		return nil
+	}
+	return func(_ context.Context, mainModelID string) (zeroruntime.Provider, error) {
+		profile := base
+		if strings.TrimSpace(mainModelID) != "" {
+			profile.Model = mainModelID
+		}
+		modelID := CompactionModelID(profile, preference)
+		if modelID == "" {
+			return nil, nil
+		}
+		profile.Model = modelID
+		return newProvider(profile)
+	}
+}

--- a/internal/providers/compaction_model_test.go
+++ b/internal/providers/compaction_model_test.go
@@ -1,0 +1,108 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestCompactionModelIDResolutionOrder(t *testing.T) {
+	anthropic := config.ProviderProfile{
+		Name:         "anthropic",
+		ProviderKind: config.ProviderKindAnthropic,
+		Model:        "claude-sonnet-4.5",
+	}
+
+	t.Setenv(CompactionModelEnv, "my-env-model")
+	if got := CompactionModelID(anthropic, "my-config-model"); got != "my-env-model" {
+		t.Fatalf("env must win, got %q", got)
+	}
+
+	t.Setenv(CompactionModelEnv, "main")
+	if got := CompactionModelID(anthropic, "my-config-model"); got != "" {
+		t.Fatalf("env 'main' must force the main model, got %q", got)
+	}
+
+	t.Setenv(CompactionModelEnv, "")
+	if got := CompactionModelID(anthropic, "my-config-model"); got != "my-config-model" {
+		t.Fatalf("config preference must apply when env unset, got %q", got)
+	}
+	if got := CompactionModelID(anthropic, "main"); got != "" {
+		t.Fatalf("config 'main' must force the main model, got %q", got)
+	}
+}
+
+func TestCompactionModelIDCuratedDefaults(t *testing.T) {
+	t.Setenv(CompactionModelEnv, "")
+
+	anthropic := config.ProviderProfile{Name: "anthropic", ProviderKind: config.ProviderKindAnthropic, Model: "claude-sonnet-4.5"}
+	if got := CompactionModelID(anthropic, ""); got != defaultAnthropicCompactionModel {
+		t.Fatalf("anthropic default = %q, want %q", got, defaultAnthropicCompactionModel)
+	}
+
+	google := config.ProviderProfile{Name: "google", ProviderKind: config.ProviderKindGoogle, Model: "gemini-2.5-pro"}
+	if got := CompactionModelID(google, ""); got != defaultGoogleCompactionModel {
+		t.Fatalf("google default = %q, want %q", got, defaultGoogleCompactionModel)
+	}
+
+	// Custom/compatible endpoints: catalog unknowable, no default.
+	compatible := config.ProviderProfile{
+		Name:         "opengateway",
+		ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL:      "https://opengateway.gitlawb.com/v1",
+		Model:        "some-model",
+	}
+	if got := CompactionModelID(compatible, ""); got != "" {
+		t.Fatalf("openai-compatible must have no default, got %q", got)
+	}
+}
+
+func TestCompactionModelIDSkipsWhenMainIsAlreadyCheap(t *testing.T) {
+	t.Setenv(CompactionModelEnv, "")
+	haiku := config.ProviderProfile{
+		Name:         "anthropic",
+		ProviderKind: config.ProviderKindAnthropic,
+		Model:        defaultAnthropicCompactionModel,
+	}
+	if got := CompactionModelID(haiku, ""); got != "" {
+		t.Fatalf("already-cheap session must not get a dedicated summarizer, got %q", got)
+	}
+}
+
+func TestCompactionSummarizerFactoryTracksMainModel(t *testing.T) {
+	t.Setenv(CompactionModelEnv, "")
+	base := config.ProviderProfile{Name: "anthropic", ProviderKind: config.ProviderKindAnthropic, Model: defaultAnthropicCompactionModel}
+	var built []string
+	newProvider := func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+		built = append(built, profile.Model)
+		return nil, errors.New("not needed")
+	}
+	factory := CompactionSummarizerFactory(base, "", newProvider)
+	if factory == nil {
+		t.Fatal("factory must exist when a provider builder exists")
+	}
+	// Main model is the cheap default: no dedicated summarizer, nothing built.
+	if provider, err := factory(context.Background(), defaultAnthropicCompactionModel); provider != nil || err != nil || len(built) != 0 {
+		t.Fatalf("cheap main model must yield (nil, nil) without building, got %v %v built=%v", provider, err, built)
+	}
+	// After escalating to an expensive model the cheap default is built.
+	if _, err := factory(context.Background(), "claude-sonnet-4-5"); err == nil || len(built) != 1 || built[0] != defaultAnthropicCompactionModel {
+		t.Fatalf("escalated main model must build the cheap summarizer, built=%v err=%v", built, err)
+	}
+	// An empty main model falls back to the base profile's model — the cheap
+	// default here, so again nothing is built.
+	built = nil
+	if provider, err := factory(context.Background(), ""); provider != nil || err != nil || len(built) != 0 {
+		t.Fatalf("empty main model must use the base profile, got %v %v built=%v", provider, err, built)
+	}
+	// The explicit "main" preference disables the dedicated summarizer.
+	if provider, err := CompactionSummarizerFactory(base, "main", newProvider)(context.Background(), "claude-sonnet-4-5"); provider != nil || err != nil {
+		t.Fatalf("preference main must disable the summarizer, got %v %v", provider, err)
+	}
+	if CompactionSummarizerFactory(base, "", nil) != nil {
+		t.Fatal("no provider builder means no factory")
+	}
+}

--- a/internal/providers/compaction_model_test.go
+++ b/internal/providers/compaction_model_test.go
@@ -48,6 +48,11 @@ func TestCompactionModelIDCuratedDefaults(t *testing.T) {
 		t.Fatalf("google default = %q, want %q", got, defaultGoogleCompactionModel)
 	}
 
+	openai := config.ProviderProfile{Name: "openai", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"}
+	if got := CompactionModelID(openai, ""); got != defaultOpenAICompactionModel {
+		t.Fatalf("openai default = %q, want %q", got, defaultOpenAICompactionModel)
+	}
+
 	// Custom/compatible endpoints: catalog unknowable, no default.
 	compatible := config.ProviderProfile{
 		Name:         "opengateway",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Gitlawb/zero/internal/peermsg"
 	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
+	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/providers/providerio"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -541,6 +542,7 @@ type model struct {
 	recapIdleArmed               bool
 	recapIdleRunID               int
 	idleRecap                    string
+	compactionModel              string // preferences.compactionModel (see providers.CompactionModelID)
 	modelPickerLoading           bool
 	modelPickerLoadingProviderID string
 	modelPickerLoadError         string
@@ -963,6 +965,7 @@ func newModel(ctx context.Context, options Options) model {
 		providerProfile:             options.ProviderProfile,
 		favoriteModels:              favoriteModelSet(options.FavoriteModels),
 		recentModels:                normalizeRecentModelEntries(options.RecentModels),
+		compactionModel:             options.CompactionModel,
 		recapsEnabled:               options.RecapsEnabled,
 		provider:                    options.Provider,
 		newProvider:                 options.NewProvider,
@@ -5422,6 +5425,18 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 		// compaction (proactive + reactive) is enabled for every model, not just
 		// catalogued ones.
 		options.ContextWindow = modelregistry.AgentContextWindow(m.modelContextWindow(m.modelName))
+		// Route compaction summarization to a cheap model when one applies
+		// (env > config > curated default). The factory is lazy, re-evaluated
+		// against the model in force when the compactor asks (so an escalation
+		// away from the cheap model gains a summarizer), and the agent falls
+		// back to the main provider on any summarizer failure. Resolved against
+		// the ACTIVE profile so it tracks mid-session model switches.
+		options.Summarizer = providers.CompactionSummarizerFactory(m.providerProfile, m.compactionModel, m.newProvider)
+		// Let compaction re-derive its threshold after a mid-run escalate_model
+		// switch instead of keeping the original model's window.
+		options.ContextWindowFor = func(modelID string) int {
+			return modelregistry.AgentContextWindow(m.modelContextWindow(modelID))
+		}
 
 		// Post-edit self-correction is on by default in the TUI but kept FAST: it
 		// runs LSP diagnostics over the changed files only — cheap, change-scoped,

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -22,18 +22,22 @@ import (
 
 // Options configures the reusable Zero terminal UI shell.
 type Options struct {
-	Cwd                         string
-	Version                     string // CLI build version, shown on the home screen; empty hides it
-	UserConfigPath              string
-	DoctorUserConfigPath        string
-	ProjectConfigPath           string
-	ProviderName                string
-	ModelName                   string
-	ProviderProfile             config.ProviderProfile
-	SavedProviders              []config.ProviderProfile // all configured providers, for the /model multi-provider list
-	FavoriteModels              []string
-	RecentModels                []config.RecentModelEntry
-	RecapsEnabled               bool
+	Cwd                  string
+	Version              string // CLI build version, shown on the home screen; empty hides it
+	UserConfigPath       string
+	DoctorUserConfigPath string
+	ProjectConfigPath    string
+	ProviderName         string
+	ModelName            string
+	ProviderProfile      config.ProviderProfile
+	SavedProviders       []config.ProviderProfile // all configured providers, for the /model multi-provider list
+	FavoriteModels       []string
+	RecentModels         []config.RecentModelEntry
+	RecapsEnabled        bool
+	// CompactionModel is the resolved preferences.compactionModel value; see
+	// providers.CompactionModelID for how it combines with the env override
+	// and the curated cheap defaults.
+	CompactionModel             string
 	Provider                    zeroruntime.Provider
 	NewProvider                 func(config.ProviderProfile) (zeroruntime.Provider, error)
 	ProbeProviderHealth         func(context.Context, providerhealth.Options) providerhealth.Result


### PR DESCRIPTION
## Summary

Compaction summarization was the single most expensive recurring event in a
long run: the full elided middle — verbatim tool bodies included — went to
the session's main model at full price. Near a 200k window that is a
~100k-token input call, recursively multiplied when the middle itself
overflows the summarizer. This PR makes compaction cheap on four independent
axes, each safe on its own.

### 1. Dedicated summarizer model

Compaction summaries route to a cheap model instead of the session's main
model. Resolution order (`providers.CompactionModelID`):

1. `ZERO_COMPACTION_MODEL` env
2. `preferences.compactionModel` in config
3. Curated default — **official endpoints only**: Anthropic → Claude Haiku
   4.5, Google → Gemini 2.5 Flash-Lite, OpenAI → GPT-4.1 mini. Custom /
   `*-compatible` endpoints get **no default** (their catalogs are
   unknowable; a guaranteed failed call per run is worse than main-model
   prices), so they opt in via config only.

The literal value `main` at any level forces the old behavior. The provider
is built **lazily** on the first paid compaction (chat-only sessions never
build it), and **any failure — factory or call — permanently falls back to
the main provider for the rest of the run**, so a misconfigured summarizer
can never break or repeatedly delay compaction. When the session already
runs on the curated cheap model, no dedicated summarizer is created.

Wired in exec (`internal/cli/summarizer.go`) and the TUI (resolved against
the **active** profile at run start, so it tracks mid-session model
switches).

### 2. Summarizer input caps

`renderTranscript` now clamps each tool-result body to 2,000 chars and each
tool-call argument blob (a `write_file` call carries the whole file) to 500,
head+tail with a rune-safe split and an explicit omission marker. The
summary needs what was done and decided, not raw payloads — the model that
acted on the full output already turned it into decisions the surrounding
messages record. Cuts summarizer input 5–10× on tool-heavy sessions, and
compounds with (1): cheap model × small input.

### 3. Free reactive prune

`recover()` (the context-limit-error path) now runs the same
prune-stale-tool-output stage the proactive path already had: the first
context-limit error is answered by pruning old tool bodies at **zero cost**,
without consuming the one-shot reactive budget. The paid summarizer only
runs when a later error finds nothing left to prune.

### 4. Context-window re-derivation on model switch

New `Options.ContextWindowFor` (wired to the model registry in exec and the
TUI) lets the loop re-derive the compaction threshold after an
`escalate_model` switch — closing the documented KNOWN LIMITATION where a
switch to a smaller-window model could overflow the target and a larger one
over-compacted. The low-water mark resets on window change so a smaller
window can't be suppressed by stale bookkeeping.

## Deliberately not in this PR

- **Trigger raise (0.7 → 0.8) and background/anticipatory compaction with a
  visible "compacting…" notice** — next PR; they belong together (the
  background path is the validation the `compactionTriggerRatio` comment
  asks for before raising).
- **Summarizer output-token cap** — needs `CompletionRequest.MaxTokens`
  plumbed through all three providers; follow-up.
- **exec spec-draft wiring** — draft runs are short planning sessions; the
  main provider is fine there.

## Checklist

- [ ] The linked issue already has the `issue-approved` label.
      No linked issue — core-team change, same waiver as #506/#518.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
      Build and vet clean. Full suite passes except the 6 pre-existing
      `internal/cli` failures from the local `opengateway` provider profile
      ("openai provider opengateway requires official baseURL") —
      byte-identical failure set on `main`, unrelated to this change.
- [x] `gofmt` clean.
- [x] Tests added/updated for the change (and run under `-race` where relevant).
      New: summarizer routing (cheap provider gets the call, main gets none,
      factory lazy+memoized), sticky fallback on call failure AND factory
      failure, transcript clamping (bodies + args, head/tail survival),
      reactive prune-before-pay with budget semantics across two recovers,
      `updateWindow` unit test, end-to-end escalation window re-derivation
      observed via `OnContext`, and `CompactionModelID` resolution-order /
      curated-default / already-cheap tests. `internal/agent` and
      `internal/providers` pass under `-race`.
- [ ] UI changes include screenshots or a short recording where possible.
      N/A — no visual changes (a config preference and wiring only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a dedicated compaction and summarization model, with automatic provider defaults and environment overrides.
  * Context limits now recalculate when the active model changes during a run.

* **Bug Fixes**
  * Improved recovery from context-limit situations by pruning excess tool output before summarizing.
  * Added fallback to the main model when the summarizer is unavailable or fails.
  * Reduced summarization payload sizes while preserving essential content from large tool calls and results.
  * Recovery now retries without summarization when pruning alone resolves the issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->