### PR TITLE
Introduce opencode-go-anthropic that uses anthropic SDK for qwen and …

### DIFF
--- a/internal/cli/provider_models.go
+++ b/internal/cli/provider_models.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providermodelcatalog"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 )
 
@@ -49,6 +50,19 @@ func runProvidersModels(args []string, stdout io.Writer, stderr io.Writer, deps 
 	models, err := deps.discoverProviderModels(ctx, discoveryCredentialProfile(profile))
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitProvider)
+	}
+
+	// Apply provider-specific model filtering for catalog-backed profiles.
+	// For example, opencode-go-anthropic-compatible only permits Qwen and
+	// MiniMax model IDs; the raw /zen/go/v1/models endpoint returns many more.
+	if profile.CatalogID != "" {
+		filtered := make([]providermodeldiscovery.Model, 0, len(models))
+		for _, model := range models {
+			if providermodelcatalog.ModelIDAllowedForProvider(profile.CatalogID, model.ID) {
+				filtered = append(filtered, model)
+			}
+		}
+		models = filtered
 	}
 
 	if options.json {

--- a/internal/cli/provider_models_test.go
+++ b/internal/cli/provider_models_test.go
@@ -132,6 +132,62 @@ func TestRunProvidersModelsUnknownProviderFails(t *testing.T) {
 	}
 }
 
