### PR TITLE
fix(agent): keep tools exposed for max-turn finalization

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -721,7 +721,8 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			Content: nudge,
 		})
 	}
-	if answer, finalMessages, finishReason := finalAnswerAfterMaxTurns(ctx, provider, messages, options); strings.TrimSpace(answer) != "" {
+	finalExposed, _ := partitionToolsCached(registry, permissionMode, options, loaded, toolDefCache)
+	if answer, finalMessages, finishReason := finalAnswerAfterMaxTurns(ctx, provider, messages, finalExposed, options); strings.TrimSpace(answer) != "" {
 		result.FinalAnswer = answer
 		result.FinishReason = finishReason
 		result.Messages = copyMessages(finalMessages)
@@ -741,7 +742,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	return result, nil
 }
 
-func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages []zeroruntime.Message, options Options) (string, []zeroruntime.Message, string) {
+func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages []zeroruntime.Message, tools []zeroruntime.ToolDefinition, options Options) (string, []zeroruntime.Message, string) {
 	finalMessages := copyMessages(messages)
 	finalMessages = append(finalMessages, zeroruntime.Message{
 		Role:    zeroruntime.MessageRoleUser,
@@ -752,6 +753,7 @@ func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages [
 	// transient hiccup doesn't drop the final summary (AUDIT-L1).
 	stream, err := streamWithReconnect(ctx, provider, zeroruntime.CompletionRequest{
 		Messages:        copyMessages(finalMessages),
+		Tools:           tools,
 		ReasoningEffort: options.ReasoningEffort,
 		PromptCacheKey:  options.SessionID,
 	}, reconnectNoticeFor(options))

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -742,7 +742,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	return result, nil
 }
 
-func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages []zeroruntime.Message, tools []zeroruntime.ToolDefinition, options Options) (string, []zeroruntime.Message, string) {
+func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages []zeroruntime.Message, toolDefs []zeroruntime.ToolDefinition, options Options) (string, []zeroruntime.Message, string) {
 	finalMessages := copyMessages(messages)
 	finalMessages = append(finalMessages, zeroruntime.Message{
 		Role:    zeroruntime.MessageRoleUser,
@@ -753,7 +753,7 @@ func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages [
 	// transient hiccup doesn't drop the final summary (AUDIT-L1).
 	stream, err := streamWithReconnect(ctx, provider, zeroruntime.CompletionRequest{
 		Messages:        copyMessages(finalMessages),
-		Tools:           tools,
+		Tools:           toolDefs,
 		ReasoningEffort: options.ReasoningEffort,
 		PromptCacheKey:  options.SessionID,
 	}, reconnectNoticeFor(options))

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -2768,11 +2768,11 @@ func TestRunRequestsFinalAnswerAfterMaxTurns(t *testing.T) {
 		t.Fatalf("expected final answer from finalization turn, got %q", result.FinalAnswer)
 	}
 	if len(provider.requests) != 2 {
-		t.Fatalf("expected final no-tools request after max turns, got %d requests", len(provider.requests))
+		t.Fatalf("expected finalization request after max turns, got %d requests", len(provider.requests))
 	}
 	finalRequest := provider.requests[1]
-	if len(finalRequest.Tools) != 0 {
-		t.Fatalf("finalization request must not advertise tools, got %#v", finalRequest.Tools)
+	if toolDefinitionByName(finalRequest.Tools, "read_file") == nil {
+		t.Fatalf("finalization request must keep prior tools exposed for strict provider replay, got %#v", finalRequest.Tools)
 	}
 	lastMessage := finalRequest.Messages[len(finalRequest.Messages)-1]
 	if lastMessage.Role != zeroruntime.MessageRoleUser || !strings.Contains(lastMessage.Content, "tool-turn limit") {


### PR DESCRIPTION
## Summary
- keep tool definitions exposed during max-turn finalization requests
- fix a finding where, after the agent runs for N turns mid-session, previously available edit/exec tools could suddenly be reported as not available/exposed
- prevent strict providers from rejecting replayed tool-call history as unavailable tools during the final-answer follow-up

## Why
The issue appeared after longer sessions hit the max-turn path: Zero replayed prior tool-call history for finalization but did not include the active tool definitions on that request. Providers that validate tool history strictly can then fail with errors like `tool edit/exec not exposed in this session`, even though those tools worked earlier in the same session.

## Tests
- go test ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the final response flow when the agent reaches its turn limit, so the last request now keeps the same available tools as earlier turns.
  * This helps preserve tool access consistency during finalization and supports more reliable provider replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->