### PR TITLE
feat(tui): show CLI version on the startup home screen

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -731,6 +731,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	lastKnownMCPConfig := mcpConfig
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:                  workspaceRoot,
+		Version:              version,
 		Theme:                theme,
 		SavedTheme:           resolved.Preferences.Theme,
 		UserConfigPath:       userConfigPath,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -62,6 +62,7 @@ const dragEdgeScrollStep = 1
 type model struct {
 	ctx                         context.Context
 	cwd                         string
+	appVersion                  string
 	userCommands                []usercommands.Command // file-sourced /commands (.zero/commands)
 	loadSkills                  func() []skills.Skill  // lazy installed-skills loader for /skills + /<skill-name>
 	userConfigPath              string
@@ -747,6 +748,7 @@ func newModel(ctx context.Context, options Options) model {
 	m := model{
 		ctx:                         ctx,
 		cwd:                         cwd,
+		appVersion:                  strings.TrimSpace(options.Version),
 		swarmDoneAt:                 map[string]time.Time{},
 		userCommands:                loadedUserCommands,
 		loadSkills:                  options.LoadSkills,

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -22,6 +22,7 @@ import (
 // Options configures the reusable Zero terminal UI shell.
 type Options struct {
 	Cwd                         string
+	Version                     string // CLI build version, shown on the home screen; empty hides it
 	UserConfigPath              string
 	DoctorUserConfigPath        string
 	ProjectConfigPath           string

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -92,10 +92,14 @@ func (m model) emptyStateLines(width int) []string {
 // emptyStateExamples seeds the first prompt with a few representative asks.
 const emptyStateExamples = `Try  "explain this codebase"  ·  "fix the failing test"  ·  "add a --json flag"`
 
-// emptyStateOrientation renders a faint "cwd · branch · model" line for the home
-// screen, omitting any piece that's unknown. Empty when nothing is known.
+// emptyStateOrientation renders a faint "version · cwd · branch · model" line
+// for the home screen, omitting any piece that's unknown. Empty when nothing
+// is known.
 func (m model) emptyStateOrientation() string {
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 4)
+	if version := displayVersion(m.appVersion); version != "" {
+		parts = append(parts, version)
+	}
 	if cwd := strings.TrimSpace(m.cwd); cwd != "" {
 		parts = append(parts, shortenPath(cwd))
 	}
@@ -109,6 +113,20 @@ func (m model) emptyStateOrientation() string {
 		return ""
 	}
 	return zeroTheme.faint.Render(strings.Join(parts, "  ·  "))
+}
+
+// displayVersion formats the CLI build version for display: numeric releases
+// gain a "v" prefix (0.2.0 → v0.2.0), anything else (dev, git SHAs) passes
+// through unchanged. Empty stays empty so unset builds show nothing.
+func displayVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ""
+	}
+	if version[0] >= '0' && version[0] <= '9' {
+		return "v" + version
+	}
+	return version
 }
 
 func zeroWordmarkLines() []string {

--- a/internal/tui/startup_test.go
+++ b/internal/tui/startup_test.go
@@ -21,6 +21,29 @@ func TestEmptyStateShowsBrandAndTaglineOnly(t *testing.T) {
 	assertNotContains(t, view, "fix the failing test in internal/tools")
 }
 
+func TestEmptyStateShowsVersion(t *testing.T) {
+	m := newModel(context.Background(), Options{Version: "0.2.0"})
+	m.width, m.height = 100, 30
+
+	view := plainRender(t, m.View())
+	assertContains(t, view, "v0.2.0")
+}
+
+func TestDisplayVersion(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"0.2.0", "v0.2.0"},
+		{"v0.2.0", "v0.2.0"},
+		{"dev", "dev"},
+		{"  ", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := displayVersion(tc.in); got != tc.want {
+			t.Fatalf("displayVersion(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestEmptyStateDisappearsAfterFirstRow(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.width, m.height = 100, 30


### PR DESCRIPTION
  ## Summary

  The startup home screen now shows which version of Zero is running. The
  orientation line under the wordmark leads with the build version:

      v0.2.0  ·  ~/Projects/app  ·  main  ·  gpt-5

  Previously the only way to check the version was `zero --version`; after an
  update (e.g. via npm) there was no visible confirmation of what you're on.

  ## Changes

  - `internal/tui/options.go` — new `Version` field on `Options`; empty hides it
  - `internal/cli/app.go` — passes the build-injected `version` var into the TUI
  - `internal/tui/model.go` — threads it onto the model as `appVersion`
  - `internal/tui/startup.go` — orientation line includes the version, plus a
    `displayVersion` helper: numeric versions gain a `v` prefix (`0.2.0` →
    `v0.2.0`), non-numeric values (`dev`) pass through, empty stays hidden

  Release builds already inject `internal/cli.version` via ldflags
  (`internal/release/release.go`), so released binaries show the real version;
  plain `go build` binaries show `dev`.

  ## Testing

  - `TestEmptyStateShowsVersion` — home screen render includes `v0.2.0`
  - `TestDisplayVersion` — formatting table (numeric, prefixed, dev, empty)
  - Full `internal/tui` and `internal/cli` suites pass; verified manually with a
    ldflags-stamped local build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The TUI home screen can now display the application version.
  * Version values are formatted consistently, including adding a `v` prefix for numeric versions and hiding blank values.

* **Tests**
  * Added coverage for version display and formatting behavior in the TUI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->