+func TestRunProvidersModelsFiltersForCatalogProfile(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	// Override the resolved config to include a catalog-backed profile.
+	deps.resolveConfig = func(_ string, _ config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{
+			Name:         "opencode-go",
+			ProviderKind: config.ProviderKindAnthropicCompat,
+			CatalogID:    "opencode-go-anthropic-compatible",
+			BaseURL:      "https://api.example.com/zen/go/v1",
+			APIKey:       "sk-test",
+			Model:        "minimax-max",
+		}
+		return config.ResolvedConfig{
+			ActiveProvider: "opencode-go",
+			Providers:      []config.ProviderProfile{profile},
+			Provider:       profile,
+		}, nil
+	}
+	deps.discoverProviderModels = func(_ context.Context, _ config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+		return []providermodeldiscovery.Model{
+			{ID: "deepseek-chat", Description: "DeepSeek Chat"},
+			{ID: "qwen-max", Description: "Qwen Max"},
+			{ID: "minimax-max-01", Description: "MiniMax Max"},
+			{ID: "kimi-k2", Description: "Kimi K2"},
+			{ID: "glm-4", Description: "GLM-4"},
+		}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "models"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", exitCode, exitSuccess, stderr.String())
+	}
+	out := stdout.String()
+	// Only Qwen and MiniMax model IDs should survive the filter.
+	if strings.Contains(out, "deepseek-chat") {
+		t.Error("output should not contain deepseek-chat (blocked by opencode-go-anthropic filter)")
+	}
+	if strings.Contains(out, "kimi-k2") {
+		t.Error("output should not contain kimi-k2 (blocked by opencode-go-anthropic filter)")
+	}
+	if strings.Contains(out, "glm-4") {
+		t.Error("output should not contain glm-4 (blocked by opencode-go-anthropic filter)")
+	}
+	for _, want := range []string{"qwen-max", "minimax-max-01"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing allowed model %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "2 models discovered") {
+		t.Fatalf("output should show 2 models:\n%s", out)
+	}
+}
+
 func TestRunProvidersModelsSurfacesDiscoveryError(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -140,7 +140,7 @@ var descriptors = []Descriptor{
 	openAICompat("kilocode", "KiloCode", "https://api.kilo.ai/api/gateway", "anthropic/claude-sonnet-4.6", []string{"KILO_API_KEY"}, "kilo", "kilo gateway"),
 	openAICompat("opencode", "OpenCode Zen", "https://opencode.ai/zen/v1", "deepseek-v4-flash", []string{"OPENCODE_API_KEY"}, "opencode zen"),
 	openAICompat("opencode-go", "OpenCode Go", "https://opencode.ai/zen/go/v1", "deepseek-v4-pro", []string{"OPENCODE_API_KEY"}, "opencode go"),
-	anthropicCompat("opencode-go-anthropic-compatible", "OpenCode Go Anthropic-compatible", "https://opencode.ai/zen/go", "MiniMax-M3", []string{"OPENCODE_API_KEY"}),
+	anthropicCompat("opencode-go-anthropic-compatible", "OpenCode Go Anthropic-compatible", "https://opencode.ai/zen/go", "minimax-m3", []string{"OPENCODE_API_KEY"}),
 	openAICompat("atomic-chat", "Atomic Chat", "https://api.atomic.chat/v1", "gpt-4.1", []string{"ATOMIC_CHAT_API_KEY"}),
 	// ChatGPT subscription via a local OAuth proxy. A ChatGPT (Plus/Pro) OAuth
 	// token only works against ChatGPT's own backend (which is Cloudflare-gated to

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -140,6 +140,7 @@ var descriptors = []Descriptor{
 	openAICompat("kilocode", "KiloCode", "https://api.kilo.ai/api/gateway", "anthropic/claude-sonnet-4.6", []string{"KILO_API_KEY"}, "kilo", "kilo gateway"),
 	openAICompat("opencode", "OpenCode Zen", "https://opencode.ai/zen/v1", "deepseek-v4-flash", []string{"OPENCODE_API_KEY"}, "opencode zen"),
 	openAICompat("opencode-go", "OpenCode Go", "https://opencode.ai/zen/go/v1", "deepseek-v4-pro", []string{"OPENCODE_API_KEY"}, "opencode go"),
+	anthropicCompat("opencode-go-anthropic", "OpenCode-Go-Anthropic SDK", "https://opencode.ai/zen/go", "MiniMax-M3", []string{"OPENCODE_API_KEY"}),
 	openAICompat("atomic-chat", "Atomic Chat", "https://api.atomic.chat/v1", "gpt-4.1", []string{"ATOMIC_CHAT_API_KEY"}),
 	// ChatGPT subscription via a local OAuth proxy. A ChatGPT (Plus/Pro) OAuth
 	// token only works against ChatGPT's own backend (which is Cloudflare-gated to

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -140,7 +140,7 @@ var descriptors = []Descriptor{
 	openAICompat("kilocode", "KiloCode", "https://api.kilo.ai/api/gateway", "anthropic/claude-sonnet-4.6", []string{"KILO_API_KEY"}, "kilo", "kilo gateway"),
 	openAICompat("opencode", "OpenCode Zen", "https://opencode.ai/zen/v1", "deepseek-v4-flash", []string{"OPENCODE_API_KEY"}, "opencode zen"),
 	openAICompat("opencode-go", "OpenCode Go", "https://opencode.ai/zen/go/v1", "deepseek-v4-pro", []string{"OPENCODE_API_KEY"}, "opencode go"),
-	anthropicCompat("opencode-go-anthropic", "OpenCode Go Anthropic SDK", "https://opencode.ai/zen/go", "MiniMax-M3", []string{"OPENCODE_API_KEY"}),
+	anthropicCompat("opencode-go-anthropic-compatible", "OpenCode Go Anthropic-compatible", "https://opencode.ai/zen/go", "MiniMax-M3", []string{"OPENCODE_API_KEY"}),
 	openAICompat("atomic-chat", "Atomic Chat", "https://api.atomic.chat/v1", "gpt-4.1", []string{"ATOMIC_CHAT_API_KEY"}),
 	// ChatGPT subscription via a local OAuth proxy. A ChatGPT (Plus/Pro) OAuth
 	// token only works against ChatGPT's own backend (which is Cloudflare-gated to

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -140,7 +140,7 @@ var descriptors = []Descriptor{
 	openAICompat("kilocode", "KiloCode", "https://api.kilo.ai/api/gateway", "anthropic/claude-sonnet-4.6", []string{"KILO_API_KEY"}, "kilo", "kilo gateway"),
 	openAICompat("opencode", "OpenCode Zen", "https://opencode.ai/zen/v1", "deepseek-v4-flash", []string{"OPENCODE_API_KEY"}, "opencode zen"),
 	openAICompat("opencode-go", "OpenCode Go", "https://opencode.ai/zen/go/v1", "deepseek-v4-pro", []string{"OPENCODE_API_KEY"}, "opencode go"),
-	anthropicCompat("opencode-go-anthropic", "OpenCode-Go-Anthropic SDK", "https://opencode.ai/zen/go", "MiniMax-M3", []string{"OPENCODE_API_KEY"}),
+	anthropicCompat("opencode-go-anthropic", "OpenCode Go Anthropic SDK", "https://opencode.ai/zen/go", "MiniMax-M3", []string{"OPENCODE_API_KEY"}),
 	openAICompat("atomic-chat", "Atomic Chat", "https://api.atomic.chat/v1", "gpt-4.1", []string{"ATOMIC_CHAT_API_KEY"}),
 	// ChatGPT subscription via a local OAuth proxy. A ChatGPT (Plus/Pro) OAuth
 	// token only works against ChatGPT's own backend (which is Cloudflare-gated to

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -40,6 +40,7 @@ var expectedCatalogIDs = []string{
 	"kilocode",
 	"opencode",
 	"opencode-go",
+	"opencode-go-anthropic",
 	"atomic-chat",
 	"chatgpt-proxy",
 	"custom-openai-compatible",
@@ -291,7 +292,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportGoogle:          {"google"},
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
-		TransportAnthropicCompat: {"minimax", "minimaxi-cn", "custom-anthropic-compatible"},
+		TransportAnthropicCompat: {"minimax", "minimaxi-cn", "opencode-go-anthropic", "custom-anthropic-compatible"},
 		TransportOpenAICompat:    {"gitlawb-opengateway", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "longcat", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "zai-cn", "kilocode", "opencode", "opencode-go", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -40,7 +40,7 @@ var expectedCatalogIDs = []string{
 	"kilocode",
 	"opencode",
 	"opencode-go",
-	"opencode-go-anthropic",
+	"opencode-go-anthropic-compatible",
 	"atomic-chat",
 	"chatgpt-proxy",
 	"custom-openai-compatible",
@@ -292,7 +292,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportGoogle:          {"google"},
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
-		TransportAnthropicCompat: {"minimax", "minimaxi-cn", "opencode-go-anthropic", "custom-anthropic-compatible"},
+		TransportAnthropicCompat: {"minimax", "minimaxi-cn", "opencode-go-anthropic-compatible", "custom-anthropic-compatible"},
 		TransportOpenAICompat:    {"gitlawb-opengateway", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "longcat", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "zai-cn", "kilocode", "opencode", "opencode-go", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -158,10 +158,10 @@ var curatedModels = map[string][]Model{
 		{ID: "gpt-4o-mini", Description: "fast model"},
 	},
 	"opencode-go-anthropic-compatible": {
-		{ID: "MiniMax-M3", Description: "catalog default"},
-		{ID: "MiniMax-M2.7", Description: "coding model"},
-		{ID: "qwen-plus", Description: "Qwen balanced model"},
-		{ID: "qwen-max", Description: "Qwen strong model"},
+		{ID: "MiniMax-M3", Description: "MiniMax M3: default"},
+		{ID: "MiniMax-M2.7", Description: "Minimax M2.7: coding model"},
+		{ID: "qwen3.7-plus", Description: "Qwen 3.7 Plus: balanced model"},
+		{ID: "qwen3.7-max", Description: "Qwen 3.7 Max: strong model"},
 	},
 	"custom-openai-compatible": {
 		{ID: "custom-model", Description: "custom endpoint model"},

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -157,6 +157,12 @@ var curatedModels = map[string][]Model{
 		{ID: "gpt-4.1", Description: "catalog default"},
 		{ID: "gpt-4o-mini", Description: "fast model"},
 	},
+	"opencode-go-anthropic": {
+		{ID: "MiniMax-M3", Description: "catalog default"},
+		{ID: "MiniMax-M2.7", Description: "coding model"},
+		{ID: "qwen-plus", Description: "Qwen balanced model"},
+		{ID: "qwen-max", Description: "Qwen strong model"},
+	},
 	"custom-openai-compatible": {
 		{ID: "custom-model", Description: "custom endpoint model"},
 	},
@@ -167,13 +173,13 @@ var curatedModels = map[string][]Model{
 
 func Models(provider providercatalog.Descriptor) []Model {
 	if models, ok := curatedModels[provider.ID]; ok {
-		return dedupeModels(provider.DefaultModel, models)
+		return FilterModelsForProvider(provider.ID, dedupeModels(provider.DefaultModel, models))
 	}
 	models := registryModels(provider)
 	if len(models) > 0 {
-		return dedupeModels(provider.DefaultModel, models)
+		return FilterModelsForProvider(provider.ID, dedupeModels(provider.DefaultModel, models))
 	}
-	return dedupeModels(provider.DefaultModel, nil)
+	return FilterModelsForProvider(provider.ID, dedupeModels(provider.DefaultModel, nil))
 }
 
 func registryModels(provider providercatalog.Descriptor) []Model {

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -158,8 +158,8 @@ var curatedModels = map[string][]Model{
 		{ID: "gpt-4o-mini", Description: "fast model"},
 	},
 	"opencode-go-anthropic-compatible": {
-		{ID: "MiniMax-M3", Description: "MiniMax M3: default"},
-		{ID: "MiniMax-M2.7", Description: "Minimax M2.7: coding model"},
+		{ID: "minimax-m3", Description: "MiniMax M3: default"},
+		{ID: "minimax-m2.7", Description: "MiniMax M2.7: coding model"},
 		{ID: "qwen3.7-plus", Description: "Qwen 3.7 Plus: balanced model"},
 		{ID: "qwen3.7-max", Description: "Qwen 3.7 Max: strong model"},
 	},

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -157,7 +157,7 @@ var curatedModels = map[string][]Model{
 		{ID: "gpt-4.1", Description: "catalog default"},
 		{ID: "gpt-4o-mini", Description: "fast model"},
 	},
-	"opencode-go-anthropic": {
+	"opencode-go-anthropic-compatible": {
 		{ID: "MiniMax-M3", Description: "catalog default"},
 		{ID: "MiniMax-M2.7", Description: "coding model"},
 		{ID: "qwen-plus", Description: "Qwen balanced model"},

--- a/internal/providermodelcatalog/catalog_test.go
+++ b/internal/providermodelcatalog/catalog_test.go
@@ -54,7 +54,7 @@ func TestModelsAreProviderScoped(t *testing.T) {
 		},
 		{
 			provider: "opencode-go-anthropic-compatible",
-			want:     []string{"MiniMax-M3", "MiniMax-M2.7", "qwen-plus", "qwen-max"},
+			want:     []string{"MiniMax-M3", "MiniMax-M2.7", "qwen3.7-plus", "qwen3.7-max"},
 			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5", "deepseek-chat"},
 		},
 	}

--- a/internal/providermodelcatalog/catalog_test.go
+++ b/internal/providermodelcatalog/catalog_test.go
@@ -54,7 +54,7 @@ func TestModelsAreProviderScoped(t *testing.T) {
 		},
 		{
 			provider: "opencode-go-anthropic-compatible",
-			want:     []string{"MiniMax-M3", "MiniMax-M2.7", "qwen3.7-plus", "qwen3.7-max"},
+			want:     []string{"minimax-m3", "minimax-m2.7", "qwen3.7-plus", "qwen3.7-max"},
 			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5", "deepseek-chat"},
 		},
 	}

--- a/internal/providermodelcatalog/catalog_test.go
+++ b/internal/providermodelcatalog/catalog_test.go
@@ -52,6 +52,11 @@ func TestModelsAreProviderScoped(t *testing.T) {
 			want:     []string{"mimo-v2.5-pro", "tencent/hy3"},
 			notWant:  []string{"openai/gpt-4.1", "claude-sonnet-4.5"},
 		},
+		{
+			provider: "opencode-go-anthropic",
+			want:     []string{"MiniMax-M3", "MiniMax-M2.7", "qwen-plus", "qwen-max"},
+			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5", "deepseek-chat"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/providermodelcatalog/catalog_test.go
+++ b/internal/providermodelcatalog/catalog_test.go
@@ -53,7 +53,7 @@ func TestModelsAreProviderScoped(t *testing.T) {
 			notWant:  []string{"openai/gpt-4.1", "claude-sonnet-4.5"},
 		},
 		{
-			provider: "opencode-go-anthropic",
+			provider: "opencode-go-anthropic-compatible",
 			want:     []string{"MiniMax-M3", "MiniMax-M2.7", "qwen-plus", "qwen-max"},
 			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5", "deepseek-chat"},
 		},

--- a/internal/providermodelcatalog/filter.go
+++ b/internal/providermodelcatalog/filter.go
@@ -1,6 +1,38 @@
 package providermodelcatalog
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/providercatalog"
+)
+
+// ModelIDAllowedForProvider reports whether a model ID is permitted for the
+// given provider under provider-specific allow/block rules.
+// For opencode-go-anthropic: only Qwen and MiniMax model IDs are allowed.
+// For all other providers: all model IDs are allowed.
+func ModelIDAllowedForProvider(providerID, modelID string) bool {
+	modelID = strings.ToLower(strings.TrimSpace(modelID))
+	if modelID == "" {
+		return false
+	}
+	switch providercatalog.NormalizeID(providerID) {
+	case "opencode-go-anthropic":
+		return strings.Contains(modelID, "qwen") || strings.Contains(modelID, "minimax")
+	default:
+		return true
+	}
+}
+
+// FilterModelsForProvider filters a model slice by ModelIDAllowedForProvider.
+func FilterModelsForProvider(providerID string, models []Model) []Model {
+	result := make([]Model, 0, len(models))
+	for _, model := range models {
+		if ModelIDAllowedForProvider(providerID, model.ID) {
+			result = append(result, model)
+		}
+	}
+	return result
+}
 
 func IsCodingModel(model Model) bool {
 	if IsKnownNonCodingModelID(model.ID) {

--- a/internal/providermodelcatalog/filter.go
+++ b/internal/providermodelcatalog/filter.go
@@ -9,7 +9,7 @@ import (
 // ModelIDAllowedForProvider reports whether a model ID is permitted for the
 // given provider under provider-specific allow/block rules.
 // For opencode-go-anthropic-compatible: only Qwen and MiniMax model IDs are allowed.
-// For all other providers: all model IDs are allowed.
+// Allows ANY model by default
 func ModelIDAllowedForProvider(providerID, modelID string) bool {
 	modelID = strings.ToLower(strings.TrimSpace(modelID))
 	if modelID == "" {

--- a/internal/providermodelcatalog/filter.go
+++ b/internal/providermodelcatalog/filter.go
@@ -8,7 +8,7 @@ import (
 
 // ModelIDAllowedForProvider reports whether a model ID is permitted for the
 // given provider under provider-specific allow/block rules.
-// For opencode-go-anthropic: only Qwen and MiniMax model IDs are allowed.
+// For opencode-go-anthropic-compatible: only Qwen and MiniMax model IDs are allowed.
 // For all other providers: all model IDs are allowed.
 func ModelIDAllowedForProvider(providerID, modelID string) bool {
 	modelID = strings.ToLower(strings.TrimSpace(modelID))
@@ -16,7 +16,7 @@ func ModelIDAllowedForProvider(providerID, modelID string) bool {
 		return false
 	}
 	switch providercatalog.NormalizeID(providerID) {
-	case "opencode-go-anthropic":
+	case "opencode-go-anthropic-compatible":
 		return strings.Contains(modelID, "qwen") || strings.Contains(modelID, "minimax")
 	default:
 		return true

--- a/internal/providermodelcatalog/filter_test.go
+++ b/internal/providermodelcatalog/filter_test.go
@@ -1,0 +1,108 @@
+package providermodelcatalog
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/providercatalog"
+)
+
+func TestModelIDAllowedForProvider(t *testing.T) {
+	cases := []struct {
+		testName   string
+		providerID string
+		modelID    string
+		want       bool
+	}{
+		// Empty model ID is always rejected.
+		{"empty model", "any-provider", "", false},
+		{"empty model after trim", "any-provider", "  ", false},
+
+		// opencode-go-anthropic-compatible: only qwen and minimax allowed.
+		{"opencode-anthropic qwen", "opencode-go-anthropic-compatible", "qwen3.7-plus", true},
+		{"opencode-anthropic minimax", "opencode-go-anthropic-compatible", "MiniMax-M3", true},
+		{"opencode-anthropic non-allowed", "opencode-go-anthropic-compatible", "claude-sonnet-4.5", false},
+		{"opencode-anthropic deepseek", "opencode-go-anthropic-compatible", "deepseek-chat", false},
+
+		// Case insensitivity and trimming for the blocked provider.
+		{"opencode-anthropic case insensitive", "opencode-go-anthropic-compatible", "QWEN3.7-PLUS", true},
+		{"opencode-anthropic whitespace", "opencode-go-anthropic-compatible", "  minimax-m3  ", true},
+
+		// Normalized provider ID — e.g. NormalizeID converts spaces/dots to dashes.
+		{"opencode-anthropic normalized provider", "opencode go anthropic compatible", "qwen3.7-plus", true},
+
+		// Default branch: all model IDs allowed.
+		{"default provider allows anything", "openai", "claude-sonnet-4.5", true},
+		{"default provider allows any name", "openai", "x", true},
+		{"default provider groq", "groq", "deepseek-chat", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			got := ModelIDAllowedForProvider(tc.providerID, tc.modelID)
+			if got != tc.want {
+				t.Errorf("ModelIDAllowedForProvider(%q, %q) = %v, want %v",
+					tc.providerID, tc.modelID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFilterModelsForProvider verifies that filtering delegates correctly.
+func TestFilterModelsForProvider(t *testing.T) {
+	models := []Model{
+		{ID: "qwen3.7-plus"},
+		{ID: "MiniMax-M3"},
+		{ID: "claude-sonnet-4.5"},
+		{ID: "deepseek-chat"},
+	}
+
+	filtered := FilterModelsForProvider("opencode-go-anthropic-compatible", models)
+	if len(filtered) != 2 {
+		t.Fatalf("FilterModelsForProvider returned %d models, want 2: %#v", len(filtered), modelIDs(filtered))
+	}
+	if filtered[0].ID != "qwen3.7-plus" || filtered[1].ID != "MiniMax-M3" {
+		t.Errorf("FilterModelsForProvider returned %#v, want [qwen3.7-plus MiniMax-M3]", modelIDs(filtered))
+	}
+
+	// With a default provider nothing is filtered out.
+	all := FilterModelsForProvider("openai", models)
+	if len(all) != len(models) {
+		t.Fatalf("FilterModelsForProvider(openai) returned %d, want %d", len(all), len(models))
+	}
+
+	// Empty input.
+	empty := FilterModelsForProvider("opencode-go-anthropic-compatible", nil)
+	if len(empty) != 0 {
+		t.Fatal("expected empty result for nil input")
+	}
+}
+
+// TestModelIDAllowedForProvider_NormalizedProviderIDs verifies that various
+// raw provider ID formats that NormalizeID maps to the same canonical form
+// are handled consistently.
+func TestModelIDAllowedForProvider_NormalizedProviderIDs(t *testing.T) {
+	canonical := providercatalog.NormalizeID("opencode-go-anthropic-compatible")
+	variants := []string{
+		"opencode-go-anthropic-compatible",
+		"opencode_go_anthropic_compatible",
+		"opencode go anthropic compatible",
+		"OpenCode-Go-Anthropic-Compatible",
+		"  opencode-go-anthropic-compatible  ",
+		"opencode.go.anthropic.compatible",
+	}
+	for _, variant := range variants {
+		if n := providercatalog.NormalizeID(variant); n != canonical {
+			t.Fatalf("NormalizeID(%q) = %q, want %q", variant, n, canonical)
+		}
+	}
+
+	// All variants should produce the same filter result.
+	for _, variant := range variants {
+		if !ModelIDAllowedForProvider(variant, "qwen3.7-plus") {
+			t.Errorf("ModelIDAllowedForProvider(%q, qwen3.7-plus) = false, want true", variant)
+		}
+		if ModelIDAllowedForProvider(variant, "claude-sonnet-4.5") {
+			t.Errorf("ModelIDAllowedForProvider(%q, claude-sonnet-4.5) = true, want false", variant)
+		}
+	}
+}

--- a/internal/providermodeldiscovery/discovery.go
+++ b/internal/providermodeldiscovery/discovery.go
@@ -405,6 +405,9 @@ func mergeLiveModels(provider providercatalog.Descriptor, liveModels []Model, ca
 }
 
 func liveModelAllowedWithoutCatalog(provider providercatalog.Descriptor, id string) bool {
+	if !providermodelcatalog.ModelIDAllowedForProvider(provider.ID, id) {
+		return false
+	}
 	if providermodelcatalog.IsKnownNonCodingModelID(id) {
 		return false
 	}

--- a/internal/providermodeldiscovery/discovery_test.go
+++ b/internal/providermodeldiscovery/discovery_test.go
@@ -261,6 +261,47 @@ func TestDiscoverCatalogMergesLiveModelsWithModelsDevMetadata(t *testing.T) {
 	t.Fatal("missing gpt-4.1")
 }
 
+func TestLiveModelAllowedWithoutCatalogChecksProviderGateFirst(t *testing.T) {
+	// The ModelIDAllowedForProvider check runs before the others.
+	// For the restricted provider (opencode-go-anthropic-compatible) a
+	// non-allowed model returns false immediately, without reaching the
+	// IsKnownNonCodingModelID, Local, or LooksLikeCodingModelID checks.
+	restricted := providercatalog.Descriptor{
+		ID:    "opencode-go-anthropic-compatible",
+		Local: true, // would pass the Local check if we got past the gate
+	}
+
+	// A model that isn't qwen/minimax is blocked at the gate, even though
+	// Local=true would let any model through on its own.
+	if got := liveModelAllowedWithoutCatalog(restricted, "claude-sonnet-4"); got != false {
+		t.Fatal("liveModelAllowedWithoutCatalog: want false for claude-sonnet-4 on opencode-go-anthropic-compatible (blocked by ModelIDAllowedForProvider)")
+	}
+
+	// A qwen model passes the gate and continues to the remaining checks;
+	// it's not a known non-coding model and looks like a coding model, so
+	// the result is true.
+	if got := liveModelAllowedWithoutCatalog(restricted, "qwen-max"); got != true {
+		t.Fatal("liveModelAllowedWithoutCatalog: want true for qwen-max on opencode-go-anthropic-compatible (passes all checks)")
+	}
+
+	// A minimax model also passes the gate.
+	if got := liveModelAllowedWithoutCatalog(restricted, "minimax-text-01"); got != true {
+		t.Fatal("liveModelAllowedWithoutCatalog: want true for minimax-text-01 on opencode-go-anthropic-compatible (passes all checks)")
+	}
+
+	// Unrestricted provider: all models pass the gate, so the other checks
+	// decide the result. claude-sonnet-4 looks like a coding model → true.
+	openAI := providercatalog.Descriptor{ID: "openai"}
+	if got := liveModelAllowedWithoutCatalog(openAI, "claude-sonnet-4"); got != true {
+		t.Fatal("liveModelAllowedWithoutCatalog: want true for claude-sonnet-4 on openai (unrestricted)")
+	}
+
+	// Non-coding model still filtered on an unrestricted provider.
+	if got := liveModelAllowedWithoutCatalog(openAI, "text-embedding-3-large"); got != false {
+		t.Fatal("liveModelAllowedWithoutCatalog: want false for embedding model on openai")
+	}
+}
+
 func modelIDs(models []Model) []string {
 	ids := make([]string, 0, len(models))
 	for _, model := range models {

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/providermodelcatalog"
 	"github.com/Gitlawb/zero/internal/providers/anthropic"
 	"github.com/Gitlawb/zero/internal/providers/gemini"
 	"github.com/Gitlawb/zero/internal/providers/openai"
@@ -205,6 +206,9 @@ func resolveProfile(profile config.ProviderProfile, options Options) (resolvedPr
 		} else if providerKind != modelProvider {
 			return resolvedProfile{}, fmt.Errorf("zero model %s belongs to %s, not %s", entry.ID, entry.Provider, providerKind)
 		}
+		if err := validateModelAllowedForProvider(profile, entry.ID); err != nil {
+			return resolvedProfile{}, err
+		}
 		return resolvedProfile{
 			providerKind:    providerKind,
 			apiModel:        entry.APIModel,
@@ -216,11 +220,37 @@ func resolveProfile(profile config.ProviderProfile, options Options) (resolvedPr
 	if providerKind == "" {
 		providerKind = config.ProviderKindOpenAI
 	}
+	if err := validateModelAllowedForProvider(profile, model); err != nil {
+		return resolvedProfile{}, err
+	}
 	return resolvedProfile{
 		providerKind: providerKind,
 		apiModel:     model,
 		baseURL:      baseURL,
 	}, nil
+}
+
+// validateModelAllowedForProvider enforces provider-scoped model allowlists at
+// runtime resolution time. It delegates to
+// providermodelcatalog.ModelIDAllowedForProvider, which encodes the per-provider
+// rules in one place; restricted providers (such as
+// opencode-go-anthropic-compatible) only accept a curated subset of model
+// families, while the default branch makes unrestricted providers a no-op. This
+// guards both New() (TUI /model, headless --model overrides) and
+// ResolveRuntimeMetadata (the read-only metadata path) so a catalog-backed
+// profile cannot persist or send a model outside its scoped allowlist.
+func validateModelAllowedForProvider(profile config.ProviderProfile, model string) error {
+	providerID := strings.TrimSpace(profile.CatalogID)
+	if providermodelcatalog.ModelIDAllowedForProvider(providerID, model) {
+		return nil
+	}
+	if providerID == "" {
+		providerID = strings.TrimSpace(profile.Name)
+	}
+	if providerID == "" {
+		providerID = "provider"
+	}
+	return fmt.Errorf("provider %s does not allow model %s", providerID, strings.TrimSpace(model))
 }
 
 func explicitProviderKind(profile config.ProviderProfile) (config.ProviderKind, bool) {

--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -516,3 +516,101 @@ func TestCodexAccountForKey(t *testing.T) {
 		t.Fatalf("account = %q, want acc-rotated (in-place refresh must be picked up)", got)
 	}
 }
+
+// TestNewRejectsModelOutsideProviderAllowlist guards the PR #544 P2 fix:
+// opencode-go-anthropic-compatible only accepts Qwen and MiniMax model IDs,
+// so a Claude model routed through this catalog-backed profile must be rejected
+// at runtime, not silently forwarded to https://opencode.ai/zen/go/v1/messages.
+func TestNewRejectsModelOutsideProviderAllowlist(t *testing.T) {
+	_, err := New(config.ProviderProfile{
+		Name:      "opencode-go-anthropic",
+		CatalogID: "opencode-go-anthropic-compatible",
+		APIKey:    "sk-test",
+		Model:     "claude-sonnet-4.5",
+	}, Options{})
+	if err == nil {
+		t.Fatal("New() error = nil, want claude-sonnet-4.5 rejected for opencode-go-anthropic-compatible")
+	}
+	if !strings.Contains(err.Error(), "opencode-go-anthropic-compatible") {
+		t.Fatalf("error = %q, want it to name the provider", err.Error())
+	}
+	if !strings.Contains(err.Error(), "claude-sonnet-4.5") {
+		t.Fatalf("error = %q, want it to name the rejected model", err.Error())
+	}
+}
+
+// TestNewRejectsRawModelOutsideProviderAllowlist covers the registry-miss
+// branch of resolveProfile: an unknown raw model id (not in the model registry)
+// typed by the user into a restricted-provider profile must still be rejected
+// rather than passthrough-sent.
+func TestNewRejectsRawModelOutsideProviderAllowlist(t *testing.T) {
+	_, err := New(config.ProviderProfile{
+		Name:      "opencode-go-anthropic",
+		CatalogID: "opencode-go-anthropic-compatible",
+		APIKey:    "sk-test",
+		Model:     "totally-custom-not-in-allowlist-12345",
+	}, Options{})
+	if err == nil {
+		t.Fatal("New() error = nil, want unknown raw model rejected for opencode-go-anthropic-compatible")
+	}
+	if !strings.Contains(err.Error(), "does not allow model") {
+		t.Fatalf("error = %q, want allowlist rejection", err.Error())
+	}
+	if !strings.Contains(err.Error(), "totally-custom-not-in-allowlist-12345") {
+		t.Fatalf("error = %q, want the raw model name to appear in the error", err.Error())
+	}
+}
+
+// TestNewAllowsCuratedModelsForRestrictedProvider proves the gate is not
+// over-eager: Qwen and MiniMax curated models pass through unchanged for
+// opencode-go-anthropic-compatible.
+func TestNewAllowsCuratedModelsForRestrictedProvider(t *testing.T) {
+	for _, model := range []string{"minimax-m3", "qwen3.7-plus", "qwen3.7-max", "minimax-m2.7"} {
+		_, err := New(config.ProviderProfile{
+			Name:      "opencode-go-anthropic",
+			CatalogID: "opencode-go-anthropic-compatible",
+			APIKey:    "sk-test",
+			Model:     model,
+		}, Options{})
+		if err != nil {
+			t.Fatalf("New() error = %v, want curated model %q to be allowed", err, model)
+		}
+	}
+}
+
+// TestNewAllowsAnyModelForUnrestrictedProvider is the regression guard:
+// unrestricted providers (no catalog or default catalog id) must continue to
+// accept any model id, including those outside the opencode allowlist.
+func TestNewAllowsAnyModelForUnrestrictedProvider(t *testing.T) {
+	_, err := New(config.ProviderProfile{
+		Name:         "anthropic",
+		ProviderKind: config.ProviderKindAnthropic,
+		APIKey:       "sk-ant",
+		Model:        "claude-sonnet-4.5",
+	}, Options{})
+	if err != nil {
+		t.Fatalf("New() error = %v, want unrestricted anthropic provider to accept claude-sonnet-4.5", err)
+	}
+}
+
+// TestResolveRuntimeMetadataRejectsModelOutsideProviderAllowlist guards the
+// read-only metadata path (called from TUI command_center, exec, provider
+// health, context report). The metadata path must enforce the same gate as
+// New() so a config-time override cannot escape through it.
+func TestResolveRuntimeMetadataRejectsModelOutsideProviderAllowlist(t *testing.T) {
+	_, err := ResolveRuntimeMetadata(config.ProviderProfile{
+		Name:      "opencode-go-anthropic",
+		CatalogID: "opencode-go-anthropic-compatible",
+		APIKey:    "sk-test",
+		Model:     "claude-sonnet-4.5",
+	}, Options{})
+	if err == nil {
+		t.Fatal("ResolveRuntimeMetadata error = nil, want claude-sonnet-4.5 rejected")
+	}
+	if !strings.Contains(err.Error(), "opencode-go-anthropic-compatible") {
+		t.Fatalf("error = %q, want it to name the provider", err.Error())
+	}
+	if !strings.Contains(err.Error(), "claude-sonnet-4.5") {
+		t.Fatalf("error = %q, want it to name the rejected model", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Introduce opencode-anthropic-go as Minimax and Qwen family is explicitly documented to be used with Anthropic-like API.

## Linked issue

https://github.com/Gitlawb/zero/issues/428
## Checklist

- [x] The linked issue already has the `issue-approved` label.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] `gofmt` clean.
- [x] Tests added/updated for the change (and run under `-race` where relevant).
- [x] UI changes include screenshots or a short recording where possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenCode-Go Anthropic-compatible provider (authenticated via `OPENCODE_API_KEY`) and its curated model set (`minimax-m3`, `minimax-m2.7`, `qwen3.7-plus`, `qwen3.7-max`).
* **Bug Fixes**
  * Provider-scoped model listings are now filtered by a provider allowlist, including when using live fallback and when resolving runtime metadata.
  * Improved consistent catalog/model ordering across provider IDs and transport aliases.
* **Tests**
  * Added and extended unit tests for provider gating, model allowlisting, filtering behavior, and stable ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->