### PR TITLE
feat: voice dictation (speech-to-text)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/term v0.2.2
+	github.com/coder/websocket v1.8.15
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	golang.org/x/sys v0.46.0
 	mvdan.cc/sh/v3 v3.13.1

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/dlclark/regexp2/v2 v2.2.1 h1:mf4KkFUj0gJuarK8P+LgiS+Lit7m9N1yAwEfPbee7R0=
 github.com/dlclark/regexp2/v2 v2.2.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/go-quicktest/qt v1.102.0 h1:HSQxCeh5YZH3EL3W39ixjtyaEhcWSXQHtHnMBzSs474=

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -729,6 +729,16 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		Scope:         scope,
 	})
 	lastKnownMCPConfig := mcpConfig
+	sttServerManager := newDictationServerManager(resolved.STT)
+	// Keep STT downloads in the SAME config tree the rest of the TUI uses. Deriving
+	// from userConfigPath (rather than config.UserConfigDir()) matters when the config
+	// root is overridden — e.g. in tests or a custom ZERO config dir — so the two
+	// don't diverge. userConfigPath points at .../zero/config.json, so its dir is the
+	// zero config dir.
+	sttDownloadRoot := ""
+	if userConfigPath != "" {
+		sttDownloadRoot = filepath.Join(filepath.Dir(userConfigPath), "stt")
+	}
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:                  workspaceRoot,
 		Version:              version,
@@ -792,9 +802,15 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 			merged, _ := plugins.MergedSkillsLoaded(deps.skillsDir(), pluginActivation.skillRoots)
 			return merged
 		}),
-		PermissionMode: permissionMode,
-		Notify:         resolved.Notify,
-		KeyBindings:    resolved.KeyBindings,
+		PermissionMode:            permissionMode,
+		Notify:                    resolved.Notify,
+		KeyBindings:               resolved.KeyBindings,
+		STT:                       resolved.STT,
+		BuildDictationTranscriber: newDictationTranscriberFactory(resolved, userConfigPath, sttServerManager),
+		ShutdownDictationServer:   sttServerManager.Shutdown,
+		STTDownloadRoot:           sttDownloadRoot,
+		STTKeyStatus:              newSTTKeyStatus(resolved, userConfigPath),
+		SaveSTTKey:                newSaveSTTKey(userConfigPath),
 		Setup: tui.SetupOptions{
 			Visible:    setupVisible,
 			Required:   needsSetup,

--- a/internal/cli/dictation.go
+++ b/internal/cli/dictation.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"fmt"
+	neturl "net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/dictation"
+	"github.com/Gitlawb/zero/internal/tui"
+)
+
+// Default batch cloud models (§8). Overridable via stt.model.
+const (
+	defaultGroqSTTModel   = "whisper-large-v3-turbo"
+	defaultOpenAISTTModel = "whisper-1"
+	groqSTTBaseURL        = "https://api.groq.com/openai/v1"
+)
+
+// newDictationTranscriberFactory returns the closure the TUI calls to build a
+// transcriber when a recording starts. It lives here, not in the TUI, because it
+// resolves provider API keys (credstore + env + configured providers) — logic
+// that belongs with the rest of the CLI's credential handling.
+//
+// serverMgr is the shared, session-long sherpa-onnx streaming server; it is
+// spawned lazily on the first local-streaming recording and torn down on exit.
+//
+// preferStreaming asks for the streaming backend; the returned bool reports
+// whether streaming was actually built (false → the caller uses the batch
+// pipeline). A misconfigured streaming backend surfaces its own SetupError.
+func newDictationTranscriberFactory(resolved config.ResolvedConfig, userConfigPath string, serverMgr *dictation.ServerManager) func(config.STTConfig, bool) (tui.Transcriber, bool, error) {
+	return func(stt config.STTConfig, preferStreaming bool) (tui.Transcriber, bool, error) {
+		// stt is passed in (not captured) so a mid-session change — e.g. the F9
+		// auto-download writing localModelPath — takes effect on the next call.
+		if serverMgr != nil {
+			serverMgr.SetModelPath(stt.LocalModelPath)
+		}
+		if preferStreaming {
+			t, err := buildStreamingTranscriber(stt, resolved, userConfigPath, serverMgr)
+			switch {
+			case err == nil && t != nil:
+				return t, true, nil
+			case err != nil && stt.STTStreamProvider() != config.STTProviderLocal:
+				// An explicitly-chosen cloud streaming backend that failed to build
+				// (e.g. a missing key) should surface its own error, not silently
+				// fall back to batch — the user asked for that backend specifically.
+				return nil, true, err
+			}
+			// The default local streaming backend isn't set up: fall through to the
+			// batch pipeline so a cloud-batch provider (or a batch-only setup) still
+			// works instead of erroring on a streaming server the user never asked for.
+		}
+		t, err := buildBatchTranscriber(stt, resolved, userConfigPath)
+		return t, false, err
+	}
+}
+
+// buildStreamingTranscriber constructs the configured streaming backend, or
+// returns (nil, nil) when streaming is not applicable so the caller falls back
+// to batch.
+func buildStreamingTranscriber(stt config.STTConfig, resolved config.ResolvedConfig, userConfigPath string, serverMgr *dictation.ServerManager) (dictation.Transcriber, error) {
+	switch stt.STTStreamProvider() {
+	case config.STTProviderDeepgram:
+		key := resolveSTTKey(resolved, userConfigPath, dictation.StreamProviderDeepgram, "DEEPGRAM_API_KEY")
+		return dictation.NewDeepgramTranscriber(dictation.DeepgramConfig{
+			APIKey:   key,
+			Model:    stt.StreamModel,
+			Language: stt.Language,
+		})
+	case config.STTProviderOpenAI:
+		key := resolveSTTKey(resolved, userConfigPath, dictation.ProviderOpenAI, "OPENAI_API_KEY")
+		return dictation.NewOpenAIRealtimeTranscriber(dictation.OpenAIRealtimeConfig{
+			APIKey: key,
+			Model:  stt.StreamModel,
+		})
+	default: // local streaming via the warm sherpa-onnx server
+		// STTStreamProvider() defaults to "local" whenever streamProvider is unset —
+		// including when the user picked a CLOUD batch provider (Groq/OpenAI) and
+		// never touched streaming. Don't silently stream through the local sherpa
+		// server in that case: local streaming is only appropriate when it was
+		// explicitly requested (streamProvider: "local") OR the batch provider is
+		// itself local. Otherwise report "not applicable" so the factory falls back
+		// to the cloud batch pipeline the user actually chose.
+		localWanted := stt.StreamProvider == config.STTProviderLocal || stt.STTProvider() == config.STTProviderLocal
+		if !localWanted {
+			return nil, nil
+		}
+		// The local streaming transcriber validates the model only lazily (at
+		// connect time), so gate on the model path here — with none set, report
+		// "not applicable" (nil, nil) so the factory falls back to the batch
+		// pipeline instead of committing to a server that can't start.
+		if serverMgr == nil || strings.TrimSpace(stt.LocalModelPath) == "" {
+			return nil, nil
+		}
+		return dictation.NewLocalStreamingTranscriber(serverMgr), nil
+	}
+}
+
+// newDictationServerManager builds the warm sherpa-onnx streaming server manager
+// from config. Construction is side-effect free — the server spawns lazily on
+// the first local-streaming recording — so it is always safe to create.
+func newDictationServerManager(stt config.STTConfig) *dictation.ServerManager {
+	return dictation.NewServerManager(dictation.ServerConfig{
+		Binary:     stt.LocalServerBinary,
+		ModelPath:  stt.LocalModelPath,
+		Port:       stt.LocalServerPort,
+		NumThreads: stt.NumThreads,
+	})
+}
+
+// buildBatchTranscriber constructs the configured batch transcriber, resolving
+// credentials for the cloud providers.
+func buildBatchTranscriber(stt config.STTConfig, resolved config.ResolvedConfig, userConfigPath string) (dictation.Transcriber, error) {
+	switch stt.STTProvider() {
+	case config.STTProviderGroq:
+		key := resolveSTTKey(resolved, userConfigPath, dictation.ProviderGroq, "GROQ_API_KEY")
+		model := stt.Model
+		if model == "" {
+			model = defaultGroqSTTModel
+		}
+		return dictation.NewCloudTranscriber(dictation.CloudConfig{
+			Provider: dictation.ProviderGroq,
+			BaseURL:  groqSTTBaseURL,
+			APIKey:   key,
+			Model:    model,
+			Language: stt.Language,
+		})
+	case config.STTProviderOpenAI:
+		key := resolveSTTKey(resolved, userConfigPath, dictation.ProviderOpenAI, "OPENAI_API_KEY")
+		model := stt.Model
+		if model == "" {
+			model = defaultOpenAISTTModel
+		}
+		return dictation.NewCloudTranscriber(dictation.CloudConfig{
+			Provider: dictation.ProviderOpenAI,
+			BaseURL:  config.OpenAIBaseURL,
+			APIKey:   key,
+			Model:    model,
+			Language: stt.Language,
+		})
+	default: // local
+		return dictation.NewLocalTranscriber(dictation.LocalConfig{
+			Binary:     stt.LocalBinary,
+			ModelPath:  stt.LocalModelPath,
+			NumThreads: stt.NumThreads,
+		})
+	}
+}
+
+// sttEnvVar returns the conventional environment variable a cloud STT provider's
+// key is read from.
+func sttEnvVar(provider string) string {
+	switch provider {
+	case dictation.ProviderGroq:
+		return "GROQ_API_KEY"
+	case dictation.ProviderOpenAI: // == StreamProviderOpenAI ("openai")
+		return "OPENAI_API_KEY"
+	case dictation.StreamProviderDeepgram:
+		return "DEEPGRAM_API_KEY"
+	}
+	return ""
+}
+
+// newSTTKeyStatus returns a predicate reporting whether a cloud STT provider
+// already has a resolvable API key (configured provider, credstore, or env).
+func newSTTKeyStatus(resolved config.ResolvedConfig, userConfigPath string) func(string) bool {
+	return func(provider string) bool {
+		return resolveSTTKey(resolved, userConfigPath, provider, sttEnvVar(provider)) != ""
+	}
+}
+
+// newSaveSTTKey returns a function that stores a cloud STT provider's API key in
+// the encrypted credential store, so the inline prompt can persist it.
+func newSaveSTTKey(userConfigPath string) func(string, string) error {
+	return func(provider, key string) error {
+		if strings.TrimSpace(userConfigPath) == "" {
+			return fmt.Errorf("no config path to store the key")
+		}
+		store, err := config.ProviderKeyStoreAt(filepath.Dir(userConfigPath))
+		if err != nil {
+			return err
+		}
+		return store.Set(provider, strings.TrimSpace(key))
+	}
+}
+
+// resolveSTTKey finds an API key for an STT cloud provider, reusing Zero's
+// existing credentials (§2 — "zero new credential UI"). Precedence: a matching
+// configured provider's resolved key, then the encrypted credential store, then
+// the provider's conventional environment variable.
+func resolveSTTKey(resolved config.ResolvedConfig, userConfigPath, provider, envVar string) string {
+	if key := keyFromConfiguredProviders(resolved, provider); key != "" {
+		return key
+	}
+	if userConfigPath != "" {
+		if store, err := config.ProviderKeyStoreAt(filepath.Dir(userConfigPath)); err == nil {
+			if key, ok, _ := store.Get(provider); ok && strings.TrimSpace(key) != "" {
+				return strings.TrimSpace(key)
+			}
+		}
+	}
+	return strings.TrimSpace(os.Getenv(envVar))
+}
+
+// keyFromConfiguredProviders returns the resolved API key of a configured
+// provider that belongs to the given cloud provider (matched by catalog id,
+// provider name/kind, or base-URL host), or "" when none is configured.
+func keyFromConfiguredProviders(resolved config.ResolvedConfig, provider string) string {
+	provider = strings.ToLower(provider)
+	profiles := append([]config.ProviderProfile{resolved.Provider}, resolved.Providers...)
+	for _, p := range profiles {
+		if strings.TrimSpace(p.APIKey) == "" {
+			continue
+		}
+		if providerMatches(p, provider) {
+			return strings.TrimSpace(p.APIKey)
+		}
+	}
+	return ""
+}
+
+func providerMatches(p config.ProviderProfile, provider string) bool {
+	provider = strings.ToLower(provider)
+	// Match on stable identifiers (catalog id, provider name/kind, profile
+	// name) rather than raw BaseURL substring matching: a Groq profile's
+	// BaseURL (api.groq.com/openai/v1) contains "openai", so a substring
+	// check can hand the wrong key to an OpenAI STT lookup and fail auth.
+	for _, f := range []string{
+		strings.ToLower(p.CatalogID),
+		strings.ToLower(p.Provider),
+		strings.ToLower(string(p.ProviderKind)),
+		strings.ToLower(p.Name),
+	} {
+		if f != "" && strings.Contains(f, provider) {
+			return true
+		}
+	}
+	// BaseURL: compare the parsed host only, not a raw substring on the
+	// full URL (which lets "openai" match api.groq.com/openai/v1).
+	if u, err := neturl.Parse(p.BaseURL); err == nil && u.Host != "" {
+		if host := strings.ToLower(u.Host); strings.Contains(host, provider) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/dictation_test.go
+++ b/internal/cli/dictation_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/dictation"
+)
+
+func TestFactoryFallsBackToBatchWhenLocalStreamingNotConfigured(t *testing.T) {
+	t.Setenv("GROQ_API_KEY", "gsk-test")
+	resolved := config.ResolvedConfig{STT: config.STTConfig{
+		Provider: config.STTProviderGroq, // cloud batch
+		// StreamProvider unset → defaults to local, which has no model configured.
+	}}
+	factory := newDictationTranscriberFactory(resolved, "", newDictationServerManager(resolved.STT))
+
+	tr, streaming, err := factory(resolved.STT, true) // prefer streaming
+	if err != nil {
+		t.Fatalf("expected batch fallback, got error: %v", err)
+	}
+	if streaming {
+		t.Error("should have fallen back to batch (streaming=false)")
+	}
+	if tr == nil {
+		t.Error("expected a Groq batch transcriber")
+	}
+}
+
+func TestFactoryCloudProviderIgnoresLeftoverLocalModel(t *testing.T) {
+	// Regression: pick local once (LocalModelPath gets set), then switch to a
+	// cloud batch provider. streamProvider stays unset (defaults to "local"), so
+	// the streaming factory must NOT fire up the sherpa server on the leftover
+	// path — it should fall back to the cloud batch pipeline the user chose.
+	t.Setenv("GROQ_API_KEY", "gsk-test")
+	stt := config.STTConfig{
+		Provider:       config.STTProviderGroq, // cloud batch, chosen now
+		LocalModelPath: "/leftover/model/dir",  // set by an earlier local selection
+	}
+	resolved := config.ResolvedConfig{STT: stt}
+	factory := newDictationTranscriberFactory(resolved, "", newDictationServerManager(stt))
+
+	tr, streaming, err := factory(stt, true) // prefer streaming
+	if err != nil {
+		t.Fatalf("expected cloud batch fallback, got error: %v", err)
+	}
+	if streaming {
+		t.Error("a cloud provider must not stream through the local sherpa server")
+	}
+	if tr == nil {
+		t.Error("expected a Groq batch transcriber")
+	}
+}
+
+func TestFactorySurfacesExplicitCloudStreamingError(t *testing.T) {
+	// Deepgram chosen explicitly but no key resolvable → surface the setup error.
+	resolved := config.ResolvedConfig{STT: config.STTConfig{
+		StreamProvider: config.STTProviderDeepgram,
+	}}
+	factory := newDictationTranscriberFactory(resolved, "", nil)
+
+	_, streaming, err := factory(resolved.STT, true)
+	if err == nil {
+		t.Fatal("expected a setup error for missing Deepgram key")
+	}
+	if !streaming {
+		t.Error("an explicit cloud streaming choice should report streaming=true even on error")
+	}
+	var setupErr *dictation.SetupError
+	if !errors.As(err, &setupErr) {
+		t.Errorf("want *SetupError, got %v", err)
+	}
+}
+
+func TestFactoryLocalBatchSetupErrorWhenNoModel(t *testing.T) {
+	resolved := config.ResolvedConfig{STT: config.STTConfig{Provider: config.STTProviderLocal}}
+	factory := newDictationTranscriberFactory(resolved, "", newDictationServerManager(resolved.STT))
+
+	_, _, err := factory(resolved.STT, true)
+	var setupErr *dictation.SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError guiding local model setup, got %v", err)
+	}
+}
+
+func TestResolveSTTKeyPrefersConfiguredProvider(t *testing.T) {
+	resolved := config.ResolvedConfig{
+		Providers: []config.ProviderProfile{
+			{Name: "groq", CatalogID: "groq", BaseURL: "https://api.groq.com/openai/v1", APIKey: "gsk-configured"},
+		},
+	}
+	if got := resolveSTTKey(resolved, "", dictation.ProviderGroq, "GROQ_API_KEY"); got != "gsk-configured" {
+		t.Errorf("key = %q, want the configured provider's key", got)
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -127,6 +127,9 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 			return ResolvedConfig{}, fmt.Errorf("invalid notify.focusMode %q: expected unfocused, always, or focused", focusMode)
 		}
 	}
+	if err := validateSTTConfig(cfg.STT); err != nil {
+		return ResolvedConfig{}, err
+	}
 
 	providers, active, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider, options.Env)
 	if err != nil {
@@ -150,6 +153,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		Preferences:    cfg.Preferences,
 		KeyBindings:    cfg.KeyBindings,
 		LocalControl:   cfg.LocalControl,
+		STT:            cfg.STT,
 	}, nil
 }
 
@@ -231,6 +235,7 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	}
 	mergeLocalControlConfig(&dst.LocalControl, src.LocalControl)
 	mergeKeyBindings(&dst.KeyBindings, src.KeyBindings)
+	mergeSTTConfig(&dst.STT, src.STT)
 }
 
 func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
@@ -681,6 +686,7 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 	}
 	mergeLocalControlConfig(&cfg.LocalControl, overrides.LocalControl)
 	mergeKeyBindings(&cfg.KeyBindings, overrides.KeyBindings)
+	mergeSTTConfig(&cfg.STT, overrides.STT)
 	for _, provider := range overrides.Providers {
 		mergeProvider(cfg, provider)
 	}
@@ -732,6 +738,88 @@ func mergeKeyBindings(dst *KeyBindingsConfig, src KeyBindingsConfig) {
 	if src.ToggleSidebar != "" {
 		dst.ToggleSidebar = src.ToggleSidebar
 	}
+}
+
+// mergeSTTConfig overlays any set field of src onto dst. Each field carries its
+// own "unset" sentinel (empty string, 0, or nil *bool), matching how the other
+// section mergers detect intent.
+func mergeSTTConfig(dst *STTConfig, src STTConfig) {
+	if src.Provider != "" {
+		dst.Provider = src.Provider
+	}
+	if src.StreamProvider != "" {
+		dst.StreamProvider = src.StreamProvider
+	}
+	if src.Streaming != nil {
+		dst.Streaming = src.Streaming
+	}
+	if src.Model != "" {
+		dst.Model = src.Model
+	}
+	if src.StreamModel != "" {
+		dst.StreamModel = src.StreamModel
+	}
+	if src.LocalModelPath != "" {
+		dst.LocalModelPath = src.LocalModelPath
+	}
+	if src.LocalBinary != "" {
+		dst.LocalBinary = src.LocalBinary
+	}
+	if src.LocalServerBinary != "" {
+		dst.LocalServerBinary = src.LocalServerBinary
+	}
+	if src.LocalServerPort != 0 {
+		dst.LocalServerPort = src.LocalServerPort
+	}
+	if src.EngineVersion != "" {
+		dst.EngineVersion = src.EngineVersion
+	}
+	if src.NumThreads != 0 {
+		dst.NumThreads = src.NumThreads
+	}
+	if src.Language != "" {
+		dst.Language = src.Language
+	}
+	if src.MaxDurationSeconds != 0 {
+		dst.MaxDurationSeconds = src.MaxDurationSeconds
+	}
+	if src.SilenceAutoStop != nil {
+		dst.SilenceAutoStop = src.SilenceAutoStop
+	}
+	if src.AutoSubmit != nil {
+		dst.AutoSubmit = src.AutoSubmit
+	}
+	if src.WindowsAudioDevice != "" {
+		dst.WindowsAudioDevice = src.WindowsAudioDevice
+	}
+}
+
+// validateSTTConfig rejects unknown provider/streamProvider values and a
+// negative maxDurationSeconds at load time — a clear startup error naming the
+// bad value and the valid options, never a silent fallback the user did not ask
+// for (§11a).
+func validateSTTConfig(cfg STTConfig) error {
+	if cfg.Provider != "" {
+		switch cfg.Provider {
+		case STTProviderLocal, STTProviderGroq, STTProviderOpenAI:
+		default:
+			return fmt.Errorf("invalid stt.provider %q: expected local, groq, or openai", cfg.Provider)
+		}
+	}
+	if cfg.StreamProvider != "" {
+		switch cfg.StreamProvider {
+		case STTProviderLocal, STTProviderDeepgram, STTProviderOpenAI:
+		default:
+			return fmt.Errorf("invalid stt.streamProvider %q: expected local, deepgram, or openai", cfg.StreamProvider)
+		}
+	}
+	if cfg.MaxDurationSeconds < 0 {
+		return fmt.Errorf("invalid stt.maxDurationSeconds %d: must be >= 0 (0 uses the default)", cfg.MaxDurationSeconds)
+	}
+	if cfg.LocalServerPort < 0 || cfg.LocalServerPort > 65535 {
+		return fmt.Errorf("invalid stt.localServerPort %d: must be between 1 and 65535 (0 uses the default)", cfg.LocalServerPort)
+	}
+	return nil
 }
 
 func mergeMCPConfig(dst *MCPConfig, src MCPConfig) {

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -816,6 +816,9 @@ func validateSTTConfig(cfg STTConfig) error {
 	if cfg.MaxDurationSeconds < 0 {
 		return fmt.Errorf("invalid stt.maxDurationSeconds %d: must be >= 0 (0 uses the default)", cfg.MaxDurationSeconds)
 	}
+	if cfg.NumThreads < 0 {
+		return fmt.Errorf("invalid stt.numThreads %d: must be >= 0 (0 uses the engine default)", cfg.NumThreads)
+	}
 	if cfg.LocalServerPort < 0 || cfg.LocalServerPort > 65535 {
 		return fmt.Errorf("invalid stt.localServerPort %d: must be between 1 and 65535 (0 uses the default)", cfg.LocalServerPort)
 	}

--- a/internal/config/stt_test.go
+++ b/internal/config/stt_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSetSTTLocalEngineResetsStreamProvider(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	// Pre-seed a cloud streaming provider — the situation the fix guards against.
+	if err := os.WriteFile(path, []byte(`{"stt":{"streamProvider":"deepgram"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := SetSTTLocalEngine(path, "sherpa-onnx-offline", "sherpa-onnx-online-websocket-server", "/models/kroko", true)
+	if err != nil {
+		t.Fatalf("SetSTTLocalEngine: %v", err)
+	}
+	// Switching to a local model must point BOTH pipelines at the local engine, or
+	// the leftover cloud streamProvider keeps the live transcript on the cloud.
+	if cfg.STT.Provider != STTProviderLocal || cfg.STT.StreamProvider != STTProviderLocal {
+		t.Errorf("both providers should be local, got provider=%q streamProvider=%q", cfg.STT.Provider, cfg.STT.StreamProvider)
+	}
+}
+
+func TestValidateSTTConfigRejectsUnknownProvider(t *testing.T) {
+	_, issues := ValidateBytes([]byte(`{"stt":{"provider":"assemblyai"}}`))
+	if len(issues) == 0 {
+		t.Fatal("expected an issue for unknown stt.provider")
+	}
+	if !strings.Contains(issues[0].Message, "assemblyai") || !strings.Contains(issues[0].Message, "local, groq, or openai") {
+		t.Errorf("issue message = %q, want it to name the bad value and valid options", issues[0].Message)
+	}
+}
+
+func TestValidateSTTConfigRejectsUnknownStreamProvider(t *testing.T) {
+	_, issues := ValidateBytes([]byte(`{"stt":{"streamProvider":"groq"}}`))
+	if len(issues) == 0 {
+		t.Fatal("expected an issue: groq has no streaming product, not a valid streamProvider")
+	}
+	if !strings.Contains(issues[0].Message, "deepgram") {
+		t.Errorf("issue message = %q", issues[0].Message)
+	}
+}
+
+func TestValidateSTTConfigAcceptsValid(t *testing.T) {
+	_, issues := ValidateBytes([]byte(`{"stt":{"provider":"groq","streamProvider":"deepgram","maxDurationSeconds":120}}`))
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %+v", issues)
+	}
+}
+
+func TestValidateSTTConfigRejectsNegativeDuration(t *testing.T) {
+	_, issues := ValidateBytes([]byte(`{"stt":{"maxDurationSeconds":-5}}`))
+	if len(issues) == 0 {
+		t.Fatal("expected an issue for negative maxDurationSeconds")
+	}
+}
+
+func TestSTTConfigDefaults(t *testing.T) {
+	cfg := STTConfig{}
+	if cfg.STTProvider() != STTProviderLocal {
+		t.Errorf("default provider = %q, want local", cfg.STTProvider())
+	}
+	if cfg.STTStreamProvider() != STTProviderLocal {
+		t.Errorf("default streamProvider = %q, want local", cfg.STTStreamProvider())
+	}
+	if !cfg.StreamingEnabled() {
+		t.Error("streaming should default on")
+	}
+	if !cfg.SilenceAutoStopEnabled() {
+		t.Error("silence auto-stop should default on")
+	}
+	if cfg.AutoSubmitEnabled() {
+		t.Error("auto-submit should default off (insert-for-review is the safety net)")
+	}
+	if !cfg.Empty() {
+		t.Error("zero-value STTConfig should be Empty")
+	}
+}
+
+func TestSTTConfigTriStateBools(t *testing.T) {
+	cfg, issues := ValidateBytes([]byte(`{"stt":{"autoSubmit":true,"streaming":false,"silenceAutoStop":false}}`))
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %+v", issues)
+	}
+	if !cfg.STT.AutoSubmitEnabled() {
+		t.Error("autoSubmit:true should be enabled")
+	}
+	if cfg.STT.StreamingEnabled() {
+		t.Error("streaming:false should be disabled")
+	}
+	if cfg.STT.SilenceAutoStopEnabled() {
+		t.Error("silenceAutoStop:false should be disabled")
+	}
+}
+
+func TestSTTConfigRoundTripsThroughMarshal(t *testing.T) {
+	cfg, _ := ValidateBytes([]byte(`{"stt":{"provider":"groq","model":"whisper-large-v3-turbo","localServerPort":6007}}`))
+	data, err := cfg.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"stt"`) {
+		t.Errorf("marshaled config dropped stt section: %s", data)
+	}
+	reparsed, issues := ValidateBytes(data)
+	if len(issues) != 0 {
+		t.Fatalf("re-parse issues: %+v", issues)
+	}
+	if reparsed.STT.Provider != STTProviderGroq || reparsed.STT.Model != "whisper-large-v3-turbo" || reparsed.STT.LocalServerPort != 6007 {
+		t.Errorf("round-trip lost fields: %+v", reparsed.STT)
+	}
+}
+
+func TestSetSTTModelPersists(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	// Cloud provider stores under stt.model.
+	if _, err := SetSTTModel(path, STTProviderGroq, "whisper-large-v3-turbo"); err != nil {
+		t.Fatalf("SetSTTModel: %v", err)
+	}
+	cfg, issues := ValidateFile(path)
+	if len(issues) != 0 {
+		t.Fatalf("issues: %+v", issues)
+	}
+	if cfg.STT.Provider != STTProviderGroq || cfg.STT.Model != "whisper-large-v3-turbo" {
+		t.Errorf("persisted STT = %+v", cfg.STT)
+	}
+	// Local provider stores under stt.localModelPath.
+	if _, err := SetSTTModel(path, STTProviderLocal, "/models/moonshine"); err != nil {
+		t.Fatalf("SetSTTModel local: %v", err)
+	}
+	cfg, _ = ValidateFile(path)
+	if cfg.STT.LocalModelPath != "/models/moonshine" {
+		t.Errorf("local model path = %q", cfg.STT.LocalModelPath)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -131,6 +131,115 @@ type KeyBindingsConfig struct {
 	ToggleSidebar KeyBindingDef `json:"toggleSidebar,omitempty"`
 }
 
+// STTProviderKind is the batch (or streaming) transcription backend selector.
+// Validated at config load time against the known set, so a typo fails loudly
+// with the valid options rather than silently falling back to a default.
+type STTProviderKind string
+
+const (
+	STTProviderLocal    STTProviderKind = "local"
+	STTProviderGroq     STTProviderKind = "groq"
+	STTProviderOpenAI   STTProviderKind = "openai"
+	STTProviderDeepgram STTProviderKind = "deepgram"
+)
+
+// STTConfig configures speech-to-text dictation. All fields are optional; empty
+// values take the documented defaults. Booleans that need a real tri-state
+// (distinguishing "unset" from "false") use *bool, matching PreferencesConfig.Recaps.
+type STTConfig struct {
+	// Provider is the batch transcription backend: "local" (sherpa-onnx-offline,
+	// the default), "groq", or "openai". Termux and the fallback everywhere use
+	// this path.
+	Provider STTProviderKind `json:"provider,omitempty"`
+	// StreamProvider is the streaming backend on desktop: "local" (sherpa-onnx
+	// websocket server, default), "deepgram", or "openai" (Realtime).
+	StreamProvider STTProviderKind `json:"streamProvider,omitempty"`
+	// Streaming enables the live-transcript pipeline on platforms that support
+	// it (desktop). Defaults to on; set false to always use the batch pipeline.
+	Streaming *bool `json:"streaming,omitempty"`
+	// Model overrides the cloud batch model (e.g. "whisper-large-v3-turbo" for
+	// Groq, "whisper-1" for OpenAI). Empty uses the provider default.
+	Model string `json:"model,omitempty"`
+	// StreamModel overrides the cloud streaming model (Deepgram/OpenAI Realtime).
+	StreamModel string `json:"streamModel,omitempty"`
+	// LocalModelPath is the sherpa-onnx model directory for local transcription
+	// (batch and streaming). Required to use a local provider.
+	LocalModelPath string `json:"localModelPath,omitempty"`
+	// LocalBinary overrides the offline binary name/path (default
+	// "sherpa-onnx-offline"); LocalServerBinary overrides the streaming server
+	// (default "sherpa-onnx-online-websocket-server"). Both looked up on PATH.
+	LocalBinary       string `json:"localBinary,omitempty"`
+	LocalServerBinary string `json:"localServerBinary,omitempty"`
+	// LocalServerPort is the localhost port for the sherpa-onnx websocket server
+	// (default 6006).
+	LocalServerPort int `json:"localServerPort,omitempty"`
+	// EngineVersion selects the sherpa-onnx release the auto-download fetches
+	// ("" → a pinned known-good default; "latest" or any release tag also works,
+	// so a newer engine needs no Zero update). Verified against the release's
+	// published SHA256 digest either way.
+	EngineVersion string `json:"engineVersion,omitempty"`
+	// NumThreads sets the local engine's thread count (0 = engine default).
+	NumThreads int `json:"numThreads,omitempty"`
+	// Language optionally constrains recognition (ISO-639-1, e.g. "en"). Empty =
+	// auto-detect.
+	Language string `json:"language,omitempty"`
+	// MaxDurationSeconds is the hard runaway-recording cap on every platform
+	// (0 = default 300s).
+	MaxDurationSeconds int `json:"maxDurationSeconds,omitempty"`
+	// SilenceAutoStop ends a recording ~2s after the signal goes quiet, as a
+	// backstop for a forgotten manual stop (not VAD-triggered start). Defaults on.
+	SilenceAutoStop *bool `json:"silenceAutoStop,omitempty"`
+	// AutoSubmit fires the transcript at the agent instead of inserting it for
+	// review. Defaults OFF — insert-for-review is the safety net for a misheard
+	// prompt (§3).
+	AutoSubmit *bool `json:"autoSubmit,omitempty"`
+	// WindowsAudioDevice names the dshow capture device (auto-detected when empty).
+	WindowsAudioDevice string `json:"windowsAudioDevice,omitempty"`
+}
+
+// STTProvider returns the configured batch provider, defaulting to local.
+func (c STTConfig) STTProvider() STTProviderKind {
+	if c.Provider == "" {
+		return STTProviderLocal
+	}
+	return c.Provider
+}
+
+// STTStreamProvider returns the configured streaming provider, defaulting to local.
+func (c STTConfig) STTStreamProvider() STTProviderKind {
+	if c.StreamProvider == "" {
+		return STTProviderLocal
+	}
+	return c.StreamProvider
+}
+
+// StreamingEnabled reports whether the live pipeline is on. Unset defaults ON.
+func (c STTConfig) StreamingEnabled() bool {
+	return c.Streaming == nil || *c.Streaming
+}
+
+// SilenceAutoStopEnabled reports whether trailing-silence auto-stop is on.
+// Unset defaults ON.
+func (c STTConfig) SilenceAutoStopEnabled() bool {
+	return c.SilenceAutoStop == nil || *c.SilenceAutoStop
+}
+
+// AutoSubmitEnabled reports whether transcripts are auto-fired. Unset defaults OFF.
+func (c STTConfig) AutoSubmitEnabled() bool {
+	return c.AutoSubmit != nil && *c.AutoSubmit
+}
+
+// Empty reports whether the STT config carries no user-set values (so it can be
+// omitted from a marshaled config).
+func (c STTConfig) Empty() bool {
+	return c.Provider == "" && c.StreamProvider == "" && c.Streaming == nil &&
+		c.Model == "" && c.StreamModel == "" && c.LocalModelPath == "" &&
+		c.LocalBinary == "" && c.LocalServerBinary == "" && c.LocalServerPort == 0 &&
+		c.EngineVersion == "" && c.NumThreads == 0 && c.Language == "" &&
+		c.MaxDurationSeconds == 0 && c.SilenceAutoStop == nil && c.AutoSubmit == nil &&
+		c.WindowsAudioDevice == ""
+}
+
 // LocalControlConfig controls local browser/desktop/terminal automation helpers.
 // Helpers are discovered lazily by the tool that needs them; no setup command or
 // background probe is required during startup.
@@ -227,6 +336,7 @@ type FileConfig struct {
 	Preferences    PreferencesConfig  `json:"preferences,omitempty"`
 	KeyBindings    KeyBindingsConfig  `json:"keybindings,omitempty"`
 	LocalControl   LocalControlConfig `json:"localControl,omitempty"`
+	STT            STTConfig          `json:"stt,omitempty"`
 }
 
 func (cfg FileConfig) MarshalJSON() ([]byte, error) {
@@ -242,6 +352,7 @@ func (cfg FileConfig) MarshalJSON() ([]byte, error) {
 		Preferences    PreferencesConfig   `json:"preferences,omitempty"`
 		KeyBindings    KeyBindingsConfig   `json:"keybindings,omitempty"`
 		LocalControl   *LocalControlConfig `json:"localControl,omitempty"`
+		STT            *STTConfig          `json:"stt,omitempty"`
 	}
 	raw := rawConfig{
 		ActiveProvider: cfg.ActiveProvider,
@@ -257,6 +368,9 @@ func (cfg FileConfig) MarshalJSON() ([]byte, error) {
 	}
 	if !cfg.LocalControl.Empty() {
 		raw.LocalControl = &cfg.LocalControl
+	}
+	if !cfg.STT.Empty() {
+		raw.STT = &cfg.STT
 	}
 	return json.Marshal(raw)
 }
@@ -280,6 +394,7 @@ type Overrides struct {
 	Tools          ToolsConfig
 	KeyBindings    KeyBindingsConfig
 	LocalControl   LocalControlConfig
+	STT            STTConfig
 }
 
 type ResolvedConfig struct {
@@ -295,6 +410,7 @@ type ResolvedConfig struct {
 	Preferences    PreferencesConfig
 	KeyBindings    KeyBindingsConfig
 	LocalControl   LocalControlConfig
+	STT            STTConfig
 }
 
 type MCPConfig struct {
@@ -342,6 +458,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		Preferences     PreferencesConfig          `json:"preferences"`
 		KeyBindings     KeyBindingsConfig          `json:"keybindings"`
 		LocalControl    LocalControlConfig         `json:"localControl"`
+		STT             STTConfig                  `json:"stt"`
 		MCPServers      map[string]MCPServerConfig `json:"mcpServers"`
 		MCPServersSnake map[string]MCPServerConfig `json:"mcp_servers"`
 	}
@@ -369,6 +486,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	cfg.Preferences = raw.Preferences
 	cfg.KeyBindings = raw.KeyBindings
 	cfg.LocalControl = raw.LocalControl
+	cfg.STT = raw.STT
 	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
 		cfg.MCP.Servers = map[string]MCPServerConfig{}
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -54,5 +54,8 @@ func validateSemantics(cfg FileConfig) []Issue {
 		// normalizeProviders already redacts secrets via providerError.
 		return []Issue{{FieldPath: "providers", Message: err.Error()}}
 	}
+	if err := validateSTTConfig(cfg.STT); err != nil {
+		return []Issue{{FieldPath: "stt", Message: err.Error()}}
+	}
 	return nil
 }

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -176,6 +176,106 @@ func SetTheme(path string, theme string) (FileConfig, error) {
 	return cfg, nil
 }
 
+// SetSTTModel persists the dictation model and its provider, mirroring
+// SetTheme (read-modify-atomic-write). provider must be one of the known STT
+// provider kinds; a local provider stores the model as stt.localModelPath,
+// otherwise as stt.model. A blank model clears the stored value for that slot.
+func SetSTTModel(path string, provider STTProviderKind, model string) (FileConfig, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return FileConfig{}, fmt.Errorf("config path is required")
+	}
+	cfg := FileConfig{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+	if provider != "" {
+		cfg.STT.Provider = provider
+	}
+	model = strings.TrimSpace(model)
+	if cfg.STT.STTProvider() == STTProviderLocal {
+		cfg.STT.LocalModelPath = model
+	} else {
+		cfg.STT.Model = model
+	}
+	if err := validateSTTConfig(cfg.STT); err != nil {
+		return FileConfig{}, err
+	}
+	if err := writeConfigFile(path, cfg); err != nil {
+		return FileConfig{}, err
+	}
+	return cfg, nil
+}
+
+// SetSTTLocalEngine persists the paths of an auto-downloaded local engine +
+// model and switches dictation to the local provider, mirroring SetTheme
+// (read-modify-atomic-write). streaming selects the pipeline matching the
+// downloaded model (a streaming transducer vs a batch model). Called after a
+// download completes.
+func SetSTTLocalEngine(path, binary, serverBinary, modelPath string, streaming bool) (FileConfig, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return FileConfig{}, fmt.Errorf("config path is required")
+	}
+	cfg := FileConfig{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+	cfg.STT.Provider = STTProviderLocal
+	// Point BOTH pipelines at the local engine. Without resetting StreamProvider, a
+	// previously-chosen cloud value (deepgram/openai) would still win in
+	// buildStreamingTranscriber, so the live transcript would keep hitting the cloud
+	// after the user switched to a downloaded local model.
+	cfg.STT.StreamProvider = STTProviderLocal
+	cfg.STT.LocalBinary = strings.TrimSpace(binary)
+	cfg.STT.LocalServerBinary = strings.TrimSpace(serverBinary)
+	cfg.STT.LocalModelPath = strings.TrimSpace(modelPath)
+	// Match the pipeline to the downloaded model: a streaming transducer drives
+	// the websocket server for a live transcript; a batch model uses the offline
+	// binary.
+	s := streaming
+	cfg.STT.Streaming = &s
+	if err := validateSTTConfig(cfg.STT); err != nil {
+		return FileConfig{}, err
+	}
+	if err := writeConfigFile(path, cfg); err != nil {
+		return FileConfig{}, err
+	}
+	return cfg, nil
+}
+
+// SetSTTProvider persists just the dictation batch provider, mirroring SetTheme.
+func SetSTTProvider(path string, provider STTProviderKind) (FileConfig, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return FileConfig{}, fmt.Errorf("config path is required")
+	}
+	cfg := FileConfig{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+	cfg.STT.Provider = provider
+	if err := validateSTTConfig(cfg.STT); err != nil {
+		return FileConfig{}, err
+	}
+	if err := writeConfigFile(path, cfg); err != nil {
+		return FileConfig{}, err
+	}
+	return cfg, nil
+}
+
 func normalizeFavoriteModels(models []string) []string {
 	seen := map[string]bool{}
 	favorites := make([]string, 0, len(models))

--- a/internal/dictation/dictation.go
+++ b/internal/dictation/dictation.go
@@ -1,0 +1,104 @@
+// Package dictation implements speech-to-text capture and transcription for
+// the composer: press a key, talk, and the transcript lands in the input for
+// review — never auto-fired at the agent.
+//
+// Two pipelines share a keybinding and a composer-insertion target:
+//
+//   - Batch: record to a temp WAV file (Recorder.Start/Stop), then transcribe
+//     in one shot (Transcriber.Transcribe) — a local sherpa-onnx-offline exec
+//     or a single HTTPS POST to Groq/OpenAI. The only pipeline on Termux.
+//   - Streaming: capture raw PCM from the mic tool's stdout
+//     (Recorder.StartStreaming), feed 50ms chunks to a websocket
+//     (Transcriber.StreamTranscribe), and render partial transcripts live.
+//
+// Every OS integration shells out via exec.Command with discrete argv — never
+// a shell string, never CGO — matching internal/imageinput/clipboard.go. The
+// external binaries (arecord/sox/ffmpeg/termux-microphone-record, sherpa-onnx)
+// are looked up on PATH and degrade to a clear setup message when missing,
+// matching internal/lsp's philosophy for language servers.
+package dictation
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Batch transcription providers (config value stt.provider).
+const (
+	ProviderLocal  = "local"
+	ProviderGroq   = "groq"
+	ProviderOpenAI = "openai"
+)
+
+// Streaming transcription providers (config value stt.streamProvider).
+const (
+	StreamProviderLocal    = "local"
+	StreamProviderDeepgram = "deepgram"
+	StreamProviderOpenAI   = "openai"
+)
+
+// BatchProviders lists valid stt.provider values, for config validation.
+func BatchProviders() []string {
+	return []string{ProviderLocal, ProviderGroq, ProviderOpenAI}
+}
+
+// StreamProviders lists valid stt.streamProvider values, for config validation.
+func StreamProviders() []string {
+	return []string{StreamProviderLocal, StreamProviderDeepgram, StreamProviderOpenAI}
+}
+
+// AudioFormat identifies a recorded container format, sniffed from the bytes —
+// desktop recorders produce WAV, Termux's recorder produces M4A/AAC.
+type AudioFormat string
+
+const (
+	FormatWAV     AudioFormat = "wav"
+	FormatM4A     AudioFormat = "m4a"
+	FormatUnknown AudioFormat = ""
+)
+
+// SniffFormat detects the audio container from magic bytes. WAV is
+// "RIFF....WAVE"; MP4-family (Termux's .m4a) has "ftyp" at offset 4.
+func SniffFormat(data []byte) AudioFormat {
+	if len(data) >= 12 && bytes.Equal(data[:4], []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WAVE")) {
+		return FormatWAV
+	}
+	if len(data) >= 8 && bytes.Equal(data[4:8], []byte("ftyp")) {
+		return FormatM4A
+	}
+	return FormatUnknown
+}
+
+// FileName returns a transcription-upload filename for the format.
+func (f AudioFormat) FileName() string {
+	switch f {
+	case FormatM4A:
+		return "audio.m4a"
+	default:
+		return "audio.wav"
+	}
+}
+
+// SetupError reports a missing external tool with install guidance. Missing
+// binaries are an expected condition (the user hasn't set dictation up yet),
+// not a bug — callers show the hint instead of a raw exec error.
+type SetupError struct {
+	Tool string
+	Hint string
+}
+
+func (e *SetupError) Error() string {
+	return fmt.Sprintf("%s not found — %s", e.Tool, e.Hint)
+}
+
+// AuthError reports that a cloud provider rejected a transcription request for
+// authentication reasons (HTTP 401/403) — a missing or invalid API key. It is a
+// fixable credential problem, so callers (the TUI) can offer an inline key
+// prompt for Provider instead of a dead-end error. Message is the already-
+// classified, secret-redacted user-facing text.
+type AuthError struct {
+	Provider string
+	Message  string
+}
+
+func (e *AuthError) Error() string { return e.Message }

--- a/internal/dictation/download.go
+++ b/internal/dictation/download.go
@@ -1,0 +1,864 @@
+package dictation
+
+import (
+	"archive/tar"
+	"compress/bzip2"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Auto-download of the local engine + a default model (opt-in, behind a confirm
+// in the F9 flow). Assets come from the official k2-fsa/sherpa-onnx GitHub
+// releases and are verified against a SHA256 digest before use — the same trust
+// boundary as installing them yourself, automated. Auto-downloading a native
+// executable is a real trust decision, which is why it is opt-in and verified.
+//
+// Rather than freeze a single hardcoded version, the downloader resolves the
+// release ASSETS via the GitHub API at download time and verifies each download
+// against the API's per-asset digest — so a newer sherpa-onnx release (or
+// "latest") works with no code change. A known-good version is still the DEFAULT
+// (reproducible, smoke-tested), and for that default the resolved digest is
+// cross-checked against a pinned value so a silently-changed release is caught.
+
+// DefaultSherpaVersion is the pinned, smoke-tested release used unless
+// stt.engineVersion overrides it. "latest" or any tag also works.
+const DefaultSherpaVersion = "v1.13.3"
+
+const (
+	sherpaRepo      = "k2-fsa/sherpa-onnx"
+	modelReleaseTag = "asr-models" // rolling release the ASR models live in
+	modelAssetName  = "sherpa-onnx-moonshine-tiny-en-int8.tar.bz2"
+	defaultAPIBase  = "https://api.github.com"
+)
+
+// engineAssetSuffix maps GOOS-GOARCH to the version-independent suffix of the
+// sherpa-onnx executable bundle for that platform. Matching by suffix (not a
+// full version-embedded name) is what lets any release resolve. The bundles are
+// self-contained (RPATH $ORIGIN/../lib), so the extracted bin/ executables run
+// with no library-path setup.
+var engineAssetSuffix = map[string]string{
+	"linux-amd64":   "linux-x64-shared-no-tts.tar.bz2",
+	"darwin-arm64":  "osx-arm64-shared-no-tts.tar.bz2",
+	"darwin-amd64":  "osx-x64-shared-no-tts.tar.bz2",
+	"windows-amd64": "win-x64-shared-MT-Release-no-tts.tar.bz2",
+}
+
+// pinnedEngineDigest cross-checks the DefaultSherpaVersion engine assets (a
+// silently-changed pinned release is refused). Empty for non-default versions,
+// which are verified against the API digest only.
+var pinnedEngineDigest = map[string]string{
+	"linux-amd64":   "e5cbfd96f3666c25d2272d468e337764fce6a4d50ed074e4b8e5021bfd7fefc1",
+	"darwin-arm64":  "ea73233bc250019ccf1f8a16feb29460efcd3425b50cac16980bcb76281d60bf",
+	"darwin-amd64":  "563423887d63d8a831c473e0ab6815139fe2e7a3482936716c2a128071dd217f",
+	"windows-amd64": "343c6c39cb4fe1880a9fb1abc8401d5174629ccbb147fca1fd53c440b2664570",
+}
+
+// pinnedModelDigest cross-checks the default Moonshine-tiny int8 model.
+const pinnedModelDigest = "d5fe6ec4334fef36255b2a4010412cad4c007e33103fec62fb5d17cad88086f2"
+
+// ModelVariant is a downloadable model the /stt-model picker offers, with a
+// pinned SHA256 (the model release predates GitHub's per-asset digests, so these
+// must be pinned). Batch variants use the offline binary; the streaming variant
+// (a transducer) drives the websocket server for a live transcript.
+type ModelVariant struct {
+	ID          string
+	Label       string
+	Description string
+	Bytes       int64
+	AssetName   string
+	Digest      string
+	DirName     string
+	Streaming   bool
+	// Recommended marks a curated, checksum-pinned, validated model (shown first).
+	Recommended bool
+}
+
+// ModelVariants returns the curated English models the download picker offers.
+// This is a hand-picked shortlist (each pinned by SHA256 since the model release
+// predates GitHub's per-asset digests), NOT the whole sherpa-onnx model zoo —
+// many more models (other languages, sizes, and streaming/batch families) work
+// via a manual stt.localModelPath. Streaming (live) options come first.
+func ModelVariants() []ModelVariant {
+	return []ModelVariant{
+		// Live / streaming — transcript builds up as you speak.
+		// DirName MUST match what ListModels derives from the asset ("model-"+id, id =
+		// asset minus "sherpa-onnx-" prefix and ".tar.bz2" suffix, dates included) so a
+		// model extracts to the same directory whether picked from the curated shortlist
+		// or the full browse list — otherwise installed-detection disagrees between the
+		// two views and the same model can be downloaded twice. Recommended matches the
+		// full list too (recommendedModelIDs marks every curated variant), so the ★ and
+		// ordering don't change when the background fetch swaps the curated list out.
+		{
+			ID: "streaming-zipformer-en-kroko", Label: "Kroko (newest, fastest)",
+			Description: "smallest live model", Bytes: 54 << 20,
+			AssetName:   "sherpa-onnx-streaming-zipformer-en-kroko-2025-08-06.tar.bz2",
+			Digest:      "c8676e5ff9ac2a85296e53ee0fd4d5fb1db6770e7a7647166eeafe349ade6834",
+			DirName:     "model-streaming-zipformer-en-kroko-2025-08-06",
+			Streaming:   true,
+			Recommended: true,
+		},
+		{
+			ID: "streaming-zipformer-20m", Label: "Zipformer 20M",
+			Description: "small, well-tested", Bytes: 121 << 20,
+			AssetName: "sherpa-onnx-streaming-zipformer-en-20M-2023-02-17.tar.bz2",
+			Digest:    "9c559283e8498d3fe95913c79ca1cb454bb26281ac2b102b41306c7d752765d9",
+			DirName:   "model-streaming-zipformer-en-20M-2023-02-17",
+			Streaming: true,
+		},
+		{
+			ID: "streaming-zipformer", Label: "Zipformer",
+			Description: "larger, more accurate", Bytes: 297 << 20,
+			AssetName: "sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2",
+			Digest:    "639e25b578e9e997131402199419c13a941f8e4e198e2da1ce57dbf5cf401282",
+			DirName:   "model-streaming-zipformer-en-2023-06-26",
+			Streaming: true,
+		},
+		{
+			ID: "nemo-streaming-fast-conformer-transducer-en-80ms-int8", Label: "NeMo streaming (fast)",
+			Description: "low-latency English", Bytes: 98 << 20,
+			AssetName:   "sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-80ms-int8.tar.bz2",
+			Digest:      "7bd33a914e93370a1ba9c2066d9e841bdcad8613fa2a00537c1ae15d851a14d8",
+			DirName:     "model-nemo-streaming-fast-conformer-transducer-en-80ms-int8",
+			Streaming:   true,
+			Recommended: true,
+		},
+		// Batch — transcribes once when you stop.
+		{
+			ID: "moonshine-tiny", Label: "Moonshine tiny",
+			Description: "fast, smallest", Bytes: 103 << 20,
+			AssetName: "sherpa-onnx-moonshine-tiny-en-int8.tar.bz2",
+			Digest:    pinnedModelDigest,
+			DirName:   "model-moonshine-tiny-en-int8",
+		},
+		{
+			ID: "moonshine-base", Label: "Moonshine base",
+			Description: "more accurate, larger", Bytes: 239 << 20,
+			AssetName:   "sherpa-onnx-moonshine-base-en-int8.tar.bz2",
+			Digest:      "21870cecaa2e44e4e2bf63e02d1072bed183ccd10284871353bd9d24dad14e5e",
+			DirName:     "model-moonshine-base-en-int8",
+			Recommended: true,
+		},
+		{
+			ID: "sense-voice-zh-en-ja-ko-yue-int8-2025-09-09", Label: "SenseVoice",
+			Description: "multilingual, accurate", Bytes: 158 << 20,
+			AssetName:   "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09.tar.bz2",
+			Digest:      "7305f7905bfcf77fa0b39388a313f3da35c68d971661a65475b56fb2162c8e63",
+			DirName:     "model-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09",
+			Recommended: true,
+		},
+		{
+			// Heavy (~1 GB) but the best transcription quality — recommended when
+			// accuracy matters more than speed/size. The asr-models release publishes
+			// no digest for it, so (like every browse-listed model) it downloads with
+			// TLS-only verification.
+			ID: "whisper-large-v3", Label: "Whisper large v3",
+			Description: "best accuracy, heavy", Bytes: 1019 << 20,
+			AssetName:   "sherpa-onnx-whisper-large-v3.tar.bz2",
+			DirName:     "model-whisper-large-v3",
+			Recommended: true,
+		},
+	}
+}
+
+// recommendedModelIDs marks the curated variants flagged Recommended so the full
+// browse list stars (and surfaces) exactly the ones the curated shortlist does —
+// keyed off the same Recommended flag so the two views never disagree.
+var recommendedModelIDs = func() map[string]bool {
+	m := map[string]bool{}
+	for _, v := range ModelVariants() {
+		if v.Recommended {
+			m[v.AssetName] = true
+		}
+	}
+	return m
+}()
+
+// pinnedModelDigests maps a model asset name to its pinned SHA256 (the curated
+// variants), so browse-listed models we happen to know get verified too.
+var pinnedModelDigests = func() map[string]string {
+	m := map[string]string{}
+	for _, v := range ModelVariants() {
+		m[v.AssetName] = v.Digest
+	}
+	return m
+}()
+
+// curatedLabels maps a curated model's asset name to its friendly label, so the
+// recommended rows read nicely in the full browse list too.
+var curatedLabels = func() map[string]string {
+	m := map[string]string{}
+	for _, v := range ModelVariants() {
+		m[v.AssetName] = v.Label
+	}
+	return m
+}()
+
+// browseLabel turns a raw asset id into a shorter display label: it drops the
+// redundant "-int8"/quantization noise and the "streaming-" prefix (the group
+// header already says live vs batch).
+func browseLabel(id string) string {
+	label := strings.TrimPrefix(id, "streaming-")
+	for _, drop := range []string{"-int8", ".int8", "-quantized", "-fp16"} {
+		label = strings.ReplaceAll(label, drop, "")
+	}
+	return label
+}
+
+// ListModels fetches every transcription model in the sherpa-onnx asr-models
+// release and returns them as variants (the curated ones flagged Recommended and
+// carrying a pinned digest; the rest with an empty digest, downloaded with
+// TLS-only verification since that release predates GitHub's per-asset digests).
+// Non-ASR assets (VAD, TTS, punctuation, speaker/keyword/…): filtered out.
+func ListModels(ctx context.Context, client *http.Client, apiBase string) ([]ModelVariant, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if apiBase == "" {
+		apiBase = defaultAPIBase
+	}
+	// Resolve the release id, then page its assets (a release can have hundreds).
+	relURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", strings.TrimRight(apiBase, "/"), sherpaRepo, modelReleaseTag)
+	var rel struct {
+		ID     int64 `json:"id"`
+		Assets []githubAsset
+	}
+	if err := getJSON(ctx, client, relURL, &rel); err != nil {
+		return nil, fmt.Errorf("listing dictation models: %w", err)
+	}
+	assets := rel.Assets
+	// If the inline assets look capped, page the assets endpoint for the rest.
+	for page := 1; len(assets)%100 == 0 && len(assets) > 0; page++ {
+		var more []githubAsset
+		u := fmt.Sprintf("%s/repos/%s/releases/%d/assets?per_page=100&page=%d", strings.TrimRight(apiBase, "/"), sherpaRepo, rel.ID, page+1)
+		if err := getJSON(ctx, client, u, &more); err != nil || len(more) == 0 {
+			break
+		}
+		assets = append(assets, more...)
+		if len(more) < 100 {
+			break
+		}
+	}
+
+	seen := map[string]bool{}
+	var out []ModelVariant
+	for _, a := range assets {
+		if seen[a.Name] || !isTranscriptionModelAsset(a.Name) {
+			continue
+		}
+		seen[a.Name] = true
+		id := strings.TrimSuffix(strings.TrimPrefix(a.Name, "sherpa-onnx-"), ".tar.bz2")
+		digest := strings.TrimPrefix(a.Digest, "sha256:")
+		if digest == "" {
+			digest = pinnedModelDigests[a.Name] // may still be empty (browse/unverified)
+		}
+		label := browseLabel(id)
+		desc := modelFamily(a.Name) // readable language, e.g. "French"
+		if nice, ok := curatedLabels[a.Name]; ok {
+			label = nice
+			desc = curatedDescriptions[a.Name] // curated blurb ("fast, smallest")
+		}
+		out = append(out, ModelVariant{
+			ID:          id,
+			Label:       label,
+			Description: desc,
+			Bytes:       a.Size,
+			AssetName:   a.Name,
+			Digest:      digest,
+			DirName:     "model-" + id,
+			Streaming:   strings.Contains(strings.ToLower(a.Name), "streaming-"),
+			Recommended: recommendedModelIDs[a.Name],
+		})
+	}
+	return out, nil
+}
+
+type githubAsset struct {
+	Name   string `json:"name"`
+	Digest string `json:"digest"`
+	Size   int64  `json:"size"`
+}
+
+func getJSON(ctx context.Context, client *http.Client, url string, v any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GitHub API HTTP %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+// isTranscriptionModelAsset reports whether an asset is a speech-to-text model
+// (as opposed to a VAD/TTS/punctuation/speaker/keyword/enhancement tool).
+func isTranscriptionModelAsset(name string) bool {
+	n := strings.ToLower(name)
+	if !strings.HasPrefix(n, "sherpa-onnx-") || !strings.HasSuffix(n, ".tar.bz2") {
+		return false
+	}
+	for _, bad := range []string{
+		"-vad", "vad-", "tts", "punct", "speaker", "diariz", "kws", "keyword",
+		"audio-tagging", "denois", "source-separation", "speech-enhancement",
+		"spoken-language", "language-identification", "-lid", "melo", "kokoro",
+		"vits", "matcha", "piper", "wespeaker",
+		// Rockchip NPU (RKNN) builds for specific ARM boards — not CPU/ONNX, so
+		// the standard sherpa-onnx binary can't run them.
+		"rknn", "rk3566", "rk3568", "rk3562", "rk3588", "rk3576", "rk3528", "rk3399",
+	} {
+		if strings.Contains(n, bad) {
+			return false
+		}
+	}
+	for _, fam := range []string{
+		"zipformer", "moonshine", "whisper", "paraformer", "sense-voice",
+		"sensevoice", "conformer", "nemo", "canary", "parakeet", "fire-red",
+		"fireredasr", "dolphin", "telespeech", "wenet", "omnilingual", "funasr",
+		"medasr", "cohere", "qwen", "citrinet", "transducer", "-ctc-", "zipvoice",
+	} {
+		if strings.Contains(n, fam) {
+			return true
+		}
+	}
+	return false
+}
+
+// langNames maps ISO-ish language tokens in a model name to readable names.
+var langNames = map[string]string{
+	"en": "English", "zh": "Chinese", "yue": "Cantonese", "fr": "French",
+	"de": "German", "es": "Spanish", "ru": "Russian", "ja": "Japanese",
+	"ko": "Korean", "bn": "Bengali", "ar": "Arabic", "hi": "Hindi",
+	"pt": "Portuguese", "nl": "Dutch", "vi": "Vietnamese", "th": "Thai",
+	"uk": "Ukrainian", "fa": "Persian", "pl": "Polish", "tr": "Turkish",
+	"cs": "Czech", "sv": "Swedish", "fil": "Filipino", "tl": "Tagalog",
+	"fi": "Finnish", "el": "Greek", "he": "Hebrew", "ro": "Romanian",
+}
+
+// modelFamily is a short readable descriptor for a model, favoring the language
+// (the most useful thing not already obvious from the group header) and falling
+// back to the family. E.g. "French", "Chinese", "Multilingual".
+func modelFamily(name string) string {
+	n := strings.ToLower(name)
+	if strings.Contains(n, "multi") || strings.Contains(n, "bilingual") ||
+		strings.Contains(n, "trilingual") || strings.Contains(n, "polyglot") ||
+		strings.Contains(n, "omnilingual") {
+		return "Multilingual"
+	}
+	var langs []string
+	seen := map[string]bool{}
+	add := func(name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			langs = append(langs, name)
+		}
+	}
+	for _, tok := range strings.Split(strings.TrimSuffix(n, ".tar.bz2"), "-") {
+		add(langNames[tok])
+	}
+	// Full language words spelled out in some names (e.g. "-cantonese-").
+	for word, name := range map[string]string{
+		"cantonese": "Cantonese", "mandarin": "Chinese", "english": "English",
+		"chinese": "Chinese", "korean": "Korean", "japanese": "Japanese",
+		"russian": "Russian", "arabic": "Arabic", "spanish": "Spanish",
+		"french": "French", "german": "German", "vietnamese": "Vietnamese",
+		"thai": "Thai", "farsi": "Persian", "persian": "Persian",
+		"portuguese": "Portuguese", "italian": "Italian", "dutch": "Dutch",
+		"ukrainian": "Ukrainian", "polish": "Polish", "turkish": "Turkish",
+	} {
+		if strings.Contains(n, word) {
+			add(name)
+		}
+	}
+	switch {
+	case len(langs) == 0:
+		return ""
+	case len(langs) > 2:
+		return "Multilingual"
+	default:
+		return strings.Join(langs, " + ")
+	}
+}
+
+// curatedDescriptions maps a curated model's asset name to its quality blurb.
+var curatedDescriptions = func() map[string]string {
+	m := map[string]string{}
+	for _, v := range ModelVariants() {
+		m[v.AssetName] = v.Description
+	}
+	return m
+}()
+
+// EngineComponents identifies the resolved local-engine paths.
+type EngineComponents struct {
+	BinaryPath string // extracted sherpa-onnx-offline
+	ServerPath string // extracted sherpa-onnx-online-websocket-server
+	ModelPath  string // extracted model directory
+}
+
+// DownloadOptions configures EnsureLocalEngine.
+type DownloadOptions struct {
+	// DestRoot is where extracted engines/models live (e.g. ~/.config/zero/stt).
+	DestRoot string
+	// EngineVersion selects the sherpa-onnx release tag ("" → DefaultSherpaVersion;
+	// "latest" and any tag also work).
+	EngineVersion string
+	// HTTPClient is injectable for tests; nil uses a plain client.
+	HTTPClient *http.Client
+	// APIBase overrides the GitHub API base (tests). "" → api.github.com.
+	APIBase string
+	// Model selection (default: the Moonshine-tiny int8 batch model). Set these
+	// from a ModelVariant to download a different model.
+	ModelAssetName    string
+	ModelPinnedDigest string
+	ModelDirName      string
+	// ModelLabel is the friendly model name shown in progress ("Zipformer 20M").
+	ModelLabel string
+	// Progress receives live status strings for the UI, including a percentage
+	// while downloading (e.g. "Engine 45% · 57/126 MB").
+	Progress func(status string)
+	// platformKey overrides runtime detection (tests).
+	platformKey string
+	// skipPinned disables the pinned-digest cross-check (tests, which use fixture
+	// assets); the API-digest verification still runs.
+	skipPinned bool
+}
+
+// AutoDownloadSupported reports whether the current platform has a known engine
+// asset (so the F9 flow can offer the download). Termux/Android and unusual
+// arches install manually or use a cloud provider.
+func AutoDownloadSupported() bool {
+	_, ok := engineAssetSuffix[platformKey()]
+	return ok
+}
+
+func platformKey() string { return runtime.GOOS + "-" + runtime.GOARCH }
+
+// EnsureLocalEngine downloads (if absent) and verifies the sherpa-onnx engine and
+// the default model into DestRoot, returning the resolved paths. Idempotent: an
+// already-extracted, still-present engine/model is reused without re-downloading.
+// Every archive is SHA256-verified against the GitHub API digest before extraction.
+func EnsureLocalEngine(ctx context.Context, opts DownloadOptions) (EngineComponents, error) {
+	if strings.TrimSpace(opts.DestRoot) == "" {
+		return EngineComponents{}, fmt.Errorf("dictation download: DestRoot is required")
+	}
+	key := opts.platformKey
+	if key == "" {
+		key = platformKey()
+	}
+	suffix, ok := engineAssetSuffix[key]
+	if !ok {
+		return EngineComponents{}, &SetupError{
+			Tool: "sherpa-onnx auto-download",
+			Hint: fmt.Sprintf("no prebuilt engine is known for %s — install sherpa-onnx manually or use a cloud provider (see docs/dictation.md)", key),
+		}
+	}
+	version := strings.TrimSpace(opts.EngineVersion)
+	if version == "" {
+		version = DefaultSherpaVersion
+	}
+	progress := opts.Progress
+	if progress == nil {
+		progress = func(string) {}
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	apiBase := opts.APIBase
+	if apiBase == "" {
+		apiBase = defaultAPIBase
+	}
+
+	engineDir := filepath.Join(opts.DestRoot, "engine-"+version+"-"+key)
+	targetWindows := strings.HasPrefix(key, "windows-")
+	// Resolve through the tarball's flattened subdir so an ALREADY-extracted
+	// engine is found and not needlessly re-downloaded (the idempotency check).
+	binPath, serverPath := resolveEnginePaths(engineDir, targetWindows)
+	if !fileExists(binPath) {
+		pinned := ""
+		if version == DefaultSherpaVersion && !opts.skipPinned {
+			pinned = pinnedEngineDigest[key]
+		}
+		asset, err := resolveAsset(ctx, client, apiBase, version, "sherpa-onnx-", suffix)
+		if err != nil {
+			return EngineComponents{}, err
+		}
+		if err := downloadVerifyExtract(ctx, client, asset, pinned, false, "Engine", engineDir, progress); err != nil {
+			return EngineComponents{}, err
+		}
+		binPath, serverPath = resolveEnginePaths(engineDir, targetWindows)
+	}
+	if !fileExists(binPath) {
+		return EngineComponents{}, fmt.Errorf("dictation download: engine binary not found after extraction in %s", engineDir)
+	}
+
+	modelName := opts.ModelAssetName
+	if modelName == "" {
+		modelName = modelAssetName
+	}
+	modelDirName := opts.ModelDirName
+	if modelDirName == "" {
+		modelDirName = "model-moonshine-tiny-en-int8"
+	}
+	modelDir := filepath.Join(opts.DestRoot, modelDirName)
+	if !dirHasModel(modelDir) {
+		asset, err := resolveAsset(ctx, client, apiBase, modelReleaseTag, modelName, "")
+		if err != nil {
+			return EngineComponents{}, err
+		}
+		modelPinned := opts.ModelPinnedDigest
+		// Only fall back to the built-in digest for the DEFAULT model — a different
+		// (browse-listed) model must never be checked against the default's digest.
+		if modelPinned == "" && opts.ModelAssetName == "" {
+			modelPinned = pinnedModelDigest
+		}
+		if opts.skipPinned {
+			modelPinned = ""
+		}
+		modelLabel := opts.ModelLabel
+		if modelLabel == "" {
+			modelLabel = "Model"
+		}
+		// Models are data files from the official release: verify against a digest
+		// when we have one (curated/pinned or API-provided), else allow a TLS-only
+		// download (the model release predates GitHub's per-asset digests). The
+		// engine BINARY above never allows this — a native executable is always
+		// digest-verified.
+		if err := downloadVerifyExtract(ctx, client, asset, modelPinned, true, modelLabel, modelDir, progress); err != nil {
+			return EngineComponents{}, err
+		}
+	}
+	resolvedModel := modelDir
+	if !hasTokensFile(resolvedModel) {
+		if child, err := flattenSingleChild(modelDir); err == nil {
+			resolvedModel = child
+		}
+	}
+	if !hasTokensFile(resolvedModel) {
+		return EngineComponents{}, fmt.Errorf("dictation download: model files not found after extraction in %s", modelDir)
+	}
+	return EngineComponents{BinaryPath: binPath, ServerPath: serverPath, ModelPath: resolvedModel}, nil
+}
+
+type resolvedAsset struct {
+	url    string
+	sha256 string
+	size   int64
+	name   string
+}
+
+// resolveAsset queries the GitHub release for tag and returns the asset whose
+// name has the given prefix and suffix, plus its SHA256 digest and size.
+func resolveAsset(ctx context.Context, client *http.Client, apiBase, tag, namePrefix, nameSuffix string) (resolvedAsset, error) {
+	tagPath := "tags/" + tag
+	if tag == "" || tag == "latest" {
+		tagPath = "latest"
+	}
+	url := fmt.Sprintf("%s/repos/%s/releases/%s", strings.TrimRight(apiBase, "/"), sherpaRepo, tagPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return resolvedAsset{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return resolvedAsset{}, fmt.Errorf("resolving sherpa-onnx release %s: %w", tag, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return resolvedAsset{}, fmt.Errorf("resolving sherpa-onnx release %s: GitHub API HTTP %d", tag, resp.StatusCode)
+	}
+	var release struct {
+		TagName string `json:"tag_name"`
+		Assets  []struct {
+			Name        string `json:"name"`
+			DownloadURL string `json:"browser_download_url"`
+			Digest      string `json:"digest"`
+			Size        int64  `json:"size"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return resolvedAsset{}, fmt.Errorf("parsing sherpa-onnx release %s: %w", tag, err)
+	}
+	for _, a := range release.Assets {
+		if !strings.HasPrefix(a.Name, namePrefix) || !strings.HasSuffix(a.Name, nameSuffix) {
+			continue
+		}
+		// The API digest may be empty for older assets (GitHub only populates it for
+		// assets uploaded after ~2024 — the ASR models predate that). An empty
+		// digest is fine here; downloadVerifyExtract requires the API digest OR a
+		// pinned one and refuses only when neither exists.
+		digest := strings.TrimPrefix(a.Digest, "sha256:")
+		return resolvedAsset{url: a.DownloadURL, sha256: digest, size: a.Size, name: a.Name}, nil
+	}
+	return resolvedAsset{}, &SetupError{
+		Tool: "sherpa-onnx auto-download",
+		Hint: fmt.Sprintf("release %s has no asset matching %s*%s — try a different stt.engineVersion or install manually", tag, namePrefix, nameSuffix),
+	}
+}
+
+// downloadVerifyExtract fetches the asset to a temp file, verifies its SHA256
+// (against the API digest, and — when pinned is set — a cross-check that the
+// resolved digest equals the audited value), and extracts the tar.bz2. A
+// mismatch aborts before anything is extracted or run.
+func downloadVerifyExtract(ctx context.Context, client *http.Client, asset resolvedAsset, pinned string, allowUnverified bool, label, destDir string, progress func(string)) error {
+	// Determine the digest to verify against: the API digest and the pinned digest
+	// must agree when both exist; at least one must exist unless allowUnverified
+	// (models are data files from the official release — TLS-only is acceptable;
+	// a native executable never sets allowUnverified).
+	expected := asset.sha256
+	if pinned != "" {
+		if expected != "" && !strings.EqualFold(expected, pinned) {
+			return fmt.Errorf("dictation download: %s digest %s does not match the pinned known-good value %s — refusing (the release may have changed)", asset.name, asset.sha256, pinned)
+		}
+		expected = pinned
+	}
+	if expected == "" && !allowUnverified {
+		return fmt.Errorf("dictation download: no SHA256 available for %s (neither the GitHub API nor a pinned value) — refusing an unverifiable download", asset.name)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(destDir), "stt-dl-*.tar.bz2")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, asset.url, nil)
+	if err != nil {
+		tmp.Close()
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		tmp.Close()
+		return fmt.Errorf("downloading %s: %w", asset.name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		tmp.Close()
+		return fmt.Errorf("downloading %s: HTTP %d", asset.name, resp.StatusCode)
+	}
+	hasher := sha256.New()
+	total := asset.size
+	if total <= 0 {
+		total = resp.ContentLength
+	}
+	src := io.Reader(resp.Body)
+	if total > 0 {
+		src = &progressReader{r: resp.Body, total: total, label: label, report: progress, lastPct: -1}
+	}
+	if _, err := io.Copy(io.MultiWriter(tmp, hasher), src); err != nil {
+		tmp.Close()
+		return fmt.Errorf("downloading %s: %w", asset.name, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if expected != "" && !strings.EqualFold(got, expected) {
+		return fmt.Errorf("dictation download: checksum mismatch for %s (want %s, got %s) — refusing to extract", asset.name, expected, got)
+	}
+	return extractTarBz2(tmpPath, destDir, "Extracting "+label, progress)
+}
+
+// progressReader reports download progress as a percentage on each whole-percent
+// change, formatted "<label> NN% · X/Y MB".
+type progressReader struct {
+	r       io.Reader
+	total   int64
+	read    int64
+	label   string
+	report  func(string)
+	lastPct int
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	p.read += int64(n)
+	if p.total > 0 {
+		pct := int(p.read * 100 / p.total)
+		if pct != p.lastPct {
+			p.lastPct = pct
+			p.report(fmt.Sprintf("%s %d%% · %d/%d MB", p.label, pct, p.read>>20, p.total>>20))
+		}
+	}
+	return n, err
+}
+
+// enginePaths builds the engine executable paths. The ".exe" suffix follows the
+// TARGET platform (the one the engine was downloaded for), not the host — they
+// match in production (you download your own platform), but keying off the target
+// keeps resolution correct when the two differ (e.g. a cross-platform test).
+func enginePaths(engineDir string, targetWindows bool) (bin, server string) {
+	ext := ""
+	if targetWindows {
+		ext = ".exe"
+	}
+	return filepath.Join(engineDir, "bin", "sherpa-onnx-offline"+ext),
+		filepath.Join(engineDir, "bin", "sherpa-onnx-online-websocket-server"+ext)
+}
+
+// resolveEnginePaths finds the executables, flattening the tarball's single
+// top-level directory when present.
+func resolveEnginePaths(engineDir string, targetWindows bool) (bin, server string) {
+	bin, server = enginePaths(engineDir, targetWindows)
+	if fileExists(bin) {
+		return bin, server
+	}
+	if child, err := flattenSingleChild(engineDir); err == nil && child != engineDir {
+		return enginePaths(child, targetWindows)
+	}
+	return bin, server
+}
+
+// extractTarBz2 unpacks a bzip2-compressed tar into destDir, guarding against
+// path-traversal entries. It reports extraction progress by how much of the
+// (compressed) archive it has consumed — the same MB scale as the download, so
+// "Extracting … 50% · 520/1041 MB" lines up with the download that preceded it.
+func extractTarBz2(archivePath, destDir, label string, progress func(string)) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	var src io.Reader = f
+	if progress != nil {
+		if info, statErr := f.Stat(); statErr == nil && info.Size() > 0 {
+			src = &progressReader{r: f, total: info.Size(), label: label, report: progress, lastPct: -1}
+		}
+	}
+	tr := tar.NewReader(bzip2.NewReader(src))
+	destAbs, err := filepath.Abs(destDir)
+	if err != nil {
+		return err
+	}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destDir, hdr.Name)
+		absTarget, err := filepath.Abs(target)
+		if err != nil {
+			return err
+		}
+		if absTarget != destAbs && !strings.HasPrefix(absTarget, destAbs+string(os.PathSeparator)) {
+			return fmt.Errorf("dictation download: archive entry %q escapes destination", hdr.Name)
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode)&0o777)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			if err := out.Close(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// flattenSingleChild returns the sole subdirectory of dir (the tarball's
+// top-level folder) when dir contains exactly one directory entry.
+func flattenSingleChild(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, e.Name())
+		}
+	}
+	if len(dirs) == 1 {
+		return filepath.Join(dir, dirs[0]), nil
+	}
+	return dir, nil
+}
+
+// ModelDownloaded reports whether a model variant is already extracted under
+// destRoot (so the picker can mark it as installed). dirName is the variant's
+// DirName.
+func ModelDownloaded(destRoot, dirName string) bool {
+	if destRoot == "" || dirName == "" {
+		return false
+	}
+	return dirHasModel(filepath.Join(destRoot, dirName))
+}
+
+// EngineDownloaded reports whether the shared sherpa-onnx engine is already on
+// disk for this platform (one engine serves every model), so the picker can drop
+// the engine's size from a model's download total once it's been fetched.
+func EngineDownloaded(destRoot, version string) bool {
+	if destRoot == "" {
+		return false
+	}
+	if version == "" {
+		version = DefaultSherpaVersion
+	}
+	engineDir := filepath.Join(destRoot, "engine-"+version+"-"+platformKey())
+	bin, _ := resolveEnginePaths(engineDir, runtime.GOOS == "windows")
+	return fileExists(bin)
+}
+
+func dirHasModel(dir string) bool {
+	if hasTokensFile(dir) {
+		return true
+	}
+	if child, err := flattenSingleChild(dir); err == nil && child != dir {
+		return hasTokensFile(child)
+	}
+	return false
+}
+
+// hasTokensFile reports whether dir holds a sherpa tokens file — usually
+// "tokens.txt", but some families (Whisper) prefix it as "<model>-tokens.txt".
+func hasTokensFile(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), "tokens.txt") {
+			return true
+		}
+	}
+	return false
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/dictation/download.go
+++ b/internal/dictation/download.go
@@ -630,9 +630,26 @@ func downloadVerifyExtract(ctx context.Context, client *http.Client, asset resol
 	if expected == "" && !allowUnverified {
 		return fmt.Errorf("dictation download: no SHA256 available for %s (neither the GitHub API nor a pinned value) — refusing an unverifiable download", asset.name)
 	}
-	if err := os.MkdirAll(destDir, 0o755); err != nil {
+	// Ensure the parent of destDir exists; the final destDir is created by
+	// the atomic rename at the end of the function.
+	if err := os.MkdirAll(filepath.Dir(destDir), 0o755); err != nil {
 		return err
 	}
+	// Stage the extraction into a sibling temp dir and only swap it into
+	// destDir on success. An interrupted run that left a truncated engine
+	// binary in destDir would otherwise pass fileExists() on the next start
+	// and break the local recorder silently.
+	stageDir, err := os.MkdirTemp(filepath.Dir(destDir), filepath.Base(destDir)+".stage-*")
+	if err != nil {
+		return err
+	}
+	cleanupStage := true
+	defer func() {
+		if cleanupStage {
+			_ = os.RemoveAll(stageDir)
+		}
+	}()
+
 	tmp, err := os.CreateTemp(filepath.Dir(destDir), "stt-dl-*.tar.bz2")
 	if err != nil {
 		return err
@@ -675,7 +692,19 @@ func downloadVerifyExtract(ctx context.Context, client *http.Client, asset resol
 	if expected != "" && !strings.EqualFold(got, expected) {
 		return fmt.Errorf("dictation download: checksum mismatch for %s (want %s, got %s) — refusing to extract", asset.name, expected, got)
 	}
-	return extractTarBz2(tmpPath, destDir, "Extracting "+label, progress)
+	if err := extractTarBz2(tmpPath, stageDir, "Extracting "+label, progress); err != nil {
+		return err
+	}
+	// Remove any pre-existing destDir so Rename is atomic on the same
+	// filesystem (os.Rename refuses to overwrite a non-empty dir).
+	if err := os.RemoveAll(destDir); err != nil {
+		return fmt.Errorf("clearing previous %s install: %w", label, err)
+	}
+	if err := os.Rename(stageDir, destDir); err != nil {
+		return fmt.Errorf("promoting staged %s: %w", label, err)
+	}
+	cleanupStage = false
+	return nil
 }
 
 // progressReader reports download progress as a percentage on each whole-percent

--- a/internal/dictation/download_smoke_test.go
+++ b/internal/dictation/download_smoke_test.go
@@ -1,0 +1,52 @@
+package dictation
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEnsureLocalEngineRealDownload exercises the full auto-download against the
+// REAL k2-fsa/sherpa-onnx GitHub API (resolve → verify digest → extract → run).
+// It downloads ~130MB, so it is opt-in via ZERO_STT_DOWNLOAD_TEST=1.
+//
+//	ZERO_STT_DOWNLOAD_TEST=1 go test ./internal/dictation/ -run RealDownload -v -timeout 10m
+func TestEnsureLocalEngineRealDownload(t *testing.T) {
+	if os.Getenv("ZERO_STT_DOWNLOAD_TEST") == "" {
+		t.Skip("set ZERO_STT_DOWNLOAD_TEST=1 to run the real ~130MB download smoke test")
+	}
+	dest := t.TempDir()
+	comp, err := EnsureLocalEngine(context.Background(), DownloadOptions{
+		DestRoot: dest,
+		Progress: func(s string) { t.Logf("stage: %s", s) },
+	})
+	if err != nil {
+		t.Fatalf("EnsureLocalEngine: %v", err)
+	}
+	if !fileExists(comp.BinaryPath) || !fileExists(filepath.Join(comp.ModelPath, "tokens.txt")) {
+		t.Fatalf("missing components: %+v", comp)
+	}
+
+	// The downloaded engine + model must actually transcribe.
+	wav := filepath.Join(comp.ModelPath, "test_wavs", "0.wav")
+	if !fileExists(wav) {
+		t.Skipf("no bundled test wav at %s", wav)
+	}
+	audio, err := os.ReadFile(wav)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr, err := NewLocalTranscriber(LocalConfig{Binary: comp.BinaryPath, ModelPath: comp.ModelPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text, err := tr.Transcribe(context.Background(), audio)
+	if err != nil {
+		t.Fatalf("Transcribe with downloaded engine: %v", err)
+	}
+	if text == "" {
+		t.Fatal("downloaded engine returned empty transcript")
+	}
+	t.Logf("downloaded-engine transcript: %q", text)
+}

--- a/internal/dictation/download_test.go
+++ b/internal/dictation/download_test.go
@@ -1,0 +1,245 @@
+package dictation
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Tiny tar.bz2 fixtures (generated in-repo): the engine has top/bin/sherpa-onnx-
+// offline + server; the model has top/tokens.txt.
+const (
+	engineTarB64 = "QlpoOTFBWSZTWW+fEfAAAW1/hMGRAIBAA/+AAgAgRH9v3+AAAQCoMAEYAYA00NGjEZANABoYYA00NGjEZANABoYIpE0TRoTGkA2poGgxqepl1H6w5anW3tY2OggUi1AW/d29pO0GLUoOtnQsrGFNowIEh0cImtQ9gyHqYH7unm+/wZSLXsBuBDDCfHiahCsGEgGL9/pUG+RQZo76xlaDIGKWDErPKuyhXYOlzJMG3iNa56kiluctzUqgZ2A1AGwgcB3jtB5PB7pYYlDHH8OvOznM6B6MHPRqa7sTE1vwDBc0LjmG4ah5F+YYaXHTZpGmcemWW1yMh1adhdrB6A3nAQP8XckU4UJBvnxHwA=="
+	engineSHA    = "97b5cb6a417705860f8940e1bf9ffec8cc60e8666a0d228cd60f1de7607d503d"
+	modelTarB64  = "QlpoOTFBWSZTWTtAoX4AANp/hMOQBIBAAf+AAAIQBHoJ3mAAAQAIMAC5sG1SNMhNqGmQwIyeKEagam1DQ0AAABFRT0T0mg0aeoDQHpH7Nzrs24wsbVW8hMQHClNI0LuLhKMGY4sEQi6N2qQWP1id8o1KtprGd4hll4uQkMGA1nFMXAwohEZOnIMIPQKQl2k0GbSGwkC0lJb2IWOQ57ETYbmxFGspaRp1QyT6q4sKj855st7GzOGj5eIwmWt6wRajEQl/F3JFOFCQO0Chfg=="
+	modelSHA     = "16c6b1dcb40f6b21c0de70bc1a8edab95375e4de90dac7c076fd2cc7a34fc59a"
+)
+
+// fakeReleaseServer serves the GitHub release API + asset bytes for the engine
+// and model, exercising resolveAsset + downloadVerifyExtract against a real HTTP
+// round-trip (with the real coder/websocket-free download path).
+func fakeReleaseServer(t *testing.T, engineDigest, modelDigest string) *httptest.Server {
+	t.Helper()
+	engineBytes, _ := base64.StdEncoding.DecodeString(engineTarB64)
+	modelBytes, _ := base64.StdEncoding.DecodeString(modelTarB64)
+	mux := http.NewServeMux()
+	base := ""
+	release := func(assetName, digest, dlPath string) string {
+		body, _ := json.Marshal(map[string]any{
+			"tag_name": "test",
+			"assets": []map[string]any{{
+				"name":                 assetName,
+				"browser_download_url": base + dlPath,
+				"digest":               "sha256:" + digest,
+				"size":                 123,
+			}},
+		})
+		return string(body)
+	}
+	var srv *httptest.Server
+	// Any release tag under this prefix resolves: asr-models → the model, every
+	// other tag → the engine (so the default-version pinned-check test works too).
+	mux.HandleFunc("/repos/k2-fsa/sherpa-onnx/releases/tags/", func(w http.ResponseWriter, r *http.Request) {
+		base = srv.URL
+		if strings.HasSuffix(r.URL.Path, "/asr-models") {
+			fmt.Fprint(w, release(modelAssetName, modelDigest, "/model.tar.bz2"))
+			return
+		}
+		fmt.Fprint(w, release("sherpa-onnx-test-linux-x64-shared-no-tts.tar.bz2", engineDigest, "/engine.tar.bz2"))
+	})
+	mux.HandleFunc("/engine.tar.bz2", func(w http.ResponseWriter, r *http.Request) { w.Write(engineBytes) })
+	mux.HandleFunc("/model.tar.bz2", func(w http.ResponseWriter, r *http.Request) { w.Write(modelBytes) })
+	srv = httptest.NewServer(mux)
+	base = srv.URL
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestResolveEnginePathsHonorsTargetPlatform(t *testing.T) {
+	// The engine binary name follows the TARGET platform, not the host: a Windows
+	// engine has ".exe", a Linux one doesn't. Resolution must find each regardless
+	// of the OS the test runs on (this is what makes the cross-platform download
+	// test pass on Windows CI).
+	for _, tc := range []struct {
+		name    string
+		target  bool
+		binName string
+	}{
+		{"linux target", false, "sherpa-onnx-offline"},
+		{"windows target", true, "sherpa-onnx-offline.exe"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			binDir := filepath.Join(dir, "bin")
+			if err := os.MkdirAll(binDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(binDir, tc.binName), []byte("x"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			bin, _ := resolveEnginePaths(dir, tc.target)
+			if !fileExists(bin) {
+				t.Errorf("resolveEnginePaths(target-windows=%v) = %q; not found", tc.target, bin)
+			}
+			if !strings.HasSuffix(bin, tc.binName) {
+				t.Errorf("bin = %q, want suffix %q", bin, tc.binName)
+			}
+		})
+	}
+}
+
+func TestEnsureLocalEngineDownloadsAndExtracts(t *testing.T) {
+	srv := fakeReleaseServer(t, engineSHA, modelSHA)
+	dest := t.TempDir()
+	var stages []string
+	comp, err := EnsureLocalEngine(context.Background(), DownloadOptions{
+		DestRoot:      dest,
+		EngineVersion: "test",
+		APIBase:       srv.URL,
+		platformKey:   "linux-amd64",
+		skipPinned:    true,
+		Progress:      func(s string) { stages = append(stages, s) },
+	})
+	if err != nil {
+		t.Fatalf("EnsureLocalEngine: %v", err)
+	}
+	if !fileExists(comp.BinaryPath) || !strings.HasSuffix(comp.BinaryPath, "sherpa-onnx-offline") {
+		t.Errorf("binary path wrong: %q", comp.BinaryPath)
+	}
+	if !fileExists(comp.ServerPath) {
+		t.Errorf("server path missing: %q", comp.ServerPath)
+	}
+	if !fileExists(filepath.Join(comp.ModelPath, "tokens.txt")) {
+		t.Errorf("model tokens.txt missing under %q", comp.ModelPath)
+	}
+	// The extracted binary keeps its exec bit — Unix only; Windows has no
+	// executable permission bit, so os.FileMode never reports 0o100 there.
+	if runtime.GOOS != "windows" {
+		if info, err := os.Stat(comp.BinaryPath); err == nil && info.Mode()&0o100 == 0 {
+			t.Error("engine binary should be executable")
+		}
+	}
+	if len(stages) == 0 {
+		t.Error("expected progress stages")
+	}
+
+	// Idempotent: a second call reuses the extracted engine + model and downloads
+	// NOTHING (no progress stages) — the fix for re-downloading an already-present
+	// engine whose binary lives in the tarball's flattened subdir.
+	var stages2 []string
+	comp2, err := EnsureLocalEngine(context.Background(), DownloadOptions{
+		DestRoot: dest, EngineVersion: "test", APIBase: srv.URL, platformKey: "linux-amd64", skipPinned: true,
+		Progress: func(s string) { stages2 = append(stages2, s) },
+	})
+	if err != nil || comp2.BinaryPath != comp.BinaryPath {
+		t.Errorf("second call should reuse: %v / %q vs %q", err, comp2.BinaryPath, comp.BinaryPath)
+	}
+	if len(stages2) != 0 {
+		t.Errorf("a fully-cached second call must not download/extract anything, got stages: %v", stages2)
+	}
+}
+
+func TestEnsureLocalEngineRejectsChecksumMismatch(t *testing.T) {
+	// Serve the engine with a wrong digest → verification must refuse to extract.
+	srv := fakeReleaseServer(t, strings.Repeat("0", 64), modelSHA)
+	_, err := EnsureLocalEngine(context.Background(), DownloadOptions{
+		DestRoot: t.TempDir(), EngineVersion: "test", APIBase: srv.URL, platformKey: "linux-amd64", skipPinned: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum-mismatch error, got %v", err)
+	}
+}
+
+func TestEnsureLocalEnginePinnedCrossCheckRefusesChangedRelease(t *testing.T) {
+	// Default version + a digest that doesn't match the pinned value → refuse,
+	// even though the download itself would verify against the API digest.
+	srv := fakeReleaseServer(t, engineSHA, modelSHA)
+	_, err := EnsureLocalEngine(context.Background(), DownloadOptions{
+		DestRoot:      t.TempDir(),
+		EngineVersion: DefaultSherpaVersion, // triggers the pinned cross-check
+		APIBase:       srv.URL,
+		platformKey:   "linux-amd64",
+		// skipPinned false: the pinned digest for linux-amd64 != engineSHA fixture.
+	})
+	if err == nil || !strings.Contains(err.Error(), "pinned known-good") {
+		t.Fatalf("expected pinned cross-check refusal, got %v", err)
+	}
+}
+
+func TestResolveAssetMissingDigestAllowed(t *testing.T) {
+	// An older asset with no API digest resolves fine (verification against a
+	// pinned value happens later); resolveAsset no longer refuses here.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"assets": []map[string]any{{"name": "x-linux-x64-shared-no-tts.tar.bz2", "browser_download_url": "http://x", "digest": ""}},
+		})
+	}))
+	defer srv.Close()
+	asset, err := resolveAsset(context.Background(), http.DefaultClient, srv.URL, "test", "x-", "linux-x64-shared-no-tts.tar.bz2")
+	if err != nil {
+		t.Fatalf("resolveAsset should tolerate a missing digest, got %v", err)
+	}
+	if asset.sha256 != "" {
+		t.Errorf("expected empty digest, got %q", asset.sha256)
+	}
+}
+
+func TestUnverifiableDownloadRefused(t *testing.T) {
+	// No API digest AND no pinned digest → refuse to download/extract.
+	srv := fakeReleaseServer(t, "", "") // both assets served with empty digest
+	_, err := EnsureLocalEngine(context.Background(), DownloadOptions{
+		DestRoot: t.TempDir(), EngineVersion: "test", APIBase: srv.URL, platformKey: "linux-amd64", skipPinned: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unverifiable") {
+		t.Fatalf("expected refusal of an unverifiable download, got %v", err)
+	}
+}
+
+func TestProgressReaderReportsPercent(t *testing.T) {
+	data := make([]byte, 1000)
+	var last string
+	pr := &progressReader{r: bytesReader(data), total: 1000, label: "Engine", report: func(s string) { last = s }, lastPct: -1}
+	buf := make([]byte, 100)
+	for {
+		if _, err := pr.Read(buf); err != nil {
+			break
+		}
+	}
+	if !strings.Contains(last, "Engine") || !strings.Contains(last, "100%") {
+		t.Errorf("expected a final 'Engine 100%%' report, got %q", last)
+	}
+}
+
+func bytesReader(b []byte) *sliceReader { return &sliceReader{b: b} }
+
+type sliceReader struct {
+	b   []byte
+	pos int
+}
+
+func (s *sliceReader) Read(p []byte) (int, error) {
+	if s.pos >= len(s.b) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.b[s.pos:])
+	s.pos += n
+	return n, nil
+}
+
+func TestUnsupportedPlatformSetupError(t *testing.T) {
+	_, err := EnsureLocalEngine(context.Background(), DownloadOptions{DestRoot: t.TempDir(), platformKey: "plan9-mips"})
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError for unsupported platform, got %v", err)
+	}
+}

--- a/internal/dictation/listmodels_test.go
+++ b/internal/dictation/listmodels_test.go
@@ -1,0 +1,67 @@
+package dictation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListModelsFiltersAndFlags(t *testing.T) {
+	assets := []map[string]any{
+		{"name": "sherpa-onnx-streaming-zipformer-en-2023-06-26.tar.bz2", "size": 1 << 20, "digest": "sha256:abc"},
+		{"name": "sherpa-onnx-whisper-tiny.en.tar.bz2", "size": 2 << 20},
+		{"name": "sherpa-onnx-moonshine-tiny-en-int8.tar.bz2", "size": 3 << 20},                  // curated but not flagged recommended
+		{"name": "sherpa-onnx-streaming-zipformer-en-kroko-2025-08-06.tar.bz2", "size": 1 << 20}, // curated → recommended
+		{"name": "sherpa-onnx-paraformer-zh-2024-03-09.tar.bz2", "size": 4 << 20},
+		// Non-ASR tools that MUST be filtered out:
+		{"name": "sherpa-onnx-vad-silero.tar.bz2", "size": 1},
+		{"name": "vits-piper-en_US-amy.tar.bz2", "size": 1},
+		{"name": "sherpa-onnx-punct-en.tar.bz2", "size": 1},
+		{"name": "sherpa-onnx-kws-zipformer.tar.bz2", "size": 1},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"id": 1, "assets": assets})
+	}))
+	defer srv.Close()
+
+	vs, err := ListModels(context.Background(), http.DefaultClient, srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 5 {
+		t.Fatalf("expected 5 transcription models (tools filtered), got %d", len(vs))
+	}
+	byID := map[string]ModelVariant{}
+	for _, v := range vs {
+		byID[v.ID] = v
+	}
+	if !byID["streaming-zipformer-en-2023-06-26"].Streaming {
+		t.Error("streaming model should be flagged Streaming")
+	}
+	if byID["whisper-tiny.en"].Streaming {
+		t.Error("whisper is batch, not streaming")
+	}
+	if !byID["streaming-zipformer-en-kroko-2025-08-06"].Recommended {
+		t.Error("a curated model flagged Recommended should be Recommended")
+	}
+	if byID["moonshine-tiny-en-int8"].Recommended {
+		t.Error("moonshine tiny is curated but no longer flagged Recommended (no star)")
+	}
+	if byID["paraformer-zh-2024-03-09"].Recommended {
+		t.Error("an uncurated model should not be Recommended")
+	}
+	// A curated model with no API digest still gets its pinned digest.
+	if byID["moonshine-tiny-en-int8"].Digest == "" {
+		t.Error("curated model should carry a pinned digest")
+	}
+	// An uncurated model with no API digest has an empty digest (TLS-only download).
+	if byID["whisper-tiny.en"].Digest != "" {
+		t.Error("uncurated model without an API digest should have an empty digest")
+	}
+	// The API-provided digest is used when present.
+	if byID["streaming-zipformer-en-2023-06-26"].Digest != "abc" {
+		t.Errorf("expected the API digest, got %q", byID["streaming-zipformer-en-2023-06-26"].Digest)
+	}
+}

--- a/internal/dictation/local_smoke_test.go
+++ b/internal/dictation/local_smoke_test.go
@@ -1,0 +1,40 @@
+package dictation
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// TestLocalTranscribeRealBinary exercises the full local batch path against a
+// REAL sherpa-onnx-offline binary and model — the manual smoke test §14 calls
+// out as not CI-able. Skipped unless both env vars point at a real install:
+//
+//	ZERO_STT_TEST_BINARY=/path/to/sherpa-onnx-offline \
+//	ZERO_STT_TEST_MODEL=/path/to/model-dir \
+//	ZERO_STT_TEST_WAV=/path/to/16k-mono.wav \
+//	go test ./internal/dictation/ -run TestLocalTranscribeRealBinary -v
+func TestLocalTranscribeRealBinary(t *testing.T) {
+	binary := os.Getenv("ZERO_STT_TEST_BINARY")
+	model := os.Getenv("ZERO_STT_TEST_MODEL")
+	wav := os.Getenv("ZERO_STT_TEST_WAV")
+	if binary == "" || model == "" || wav == "" {
+		t.Skip("set ZERO_STT_TEST_BINARY, ZERO_STT_TEST_MODEL, ZERO_STT_TEST_WAV to run the real-engine smoke test")
+	}
+	audio, err := os.ReadFile(wav)
+	if err != nil {
+		t.Fatalf("read wav: %v", err)
+	}
+	tr, err := NewLocalTranscriber(LocalConfig{Binary: binary, ModelPath: model})
+	if err != nil {
+		t.Fatalf("NewLocalTranscriber: %v", err)
+	}
+	text, err := tr.Transcribe(context.Background(), audio)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if text == "" {
+		t.Fatal("real engine returned an empty transcript")
+	}
+	t.Logf("transcript: %q", text)
+}

--- a/internal/dictation/owner_unix.go
+++ b/internal/dictation/owner_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package dictation
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// checkAudioDirOwner rejects a dictation temp directory not owned by the
+// current user — on a shared /tmp another user could have pre-created the
+// path and would then control its lifetime. Mirrors
+// internal/tools/spill_owner_unix.go.
+func checkAudioDirOwner(info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	if int(stat.Uid) != os.Geteuid() {
+		return fmt.Errorf("dictation temp directory is owned by uid %d, not the current user", stat.Uid)
+	}
+	return nil
+}

--- a/internal/dictation/owner_windows.go
+++ b/internal/dictation/owner_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package dictation
+
+import "os"
+
+// checkAudioDirOwner is a no-op on Windows: %TEMP% is per-user by default and
+// there is no portable uid to compare. The Lstat symlink/dir check in
+// audioSpillDir still applies. Mirrors internal/tools/spill_owner_windows.go.
+func checkAudioDirOwner(os.FileInfo) error {
+	return nil
+}

--- a/internal/dictation/recorder.go
+++ b/internal/dictation/recorder.go
@@ -1,0 +1,573 @@
+package dictation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Recorder captures microphone audio. Start/Stop is the batch path (used on
+// Termux, and as the fallback everywhere); StartStreaming is the desktop-only
+// continuous-PCM path.
+type Recorder interface {
+	Start() error
+	// Stop ends a batch recording and returns the recorded audio bytes (WAV on
+	// desktop, M4A on Termux — SniffFormat distinguishes them).
+	Stop() ([]byte, error)
+	// StartStreaming begins continuous capture of raw little-endian PCM16 mono
+	// at the configured sample rate. Chunks arrive on the channel in ~50ms
+	// units; the channel closes when capture ends (stop called, max duration
+	// hit, or trailing-silence auto-stop). stop is idempotent.
+	StartStreaming() (chunks <-chan []byte, stop func() error, err error)
+}
+
+// Platform selects the audio-capture toolchain (§9 of the design doc).
+type Platform string
+
+const (
+	PlatformLinux       Platform = "linux"
+	PlatformDarwin      Platform = "darwin"
+	PlatformWindows     Platform = "windows"
+	PlatformTermux      Platform = "termux"
+	PlatformUnsupported Platform = ""
+)
+
+// DetectPlatform picks the capture toolchain for the current host. Termux is
+// detected by its environment (it reports GOOS=linux/android): TERMUX_VERSION
+// is exported to every Termux shell, and PREFIX carries the app package path.
+func DetectPlatform() Platform {
+	if os.Getenv("TERMUX_VERSION") != "" || strings.Contains(os.Getenv("PREFIX"), "com.termux") {
+		return PlatformTermux
+	}
+	switch runtime.GOOS {
+	case "linux":
+		return PlatformLinux
+	case "darwin":
+		return PlatformDarwin
+	case "windows":
+		return PlatformWindows
+	}
+	return PlatformUnsupported
+}
+
+// StreamingSupported reports whether the platform's capture tool can write raw
+// PCM to stdout. Termux's termux-microphone-record requires a regular output
+// file — a hard tool limitation, so Termux is batch-only permanently.
+func (p Platform) StreamingSupported() bool {
+	switch p {
+	case PlatformLinux, PlatformDarwin, PlatformWindows:
+		return true
+	}
+	return false
+}
+
+const (
+	// DefaultSampleRate is what the local engine and Deepgram consume.
+	// OpenAI Realtime's pcm16 requires 24kHz; its transcriber constructs the
+	// recorder accordingly.
+	DefaultSampleRate = 16000
+	// DefaultMaxDuration is the hard runaway-recording cap (§12), applied on
+	// every platform, batch and streaming. Overridable via
+	// stt.maxDurationSeconds.
+	DefaultMaxDuration = 5 * time.Minute
+
+	// Trailing-silence auto-stop (§9): stop ~2s after the signal falls below a
+	// 3% amplitude threshold — SoX's own `silence 1 0.1 3% 1 2.0 3%` numbers.
+	silenceThresholdPct = 3
+	silenceHold         = 2 * time.Second
+
+	chunkInterval = 50 * time.Millisecond
+	stopGrace     = 3 * time.Second
+)
+
+// RecorderOptions configures a Recorder. Zero values pick sensible defaults.
+type RecorderOptions struct {
+	Platform        Platform
+	SampleRate      int
+	MaxDuration     time.Duration
+	SilenceAutoStop bool
+	// WindowsAudioDevice is the dshow capture device name; auto-detected from
+	// `ffmpeg -list_devices` when empty.
+	WindowsAudioDevice string
+
+	// Test seams (unexported): fake the OS boundary, mirroring how
+	// internal/lsp/manager_test.go stubs serverStarter.
+	starter   processStarter
+	runOutput commandOutputRunner
+	tempDir   func() (string, error)
+	now       func() time.Time
+}
+
+func (o RecorderOptions) withDefaults() RecorderOptions {
+	if o.Platform == PlatformUnsupported {
+		o.Platform = DetectPlatform()
+	}
+	if o.SampleRate <= 0 {
+		o.SampleRate = DefaultSampleRate
+	}
+	if o.MaxDuration <= 0 {
+		o.MaxDuration = DefaultMaxDuration
+	}
+	if o.starter == nil {
+		o.starter = startProcess
+	}
+	if o.runOutput == nil {
+		o.runOutput = runCommandOutput
+	}
+	if o.tempDir == nil {
+		o.tempDir = audioSpillDir
+	}
+	if o.now == nil {
+		o.now = time.Now
+	}
+	return o
+}
+
+// NewRecorder builds the platform recorder. Construction is cheap and
+// side-effect free; tools are only exec'd on Start/StartStreaming.
+func NewRecorder(opts RecorderOptions) Recorder {
+	o := opts.withDefaults()
+	return &recorder{opts: o}
+}
+
+type recorder struct {
+	opts RecorderOptions
+
+	mu        sync.Mutex
+	proc      processHandle
+	filePath  string
+	recording bool
+}
+
+var errAlreadyRecording = errors.New("a recording is already in progress")
+
+// Start begins a batch (record-to-file) capture.
+func (r *recorder) Start() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.recording {
+		return errAlreadyRecording
+	}
+	if r.opts.Platform == PlatformUnsupported {
+		return fmt.Errorf("dictation is not supported on %s", runtime.GOOS)
+	}
+
+	dir, err := r.opts.tempDir()
+	if err != nil {
+		return fmt.Errorf("preparing dictation temp dir: %w", err)
+	}
+	ext := ".wav"
+	if r.opts.Platform == PlatformTermux {
+		ext = ".m4a"
+	}
+	tmp, err := os.CreateTemp(dir, "rec-*"+ext)
+	if err != nil {
+		return fmt.Errorf("creating dictation temp file: %w", err)
+	}
+	path := tmp.Name()
+	_ = tmp.Close()
+
+	if r.opts.Platform == PlatformTermux {
+		// termux-microphone-record starts the recording in the Termux:API
+		// companion app and exits immediately; there is no long-lived process
+		// to hold. Stop is a separate `-q` invocation.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		out, err := r.opts.runOutput(ctx, "termux-microphone-record",
+			"-l", strconv.Itoa(maxSeconds(r.opts.MaxDuration)), "-f", path)
+		if err != nil {
+			_ = os.Remove(path)
+			return startError("termux-microphone-record", r.opts.Platform, err, out)
+		}
+		r.filePath = path
+		r.recording = true
+		return nil
+	}
+
+	spec, err := batchCommand(r.opts, path)
+	if err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	proc, _, err := r.opts.starter(spec)
+	if err != nil {
+		_ = os.Remove(path)
+		return startError(spec.name, r.opts.Platform, err, nil)
+	}
+	r.proc = proc
+	r.filePath = path
+	r.recording = true
+	return nil
+}
+
+// Stop ends a batch capture, reads the recorded file, deletes it, and returns
+// the audio bytes.
+func (r *recorder) Stop() ([]byte, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.recording {
+		return nil, errors.New("no recording in progress")
+	}
+	proc, path := r.proc, r.filePath
+	r.proc, r.filePath, r.recording = nil, "", false
+	defer os.Remove(path)
+
+	if r.opts.Platform == PlatformTermux {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if out, err := r.opts.runOutput(ctx, "termux-microphone-record", "-q"); err != nil {
+			return nil, fmt.Errorf("stopping termux recording: %w (%s)", err, strings.TrimSpace(string(out)))
+		}
+		return readRecordingWithRetry(path, r.opts.now)
+	}
+
+	if err := proc.StopGracefully(); err != nil {
+		_ = proc.Kill()
+	}
+	// A signal-terminated capture tool reports a non-zero exit — expected, not
+	// an error. The recorded file's contents are the real success signal.
+	_ = waitWithTimeout(proc, stopGrace)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading recorded audio: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, errors.New("no audio was captured (is the microphone available?)")
+	}
+	return data, nil
+}
+
+// readRecordingWithRetry reads the Termux recording, retrying briefly: the
+// companion app finalizes the file asynchronously after `-q` returns.
+func readRecordingWithRetry(path string, now func() time.Time) ([]byte, error) {
+	deadline := now().Add(2 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil && len(data) > 0 {
+			return data, nil
+		}
+		if now().After(deadline) {
+			if err != nil {
+				return nil, fmt.Errorf("reading recorded audio: %w", err)
+			}
+			return nil, errors.New("no audio was captured (check Termux:API app and microphone permission)")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// batchCommand builds the record-to-file argv for desktop platforms (§9).
+// The max-duration cap is enforced by the tool itself so a runaway recording
+// ends even if Zero never calls Stop.
+func batchCommand(opts RecorderOptions, path string) (commandSpec, error) {
+	rate := strconv.Itoa(opts.SampleRate)
+	maxSec := strconv.Itoa(maxSeconds(opts.MaxDuration))
+	switch opts.Platform {
+	case PlatformLinux:
+		return commandSpec{
+			name: "arecord",
+			args: []string{"-q", "-f", "S16_LE", "-r", rate, "-c", "1", "-t", "wav", "-d", maxSec, path},
+		}, nil
+	case PlatformDarwin:
+		args := []string{"-q", "-d", "-r", rate, "-c", "1", "-b", "16", "-e", "signed-integer", path, "trim", "0", maxSec}
+		if opts.SilenceAutoStop {
+			// SoX's built-in trailing-silence auto-stop: end ~2s after the
+			// signal falls below 3% amplitude. A backstop for a forgotten
+			// manual stop, not VAD — recording still starts on an explicit key.
+			args = append(args, "silence", "1", "0.1", "3%", "1", "2.0", "3%")
+		}
+		return commandSpec{name: "sox", args: args}, nil
+	case PlatformWindows:
+		device := opts.WindowsAudioDevice
+		if device == "" {
+			detected, err := detectWindowsAudioDevice(opts.runOutput)
+			if err != nil {
+				return commandSpec{}, err
+			}
+			device = detected
+		}
+		return commandSpec{
+			name: "ffmpeg",
+			args: []string{"-hide_banner", "-loglevel", "error", "-f", "dshow", "-i", "audio=" + device,
+				"-ac", "1", "-ar", rate, "-c:a", "pcm_s16le", "-t", maxSec, "-y", path},
+			stopViaStdin: "q",
+		}, nil
+	}
+	return commandSpec{}, fmt.Errorf("no batch capture tool for platform %q", opts.Platform)
+}
+
+// streamCommand builds the raw-PCM-to-stdout argv for desktop platforms (§9).
+// Same tools as batch, invoked with their stdout flag — Termux has no stdout
+// mode, which is why it is batch-only.
+func streamCommand(opts RecorderOptions) (commandSpec, error) {
+	rate := strconv.Itoa(opts.SampleRate)
+	switch opts.Platform {
+	case PlatformLinux:
+		return commandSpec{
+			name:       "arecord",
+			args:       []string{"-q", "-t", "raw", "-f", "S16_LE", "-r", rate, "-c", "1", "-"},
+			wantStdout: true,
+		}, nil
+	case PlatformDarwin:
+		return commandSpec{
+			name:       "sox",
+			args:       []string{"-q", "-d", "-t", "raw", "-r", rate, "-e", "signed", "-b", "16", "-c", "1", "-"},
+			wantStdout: true,
+		}, nil
+	case PlatformWindows:
+		device := opts.WindowsAudioDevice
+		if device == "" {
+			detected, err := detectWindowsAudioDevice(opts.runOutput)
+			if err != nil {
+				return commandSpec{}, err
+			}
+			device = detected
+		}
+		return commandSpec{
+			name: "ffmpeg",
+			args: []string{"-hide_banner", "-loglevel", "error", "-f", "dshow", "-i", "audio=" + device,
+				"-ac", "1", "-ar", rate, "-f", "s16le", "-"},
+			wantStdout:   true,
+			stopViaStdin: "q",
+		}, nil
+	}
+	return commandSpec{}, fmt.Errorf("streaming capture is not supported on platform %q", opts.Platform)
+}
+
+// StartStreaming begins continuous PCM capture with the §12 safety nets: a
+// hard max-duration cap and Go-side trailing-silence auto-stop (the streaming
+// analog of SoX's silence effect — we see the samples, so we measure them).
+func (r *recorder) StartStreaming() (<-chan []byte, func() error, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.recording {
+		return nil, nil, errAlreadyRecording
+	}
+	spec, err := streamCommand(r.opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	proc, stdout, err := r.opts.starter(spec)
+	if err != nil {
+		return nil, nil, startError(spec.name, r.opts.Platform, err, nil)
+	}
+	if stdout == nil {
+		_ = proc.Kill()
+		return nil, nil, errors.New("capture process has no stdout pipe")
+	}
+	r.recording = true
+
+	chunkBytes := chunkSizeBytes(r.opts.SampleRate)
+	chunks := make(chan []byte, 8)
+	done := make(chan struct{})
+	var stopOnce sync.Once
+	stop := func() error {
+		stopOnce.Do(func() {
+			close(done)
+			if err := proc.StopGracefully(); err != nil {
+				_ = proc.Kill()
+			}
+			_ = waitWithTimeout(proc, stopGrace)
+			_ = stdout.Close()
+			r.mu.Lock()
+			r.recording = false
+			r.mu.Unlock()
+		})
+		return nil
+	}
+
+	// Max-duration cap: streaming has no tool-side -d/-t equivalent that also
+	// flushes stdout cleanly everywhere, so the cap runs on our side of the pipe.
+	capTimer := time.AfterFunc(r.opts.MaxDuration, func() { _ = stop() })
+
+	go func() {
+		defer close(chunks)
+		defer capTimer.Stop()
+		// Tear down on ANY exit — including the capture process ending on its own
+		// (EOF/crash), which the loop below returns on without going through an
+		// explicit stop(). stop() is idempotent (sync.Once), so this is safe even
+		// when the session was already stopped externally; it clears r.recording and
+		// closes proc/stdout so a self-terminating device doesn't wedge the recorder.
+		defer func() { _ = stop() }()
+		threshold := int16(32767 * silenceThresholdPct / 100)
+		silentChunks, speechSeen := 0, false
+		silenceLimit := int(silenceHold / chunkInterval)
+		for {
+			buf := make([]byte, chunkBytes)
+			n, err := readFullOrEOF(stdout, buf)
+			if n > 0 {
+				chunk := buf[:n]
+				if r.opts.SilenceAutoStop {
+					if chunkPeak(chunk) >= threshold {
+						speechSeen = true
+						silentChunks = 0
+					} else if speechSeen {
+						silentChunks++
+						if silentChunks >= silenceLimit {
+							go func() { _ = stop() }()
+						}
+					}
+				}
+				select {
+				case chunks <- chunk:
+				case <-done:
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return chunks, stop, nil
+}
+
+// chunkSizeBytes is 50ms of PCM16 mono at the given rate — small chunks mean
+// faster time-to-first-partial (§6a).
+func chunkSizeBytes(sampleRate int) int {
+	return sampleRate * 2 / int(time.Second/chunkInterval)
+}
+
+// readFullOrEOF fills buf from r, returning what it read and any terminal
+// error. A short final read (pipe closing mid-chunk) still returns its bytes.
+func readFullOrEOF(r interface{ Read([]byte) (int, error) }, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := r.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+// chunkPeak returns the loudest absolute sample in a little-endian PCM16 chunk.
+func chunkPeak(chunk []byte) int16 {
+	var peak int16
+	for i := 0; i+1 < len(chunk); i += 2 {
+		s := int16(uint16(chunk[i]) | uint16(chunk[i+1])<<8)
+		if s == -32768 {
+			return 32767
+		}
+		if s < 0 {
+			s = -s
+		}
+		if s > peak {
+			peak = s
+		}
+	}
+	return peak
+}
+
+// levelFloorDB and levelCeilDB bound the RMS→meter mapping. Speech RMS is small
+// (roughly -45 dBFS quiet to -15 dBFS loud), so a LINEAR scale barely moves the
+// bars — a dB (logarithmic) scale, like real audio meters, is what makes normal
+// speech span the meter.
+const (
+	levelFloorDB = -50.0 // ≈ near-silence → empty
+	levelCeilDB  = -15.0 // loud speech → full
+)
+
+// ChunkLevel returns a perceptual 0..1 loudness for a little-endian PCM16 chunk,
+// driving the live recording waveform from the actual microphone input. It uses
+// an RMS→dBFS→linear mapping over [levelFloorDB, levelCeilDB].
+func ChunkLevel(chunk []byte) float64 {
+	var sumSq float64
+	n := 0
+	for i := 0; i+1 < len(chunk); i += 2 {
+		s := int16(uint16(chunk[i]) | uint16(chunk[i+1])<<8)
+		f := float64(s) / 32768.0
+		sumSq += f * f
+		n++
+	}
+	if n == 0 {
+		return 0
+	}
+	rms := math.Sqrt(sumSq / float64(n))
+	if rms <= 0 {
+		return 0
+	}
+	db := 20 * math.Log10(rms) // dBFS (negative)
+	level := (db - levelFloorDB) / (levelCeilDB - levelFloorDB)
+	if level < 0 {
+		level = 0
+	}
+	if level > 1 {
+		level = 1
+	}
+	return level
+}
+
+func maxSeconds(d time.Duration) int {
+	sec := int(d / time.Second)
+	if sec < 1 {
+		sec = 1
+	}
+	return sec
+}
+
+// detectWindowsAudioDevice picks the first dshow audio capture device from
+// `ffmpeg -list_devices`. dshow has no "default" alias, so a concrete device
+// name is required; stt.windowsAudioDevice overrides the auto-pick.
+func detectWindowsAudioDevice(runOutput commandOutputRunner) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, _ := runOutput(ctx, "ffmpeg", "-hide_banner", "-list_devices", "true", "-f", "dshow", "-i", "dummy")
+	// Listing always "fails" (dummy isn't a real input); the device table is
+	// in the output regardless. Lines look like: [dshow @ ...] "Mic name" (audio)
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "(audio)") {
+			continue
+		}
+		start := strings.Index(line, `"`)
+		if start < 0 {
+			continue
+		}
+		rest := line[start+1:]
+		end := strings.Index(rest, `"`)
+		if end <= 0 {
+			continue
+		}
+		return rest[:end], nil
+	}
+	return "", &SetupError{
+		Tool: "ffmpeg",
+		Hint: "no dshow audio capture device found — set stt.windowsAudioDevice to your microphone's name (list with: ffmpeg -list_devices true -f dshow -i dummy)",
+	}
+}
+
+// startError maps a failed capture-tool launch to setup guidance: a missing
+// binary is an expected unconfigured state (matching internal/lsp's
+// missing-server philosophy), not an internal error.
+func startError(tool string, platform Platform, err error, output []byte) error {
+	if errors.Is(err, exec.ErrNotFound) {
+		return &SetupError{Tool: tool, Hint: installHint(platform)}
+	}
+	if len(output) > 0 {
+		return fmt.Errorf("starting %s: %w (%s)", tool, err, strings.TrimSpace(string(output)))
+	}
+	return fmt.Errorf("starting %s: %w", tool, err)
+}
+
+func installHint(platform Platform) string {
+	switch platform {
+	case PlatformLinux:
+		return "install alsa-utils to enable dictation (e.g. sudo dnf install alsa-utils / sudo apt install alsa-utils)"
+	case PlatformDarwin:
+		return "install sox to enable dictation (brew install sox)"
+	case PlatformWindows:
+		return "install ffmpeg and ensure it is on PATH to enable dictation"
+	case PlatformTermux:
+		return "run `pkg install termux-api` and install the Termux:API companion app to enable dictation"
+	}
+	return "dictation is not supported on this platform"
+}

--- a/internal/dictation/recorder.go
+++ b/internal/dictation/recorder.go
@@ -217,6 +217,14 @@ func (r *recorder) Stop() ([]byte, error) {
 		return nil, errors.New("no recording in progress")
 	}
 	proc, path := r.proc, r.filePath
+	// Termux: Start's termux-microphone-record branch leaves r.proc nil because
+	// there's no long-lived process to hold (Stop is a separate `-q` invocation
+	// via runOutput). Treat that as legitimate; only reject a nil proc that
+	// came from StartStreaming (which owns its process via the returned
+	// closure).
+	if proc == nil && r.opts.Platform != PlatformTermux {
+		return nil, errors.New("recording was started with StartStreaming; call the stop closure returned from StartStreaming instead of Stop()")
+	}
 	r.proc, r.filePath, r.recording = nil, "", false
 	defer os.Remove(path)
 

--- a/internal/dictation/recorder_test.go
+++ b/internal/dictation/recorder_test.go
@@ -1,0 +1,501 @@
+package dictation
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeProcess is a processHandle whose stdout is driven from an in-memory
+// buffer, mirroring how internal/lsp/manager_test.go stubs its subprocess over
+// in-memory pipes rather than spawning a real one.
+type fakeProcess struct {
+	stopped   bool
+	killed    bool
+	waitErr   error
+	stopErr   error
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+func newFakeProcess() *fakeProcess { return &fakeProcess{done: make(chan struct{})} }
+
+func (f *fakeProcess) StopGracefully() error {
+	f.stopped = true
+	f.closeOnce.Do(func() { close(f.done) })
+	return f.stopErr
+}
+func (f *fakeProcess) Wait() error {
+	<-f.done
+	return f.waitErr
+}
+func (f *fakeProcess) Kill() error {
+	f.killed = true
+	f.closeOnce.Do(func() { close(f.done) })
+	return nil
+}
+
+// captured records the last spec a starter was asked to launch, so tests can
+// assert the exact discrete argv per platform.
+type captured struct {
+	spec commandSpec
+}
+
+// fileWritingStarter simulates a record-to-file batch tool: on Start it writes
+// fixture bytes to the output path (last positional arg for arecord/sox, or the
+// -y target for ffmpeg) and returns a process that "records" until stopped.
+func fileWritingStarter(t *testing.T, cap *captured, fixture []byte) processStarter {
+	t.Helper()
+	return func(spec commandSpec) (processHandle, io.ReadCloser, error) {
+		cap.spec = spec
+		path := outputPath(spec)
+		if path == "" {
+			t.Fatalf("could not determine output path from argv: %v", spec.args)
+		}
+		if err := os.WriteFile(path, fixture, 0o600); err != nil {
+			t.Fatalf("fixture write: %v", err)
+		}
+		return newFakeProcess(), nil, nil
+	}
+}
+
+func outputPath(spec commandSpec) string {
+	for i, a := range spec.args {
+		if a == "-y" && i+1 < len(spec.args) {
+			return spec.args[i+1]
+		}
+	}
+	// arecord/sox: the path is the last arg (sox appends trim/silence effects
+	// after it, so scan from the front for the first existing-dir target).
+	last := spec.args[len(spec.args)-1]
+	if filepath.IsAbs(last) {
+		return last
+	}
+	for _, a := range spec.args {
+		if filepath.IsAbs(a) && filepath.Ext(a) != "" {
+			return a
+		}
+	}
+	return ""
+}
+
+func wavFixture() []byte {
+	// Minimal valid RIFF/WAVE header + a little data, enough for SniffFormat.
+	var b bytes.Buffer
+	b.WriteString("RIFF")
+	binary.Write(&b, binary.LittleEndian, uint32(36))
+	b.WriteString("WAVE")
+	b.WriteString("fmt ")
+	binary.Write(&b, binary.LittleEndian, uint32(16))
+	b.Write(make([]byte, 16))
+	b.WriteString("data")
+	binary.Write(&b, binary.LittleEndian, uint32(4))
+	b.Write([]byte{1, 2, 3, 4})
+	return b.Bytes()
+}
+
+func testTempDir(t *testing.T) func() (string, error) {
+	dir := t.TempDir()
+	return func() (string, error) { return dir, nil }
+}
+
+func TestBatchRecordLinuxArgv(t *testing.T) {
+	cap := &captured{}
+	fixture := wavFixture()
+	r := NewRecorder(RecorderOptions{
+		Platform: PlatformLinux,
+		starter:  fileWritingStarter(t, cap, fixture),
+		tempDir:  testTempDir(t),
+	})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	got, err := r.Stop()
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if !bytes.Equal(got, fixture) {
+		t.Fatalf("audio mismatch: got %d bytes", len(got))
+	}
+	if cap.spec.name != "arecord" {
+		t.Errorf("tool = %q, want arecord", cap.spec.name)
+	}
+	assertArgs(t, cap.spec.args, "-f", "S16_LE")
+	assertArgs(t, cap.spec.args, "-r", "16000")
+	assertArgs(t, cap.spec.args, "-c", "1")
+}
+
+func TestBatchRecordDarwinArgv(t *testing.T) {
+	cap := &captured{}
+	r := NewRecorder(RecorderOptions{
+		Platform:        PlatformDarwin,
+		SilenceAutoStop: true,
+		starter:         fileWritingStarter(t, cap, wavFixture()),
+		tempDir:         testTempDir(t),
+	})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := r.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if cap.spec.name != "sox" {
+		t.Errorf("tool = %q, want sox", cap.spec.name)
+	}
+	if !containsSubseq(cap.spec.args, []string{"silence", "1", "0.1", "3%", "1", "2.0", "3%"}) {
+		t.Errorf("expected SoX silence auto-stop effect in argv: %v", cap.spec.args)
+	}
+}
+
+func TestBatchRecordWindowsArgv(t *testing.T) {
+	cap := &captured{}
+	r := NewRecorder(RecorderOptions{
+		Platform:           PlatformWindows,
+		WindowsAudioDevice: "Microphone (Realtek)",
+		starter:            fileWritingStarter(t, cap, wavFixture()),
+		tempDir:            testTempDir(t),
+	})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := r.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if cap.spec.name != "ffmpeg" {
+		t.Errorf("tool = %q, want ffmpeg", cap.spec.name)
+	}
+	assertArgs(t, cap.spec.args, "-i", "audio=Microphone (Realtek)")
+	if cap.spec.stopViaStdin != "q" {
+		t.Errorf("ffmpeg should stop via stdin 'q', got %q", cap.spec.stopViaStdin)
+	}
+}
+
+func TestBatchRecordTermuxUsesCommandRunner(t *testing.T) {
+	dir := t.TempDir()
+	var calls [][]string
+	runOutput := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{name}, args...))
+		if len(args) > 0 && args[0] == "-l" {
+			// The -f target is the last arg; write the fixture there.
+			path := args[len(args)-1]
+			_ = os.WriteFile(path, m4aFixture(), 0o600)
+		}
+		return nil, nil
+	}
+	r := NewRecorder(RecorderOptions{
+		Platform: PlatformTermux,
+		starter: func(commandSpec) (processHandle, io.ReadCloser, error) {
+			t.Fatal("termux must not use the process starter")
+			return nil, nil, nil
+		},
+		runOutput: runOutput,
+		tempDir:   func() (string, error) { return dir, nil },
+	})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	got, err := r.Stop()
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if SniffFormat(got) != FormatM4A {
+		t.Errorf("expected m4a audio, got format %q", SniffFormat(got))
+	}
+	if len(calls) != 2 || calls[0][0] != "termux-microphone-record" || calls[1][len(calls[1])-1] != "-q" {
+		t.Errorf("unexpected termux calls: %v", calls)
+	}
+}
+
+func TestStartMissingBinaryReturnsSetupError(t *testing.T) {
+	r := NewRecorder(RecorderOptions{
+		Platform: PlatformLinux,
+		starter: func(commandSpec) (processHandle, io.ReadCloser, error) {
+			return nil, nil, exec.ErrNotFound
+		},
+		tempDir: testTempDir(t),
+	})
+	err := r.Start()
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError for missing binary, got %v", err)
+	}
+	if setupErr.Tool != "arecord" {
+		t.Errorf("SetupError.Tool = %q, want arecord", setupErr.Tool)
+	}
+}
+
+func TestDoubleStartRejected(t *testing.T) {
+	r := NewRecorder(RecorderOptions{
+		Platform: PlatformLinux,
+		starter:  fileWritingStarter(t, &captured{}, wavFixture()),
+		tempDir:  testTempDir(t),
+	})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := r.Start(); !errors.Is(err, errAlreadyRecording) {
+		t.Errorf("second Start should be rejected, got %v", err)
+	}
+}
+
+func TestStreamingChunksAndStop(t *testing.T) {
+	// 300ms of PCM16 @16kHz = 6 chunks of 50ms. Feed a fixed buffer, then EOF.
+	pcm := make([]byte, chunkSizeBytes(16000)*6)
+	starter := func(spec commandSpec) (processHandle, io.ReadCloser, error) {
+		if !spec.wantStdout {
+			t.Fatal("streaming spec must request stdout")
+		}
+		return newFakeProcess(), io.NopCloser(bytes.NewReader(pcm)), nil
+	}
+	r := NewRecorder(RecorderOptions{
+		Platform: PlatformLinux,
+		starter:  starter,
+		tempDir:  testTempDir(t),
+	})
+	chunks, stop, err := r.StartStreaming()
+	if err != nil {
+		t.Fatalf("StartStreaming: %v", err)
+	}
+	var total int
+	for c := range chunks {
+		total += len(c)
+	}
+	_ = stop()
+	if total != len(pcm) {
+		t.Errorf("streamed %d bytes, want %d", total, len(pcm))
+	}
+}
+
+func TestStreamingStopIdempotent(t *testing.T) {
+	// A blocking reader so the capture goroutine parks until we stop it.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	starter := func(commandSpec) (processHandle, io.ReadCloser, error) {
+		return newFakeProcess(), pr, nil
+	}
+	r := NewRecorder(RecorderOptions{Platform: PlatformLinux, starter: starter, tempDir: testTempDir(t)})
+	chunks, stop, err := r.StartStreaming()
+	if err != nil {
+		t.Fatalf("StartStreaming: %v", err)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("second stop should be a no-op, got %v", err)
+	}
+	// Draining the channel must terminate now that we've stopped.
+	drained := make(chan struct{})
+	go func() {
+		for range chunks {
+		}
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("chunks channel did not close after stop")
+	}
+}
+
+func TestBatchMaxDurationCapInArgv(t *testing.T) {
+	cap := &captured{}
+	r := NewRecorder(RecorderOptions{
+		Platform:    PlatformLinux,
+		MaxDuration: 90 * time.Second,
+		starter:     fileWritingStarter(t, cap, wavFixture()),
+		tempDir:     testTempDir(t),
+	})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := r.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	// arecord's -d bounds a runaway recording even if Stop is never called.
+	assertArgs(t, cap.spec.args, "-d", "90")
+}
+
+func TestRecordedTempFileDeletedAfterStop(t *testing.T) {
+	dir := t.TempDir()
+	cap := &captured{}
+	r := NewRecorder(RecorderOptions{
+		Platform: PlatformLinux,
+		starter:  fileWritingStarter(t, cap, wavFixture()),
+		tempDir:  func() (string, error) { return dir, nil },
+	})
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := r.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("recorded audio should be deleted after Stop; found %d files", len(entries))
+	}
+}
+
+func TestStreamingSilenceAutoStop(t *testing.T) {
+	// Speech (loud) then a run of silence longer than silenceHold must auto-stop.
+	rate := 16000
+	chunk := chunkSizeBytes(rate)
+	loud := make([]byte, chunk)
+	for i := 0; i+1 < len(loud); i += 2 {
+		loud[i], loud[i+1] = 0x00, 0x40 // +16384, well above threshold
+	}
+	silence := make([]byte, chunk) // zeros
+	var buf []byte
+	buf = append(buf, loud...)
+	silentChunks := int(silenceHold/chunkInterval) + 3
+	for i := 0; i < silentChunks; i++ {
+		buf = append(buf, silence...)
+	}
+	starter := func(commandSpec) (processHandle, io.ReadCloser, error) {
+		return newFakeProcess(), io.NopCloser(bytes.NewReader(buf)), nil
+	}
+	r := NewRecorder(RecorderOptions{
+		Platform:        PlatformLinux,
+		SampleRate:      rate,
+		SilenceAutoStop: true,
+		starter:         starter,
+		tempDir:         testTempDir(t),
+	})
+	chunks, stop, err := r.StartStreaming()
+	if err != nil {
+		t.Fatalf("StartStreaming: %v", err)
+	}
+	defer stop()
+	// Draining must terminate on its own once silence auto-stop fires.
+	drained := make(chan struct{})
+	go func() {
+		for range chunks {
+		}
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(3 * time.Second):
+		t.Fatal("silence auto-stop did not end the stream")
+	}
+}
+
+func TestChunkPeak(t *testing.T) {
+	loud := []byte{0x00, 0x40} // +16384
+	if got := chunkPeak(loud); got != 16384 {
+		t.Errorf("peak = %d, want 16384", got)
+	}
+	quiet := []byte{0x10, 0x00} // +16
+	if got := chunkPeak(quiet); got != 16 {
+		t.Errorf("peak = %d, want 16", got)
+	}
+	min := []byte{0x00, 0x80} // -32768 -> clamped to 32767
+	if got := chunkPeak(min); got != 32767 {
+		t.Errorf("peak = %d, want 32767 (clamp)", got)
+	}
+}
+
+func TestDetectWindowsAudioDevice(t *testing.T) {
+	listing := `[dshow @ 0000] DirectShow audio devices
+[dshow @ 0000]  "Microphone (USB Audio)" (audio)
+[dshow @ 0000]     Alternative name "@device_cm_..."`
+	runOutput := func(context.Context, string, ...string) ([]byte, error) { return []byte(listing), nil }
+	got, err := detectWindowsAudioDevice(runOutput)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if got != "Microphone (USB Audio)" {
+		t.Errorf("device = %q", got)
+	}
+}
+
+func TestSniffFormat(t *testing.T) {
+	if SniffFormat(wavFixture()) != FormatWAV {
+		t.Error("wav not detected")
+	}
+	if SniffFormat(m4aFixture()) != FormatM4A {
+		t.Error("m4a not detected")
+	}
+	if SniffFormat([]byte("nope")) != FormatUnknown {
+		t.Error("unknown not detected")
+	}
+}
+
+func m4aFixture() []byte {
+	b := make([]byte, 16)
+	copy(b[4:], []byte("ftyp"))
+	copy(b[8:], []byte("M4A "))
+	return b
+}
+
+func assertArgs(t *testing.T, args []string, want ...string) {
+	t.Helper()
+	if !containsSubseq(args, want) {
+		t.Errorf("argv %v missing subsequence %v", args, want)
+	}
+}
+
+func containsSubseq(hay, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if equalSlice(hay[i:i+len(needle)], needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestChunkLevel(t *testing.T) {
+	// Silence → ~0.
+	silence := make([]byte, 640)
+	if lvl := ChunkLevel(silence); lvl > 0.01 {
+		t.Errorf("silence level = %f, want ~0", lvl)
+	}
+	// A loud full-scale tone → clamped to 1.
+	loud := make([]byte, 640)
+	for i := 0; i+1 < len(loud); i += 2 {
+		loud[i], loud[i+1] = 0xFF, 0x7F // +32767
+	}
+	if lvl := ChunkLevel(loud); lvl < 0.99 {
+		t.Errorf("full-scale level = %f, want ~1", lvl)
+	}
+	// A normal speech-level signal (~-30 dBFS) should land mid-meter, not pinned
+	// to the bottom (the whole point of the dB mapping).
+	mid := make([]byte, 640)
+	for i := 0; i+1 < len(mid); i += 2 {
+		mid[i], mid[i+1] = byte(1000&0xFF), byte(1000>>8) // ≈ -30 dBFS
+	}
+	if lvl := ChunkLevel(mid); lvl < 0.4 || lvl > 0.75 {
+		t.Errorf("normal-speech level = %f, want a visible mid-range value", lvl)
+	}
+	// A quiet signal (~-45 dBFS) should be low but non-zero.
+	quiet := make([]byte, 640)
+	for i := 0; i+1 < len(quiet); i += 2 {
+		quiet[i], quiet[i+1] = byte(180&0xFF), byte(180>>8)
+	}
+	if lvl := ChunkLevel(quiet); lvl <= 0 || lvl > 0.35 {
+		t.Errorf("quiet level = %f, want a small non-zero value", lvl)
+	}
+}

--- a/internal/dictation/runner.go
+++ b/internal/dictation/runner.go
@@ -64,6 +64,15 @@ func startProcess(spec commandSpec) (processHandle, io.ReadCloser, error) {
 		stdin = pipe
 	}
 	if err := cmd.Start(); err != nil {
+		// StdoutPipe/StdinPipe allocate fds the runtime only reclaims via
+		// Wait; on Start failure the process is never established, so close
+		// any pipes we already opened to avoid leaking them.
+		if stdout != nil {
+			_ = stdout.Close()
+		}
+		if stdin != nil {
+			_ = stdin.Close()
+		}
 		return nil, nil, err
 	}
 	return &realProcess{cmd: cmd, stdin: stdin, stopText: spec.stopViaStdin}, stdout, nil

--- a/internal/dictation/runner.go
+++ b/internal/dictation/runner.go
@@ -1,0 +1,119 @@
+package dictation
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// commandSpec describes one capture-process invocation. Argv is always
+// discrete — never a shell string (the same invariant documented in
+// internal/imageinput/clipboard.go).
+type commandSpec struct {
+	name string
+	args []string
+	// wantStdout wires up a stdout pipe (streaming capture reads raw PCM).
+	wantStdout bool
+	// stopViaStdin, when non-empty, makes graceful stop write this to the
+	// process's stdin instead of signaling — ffmpeg finalizes cleanly on "q",
+	// and Windows has no os.Interrupt delivery anyway.
+	stopViaStdin string
+}
+
+// processHandle is a started capture process. Injectable via processStarter so
+// unit tests fake OS-boundary behavior, mirroring internal/lsp's serverStarter
+// seam (this package's clipboard.go-style shell-outs get the test seam that
+// file lacks).
+type processHandle interface {
+	// StopGracefully asks the tool to finish and flush output (SIGINT, or the
+	// spec's stdin stop text). The recorder falls back to Kill on timeout.
+	StopGracefully() error
+	Wait() error
+	Kill() error
+}
+
+// processStarter launches a capture process, returning its handle and — when
+// the spec asks for it — its stdout pipe.
+type processStarter func(spec commandSpec) (processHandle, io.ReadCloser, error)
+
+// commandOutputRunner runs a short one-shot command to completion and returns
+// its combined output. Used for helper invocations that aren't recordings
+// (Termux start/stop, Windows ffmpeg device listing) and the offline
+// transcription exec — ctx lets a caller cancel/timeout a wedged process.
+type commandOutputRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func startProcess(spec commandSpec) (processHandle, io.ReadCloser, error) {
+	cmd := exec.Command(spec.name, spec.args...)
+	var stdout io.ReadCloser
+	if spec.wantStdout {
+		pipe, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, nil, err
+		}
+		stdout = pipe
+	}
+	var stdin io.WriteCloser
+	if spec.stopViaStdin != "" {
+		pipe, err := cmd.StdinPipe()
+		if err != nil {
+			return nil, nil, err
+		}
+		stdin = pipe
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+	return &realProcess{cmd: cmd, stdin: stdin, stopText: spec.stopViaStdin}, stdout, nil
+}
+
+type realProcess struct {
+	cmd      *exec.Cmd
+	stdin    io.WriteCloser
+	stopText string
+}
+
+func (p *realProcess) StopGracefully() error {
+	if p.stopText != "" && p.stdin != nil {
+		_, err := io.WriteString(p.stdin, p.stopText)
+		closeErr := p.stdin.Close()
+		if err != nil {
+			return err
+		}
+		return closeErr
+	}
+	// os.Interrupt is how arecord/sox finalize their WAV header. Unsupported
+	// on Windows, but the only Windows tool (ffmpeg) stops via stdin above.
+	return p.cmd.Process.Signal(os.Interrupt)
+}
+
+func (p *realProcess) Wait() error { return p.cmd.Wait() }
+
+func (p *realProcess) Kill() error { return p.cmd.Process.Kill() }
+
+func runCommandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+// waitWithTimeout waits for the process, killing it if it ignores the graceful
+// stop for longer than the grace window. Capture tools exit on SIGINT/"q"
+// almost instantly; a hang here means a wedged device driver, and a leaked
+// recording process holds the microphone open.
+func waitWithTimeout(proc processHandle, grace time.Duration) error {
+	done := make(chan error, 1)
+	go func() { done <- proc.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(grace):
+		_ = proc.Kill()
+		return <-done
+	}
+}

--- a/internal/dictation/server.go
+++ b/internal/dictation/server.go
@@ -145,7 +145,15 @@ func (m *ServerManager) Shutdown(ctx context.Context) error {
 	if err := proc.StopGracefully(); err != nil {
 		_ = proc.Kill()
 	}
-	return waitWithTimeout(proc, stopGrace)
+	done := make(chan error, 1)
+	go func() { done <- waitWithTimeout(proc, stopGrace) }()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		_ = proc.Kill()
+		return ctx.Err()
+	}
 }
 
 // URL returns the current server URL without starting one ("" when not running).

--- a/internal/dictation/server.go
+++ b/internal/dictation/server.go
@@ -1,0 +1,247 @@
+package dictation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultServerPort is the localhost port the sherpa-onnx streaming server binds.
+const DefaultServerPort = 6006
+
+// ServerConfig configures the warm sherpa-onnx streaming server (§6a).
+type ServerConfig struct {
+	// Binary is the streaming server executable (default
+	// "sherpa-onnx-online-websocket-server"); looked up on PATH.
+	Binary string
+	// ModelPath is the sherpa-onnx streaming model directory (transducer:
+	// encoder/decoder/joiner + tokens).
+	ModelPath  string
+	Port       int
+	NumThreads int
+
+	// Test seams.
+	starter     processStarter
+	healthCheck func(ctx context.Context, port int) error
+	aliveCheck  func(port int) bool
+	now         func() time.Time
+}
+
+// ServerManager owns one long-lived sherpa-onnx streaming server, spawned lazily
+// on first streaming use and kept warm for the session — a websocket server with
+// ~1-2s startup latency can't be respawned per utterance (§6a). Its lifecycle
+// mirrors internal/lsp's Manager: lazy start, health-checked reuse, one restart
+// on a crashed process, torn down on exit. Safe for concurrent use.
+type ServerManager struct {
+	cfg ServerConfig
+
+	mu   sync.Mutex
+	proc processHandle
+	url  string
+}
+
+// NewServerManager builds a manager. Construction is side-effect free; the
+// server is only spawned on the first EnsureRunning.
+func NewServerManager(cfg ServerConfig) *ServerManager {
+	if cfg.Binary == "" {
+		cfg.Binary = "sherpa-onnx-online-websocket-server"
+	}
+	if cfg.Port == 0 {
+		cfg.Port = DefaultServerPort
+	}
+	if cfg.starter == nil {
+		cfg.starter = startProcess
+	}
+	if cfg.healthCheck == nil {
+		cfg.healthCheck = dialHealthCheck
+	}
+	if cfg.aliveCheck == nil {
+		cfg.aliveCheck = func(port int) bool { return portListening(port) }
+	}
+	if cfg.now == nil {
+		cfg.now = time.Now
+	}
+	return &ServerManager{cfg: cfg}
+}
+
+// EnsureRunning returns the websocket URL of a live server, starting one if
+// needed. A previously-started server whose process has since died is reaped and
+// replaced (mirroring the LSP manager's crashed-session eviction).
+func (m *ServerManager) EnsureRunning(ctx context.Context) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.proc != nil {
+		if m.processAlive() {
+			return m.url, nil
+		}
+		// The cached server died; reap it so a fresh one starts below.
+		_ = m.proc.Kill()
+		m.proc = nil
+		m.url = ""
+	}
+
+	spec, err := onlineServerCommand(m.cfg)
+	if err != nil {
+		return "", err
+	}
+	proc, _, err := m.cfg.starter(spec)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", &SetupError{
+				Tool: m.cfg.Binary,
+				Hint: "install sherpa-onnx and put its online-websocket-server binary on PATH (see docs/dictation.md)",
+			}
+		}
+		return "", fmt.Errorf("starting sherpa-onnx server: %w", err)
+	}
+
+	// Health-check the port before handing back a URL — the server takes ~1-2s to
+	// bind, and a client connecting too early would fail (§6a).
+	if err := m.cfg.healthCheck(ctx, m.cfg.Port); err != nil {
+		_ = proc.Kill()
+		return "", fmt.Errorf("sherpa-onnx server did not become ready: %w", err)
+	}
+	m.proc = proc
+	m.url = fmt.Sprintf("ws://127.0.0.1:%d", m.cfg.Port)
+	return m.url, nil
+}
+
+// processAlive reports whether the tracked server is still reachable. Probing
+// the port (rather than the process handle) reflects real reachability and is
+// the seam tests replace.
+func (m *ServerManager) processAlive() bool {
+	return m.cfg.aliveCheck(m.cfg.Port)
+}
+
+// portListening reports whether something accepts TCP connections on the port.
+func portListening(port int) bool {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// Shutdown stops the running server. Called alongside the LSP manager's shutdown
+// on exit — a leaked warm server holds a port and CPU.
+func (m *ServerManager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	proc := m.proc
+	m.proc = nil
+	m.url = ""
+	m.mu.Unlock()
+	if proc == nil {
+		return nil
+	}
+	if err := proc.StopGracefully(); err != nil {
+		_ = proc.Kill()
+	}
+	return waitWithTimeout(proc, stopGrace)
+}
+
+// URL returns the current server URL without starting one ("" when not running).
+func (m *ServerManager) URL() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.url
+}
+
+// SetModelPath updates the model directory the server launches with, for a
+// mid-session config change (e.g. an F9 auto-download). It takes effect the next
+// time the server (re)starts; a running server is left as-is.
+func (m *ServerManager) SetModelPath(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if path != "" {
+		m.cfg.ModelPath = path
+	}
+}
+
+// onlineServerCommand builds the streaming-server argv from the model directory.
+// The online server uses a streaming transducer (encoder/decoder/joiner) plus
+// tokens — the shape the sherpa-onnx docs' example uses (§6a).
+func onlineServerCommand(cfg ServerConfig) (commandSpec, error) {
+	if strings.TrimSpace(cfg.ModelPath) == "" {
+		return commandSpec{}, &SetupError{
+			Tool: "local STT streaming model",
+			Hint: "set stt.localModelPath to a sherpa-onnx streaming model directory (see docs/dictation.md)",
+		}
+	}
+	files, err := onnxFilesIn(cfg.ModelPath)
+	if err != nil {
+		return commandSpec{}, &SetupError{Tool: "local STT streaming model", Hint: err.Error()}
+	}
+	tokens := findTokensFile(files)
+	// A streaming model ships encoder/decoder/joiner, often BOTH an int8 and an
+	// fp32 copy of each. Pick a CONSISTENT set — all int8 or all fp32 — because
+	// mixing (int8 encoder + fp32 decoder) is invalid. Prefer int8 (smaller,
+	// faster) when a full int8 set is present.
+	set := consistentQuantizedSet(files, "encoder", "decoder", "joiner")
+	var encoder, decoder, joiner string
+	if set != nil {
+		encoder, decoder, joiner = set[0], set[1], set[2]
+	}
+	if tokens == "" || encoder == "" || decoder == "" || joiner == "" {
+		return commandSpec{}, &SetupError{
+			Tool: "local STT streaming model",
+			Hint: fmt.Sprintf("streaming needs a transducer model (encoder/decoder/joiner .onnx + tokens.txt) in %q; see docs/dictation.md", cfg.ModelPath),
+		}
+	}
+	args := []string{
+		"--port=" + strconv.Itoa(cfg.Port),
+		"--tokens=" + tokens,
+		"--encoder=" + encoder,
+		"--decoder=" + decoder,
+		"--joiner=" + joiner,
+		"--decoding-method=greedy_search",
+	}
+	if cfg.NumThreads > 0 {
+		args = append(args, "--num-threads="+strconv.Itoa(cfg.NumThreads))
+	}
+	return commandSpec{name: cfg.Binary, args: args}, nil
+}
+
+func onnxFilesIn(dir string) (map[string]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("stt.localModelPath %q is not readable: %v", dir, err)
+	}
+	files := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		files[strings.ToLower(e.Name())] = dir + string(os.PathSeparator) + e.Name()
+	}
+	return files, nil
+}
+
+// dialHealthCheck polls the server's TCP port until it accepts a connection or
+// the deadline passes.
+func dialHealthCheck(ctx context.Context, port int) error {
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("port %d not listening after 5s", port)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/internal/dictation/server_test.go
+++ b/internal/dictation/server_test.go
@@ -1,0 +1,189 @@
+package dictation
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func streamingModelDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, f := range []string{"encoder.onnx", "decoder.onnx", "joiner.onnx", "tokens.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestServerManagerLazyStartAndReuse(t *testing.T) {
+	var startCount int
+	var mu sync.Mutex
+	starter := func(spec commandSpec) (processHandle, io.ReadCloser, error) {
+		mu.Lock()
+		startCount++
+		mu.Unlock()
+		if spec.name != "sherpa-onnx-online-websocket-server" {
+			t.Errorf("binary = %q", spec.name)
+		}
+		return newFakeProcess(), nil, nil
+	}
+	alive := true
+	m := NewServerManager(ServerConfig{
+		ModelPath:   streamingModelDir(t),
+		Port:        6006,
+		starter:     starter,
+		healthCheck: func(context.Context, int) error { return nil },
+		aliveCheck:  func(int) bool { return alive },
+	})
+
+	url, err := m.EnsureRunning(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureRunning: %v", err)
+	}
+	if url != "ws://127.0.0.1:6006" {
+		t.Errorf("url = %q", url)
+	}
+	// Second call reuses the warm server (alive) — no new start.
+	if _, err := m.EnsureRunning(context.Background()); err != nil {
+		t.Fatalf("EnsureRunning reuse: %v", err)
+	}
+	if startCount != 1 {
+		t.Errorf("expected 1 start (warm reuse), got %d", startCount)
+	}
+}
+
+func TestServerManagerRestartsCrashedServer(t *testing.T) {
+	var startCount int
+	starter := func(commandSpec) (processHandle, io.ReadCloser, error) {
+		startCount++
+		return newFakeProcess(), nil, nil
+	}
+	alive := true
+	m := NewServerManager(ServerConfig{
+		ModelPath:   streamingModelDir(t),
+		starter:     starter,
+		healthCheck: func(context.Context, int) error { return nil },
+		aliveCheck:  func(int) bool { return alive },
+	})
+	if _, err := m.EnsureRunning(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	alive = false // simulate a crashed server
+	if _, err := m.EnsureRunning(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if startCount != 2 {
+		t.Errorf("expected a restart (2 starts), got %d", startCount)
+	}
+}
+
+func TestServerManagerMissingBinaryIsSetupError(t *testing.T) {
+	m := NewServerManager(ServerConfig{
+		ModelPath: streamingModelDir(t),
+		starter:   func(commandSpec) (processHandle, io.ReadCloser, error) { return nil, nil, exec.ErrNotFound },
+	})
+	_, err := m.EnsureRunning(context.Background())
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError, got %v", err)
+	}
+}
+
+func TestServerManagerMissingModelIsSetupError(t *testing.T) {
+	m := NewServerManager(ServerConfig{
+		ModelPath: t.TempDir(), // empty dir, no onnx/tokens
+		starter:   func(commandSpec) (processHandle, io.ReadCloser, error) { return newFakeProcess(), nil, nil },
+	})
+	_, err := m.EnsureRunning(context.Background())
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError for missing streaming model, got %v", err)
+	}
+}
+
+func TestServerManagerShutdown(t *testing.T) {
+	proc := newFakeProcess()
+	m := NewServerManager(ServerConfig{
+		ModelPath:   streamingModelDir(t),
+		starter:     func(commandSpec) (processHandle, io.ReadCloser, error) { return proc, nil, nil },
+		healthCheck: func(context.Context, int) error { return nil },
+		aliveCheck:  func(int) bool { return true },
+	})
+	if _, err := m.EnsureRunning(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if !proc.stopped && !proc.killed {
+		t.Error("Shutdown should stop the server process")
+	}
+	if m.URL() != "" {
+		t.Error("URL should be empty after shutdown")
+	}
+}
+
+func TestOnlineServerCommandBuildsTransducerArgs(t *testing.T) {
+	spec, err := onlineServerCommand(ServerConfig{Binary: "sherpa-onnx-online-websocket-server", ModelPath: streamingModelDir(t), Port: 6007})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := ""
+	for _, a := range spec.args {
+		joined += a + " "
+	}
+	for _, want := range []string{"--port=6007", "--tokens=", "--encoder=", "--decoder=", "--joiner=", "--decoding-method=greedy_search"} {
+		if !contains(joined, want) {
+			t.Errorf("missing %q in args: %s", want, joined)
+		}
+	}
+}
+
+func TestPCM16ToFloat32LE(t *testing.T) {
+	// int16 max (32767) and min (-32768), little-endian.
+	pcm := []byte{0xFF, 0x7F, 0x00, 0x80}
+	out := pcm16ToFloat32LE(pcm)
+	if len(out) != 8 {
+		t.Fatalf("expected 8 bytes (2 float32), got %d", len(out))
+	}
+	f0 := math.Float32frombits(binary.LittleEndian.Uint32(out[0:4]))
+	f1 := math.Float32frombits(binary.LittleEndian.Uint32(out[4:8]))
+	if f0 < 0.99 || f0 > 1.0 {
+		t.Errorf("32767 → %f, want ~1.0", f0)
+	}
+	if f1 != -1.0 {
+		t.Errorf("-32768 → %f, want -1.0", f1)
+	}
+}
+
+func TestParseSherpaStreamResult(t *testing.T) {
+	text, segment, final, ok := parseSherpaStreamResult([]byte(`{"text":" hello world ","segment":2,"is_final":true}`))
+	if !ok || text != "hello world" || segment != 2 || !final {
+		t.Errorf("parsed = (%q, %d, %v, %v)", text, segment, final, ok)
+	}
+	if _, _, _, ok := parseSherpaStreamResult([]byte("not json")); ok {
+		t.Error("non-JSON should not parse")
+	}
+}
+
+func contains(hay, needle string) bool {
+	return len(needle) == 0 || (len(hay) >= len(needle) && indexOf(hay, needle) >= 0)
+}
+
+func indexOf(hay, needle string) int {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/dictation/spill.go
+++ b/internal/dictation/spill.go
@@ -1,0 +1,42 @@
+package dictation
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Recorded audio is staged in a hardened per-user temp directory, mirroring
+// internal/tools/spill.go (PR #506): uid-suffixed name so users on a shared
+// /tmp cannot collide, 0700 perms, and a pre-existing path is only accepted
+// when it is a real directory (not a symlink that would redirect recordings)
+// owned by the current user. Files are removed as soon as their bytes are
+// read back after Stop — audio never lingers on disk.
+
+func audioSpillRoot() string {
+	name := "zero-dictation"
+	if uid := os.Getuid(); uid >= 0 {
+		name = fmt.Sprintf("zero-dictation-%d", uid)
+	}
+	return filepath.Join(os.TempDir(), name)
+}
+
+func audioSpillDir() (string, error) {
+	dir := audioSpillRoot()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	// MkdirAll follows symlinks and leaves an existing directory untouched, so
+	// verify what is actually at the path.
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("dictation temp path %s is not a directory", dir)
+	}
+	if err := checkAudioDirOwner(info); err != nil {
+		return "", err
+	}
+	return dir, nil
+}

--- a/internal/dictation/spill.go
+++ b/internal/dictation/spill.go
@@ -35,6 +35,15 @@ func audioSpillDir() (string, error) {
 	if !info.IsDir() {
 		return "", fmt.Errorf("dictation temp path %s is not a directory", dir)
 	}
+	// MkdirAll only applies 0o700 to dirs it creates; an existing directory
+	// (e.g. one created under a loose umask in a prior run) can be group- or
+	// world-readable. Tighten it so staged audio (PII) is never visible to
+	// other users on a shared /tmp.
+	if info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return "", fmt.Errorf("tightening dictation temp dir permissions: %w", err)
+		}
+	}
 	if err := checkAudioDirOwner(info); err != nil {
 		return "", err
 	}

--- a/internal/dictation/stream_smoke_test.go
+++ b/internal/dictation/stream_smoke_test.go
@@ -1,0 +1,67 @@
+package dictation
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestLocalStreamingRealServer drives the full local streaming path against a
+// REAL sherpa-onnx-online-websocket-server + streaming model: spawn the server,
+// connect, feed a wav's PCM in 50ms chunks, and check the transcript. Opt-in:
+//
+//	ZERO_STT_STREAM_SERVER=/path/to/sherpa-onnx-online-websocket-server \
+//	ZERO_STT_STREAM_MODEL=/path/to/streaming-model-dir \
+//	ZERO_STT_STREAM_WAV=/path/to/16k-mono.wav \
+//	go test ./internal/dictation/ -run RealServer -v -timeout 5m
+func TestLocalStreamingRealServer(t *testing.T) {
+	server := os.Getenv("ZERO_STT_STREAM_SERVER")
+	model := os.Getenv("ZERO_STT_STREAM_MODEL")
+	wav := os.Getenv("ZERO_STT_STREAM_WAV")
+	if server == "" || model == "" || wav == "" {
+		t.Skip("set ZERO_STT_STREAM_SERVER, ZERO_STT_STREAM_MODEL, ZERO_STT_STREAM_WAV to run the streaming smoke test")
+	}
+	raw, err := os.ReadFile(wav)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pcm := stripWavHeader(raw)
+
+	mgr := NewServerManager(ServerConfig{Binary: server, ModelPath: model, Port: 6100})
+	defer mgr.Shutdown(context.Background())
+	tr := NewLocalStreamingTranscriber(mgr)
+
+	chunks := make(chan []byte)
+	go func() {
+		defer close(chunks)
+		size := chunkSizeBytes(DefaultSampleRate) // 50ms
+		for off := 0; off < len(pcm); off += size {
+			end := off + size
+			if end > len(pcm) {
+				end = len(pcm)
+			}
+			chunks <- pcm[off:end]
+			time.Sleep(10 * time.Millisecond) // pace it a little, like a mic
+		}
+	}()
+
+	var partials int
+	final, err := tr.StreamTranscribe(context.Background(), chunks, func(string, bool) { partials++ })
+	if err != nil {
+		t.Fatalf("StreamTranscribe: %v", err)
+	}
+	if final == "" {
+		t.Fatal("streaming returned empty transcript")
+	}
+	t.Logf("streaming transcript (%d partials): %q", partials, final)
+}
+
+// stripWavHeader drops a standard 44-byte PCM WAV header, returning the raw
+// int16 samples. Good enough for the canonical 16kHz/mono/16-bit test wavs.
+func stripWavHeader(b []byte) []byte {
+	if len(b) > 44 && string(b[:4]) == "RIFF" {
+		return b[44:]
+	}
+	return b
+}

--- a/internal/dictation/transcriber.go
+++ b/internal/dictation/transcriber.go
@@ -1,0 +1,45 @@
+package dictation
+
+import "context"
+
+// Transcriber turns captured audio into text. Batch (Transcribe) and streaming
+// (StreamTranscribe) are one interface but two independent code paths — a
+// batch-only provider (Groq/OpenAI, sherpa-onnx-offline) leaves
+// StreamTranscribe returning ErrStreamingUnsupported, and a streaming provider
+// still implements Transcribe for the batch/Termux fallback.
+type Transcriber interface {
+	// Transcribe returns the final text for one recorded clip.
+	Transcribe(ctx context.Context, audio []byte) (string, error)
+
+	// StreamTranscribe consumes PCM16 chunks and reports incremental results
+	// via onPartial(text, final) as decoding proceeds, returning the complete
+	// final transcript when the chunk channel closes.
+	//
+	// onPartial's text is the CURRENT best transcript of the utterance so far
+	// (cumulative, not a delta) so the composer can replace the live region
+	// wholesale; final marks a segment the provider considers settled.
+	//
+	// On a mid-stream failure (network drop for cloud, subprocess crash for
+	// local) StreamTranscribe returns the best-effort text accumulated from
+	// onPartial calls made so far PLUS a non-nil error — already-streamed text
+	// is never discarded, only the untranscribed tail after the failure is lost.
+	StreamTranscribe(ctx context.Context, chunks <-chan []byte, onPartial func(text string, final bool)) (string, error)
+}
+
+// SampleRate lets a Transcriber declare the capture rate its wire format
+// expects, so the recorder can be built to match (OpenAI Realtime wants 24kHz;
+// everything else uses 16kHz). A Transcriber that does not implement this uses
+// DefaultSampleRate.
+type SampleRate interface {
+	SampleRate() int
+}
+
+// RequiredSampleRate returns the capture rate a Transcriber needs.
+func RequiredSampleRate(t Transcriber) int {
+	if sr, ok := t.(SampleRate); ok {
+		if rate := sr.SampleRate(); rate > 0 {
+			return rate
+		}
+	}
+	return DefaultSampleRate
+}

--- a/internal/dictation/transcriber_cloud.go
+++ b/internal/dictation/transcriber_cloud.go
@@ -1,0 +1,144 @@
+package dictation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+)
+
+// CloudConfig configures a batch cloud transcriber. Groq and OpenAI share the
+// OpenAI-compatible /audio/transcriptions multipart endpoint — the design's
+// "each owns its endpoint/model specifics while sharing the request shape"
+// (§6). Key and base URL are resolved by the caller (TUI layer) from
+// config/credstore, keeping this type decoupled and unit-testable.
+type CloudConfig struct {
+	Provider string // ProviderGroq or ProviderOpenAI, for error messages
+	BaseURL  string // e.g. https://api.groq.com/openai/v1
+	APIKey   string
+	Model    string // e.g. whisper-large-v3-turbo, whisper-1
+	// Language optionally constrains recognition (ISO-639-1). Empty = auto.
+	Language string
+
+	// HTTPClient is injectable for tests; nil uses providerio's shared,
+	// stall-hardened client.
+	HTTPClient *http.Client
+}
+
+type cloudTranscriber struct {
+	cfg CloudConfig
+}
+
+// NewCloudTranscriber builds a batch transcriber for Groq or OpenAI.
+func NewCloudTranscriber(cfg CloudConfig) (Transcriber, error) {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, &SetupError{
+			Tool: cfg.Provider + " API key",
+			Hint: fmt.Sprintf("set a %s API key (run `zero auth`) to use cloud dictation", cfg.Provider),
+		}
+	}
+	if cfg.Model == "" {
+		return nil, fmt.Errorf("dictation: no model configured for provider %q", cfg.Provider)
+	}
+	base, err := providerio.NormalizeBaseURL(cfg.BaseURL, cfg.BaseURL, cfg.Provider)
+	if err != nil {
+		return nil, err
+	}
+	cfg.BaseURL = base
+	return &cloudTranscriber{cfg: cfg}, nil
+}
+
+func (c *cloudTranscriber) Transcribe(ctx context.Context, audio []byte) (string, error) {
+	if len(audio) == 0 {
+		return "", errors.New("no audio to transcribe")
+	}
+	body, contentType, err := c.buildMultipart(audio)
+	if err != nil {
+		return "", err
+	}
+	endpoint := c.cfg.BaseURL + "/audio/transcriptions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+
+	resp, err := providerio.HTTPClient(c.cfg.HTTPClient).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%s transcription request failed: %w", c.cfg.Provider, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		msg := providerio.ClassifiedError(resp.StatusCode, strings.TrimSpace(string(respBody)), c.cfg.APIKey)
+		// A 401/403 is a fixable credential problem: surface it as a typed AuthError
+		// so the TUI can offer an inline key prompt instead of a dead-end message.
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return "", &AuthError{Provider: c.cfg.Provider, Message: msg}
+		}
+		return "", errors.New(msg)
+	}
+	var parsed struct {
+		Text  string `json:"text"`
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("%s transcription: could not parse response: %w", c.cfg.Provider, err)
+	}
+	if parsed.Error.Message != "" {
+		return "", fmt.Errorf("%s transcription error: %s", c.cfg.Provider, providerio.Redact(parsed.Error.Message, c.cfg.APIKey))
+	}
+	return strings.TrimSpace(parsed.Text), nil
+}
+
+// buildMultipart assembles the transcription upload. The file field name and
+// the "model"/"response_format" fields match the OpenAI audio API that Groq
+// mirrors. The filename's extension tells the server the container type —
+// SniffFormat keeps WAV/M4A honest so Termux's AAC uploads work.
+func (c *cloudTranscriber) buildMultipart(audio []byte) ([]byte, string, error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("file", SniffFormat(audio).FileName())
+	if err != nil {
+		return nil, "", err
+	}
+	if _, err := fw.Write(audio); err != nil {
+		return nil, "", err
+	}
+	if err := w.WriteField("model", c.cfg.Model); err != nil {
+		return nil, "", err
+	}
+	if err := w.WriteField("response_format", "json"); err != nil {
+		return nil, "", err
+	}
+	if c.cfg.Language != "" {
+		if err := w.WriteField("language", c.cfg.Language); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), w.FormDataContentType(), nil
+}
+
+// StreamTranscribe is not supported for the batch cloud providers (Groq has no
+// streaming product; OpenAI batch is one-shot). Streaming uses the dedicated
+// Deepgram/OpenAI-Realtime transcribers instead.
+func (c *cloudTranscriber) StreamTranscribe(context.Context, <-chan []byte, func(string, bool)) (string, error) {
+	return "", ErrStreamingUnsupported
+}
+
+// ErrStreamingUnsupported reports that a batch-only Transcriber cannot stream;
+// the caller falls back to the batch pipeline.
+var ErrStreamingUnsupported = errors.New("this transcription provider does not support streaming")

--- a/internal/dictation/transcriber_cloud_test.go
+++ b/internal/dictation/transcriber_cloud_test.go
@@ -1,0 +1,142 @@
+package dictation
+
+import (
+	"context"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCloudTranscribeBuildsMultipartAndParsesText(t *testing.T) {
+	var gotModel, gotAuth, gotFilename string
+	var gotFileBytes []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/audio/transcriptions" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
+			t.Fatalf("bad content type %q: %v", r.Header.Get("Content-Type"), err)
+		}
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("multipart: %v", err)
+			}
+			switch part.FormName() {
+			case "model":
+				b, _ := io.ReadAll(part)
+				gotModel = string(b)
+			case "file":
+				gotFilename = part.FileName()
+				gotFileBytes, _ = io.ReadAll(part)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"text":"  hello world  "}`)
+	}))
+	defer srv.Close()
+
+	tr, err := NewCloudTranscriber(CloudConfig{
+		Provider: ProviderGroq,
+		BaseURL:  srv.URL,
+		APIKey:   "secret-key",
+		Model:    "whisper-large-v3-turbo",
+	})
+	if err != nil {
+		t.Fatalf("NewCloudTranscriber: %v", err)
+	}
+	audio := wavFixture()
+	text, err := tr.Transcribe(context.Background(), audio)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if text != "hello world" {
+		t.Errorf("text = %q, want trimmed 'hello world'", text)
+	}
+	if gotModel != "whisper-large-v3-turbo" {
+		t.Errorf("model field = %q", gotModel)
+	}
+	if gotAuth != "Bearer secret-key" {
+		t.Errorf("auth header = %q", gotAuth)
+	}
+	if gotFilename != "audio.wav" {
+		t.Errorf("filename = %q, want audio.wav", gotFilename)
+	}
+	if len(gotFileBytes) != len(audio) {
+		t.Errorf("uploaded %d file bytes, want %d", len(gotFileBytes), len(audio))
+	}
+}
+
+func TestCloudTranscribeM4AFilename(t *testing.T) {
+	var gotFilename string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			if part.FormName() == "file" {
+				gotFilename = part.FileName()
+			}
+		}
+		io.WriteString(w, `{"text":"ok"}`)
+	}))
+	defer srv.Close()
+
+	tr, _ := NewCloudTranscriber(CloudConfig{Provider: ProviderOpenAI, BaseURL: srv.URL, APIKey: "k", Model: "whisper-1"})
+	if _, err := tr.Transcribe(context.Background(), m4aFixture()); err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if gotFilename != "audio.m4a" {
+		t.Errorf("filename = %q, want audio.m4a", gotFilename)
+	}
+}
+
+func TestCloudTranscribeAuthErrorClassified(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		io.WriteString(w, `{"error":{"message":"invalid api key sk-secret-key"}}`)
+	}))
+	defer srv.Close()
+
+	tr, _ := NewCloudTranscriber(CloudConfig{Provider: ProviderGroq, BaseURL: srv.URL, APIKey: "sk-secret-key", Model: "whisper-large-v3-turbo"})
+	_, err := tr.Transcribe(context.Background(), wavFixture())
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if strings.Contains(err.Error(), "sk-secret-key") {
+		t.Errorf("API key leaked into error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "auth error") {
+		t.Errorf("expected auth-error classification, got %v", err)
+	}
+}
+
+func TestNewCloudTranscriberRequiresKey(t *testing.T) {
+	_, err := NewCloudTranscriber(CloudConfig{Provider: ProviderGroq, BaseURL: "https://api.groq.com/openai/v1", Model: "m"})
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError for missing key, got %v", err)
+	}
+}
+
+func TestCloudTranscribeStreamingUnsupported(t *testing.T) {
+	tr, _ := NewCloudTranscriber(CloudConfig{Provider: ProviderGroq, BaseURL: "https://x", APIKey: "k", Model: "m"})
+	_, err := tr.StreamTranscribe(context.Background(), nil, nil)
+	if !errors.Is(err, ErrStreamingUnsupported) {
+		t.Errorf("want ErrStreamingUnsupported, got %v", err)
+	}
+}

--- a/internal/dictation/transcriber_deepgram.go
+++ b/internal/dictation/transcriber_deepgram.go
@@ -1,0 +1,163 @@
+package dictation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// DeepgramConfig configures the Deepgram streaming transcriber (§6b, default
+// cloud streaming provider). The key is resolved by the caller.
+type DeepgramConfig struct {
+	APIKey     string
+	Model      string // default "nova-3"
+	Language   string
+	SampleRate int // capture rate; default DefaultSampleRate (16kHz)
+	// BaseURL overrides the wss endpoint (tests point it at a fake server).
+	BaseURL string
+}
+
+type deepgramTranscriber struct {
+	cfg DeepgramConfig
+}
+
+// NewDeepgramTranscriber builds the Deepgram streaming transcriber.
+func NewDeepgramTranscriber(cfg DeepgramConfig) (Transcriber, error) {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, &SetupError{
+			Tool: "Deepgram API key",
+			Hint: "set a Deepgram API key (DEEPGRAM_API_KEY, or `zero auth`) to use Deepgram streaming dictation",
+		}
+	}
+	if cfg.Model == "" {
+		cfg.Model = "nova-3"
+	}
+	if cfg.SampleRate <= 0 {
+		cfg.SampleRate = DefaultSampleRate
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "wss://api.deepgram.com/v1/listen"
+	}
+	return &deepgramTranscriber{cfg: cfg}, nil
+}
+
+// Transcribe is unsupported — Deepgram is used only on the streaming path here.
+func (d *deepgramTranscriber) Transcribe(context.Context, []byte) (string, error) {
+	return "", ErrStreamingUnsupported
+}
+
+func (d *deepgramTranscriber) SampleRate() int { return d.cfg.SampleRate }
+
+func (d *deepgramTranscriber) StreamTranscribe(ctx context.Context, chunks <-chan []byte, onPartial func(string, bool)) (string, error) {
+	endpoint := d.buildURL()
+	conn, _, err := websocket.Dial(ctx, endpoint, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": {"Token " + d.cfg.APIKey}},
+	})
+	if err != nil {
+		return "", fmt.Errorf("connecting to Deepgram: %w", err)
+	}
+	defer conn.CloseNow()
+
+	// Deepgram consumes raw linear16 (int16) PCM — the recorder's native format,
+	// so no conversion (unlike sherpa-onnx, which wants float32).
+	writeErrCh := make(chan error, 1)
+	go func() {
+		for chunk := range chunks {
+			if err := conn.Write(ctx, websocket.MessageBinary, chunk); err != nil {
+				writeErrCh <- err
+				return
+			}
+		}
+		// CloseStream flushes any buffered audio and returns final results before
+		// Deepgram closes the socket.
+		writeErrCh <- conn.Write(ctx, websocket.MessageText, []byte(`{"type":"CloseStream"}`))
+	}()
+
+	// Deepgram results are per-utterance segments, not cumulative: accumulate the
+	// is_final segments and append the current interim to build the full text.
+	var finals []string
+	var interim string
+	compose := func() string {
+		return strings.TrimSpace(strings.Join(append(finals, interim), " "))
+	}
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			// A clean close after CloseStream is success, not failure.
+			if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
+				return compose(), nil
+			}
+			select {
+			case werr := <-writeErrCh:
+				if werr != nil {
+					err = werr
+				}
+			default:
+			}
+			return compose(), fmt.Errorf("Deepgram stream error: %w", err)
+		}
+		if typ != websocket.MessageText {
+			continue
+		}
+		transcript, isFinal, ok := parseDeepgramResult(data)
+		if !ok {
+			continue
+		}
+		if isFinal {
+			if transcript != "" {
+				finals = append(finals, transcript)
+			}
+			interim = ""
+		} else {
+			interim = transcript
+		}
+		if onPartial != nil {
+			onPartial(compose(), isFinal)
+		}
+	}
+}
+
+func (d *deepgramTranscriber) buildURL() string {
+	q := url.Values{}
+	q.Set("encoding", "linear16")
+	q.Set("sample_rate", strconv.Itoa(d.cfg.SampleRate))
+	q.Set("channels", "1")
+	q.Set("interim_results", "true")
+	q.Set("punctuate", "true")
+	q.Set("model", d.cfg.Model)
+	if d.cfg.Language != "" {
+		q.Set("language", d.cfg.Language)
+	}
+	return d.cfg.BaseURL + "?" + q.Encode()
+}
+
+// parseDeepgramResult extracts the transcript and is_final flag from a Deepgram
+// "Results" message: channel.alternatives[0].transcript.
+func parseDeepgramResult(data []byte) (transcript string, isFinal bool, ok bool) {
+	var msg struct {
+		Type    string `json:"type"`
+		IsFinal bool   `json:"is_final"`
+		Channel struct {
+			Alternatives []struct {
+				Transcript string `json:"transcript"`
+			} `json:"alternatives"`
+		} `json:"channel"`
+	}
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return "", false, false
+	}
+	// Only "Results" messages carry transcripts; ignore Metadata/UtteranceEnd/etc.
+	if msg.Type != "" && msg.Type != "Results" {
+		return "", false, false
+	}
+	if len(msg.Channel.Alternatives) == 0 {
+		return "", false, false
+	}
+	return strings.TrimSpace(msg.Channel.Alternatives[0].Transcript), msg.IsFinal, true
+}

--- a/internal/dictation/transcriber_local.go
+++ b/internal/dictation/transcriber_local.go
@@ -1,0 +1,391 @@
+package dictation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// LocalConfig configures the offline sherpa-onnx batch transcriber. Every tier
+// (default/standard/high-end, §7) is just a different ModelPath — there are no
+// tier-specific code paths; the model family is detected from the files present.
+type LocalConfig struct {
+	// Binary is the sherpa-onnx-offline executable; looked up on PATH when a
+	// bare name. Empty defaults to "sherpa-onnx-offline".
+	Binary string
+	// ModelPath is the directory holding the model's .onnx + tokens.txt files
+	// (stt.localModelPath).
+	ModelPath  string
+	NumThreads int
+
+	// Test seams.
+	runOutput commandOutputRunner
+	tempDir   func() (string, error)
+}
+
+type localTranscriber struct {
+	cfg LocalConfig
+}
+
+// NewLocalTranscriber builds the offline transcriber. It does not touch the
+// filesystem or PATH until Transcribe runs, so a missing binary/model degrades
+// to a clear setup message at use time (matching internal/lsp).
+func NewLocalTranscriber(cfg LocalConfig) (Transcriber, error) {
+	if strings.TrimSpace(cfg.ModelPath) == "" {
+		return nil, &SetupError{
+			Tool: "local STT model",
+			Hint: "set stt.localModelPath to a sherpa-onnx model directory (see docs/dictation.md)",
+		}
+	}
+	if cfg.Binary == "" {
+		cfg.Binary = "sherpa-onnx-offline"
+	}
+	if cfg.runOutput == nil {
+		cfg.runOutput = runCommandOutput
+	}
+	if cfg.tempDir == nil {
+		cfg.tempDir = audioSpillDir
+	}
+	return &localTranscriber{cfg: cfg}, nil
+}
+
+func (l *localTranscriber) Transcribe(ctx context.Context, audio []byte) (string, error) {
+	if len(audio) == 0 {
+		return "", errors.New("no audio to transcribe")
+	}
+	modelArgs, err := detectModelArgs(l.cfg.ModelPath)
+	if err != nil {
+		return "", err
+	}
+
+	dir, err := l.cfg.tempDir()
+	if err != nil {
+		return "", fmt.Errorf("preparing dictation temp dir: %w", err)
+	}
+	ext := ".wav"
+	if SniffFormat(audio) == FormatM4A {
+		ext = ".m4a"
+	}
+	tmp, err := os.CreateTemp(dir, "stt-*"+ext)
+	if err != nil {
+		return "", fmt.Errorf("staging audio for transcription: %w", err)
+	}
+	path := tmp.Name()
+	defer os.Remove(path) // audio never lingers on disk (§12)
+	if _, err := tmp.Write(audio); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+
+	args := make([]string, 0, len(modelArgs)+3)
+	args = append(args, modelArgs...)
+	if l.cfg.NumThreads > 0 {
+		args = append(args, "--num-threads="+strconv.Itoa(l.cfg.NumThreads))
+	}
+	args = append(args, path)
+
+	// Fail fast if already cancelled; ctx also propagates into the exec below so a
+	// wedged sherpa-onnx-offline is killed on cancel/timeout rather than hanging.
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	out, err := l.cfg.runOutput(ctx, l.cfg.Binary, args...)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", &SetupError{
+				Tool: l.cfg.Binary,
+				Hint: "install sherpa-onnx and put its offline binary on PATH (see docs/dictation.md)",
+			}
+		}
+		return "", fmt.Errorf("sherpa-onnx transcription failed: %w (%s)", err, lastLines(out, 3))
+	}
+	text := parseSherpaOutput(out)
+	if text == "" {
+		return "", fmt.Errorf("sherpa-onnx produced no transcript (output: %s)", lastLines(out, 3))
+	}
+	return text, nil
+}
+
+// detectModelArgs inspects a sherpa-onnx model directory and builds the
+// family-specific --*=path flags. Supports the families sherpa-onnx-offline
+// accepts; Moonshine (the design's default/standard/high-end tiers) is the
+// primary target. tokens.txt is required by every family.
+func detectModelArgs(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, &SetupError{
+			Tool: "local STT model",
+			Hint: fmt.Sprintf("stt.localModelPath %q is not readable: %v", dir, err),
+		}
+	}
+	files := map[string]string{} // lowercased basename -> absolute path
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		files[strings.ToLower(e.Name())] = filepath.Join(dir, e.Name())
+	}
+
+	tokens := findTokensFile(files)
+	if tokens == "" {
+		return nil, &SetupError{
+			Tool: "local STT model",
+			Hint: fmt.Sprintf("no tokens.txt found in stt.localModelPath %q — is it a sherpa-onnx model directory?", dir),
+		}
+	}
+
+	dirName := strings.ToLower(filepath.Base(dir))
+
+	// Order matters — check the most specific signatures first so a model is
+	// never mis-classified as a family it only partially resembles.
+
+	// Moonshine: preprocessor + encoder + cached/uncached decoders. Its files are
+	// "encode"/"decode" (no trailing "r"), so they never collide with the
+	// "encoder"/"decoder" families below.
+	if pre := findContains(files, "preprocess"); pre != "" {
+		enc := findContains(files, "encode")
+		// "uncached_decode" CONTAINS "cached_decode", so match the cached decoder
+		// as "cached" AND not "uncached" to disambiguate (map order is random).
+		unc := findOnnxMatching(files, "uncached", "")
+		cac := findOnnxMatching(files, "cached", "uncached")
+		if enc != "" && unc != "" && cac != "" {
+			return []string{
+				"--moonshine-preprocessor=" + pre,
+				"--moonshine-encoder=" + enc,
+				"--moonshine-uncached-decoder=" + unc,
+				"--moonshine-cached-decoder=" + cac,
+				"--tokens=" + tokens,
+			}, nil
+		}
+	}
+
+	// Transducer (Zipformer/Conformer): encoder + decoder + joiner, matched as a
+	// consistent int8-or-fp32 set (mixing quantizations is invalid).
+	if set := consistentQuantizedSet(files, "encoder", "decoder", "joiner"); set != nil {
+		return []string{"--encoder=" + set[0], "--decoder=" + set[1], "--joiner=" + set[2], "--tokens=" + tokens}, nil
+	}
+
+	// Encoder+decoder families that share Whisper's file shape (encoder + decoder,
+	// no joiner) but need their own flags — FireRedASR-AED, Canary, Cohere. They are
+	// indistinguishable from Whisper by files alone, so disambiguate by name FIRST;
+	// anything unnamed falls through to the Whisper default below.
+	for _, fam := range encoderDecoderFamilies {
+		if nameMatchesFamily(dirName, files, fam.match) {
+			if set := consistentQuantizedSet(files, "encoder", "decoder"); set != nil {
+				return []string{fam.encoderFlag + "=" + set[0], fam.decoderFlag + "=" + set[1], "--tokens=" + tokens}, nil
+			}
+		}
+	}
+
+	// Whisper: encoder + decoder, NO joiner. Sherpa's Whisper files are named
+	// "<model>-encoder.onnx" / "<model>-decoder.onnx" (NOT "whisper-encoder"), so
+	// match on the encoder/decoder roles — a consistent pair — after transducer
+	// (which owns the encoder/decoder/joiner shape) has already been ruled out.
+	if set := consistentQuantizedSet(files, "encoder", "decoder"); set != nil {
+		return []string{"--whisper-encoder=" + set[0], "--whisper-decoder=" + set[1], "--tokens=" + tokens}, nil
+	}
+
+	// Single-model families: one generic model .onnx + tokens, indistinguishable by
+	// file shape, so they are told apart by the model directory/file name. This
+	// covers SenseVoice, Paraformer, and the CTC families (FireRedASR-CTC, NeMo,
+	// TeleSpeech, WeNet, Zipformer-CTC, Dolphin, Omnilingual). Ordered most-specific
+	// first so a compound name (e.g. "fire-red-asr2-ctc") matches its own family
+	// before a generic token in it (e.g. bare "ctc") could steer it elsewhere.
+	if m := singleModelOnnx(files); m != "" {
+		for _, fam := range singleModelFamilies {
+			if nameMatchesFamily(dirName, files, fam.match) {
+				return []string{fam.flag + "=" + m, "--tokens=" + tokens}, nil
+			}
+		}
+	}
+
+	return nil, &SetupError{
+		Tool: "local STT model",
+		Hint: fmt.Sprintf("could not recognize the model family in %q (supported: Moonshine, Whisper, transducer/Zipformer, Paraformer, SenseVoice, and the CTC families FireRedASR/NeMo/TeleSpeech/WeNet/Zipformer-CTC/Dolphin/Omnilingual). See docs/dictation.md", dir),
+	}
+}
+
+// singleModelFamilies maps a model's directory/file-name signature to the
+// sherpa-onnx-offline flag for that single-file family. Each family ships exactly
+// one generic model .onnx (+ tokens), so only the name tells them apart. Ordered
+// so a specific compound name wins before a broader one.
+var singleModelFamilies = []struct {
+	match []string // name substrings (any hit); most-specific spellings first
+	flag  string
+}{
+	{[]string{"fire-red-asr2-ctc", "fire-red-asr-ctc", "fire-red-asr", "firered"}, "--fire-red-asr-ctc"},
+	{[]string{"nemo-ctc", "nemo_ctc"}, "--nemo-ctc-model"},
+	{[]string{"zipformer2-ctc", "zipformer-ctc"}, "--zipformer-ctc-model"},
+	{[]string{"telespeech"}, "--telespeech-ctc"},
+	{[]string{"wenet"}, "--wenet-ctc-model"},
+	{[]string{"dolphin"}, "--dolphin-model"},
+	{[]string{"omnilingual"}, "--omnilingual-asr-model"},
+	{[]string{"medasr"}, "--medasr"},
+	{[]string{"tdnn"}, "--tdnn-model"},
+	{[]string{"sense-voice", "sensevoice"}, "--sense-voice-model"},
+	{[]string{"paraformer"}, "--paraformer"},
+}
+
+// encoderDecoderFamilies are offline families shaped like Whisper (an encoder +
+// decoder .onnx, no joiner) but needing their own flags; matched by name before
+// the Whisper fallback claims the shape.
+var encoderDecoderFamilies = []struct {
+	match       []string
+	encoderFlag string
+	decoderFlag string
+}{
+	{[]string{"fire-red-asr"}, "--fire-red-asr-encoder", "--fire-red-asr-decoder"},
+	{[]string{"canary"}, "--canary-encoder", "--canary-decoder"},
+	{[]string{"cohere"}, "--cohere-transcribe-encoder", "--cohere-transcribe-decoder"},
+}
+
+// nameMatchesFamily reports whether the model directory name or any of its .onnx
+// filenames contain one of the family's signature substrings.
+func nameMatchesFamily(dirName string, files map[string]string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(dirName, sub) {
+			return true
+		}
+		for name := range files {
+			if strings.HasSuffix(name, ".onnx") && strings.Contains(name, sub) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// consistentQuantizedSet returns one file per role (in order), preferring an
+// int8 build of each but falling back to fp32 when a role has no int8 file.
+// Returns nil when any role is entirely missing.
+//
+// Models legitimately SHIP mixed quantization — e.g. the x-asr streaming
+// zipformers ship an int8 encoder and joiner with an fp32 decoder — and
+// sherpa-onnx accepts that. So this must NOT require every role to share one
+// quantization; it just needs one file per role, favoring the smaller int8 when
+// a choice exists. (When a model ships both int8 and fp32 for every role, this
+// still picks all-int8, since int8 is available for each.)
+func consistentQuantizedSet(files map[string]string, roles ...string) []string {
+	pick := func(role string, int8Only bool) string {
+		for name, path := range files {
+			if !strings.HasSuffix(name, ".onnx") || !strings.Contains(name, role) {
+				continue
+			}
+			if int8Only && !strings.Contains(name, "int8") {
+				continue
+			}
+			return path
+		}
+		return ""
+	}
+	out := make([]string, len(roles))
+	for i, role := range roles {
+		p := pick(role, true) // prefer int8 (smaller, faster)
+		if p == "" {
+			p = pick(role, false) // fall back to fp32 for this role
+		}
+		if p == "" {
+			return nil // this role is genuinely absent
+		}
+		out[i] = p
+	}
+	return out
+}
+
+// findTokensFile returns the model's tokens file. It is usually "tokens.txt",
+// but some families (e.g. Whisper) prefix it as "<model>-tokens.txt".
+func findTokensFile(files map[string]string) string {
+	if p := files["tokens.txt"]; p != "" {
+		return p
+	}
+	for name, path := range files {
+		if strings.HasSuffix(name, "tokens.txt") {
+			return path
+		}
+	}
+	return ""
+}
+
+// singleModelOnnx returns the model's single .onnx file (preferring an int8
+// build), for families like SenseVoice/Paraformer that ship exactly one.
+func singleModelOnnx(files map[string]string) string {
+	best := ""
+	for name, path := range files {
+		if !strings.HasSuffix(name, ".onnx") {
+			continue
+		}
+		if strings.Contains(name, "int8") {
+			return path
+		}
+		best = path
+	}
+	return best
+}
+
+// findOnnxMatching returns an .onnx file whose name contains `must` and, when
+// `exclude` is non-empty, does NOT contain `exclude` — used to tell the cached
+// from the uncached Moonshine decoder.
+func findOnnxMatching(files map[string]string, must, exclude string) string {
+	for name, path := range files {
+		if !strings.HasSuffix(name, ".onnx") || !strings.Contains(name, must) {
+			continue
+		}
+		if exclude != "" && strings.Contains(name, exclude) {
+			continue
+		}
+		return path
+	}
+	return ""
+}
+
+func findContains(files map[string]string, substr string) string {
+	for name, path := range files {
+		if strings.HasSuffix(name, ".onnx") && strings.Contains(name, substr) {
+			return path
+		}
+	}
+	return ""
+}
+
+// parseSherpaOutput extracts the transcript from sherpa-onnx-offline's output.
+// The binary prints a JSON object with a "text" field (amid diagnostic lines);
+// scan for the first line that parses as such.
+func parseSherpaOutput(out []byte) string {
+	for _, line := range bytes.Split(out, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 || trimmed[0] != '{' {
+			continue
+		}
+		var parsed struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(trimmed, &parsed); err == nil && strings.TrimSpace(parsed.Text) != "" {
+			return strings.TrimSpace(parsed.Text)
+		}
+	}
+	return ""
+}
+
+func lastLines(out []byte, n int) string {
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, " | ")
+}
+
+// StreamTranscribe is unsupported for the offline binary; local streaming uses
+// the sherpa-onnx websocket server transcriber instead.
+func (l *localTranscriber) StreamTranscribe(context.Context, <-chan []byte, func(string, bool)) (string, error) {
+	return "", ErrStreamingUnsupported
+}

--- a/internal/dictation/transcriber_local_stream.go
+++ b/internal/dictation/transcriber_local_stream.go
@@ -1,0 +1,166 @@
+package dictation
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// localStreamingTranscriber streams audio to the warm sherpa-onnx websocket
+// server (§6a). The server keeps encoder state across chunks (a true streaming
+// transducer), so partials arrive as decoding proceeds — no redundant
+// re-inference.
+//
+// Wire protocol (verified against sherpa-onnx's reference client, NOT the
+// plan's "16-bit PCM" description, which was imprecise): the client sends
+// binary frames of little-endian float32 samples normalized to [-1, 1]
+// (int16/32768), then the text "Done" to end; the server replies with JSON
+// result messages and finally the text "Done!" to signal completion.
+type localStreamingTranscriber struct {
+	manager *ServerManager
+}
+
+// NewLocalStreamingTranscriber builds a streaming transcriber backed by the
+// shared, session-long sherpa-onnx server manager.
+func NewLocalStreamingTranscriber(manager *ServerManager) Transcriber {
+	return &localStreamingTranscriber{manager: manager}
+}
+
+// Transcribe is not this transcriber's job — the streaming path uses
+// StreamTranscribe; the batch/Termux fallback uses the offline transcriber.
+func (l *localStreamingTranscriber) Transcribe(context.Context, []byte) (string, error) {
+	return "", errors.New("local streaming transcriber does not support batch transcription")
+}
+
+func (l *localStreamingTranscriber) StreamTranscribe(ctx context.Context, chunks <-chan []byte, onPartial func(string, bool)) (string, error) {
+	url, err := l.manager.EnsureRunning(ctx)
+	if err != nil {
+		return "", err
+	}
+	conn, err := dialWithOneRestart(ctx, l.manager, url)
+	if err != nil {
+		return "", fmt.Errorf("connecting to sherpa-onnx server: %w", err)
+	}
+	defer conn.CloseNow()
+
+	// Writer goroutine: forward converted chunks, then signal end. A write error
+	// (server crashed) cancels the read side via writeErr.
+	writeErrCh := make(chan error, 1)
+	go func() {
+		for chunk := range chunks {
+			if err := conn.Write(ctx, websocket.MessageBinary, pcm16ToFloat32LE(chunk)); err != nil {
+				writeErrCh <- err
+				return
+			}
+		}
+		writeErrCh <- conn.Write(ctx, websocket.MessageText, []byte("Done"))
+	}()
+
+	// The server reports "text" PER SEGMENT, not cumulatively for the whole
+	// utterance: when it detects an endpoint (a pause between phrases, or the
+	// trailing silence when recording stops) it finalizes the current segment, bumps
+	// "segment", and resets "text" to "" for the next one. So we accumulate the text
+	// of every segment — otherwise a new segment's (often empty) result would
+	// overwrite everything already transcribed, and the transcript would vanish on
+	// stop. Displayed/returned text is all segments joined in order.
+	var segmentTexts []string
+	joinSegments := func() string {
+		parts := make([]string, 0, len(segmentTexts))
+		for _, s := range segmentTexts {
+			if t := strings.TrimSpace(s); t != "" {
+				parts = append(parts, t)
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+	lastText := ""
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			// Mid-stream failure: return the best-effort text accumulated so far
+			// plus the error — already-streamed partials are never discarded (§6).
+			select {
+			case werr := <-writeErrCh:
+				if werr != nil {
+					err = werr
+				}
+			default:
+			}
+			return lastText, fmt.Errorf("sherpa-onnx stream error: %w", err)
+		}
+		if typ == websocket.MessageText && strings.TrimSpace(string(data)) == "Done!" {
+			break
+		}
+		text, segment, final, ok := parseSherpaStreamResult(data)
+		if !ok {
+			continue
+		}
+		if segment < 0 {
+			segment = 0
+		}
+		for len(segmentTexts) <= segment {
+			segmentTexts = append(segmentTexts, "")
+		}
+		segmentTexts[segment] = text
+		lastText = joinSegments()
+		if onPartial != nil {
+			onPartial(lastText, final)
+		}
+	}
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+	return lastText, nil
+}
+
+// dialWithOneRestart dials the server, and on failure restarts it once and
+// retries — mirroring the LSP manager's single crashed-server recovery (§6/§6a).
+func dialWithOneRestart(ctx context.Context, manager *ServerManager, url string) (*websocket.Conn, error) {
+	conn, _, err := websocket.Dial(ctx, url, nil)
+	if err == nil {
+		return conn, nil
+	}
+	// The warm server may have died between EnsureRunning and Dial; reap and
+	// restart once.
+	_ = manager.Shutdown(ctx)
+	url, rerr := manager.EnsureRunning(ctx)
+	if rerr != nil {
+		return nil, rerr
+	}
+	conn, _, err = websocket.Dial(ctx, url, nil)
+	return conn, err
+}
+
+// parseSherpaStreamResult extracts one server JSON result. "text" is the
+// hypothesis for the CURRENT segment (segment index in "segment"), which resets
+// each time the recognizer endpoints — so the caller must accumulate per segment,
+// not treat "text" as the whole-utterance transcript. "is_final" marks a settled
+// segment.
+func parseSherpaStreamResult(data []byte) (text string, segment int, final bool, ok bool) {
+	var parsed struct {
+		Text    string `json:"text"`
+		Segment int    `json:"segment"`
+		IsFinal bool   `json:"is_final"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", 0, false, false
+	}
+	return strings.TrimSpace(parsed.Text), parsed.Segment, parsed.IsFinal, true
+}
+
+// pcm16ToFloat32LE converts a little-endian int16 PCM chunk to the little-endian
+// float32 samples (normalized to [-1, 1]) the sherpa-onnx server expects.
+func pcm16ToFloat32LE(pcm []byte) []byte {
+	n := len(pcm) / 2
+	out := make([]byte, n*4)
+	for i := 0; i < n; i++ {
+		s := int16(uint16(pcm[2*i]) | uint16(pcm[2*i+1])<<8)
+		bits := math.Float32bits(float32(s) / 32768.0)
+		binary.LittleEndian.PutUint32(out[4*i:], bits)
+	}
+	return out
+}

--- a/internal/dictation/transcriber_local_test.go
+++ b/internal/dictation/transcriber_local_test.go
@@ -1,0 +1,269 @@
+package dictation
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeModelDir(t *testing.T, files ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestLocalTranscribeMoonshineArgs(t *testing.T) {
+	dir := writeModelDir(t,
+		"preprocess.onnx", "encode.onnx", "uncached_decode.onnx", "cached_decode.onnx", "tokens.txt")
+	var gotBin string
+	var gotArgs []string
+	runOutput := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotBin, gotArgs = name, args
+		return []byte("Started\nDone!\n\n/tmp/a.wav\n{\"text\":\" transcribed speech \"}\n----"), nil
+	}
+	tr, err := NewLocalTranscriber(LocalConfig{ModelPath: dir, runOutput: runOutput, tempDir: func() (string, error) { return t.TempDir(), nil }})
+	if err != nil {
+		t.Fatalf("NewLocalTranscriber: %v", err)
+	}
+	text, err := tr.Transcribe(context.Background(), wavFixture())
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if text != "transcribed speech" {
+		t.Errorf("text = %q", text)
+	}
+	if gotBin != "sherpa-onnx-offline" {
+		t.Errorf("binary = %q", gotBin)
+	}
+	joined := strings.Join(gotArgs, " ")
+	for _, want := range []string{"--moonshine-preprocessor=", "--moonshine-encoder=", "--moonshine-uncached-decoder=", "--moonshine-cached-decoder=", "--tokens="} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("missing flag %q in %q", want, joined)
+		}
+	}
+}
+
+func TestLocalTranscribeTransducerArgs(t *testing.T) {
+	dir := writeModelDir(t, "encoder-epoch-99.onnx", "decoder-epoch-99.onnx", "joiner-epoch-99.onnx", "tokens.txt")
+	var gotArgs []string
+	runOutput := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`{"text":"hi"}`), nil
+	}
+	tr, _ := NewLocalTranscriber(LocalConfig{ModelPath: dir, runOutput: runOutput, tempDir: func() (string, error) { return t.TempDir(), nil }})
+	if _, err := tr.Transcribe(context.Background(), wavFixture()); err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	joined := strings.Join(gotArgs, " ")
+	for _, want := range []string{"--encoder=", "--decoder=", "--joiner=", "--tokens="} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("missing flag %q in %q", want, joined)
+		}
+	}
+}
+
+func TestDetectWhisperArgs(t *testing.T) {
+	// Sherpa Whisper models are named "<model>-encoder.onnx" (NOT "whisper-encoder")
+	// and prefix the tokens file as "<model>-tokens.txt".
+	dir := writeModelDir(t, "tiny.en-encoder.onnx", "tiny.en-encoder.int8.onnx",
+		"tiny.en-decoder.onnx", "tiny.en-decoder.int8.onnx", "tiny.en-tokens.txt")
+	args, err := detectModelArgs(dir)
+	if err != nil {
+		t.Fatalf("Whisper detection failed: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--whisper-encoder=") || !strings.Contains(joined, "--whisper-decoder=") {
+		t.Errorf("expected whisper flags, got %q", joined)
+	}
+	// Must not emit transducer flags (Whisper has no joiner).
+	if strings.Contains(joined, "--joiner=") || strings.Contains(joined, "--encoder=") {
+		t.Errorf("Whisper must not be detected as a transducer: %q", joined)
+	}
+	// Consistent quantization: both int8 (preferred) or both fp32, never mixed.
+	if strings.Contains(joined, "encoder.int8.onnx") != strings.Contains(joined, "decoder.int8.onnx") {
+		t.Errorf("mixed encoder/decoder quantization: %q", joined)
+	}
+}
+
+func TestDetectTransducerPrefersConsistentInt8(t *testing.T) {
+	dir := writeModelDir(t,
+		"encoder-epoch-99.onnx", "encoder-epoch-99.int8.onnx",
+		"decoder-epoch-99.onnx", "decoder-epoch-99.int8.onnx",
+		"joiner-epoch-99.onnx", "joiner-epoch-99.int8.onnx", "tokens.txt")
+	args, err := detectModelArgs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	// All three int8 (preferred), consistently.
+	for _, want := range []string{"--encoder=", "encoder-epoch-99.int8.onnx", "joiner-epoch-99.int8.onnx"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("missing %q in %q", want, joined)
+		}
+	}
+}
+
+func TestDetectTransducerMixedQuantization(t *testing.T) {
+	// Some models ship an int8 encoder+joiner with an fp32 decoder (e.g. the
+	// x-asr streaming zipformers). Detection must accept that mix, not reject it.
+	dir := writeModelDir(t, "encoder.int8.onnx", "decoder.onnx", "joiner.int8.onnx", "tokens.txt")
+	args, err := detectModelArgs(dir)
+	if err != nil {
+		t.Fatalf("mixed-quantization transducer should be detected, got %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "encoder.int8.onnx") || !strings.Contains(joined, "decoder.onnx") || !strings.Contains(joined, "joiner.int8.onnx") {
+		t.Errorf("expected the actual mixed files, got %q", joined)
+	}
+	// The fp32 decoder must not be mistaken for an int8 one.
+	if strings.Contains(joined, "decoder.int8") {
+		t.Errorf("no int8 decoder exists; should use decoder.onnx: %q", joined)
+	}
+}
+
+func TestDetectSenseVoiceByDirName(t *testing.T) {
+	dir := t.TempDir() // rename won't help; use a dir whose base contains sense-voice
+	sv := dir + "/sherpa-onnx-sense-voice-zh-en"
+	if err := os.MkdirAll(sv, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"model.int8.onnx", "tokens.txt"} {
+		os.WriteFile(sv+"/"+f, []byte("x"), 0o600)
+	}
+	args, err := detectModelArgs(sv)
+	if err != nil {
+		t.Fatalf("SenseVoice detection failed: %v", err)
+	}
+	if !strings.Contains(strings.Join(args, " "), "--sense-voice-model=") {
+		t.Errorf("expected sense-voice flag, got %v", args)
+	}
+}
+
+// writeNamedModelDir creates a model directory whose base name carries the family
+// signature (how sherpa-onnx distributes single-file / CTC models), with the given
+// files, and returns its path.
+func writeNamedModelDir(t *testing.T, base string, files ...string) string {
+	t.Helper()
+	dir := t.TempDir() + "/" + base
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		if err := os.WriteFile(dir+"/"+f, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestDetectSingleFileCTCFamilies(t *testing.T) {
+	// One generic model.onnx + tokens, family told apart by the directory name.
+	cases := []struct{ base, wantFlag string }{
+		{"sherpa-onnx-fire-red-asr2-ctc-zh_en-int8-2026-02-25", "--fire-red-asr-ctc="},
+		{"sherpa-onnx-nemo-ctc-en-conformer-medium", "--nemo-ctc-model="},
+		{"sherpa-onnx-zipformer-ctc-zh-2024", "--zipformer-ctc-model="},
+		{"sherpa-onnx-telespeech-ctc-int8", "--telespeech-ctc="},
+		{"sherpa-onnx-wenet-ctc-en", "--wenet-ctc-model="},
+		{"sherpa-onnx-dolphin-base-ctc-multi-lang", "--dolphin-model="},
+		{"sherpa-onnx-omnilingual-asr-ctc", "--omnilingual-asr-model="},
+		{"sherpa-onnx-tdnn-yesno", "--tdnn-model="},
+	}
+	for _, tc := range cases {
+		dir := writeNamedModelDir(t, tc.base, "model.int8.onnx", "tokens.txt")
+		args, err := detectModelArgs(dir)
+		if err != nil {
+			t.Errorf("%s: detection failed: %v", tc.base, err)
+			continue
+		}
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, tc.wantFlag) || !strings.Contains(joined, "--tokens=") {
+			t.Errorf("%s: got %q, want %s", tc.base, joined, tc.wantFlag)
+		}
+	}
+}
+
+func TestDetectEncoderDecoderFamiliesBeforeWhisper(t *testing.T) {
+	// FireRedASR-AED / Canary share Whisper's encoder+decoder shape, so they must be
+	// disambiguated by name — not fall through to --whisper-encoder.
+	cases := []struct{ base, wantFlag string }{
+		{"sherpa-onnx-fire-red-asr-large-zh_en", "--fire-red-asr-encoder="},
+		{"sherpa-onnx-canary-180m-flash", "--canary-encoder="},
+	}
+	for _, tc := range cases {
+		dir := writeNamedModelDir(t, tc.base, "encoder.int8.onnx", "decoder.int8.onnx", "tokens.txt")
+		args, err := detectModelArgs(dir)
+		if err != nil {
+			t.Errorf("%s: detection failed: %v", tc.base, err)
+			continue
+		}
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, tc.wantFlag) {
+			t.Errorf("%s: got %q, want %s", tc.base, joined, tc.wantFlag)
+		}
+		if strings.Contains(joined, "--whisper-") {
+			t.Errorf("%s must not be detected as Whisper: %q", tc.base, joined)
+		}
+	}
+}
+
+func TestDetectUnknownFamilyFailsCleanly(t *testing.T) {
+	// A model with tokens but no recognizable family → a clear SetupError, not a
+	// crash or wrong flags.
+	dir := writeModelDir(t, "some-random-model.onnx", "tokens.txt")
+	_, err := detectModelArgs(dir)
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want a clean *SetupError, got %v", err)
+	}
+	if !strings.Contains(setupErr.Error(), "could not recognize") {
+		t.Errorf("expected a recognizable failure message, got %q", setupErr.Error())
+	}
+}
+
+func TestLocalTranscribeMissingTokens(t *testing.T) {
+	dir := writeModelDir(t, "encoder.onnx", "decoder.onnx", "joiner.onnx") // no tokens.txt
+	tr, _ := NewLocalTranscriber(LocalConfig{ModelPath: dir, runOutput: func(context.Context, string, ...string) ([]byte, error) { return nil, nil }, tempDir: func() (string, error) { return t.TempDir(), nil }})
+	_, err := tr.Transcribe(context.Background(), wavFixture())
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError for missing tokens, got %v", err)
+	}
+}
+
+func TestLocalTranscribeMissingBinary(t *testing.T) {
+	dir := writeModelDir(t, "preprocess.onnx", "encode.onnx", "uncached_decode.onnx", "cached_decode.onnx", "tokens.txt")
+	runOutput := func(context.Context, string, ...string) ([]byte, error) { return nil, exec.ErrNotFound }
+	tr, _ := NewLocalTranscriber(LocalConfig{ModelPath: dir, runOutput: runOutput, tempDir: func() (string, error) { return t.TempDir(), nil }})
+	_, err := tr.Transcribe(context.Background(), wavFixture())
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError for missing binary, got %v", err)
+	}
+}
+
+func TestParseSherpaOutput(t *testing.T) {
+	out := []byte("Started\nDone!\n\naudio.wav\n{\"lang\":\"\",\"text\":\" the quick brown fox \",\"tokens\":[]}\n----\nnum threads: 2")
+	if got := parseSherpaOutput(out); got != "the quick brown fox" {
+		t.Errorf("parsed %q", got)
+	}
+	if got := parseSherpaOutput([]byte("no json here")); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestNewLocalTranscriberRequiresModelPath(t *testing.T) {
+	_, err := NewLocalTranscriber(LocalConfig{})
+	var setupErr *SetupError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("want *SetupError, got %v", err)
+	}
+}

--- a/internal/dictation/transcriber_openai_realtime.go
+++ b/internal/dictation/transcriber_openai_realtime.go
@@ -1,0 +1,210 @@
+package dictation
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// OpenAI Realtime transcription-only wants 24kHz PCM16 (§6b); the recorder is
+// built to match via the SampleRate hint.
+const openAIRealtimeSampleRate = 24000
+
+// OpenAIRealtimeConfig configures the OpenAI Realtime transcription transcriber
+// (§6b, the credential-reuse streaming alternative). Reuses the OpenAI key.
+type OpenAIRealtimeConfig struct {
+	APIKey string
+	Model  string // default "gpt-4o-transcribe"
+	// BaseURL overrides the wss endpoint (tests point it at a fake server).
+	BaseURL string
+}
+
+type openAIRealtimeTranscriber struct {
+	cfg OpenAIRealtimeConfig
+}
+
+// NewOpenAIRealtimeTranscriber builds the OpenAI Realtime streaming transcriber.
+func NewOpenAIRealtimeTranscriber(cfg OpenAIRealtimeConfig) (Transcriber, error) {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, &SetupError{
+			Tool: "OpenAI API key",
+			Hint: "set an OpenAI API key (OPENAI_API_KEY, or `zero auth`) to use OpenAI Realtime streaming dictation",
+		}
+	}
+	if cfg.Model == "" {
+		cfg.Model = "gpt-4o-transcribe"
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "wss://api.openai.com/v1/realtime?intent=transcription"
+	}
+	return &openAIRealtimeTranscriber{cfg: cfg}, nil
+}
+
+func (o *openAIRealtimeTranscriber) Transcribe(context.Context, []byte) (string, error) {
+	return "", ErrStreamingUnsupported
+}
+
+func (o *openAIRealtimeTranscriber) SampleRate() int { return openAIRealtimeSampleRate }
+
+func (o *openAIRealtimeTranscriber) StreamTranscribe(ctx context.Context, chunks <-chan []byte, onPartial func(string, bool)) (string, error) {
+	conn, _, err := websocket.Dial(ctx, o.cfg.BaseURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Authorization": {"Bearer " + o.cfg.APIKey},
+			"OpenAI-Beta":   {"realtime=v1"},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("connecting to OpenAI Realtime: %w", err)
+	}
+	defer conn.CloseNow()
+
+	// Configure a transcription-only session (pcm16 in, gpt-4o-transcribe).
+	sessionUpdate := map[string]any{
+		"type": "transcription_session.update",
+		"session": map[string]any{
+			"input_audio_format": "pcm16",
+			"input_audio_transcription": map[string]any{
+				"model": o.cfg.Model,
+			},
+		},
+	}
+	if err := writeJSON(ctx, conn, sessionUpdate); err != nil {
+		return "", fmt.Errorf("configuring OpenAI Realtime session: %w", err)
+	}
+
+	writeErrCh := make(chan error, 1)
+	go func() {
+		for chunk := range chunks {
+			appendMsg := map[string]any{
+				"type":  "input_audio_buffer.append",
+				"audio": base64.StdEncoding.EncodeToString(chunk),
+			}
+			if err := writeJSON(ctx, conn, appendMsg); err != nil {
+				writeErrCh <- err
+				return
+			}
+		}
+		// Commit the buffered audio to force final transcription of the utterance.
+		writeErrCh <- writeJSON(ctx, conn, map[string]any{"type": "input_audio_buffer.commit"})
+	}()
+
+	// OpenAI deltas are incremental (append), unlike Deepgram/sherpa's cumulative
+	// text. Accumulate completed segments plus the in-progress delta buffer.
+	var finalized, current strings.Builder
+	compose := func() string {
+		return strings.TrimSpace(finalized.String() + current.String())
+	}
+	committed := false
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
+				return compose(), nil
+			}
+			select {
+			case werr := <-writeErrCh:
+				if werr != nil {
+					err = werr
+				}
+			default:
+			}
+			return compose(), fmt.Errorf("OpenAI Realtime stream error: %w", err)
+		}
+		if typ != websocket.MessageText {
+			continue
+		}
+		evt := parseRealtimeEvent(data)
+		switch evt.kind {
+		case realtimeDelta:
+			current.WriteString(evt.text)
+			if onPartial != nil {
+				onPartial(compose(), false)
+			}
+		case realtimeCompleted:
+			// A completed item replaces the in-progress delta buffer with the
+			// server's authoritative transcript for that segment.
+			if evt.text != "" {
+				if finalized.Len() > 0 {
+					finalized.WriteString(" ")
+				}
+				finalized.WriteString(strings.TrimSpace(evt.text))
+			}
+			current.Reset()
+			if onPartial != nil {
+				onPartial(compose(), true)
+			}
+			// Once we've committed the buffer (user stopped) and the server has
+			// returned a completed transcription, the utterance is done.
+			if committed {
+				_ = conn.Close(websocket.StatusNormalClosure, "")
+				return compose(), nil
+			}
+		case realtimeCommitted:
+			committed = true
+		case realtimeError:
+			return compose(), fmt.Errorf("OpenAI Realtime error: %s", evt.text)
+		}
+		// The writer signals commit completion out of band; observe it so a
+		// stop with no further audio still flips `committed`.
+		select {
+		case werr := <-writeErrCh:
+			if werr == nil {
+				committed = true
+			}
+		default:
+		}
+	}
+}
+
+type realtimeEventKind int
+
+const (
+	realtimeOther realtimeEventKind = iota
+	realtimeDelta
+	realtimeCompleted
+	realtimeCommitted
+	realtimeError
+)
+
+type realtimeEvent struct {
+	kind realtimeEventKind
+	text string
+}
+
+func parseRealtimeEvent(data []byte) realtimeEvent {
+	var msg struct {
+		Type       string `json:"type"`
+		Delta      string `json:"delta"`
+		Transcript string `json:"transcript"`
+		Error      struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return realtimeEvent{kind: realtimeOther}
+	}
+	switch msg.Type {
+	case "conversation.item.input_audio_transcription.delta":
+		return realtimeEvent{kind: realtimeDelta, text: msg.Delta}
+	case "conversation.item.input_audio_transcription.completed":
+		return realtimeEvent{kind: realtimeCompleted, text: msg.Transcript}
+	case "input_audio_buffer.committed":
+		return realtimeEvent{kind: realtimeCommitted}
+	case "error":
+		return realtimeEvent{kind: realtimeError, text: msg.Error.Message}
+	}
+	return realtimeEvent{kind: realtimeOther}
+}
+
+func writeJSON(ctx context.Context, conn *websocket.Conn, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return conn.Write(ctx, websocket.MessageText, data)
+}

--- a/internal/dictation/transcriber_stream_test.go
+++ b/internal/dictation/transcriber_stream_test.go
@@ -1,0 +1,231 @@
+package dictation
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// wsTestServer runs handler over a real localhost websocket, returning a wss->ws
+// base URL the transcribers can dial. Exercising the real coder/websocket client
+// against a real server is the closest unit test to the wire protocol.
+func wsTestServer(t *testing.T, handler func(ctx context.Context, c *websocket.Conn)) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		handler(r.Context(), c)
+	}))
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+func TestDeepgramStreamTranscribe(t *testing.T) {
+	var gotAuth string
+	url := wsTestServer(t, func(ctx context.Context, c *websocket.Conn) {
+		defer c.Close(websocket.StatusNormalClosure, "")
+		// Read audio frames until CloseStream, then emit interim + final results.
+		for {
+			typ, data, err := c.Read(ctx)
+			if err != nil {
+				return
+			}
+			if typ == websocket.MessageText && strings.Contains(string(data), "CloseStream") {
+				break
+			}
+		}
+		_ = c.Write(ctx, websocket.MessageText, []byte(`{"type":"Results","is_final":false,"channel":{"alternatives":[{"transcript":"hello"}]}}`))
+		_ = c.Write(ctx, websocket.MessageText, []byte(`{"type":"Results","is_final":true,"channel":{"alternatives":[{"transcript":"hello world"}]}}`))
+	})
+
+	tr, err := NewDeepgramTranscriber(DeepgramConfig{APIKey: "dg-key", BaseURL: url})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = gotAuth
+
+	var partials []string
+	chunks := make(chan []byte, 2)
+	chunks <- make([]byte, 320)
+	close(chunks)
+	final, err := tr.StreamTranscribe(context.Background(), chunks, func(text string, _ bool) {
+		partials = append(partials, text)
+	})
+	if err != nil {
+		t.Fatalf("StreamTranscribe: %v", err)
+	}
+	if final != "hello world" {
+		t.Errorf("final = %q, want 'hello world'", final)
+	}
+	if len(partials) == 0 || partials[0] != "hello" {
+		t.Errorf("expected an interim 'hello' partial, got %v", partials)
+	}
+}
+
+func TestDeepgramSampleRateDefault(t *testing.T) {
+	tr, _ := NewDeepgramTranscriber(DeepgramConfig{APIKey: "k"})
+	if RequiredSampleRate(tr) != DefaultSampleRate {
+		t.Errorf("Deepgram sample rate = %d, want %d", RequiredSampleRate(tr), DefaultSampleRate)
+	}
+}
+
+func TestDeepgramMissingKey(t *testing.T) {
+	if _, err := NewDeepgramTranscriber(DeepgramConfig{}); err == nil {
+		t.Fatal("expected setup error for missing key")
+	}
+}
+
+func TestOpenAIRealtimeStreamTranscribe(t *testing.T) {
+	url := wsTestServer(t, func(ctx context.Context, c *websocket.Conn) {
+		defer c.Close(websocket.StatusNormalClosure, "")
+		committed := false
+		for {
+			typ, data, err := c.Read(ctx)
+			if err != nil {
+				return
+			}
+			if typ != websocket.MessageText {
+				continue
+			}
+			var msg struct {
+				Type string `json:"type"`
+			}
+			_ = json.Unmarshal(data, &msg)
+			switch msg.Type {
+			case "transcription_session.update":
+				// Emit incremental deltas as if audio were flowing.
+				_ = c.Write(ctx, websocket.MessageText, []byte(`{"type":"conversation.item.input_audio_transcription.delta","delta":"the "}`))
+				_ = c.Write(ctx, websocket.MessageText, []byte(`{"type":"conversation.item.input_audio_transcription.delta","delta":"answer"}`))
+			case "input_audio_buffer.commit":
+				committed = true
+				_ = c.Write(ctx, websocket.MessageText, []byte(`{"type":"input_audio_buffer.committed"}`))
+				_ = c.Write(ctx, websocket.MessageText, []byte(`{"type":"conversation.item.input_audio_transcription.completed","transcript":"the answer"}`))
+			}
+			_ = committed
+		}
+	})
+
+	tr, err := NewOpenAIRealtimeTranscriber(OpenAIRealtimeConfig{APIKey: "sk-key", BaseURL: url})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if RequiredSampleRate(tr) != openAIRealtimeSampleRate {
+		t.Errorf("OpenAI Realtime sample rate = %d, want %d", RequiredSampleRate(tr), openAIRealtimeSampleRate)
+	}
+
+	chunks := make(chan []byte, 1)
+	chunks <- make([]byte, 480)
+	close(chunks)
+	done := make(chan struct{})
+	var final string
+	var ferr error
+	go func() {
+		final, ferr = tr.StreamTranscribe(context.Background(), chunks, func(string, bool) {})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StreamTranscribe did not complete")
+	}
+	if ferr != nil {
+		t.Fatalf("StreamTranscribe: %v", ferr)
+	}
+	if final != "the answer" {
+		t.Errorf("final = %q, want 'the answer'", final)
+	}
+}
+
+// TestLocalStreamingAccumulatesSegments is the regression for the "text vanishes
+// on stop" bug: the sherpa server reports text PER SEGMENT and resets it to "" when
+// it endpoints, so the transcriber must accumulate across segments rather than let
+// a new (empty) segment overwrite everything already recognized.
+func TestLocalStreamingAccumulatesSegments(t *testing.T) {
+	url := wsTestServer(t, func(ctx context.Context, c *websocket.Conn) {
+		defer c.Close(websocket.StatusNormalClosure, "")
+		go func() { // drain the client's audio + "Done"
+			for {
+				if _, _, err := c.Read(ctx); err != nil {
+					return
+				}
+			}
+		}()
+		for _, m := range []string{
+			`{"text":" hello","segment":0,"is_final":false}`,
+			`{"text":" hello world","segment":0,"is_final":true}`,
+			`{"text":"","segment":1,"is_final":false}`, // endpoint reset — must NOT wipe seg 0
+			`{"text":" foo bar","segment":1,"is_final":true}`,
+			`{"text":"","segment":2,"is_final":true}`, // trailing empty segment at stop
+		} {
+			_ = c.Write(ctx, websocket.MessageText, []byte(m))
+		}
+		_ = c.Write(ctx, websocket.MessageText, []byte("Done!"))
+	})
+
+	colon := strings.LastIndex(url, ":")
+	port, err := strconv.Atoi(url[colon+1:])
+	if err != nil {
+		t.Fatalf("parsing test server port from %q: %v", url, err)
+	}
+	mgr := NewServerManager(ServerConfig{
+		ModelPath:   streamingModelDir(t),
+		Port:        port,
+		starter:     func(commandSpec) (processHandle, io.ReadCloser, error) { return newFakeProcess(), nil, nil },
+		healthCheck: func(context.Context, int) error { return nil },
+		aliveCheck:  func(int) bool { return false },
+	})
+	tr := NewLocalStreamingTranscriber(mgr)
+
+	chunks := make(chan []byte)
+	close(chunks) // no audio; the writer immediately sends "Done"
+	var partials []string
+	text, err := tr.StreamTranscribe(context.Background(), chunks, func(s string, _ bool) {
+		partials = append(partials, s)
+	})
+	if err != nil {
+		t.Fatalf("StreamTranscribe: %v", err)
+	}
+	if text != "hello world foo bar" {
+		t.Errorf("final text = %q, want %q", text, "hello world foo bar")
+	}
+	// Once text has appeared, no later partial may go empty — that would be the
+	// segment-reset wiping the transcript, the exact bug this guards.
+	seen := false
+	for _, p := range partials {
+		if p != "" {
+			seen = true
+		}
+		if seen && p == "" {
+			t.Errorf("transcript went empty after text appeared; partials=%v", partials)
+		}
+	}
+}
+
+func TestParseDeepgramResultIgnoresNonResults(t *testing.T) {
+	if _, _, ok := parseDeepgramResult([]byte(`{"type":"Metadata"}`)); ok {
+		t.Error("Metadata messages should be ignored")
+	}
+	tr, final, ok := parseDeepgramResult([]byte(`{"type":"Results","is_final":true,"channel":{"alternatives":[{"transcript":"hi"}]}}`))
+	if !ok || tr != "hi" || !final {
+		t.Errorf("parse = (%q,%v,%v)", tr, final, ok)
+	}
+}
+
+func TestParseRealtimeEvent(t *testing.T) {
+	if e := parseRealtimeEvent([]byte(`{"type":"conversation.item.input_audio_transcription.delta","delta":"x"}`)); e.kind != realtimeDelta || e.text != "x" {
+		t.Errorf("delta parse: %+v", e)
+	}
+	if e := parseRealtimeEvent([]byte(`{"type":"error","error":{"message":"boom"}}`)); e.kind != realtimeError || e.text != "boom" {
+		t.Errorf("error parse: %+v", e)
+	}
+}

--- a/internal/providermodelcatalog/filter.go
+++ b/internal/providermodelcatalog/filter.go
@@ -57,6 +57,67 @@ func IsKnownNonCodingModelID(id string) bool {
 	return false
 }
 
+// IsSTTModel reports whether a model transcribes speech to text — the models
+// IsKnownNonCodingModelID filters OUT of the coding picker, filtered back IN for
+// the /stt-model picker.
+//
+// The reliable signal is the model's declared modalities, not its name: a
+// transcriber consumes audio and emits text. Anything that emits audio is
+// text-to-speech or speech-to-speech, never a transcriber, so audio output is a
+// hard disqualifier. Only when a catalog entry carries no usable modality
+// metadata (common for the Groq/OpenAI transcription models, which models.dev
+// lists sparsely) do we fall back to a name heuristic.
+func IsSTTModel(model Model) bool {
+	audioIn := containsFold(model.InputModalities, "audio")
+	audioOut := containsFold(model.OutputModalities, "audio")
+	textOut := containsFold(model.OutputModalities, "text")
+
+	// Emits audio → TTS or speech-to-speech, regardless of a transcription-like
+	// name. This is what stops gpt-4o-audio-preview / *-realtime from slipping in.
+	if audioOut {
+		return false
+	}
+	// Consumes audio and emits text (or emits nothing explicit) → transcriber.
+	if audioIn && (textOut || len(model.OutputModalities) == 0) {
+		return true
+	}
+	// Declares input modalities but none is audio → cannot be speech-to-text,
+	// whatever it is called.
+	if len(model.InputModalities) > 0 && !audioIn {
+		return false
+	}
+	// No usable modality metadata: fall back to the name heuristic.
+	return IsSTTModelID(model.ID)
+}
+
+// IsSTTModelID is the name-only heuristic used when a catalog entry declares no
+// modalities. It matches the known transcription model families and explicitly
+// rejects text-to-speech names, so it never confuses a TTS model for a
+// transcriber. Weaker than the modality signal in IsSTTModel — a fallback, not
+// the primary test.
+func IsSTTModelID(id string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(id))
+	if normalized == "" {
+		return false
+	}
+	// Text-to-speech / speech-synthesis names are never transcription.
+	for _, tts := range []string{"tts", "text-to-speech"} {
+		if strings.Contains(normalized, tts) {
+			return false
+		}
+	}
+	for _, term := range []string{
+		"whisper", "transcribe", "transcription",
+		"scribe", "parakeet", "canary", "moonshine",
+		"sense-voice", "sensevoice", "wav2vec", "conformer",
+	} {
+		if strings.Contains(normalized, term) {
+			return true
+		}
+	}
+	return false
+}
+
 func hasCodingTag(tags []string) bool {
 	for _, tag := range tags {
 		normalized := strings.ToLower(strings.TrimSpace(tag))

--- a/internal/providermodelcatalog/stt_filter_test.go
+++ b/internal/providermodelcatalog/stt_filter_test.go
@@ -1,0 +1,46 @@
+package providermodelcatalog
+
+import "testing"
+
+func TestIsSTTModelID(t *testing.T) {
+	in := []string{"whisper-1", "whisper-large-v3-turbo", "distil-whisper-large-v3-en",
+		"gpt-4o-transcribe", "gpt-4o-mini-transcribe", "nova-3-scribe", "parakeet-tdt-1.1b", "canary-1b"}
+	for _, id := range in {
+		if !IsSTTModelID(id) {
+			t.Errorf("%q should be an STT model by name", id)
+		}
+	}
+	out := []string{"gpt-4o", "claude-sonnet-4", "tts-1", "gpt-4o-mini-tts",
+		"dall-e-3", "text-to-speech-1", ""}
+	for _, id := range out {
+		if IsSTTModelID(id) {
+			t.Errorf("%q should NOT be an STT model by name", id)
+		}
+	}
+}
+
+func TestIsSTTModelUsesModalities(t *testing.T) {
+	// Audio in, text out → transcriber, even with an unfamiliar name.
+	if !IsSTTModel(Model{ID: "acme-speech-v2", InputModalities: []string{"audio"}, OutputModalities: []string{"text"}}) {
+		t.Error("audio-in/text-out model should be classified STT regardless of name")
+	}
+	// Audio out → TTS or speech-to-speech, never STT, even if the name says "transcribe".
+	if IsSTTModel(Model{ID: "weird-transcribe-tts", InputModalities: []string{"text"}, OutputModalities: []string{"audio"}}) {
+		t.Error("an audio-OUTPUT model must never be classified STT")
+	}
+	// Realtime speech-to-speech: audio in AND audio out → not a transcriber.
+	if IsSTTModel(Model{ID: "gpt-4o-realtime", InputModalities: []string{"audio", "text"}, OutputModalities: []string{"audio", "text"}}) {
+		t.Error("audio-in AND audio-out (speech-to-speech) must not be classified STT")
+	}
+	// Text-only LLM: input declared, no audio → not STT.
+	if IsSTTModel(Model{ID: "gpt-4o", InputModalities: []string{"text", "image"}, OutputModalities: []string{"text"}}) {
+		t.Error("a text/image-in model must not be classified STT")
+	}
+	// No modality metadata: fall back to the name heuristic.
+	if !IsSTTModel(Model{ID: "whisper-large-v3-turbo"}) {
+		t.Error("with no modalities, a whisper id should fall back to STT-true")
+	}
+	if IsSTTModel(Model{ID: "gpt-4o-mini-tts"}) {
+		t.Error("with no modalities, a tts id should be STT-false")
+	}
+}

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -395,7 +395,7 @@ func TestSuggestionOverlayCapsRowsWithoutMoreText(t *testing.T) {
 	if strings.Contains(plain, "more") {
 		t.Fatalf("bare slash palette should not render a more-count row, got %q", plain)
 	}
-	if !strings.Contains(plain, "│ ❯ provider") || !strings.Contains(plain, "│   stop") {
+	if !strings.Contains(plain, "│ ❯ provider") || !strings.Contains(plain, "│   ps") {
 		t.Fatalf("top of palette should render first visible command window, got %q", plain)
 	}
 	if strings.Contains(plain, "compact") {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -48,6 +48,8 @@ const (
 	commandNew
 	commandSkills
 	commandLoop
+	commandVoice
+	commandSTTModel
 	commandUnknown
 )
 
@@ -90,6 +92,20 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupModel,
 		description: "Show or switch the active model.",
 		kind:        commandModel,
+	},
+	{
+		name:        "/stt-model",
+		usage:       "/stt-model",
+		group:       commandGroupModel,
+		description: "Choose the speech-to-text (dictation) model.",
+		kind:        commandSTTModel,
+	},
+	{
+		name:        "/voice",
+		usage:       "/voice",
+		group:       commandGroupRuntime,
+		description: "Toggle voice mode (hold Space to dictate).",
+		kind:        commandVoice,
 	},
 	{
 		name:        "/plan",

--- a/internal/tui/dictation.go
+++ b/internal/tui/dictation.go
@@ -1,0 +1,592 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"path/filepath"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/dictation"
+)
+
+// Transcriber and Recorder are re-exported so Options and the model can refer to
+// the dictation interfaces without importing the package everywhere.
+type (
+	Transcriber = dictation.Transcriber
+	Recorder    = dictation.Recorder
+)
+
+// dictationPhase is the recording state machine (§10): idle → recording →
+// transcribing → idle. Voice mode (§13.9) changes which key enters it, not the
+// machine itself.
+type dictationPhase int
+
+const (
+	dictIdle dictationPhase = iota
+	dictStarting
+	dictRecording
+	dictTranscribing
+)
+
+// dictationController holds the live dictation session. It is a value field on
+// the model (threaded through Update by value); the recorder/cancel it captures
+// are pointers, so they survive across frames and are shared with the async
+// commands that operate on them.
+type dictationController struct {
+	cfg            config.STTConfig
+	build          func(cfg config.STTConfig, preferStreaming bool) (Transcriber, bool, error)
+	shutdownServer func(context.Context) error
+	keyAvailable   func(provider string) bool
+	saveKey        func(provider, key string) error
+	phase          dictationPhase
+	platform       dictation.Platform
+
+	// downloadRoot is where the auto-download stores the engine + model ("" =
+	// auto-download disabled). userConfigPath is where the resolved paths persist.
+	downloadRoot   string
+	userConfigPath string
+	// downloading: a model download is in flight (started from the /stt-model
+	// download chooser). downloadStatus is the live progress line shown in the
+	// status bar while downloading. browseLoading: the full model list is being
+	// fetched; browseVariants caches it once fetched.
+	downloading    bool
+	downloadStatus string
+	browseLoading  bool
+	browseVariants []dictation.ModelVariant
+
+	// in-flight session state
+	streaming   bool
+	recorder    Recorder
+	transcriber Transcriber
+	ctx         context.Context
+	cancel      context.CancelFunc
+	streamStop  func() error
+
+	// live streaming render region: [regionStart, regionEnd) in the composer's
+	// rune space, replaced wholesale on each partial (§13.8). regionPrefix is a
+	// separator space folded into the region so a cancel restores the original
+	// text exactly.
+	regionActive bool
+	regionStart  int
+	regionEnd    int
+	regionPrefix string
+
+	// waveBars is the recording waveform's recent bar heights (a scrolling ring):
+	// audio-reactive from live mic levels on the streaming path, synthetic on the
+	// batch path. waveTick drives the batch synthetic animation.
+	waveBars []int
+	waveTick int
+
+	// voiceModeEnabled repurposes Space into hold-to-record (§13.9).
+	voiceModeEnabled bool
+	// eventTypesSupported records whether the terminal confirmed key-release
+	// reporting (Kitty protocol); eventTypesKnown gates it until the terminal has
+	// answered. Determines hold-to-record vs. press-to-toggle for voice mode.
+	eventTypesKnown     bool
+	eventTypesSupported bool
+	// spaceHeld tracks a held Space in hold-to-record mode; voiceStopPending
+	// remembers a release that arrived before the recording finished starting.
+	spaceHeld        bool
+	voiceStopPending bool
+}
+
+// dictationStartedMsg reports the outcome of Recorder.Start().
+type dictationStartedMsg struct {
+	err error
+}
+
+// dictationTranscribedMsg carries the final transcript of a batch (or a
+// completed streaming) recording.
+type dictationTranscribedMsg struct {
+	text      string
+	err       error
+	submit    bool
+	streaming bool
+}
+
+// newDictationController builds the controller from resolved options.
+func newDictationController(opts Options) dictationController {
+	return dictationController{
+		cfg:            opts.STT,
+		build:          opts.BuildDictationTranscriber,
+		shutdownServer: opts.ShutdownDictationServer,
+		keyAvailable:   opts.STTKeyStatus,
+		saveKey:        opts.SaveSTTKey,
+		platform:       dictation.DetectPlatform(),
+		downloadRoot:   opts.STTDownloadRoot,
+		userConfigPath: opts.UserConfigPath,
+	}
+}
+
+// available reports whether dictation is wired up (a transcriber factory exists).
+func (d dictationController) available() bool { return d.build != nil }
+
+// currentModelLabel names the STT model currently configured, for status hints.
+func (d dictationController) currentModelLabel() string {
+	cfg := d.cfg
+	switch cfg.STTProvider() {
+	case config.STTProviderLocal:
+		if strings.TrimSpace(cfg.LocalModelPath) == "" {
+			return "Local (no model set)"
+		}
+		// "Local" prefix mirrors the "Groq …"/"OpenAI …" cloud labels so the status
+		// line always names the backend, not just the model.
+		// Prefer a curated variant's friendly name when the path matches one.
+		for _, v := range dictation.ModelVariants() {
+			if v.DirName != "" && strings.Contains(cfg.LocalModelPath, v.DirName) {
+				return "Local · " + v.Label
+			}
+		}
+		return "Local · " + strings.TrimPrefix(filepath.Base(cfg.LocalModelPath), "sherpa-onnx-")
+	case config.STTProviderGroq:
+		return "Groq " + firstNonEmptyStr(cfg.Model, "whisper-large-v3-turbo")
+	case config.STTProviderOpenAI:
+		return "OpenAI " + firstNonEmptyStr(cfg.Model, "whisper-1")
+	}
+	return string(cfg.STTProvider())
+}
+
+func firstNonEmptyStr(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return a
+	}
+	return b
+}
+
+// active reports whether a recording/transcription is in flight.
+func (d dictationController) active() bool { return d.phase != dictIdle }
+
+// toggleDictation starts a recording when idle and stops-and-transcribes when
+// recording. Invoked by the voice-mode Space gesture; a call during
+// startup/transcription is ignored (the machine is mid-transition).
+func (m model) toggleDictation() (model, tea.Cmd) {
+	if !m.dictation.available() {
+		return m.appendSystemNotice("Dictation is not configured. See docs/dictation.md to set up a local engine or a Groq/OpenAI key."), nil
+	}
+	if m.dictation.downloading {
+		return m.appendDictationNotice("downloading", "Still setting up the dictation engine — one moment."), nil
+	}
+	switch m.dictation.phase {
+	case dictIdle:
+		return m.startDictation()
+	case dictRecording:
+		return m.stopDictation()
+	default:
+		// dictStarting / dictTranscribing: mid-transition, ignore.
+		return m, nil
+	}
+}
+
+// toggleVoiceMode flips the /voice hold-to-record gesture — the dictation
+// trigger. While on, Space records; run /voice again to type spaces normally.
+func (m model) toggleVoiceMode() (model, tea.Cmd) {
+	if !m.dictation.available() {
+		return m.appendSystemNotice("Dictation is not configured. See docs/dictation.md to set up a local engine or a Groq/OpenAI key."), nil
+	}
+	m.dictation.voiceModeEnabled = !m.dictation.voiceModeEnabled
+	if m.dictation.voiceModeEnabled {
+		return m.appendSystemNotice("Voice mode on (" + m.dictation.currentModelLabel() + ") — hold Space to dictate, release to transcribe. Run /voice again to turn it off (so Space types normally)."), nil
+	}
+	// Turning voice off is the "done dictating" signal, so release the warm sherpa
+	// streaming server — otherwise a loaded model keeps idling in RAM (and holding
+	// its port) until the app exits. It respawns lazily on the next streaming
+	// recording. Skip while a recording is still in flight so we don't kill it.
+	next := m.appendSystemNotice("Voice mode off.")
+	if next.dictation.active() {
+		return next, nil
+	}
+	return next, next.releaseDictationServerCmd()
+}
+
+// releaseDictationServerCmd tears down the warm sherpa-onnx streaming server off
+// the UI goroutine (Shutdown waits on the process). No-op when no server backend
+// is wired or none is running.
+func (m model) releaseDictationServerCmd() tea.Cmd {
+	shutdown := m.dictation.shutdownServer
+	if shutdown == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = shutdown(ctx)
+		return nil
+	}
+}
+
+// startDictation builds the recorder + transcriber and kicks off capture.
+func (m model) startDictation() (model, tea.Cmd) {
+	transcriber, streaming, err := m.dictation.build(m.dictation.cfg, m.dictation.wantStreaming())
+	if err != nil {
+		// A missing local engine on a platform we can auto-download for → point at
+		// /stt-model, which offers the download-a-model chooser (a robust single
+		// selection rather than a press-again-to-confirm dance).
+		if m.dictation.canOfferDownload(err) {
+			return m.appendDictationNotice("download-offer",
+				"No local dictation model yet. Run /stt-model to choose and download one — or set stt.localModelPath yourself, or pick a cloud provider."), nil
+		}
+		return m.appendDictationNotice("setup:"+err.Error(), dictationErrorText(err)), nil
+	}
+
+	rec := dictation.NewRecorder(dictation.RecorderOptions{
+		Platform:           m.dictation.platform,
+		SampleRate:         dictation.RequiredSampleRate(transcriber),
+		MaxDuration:        m.dictation.maxDuration(),
+		SilenceAutoStop:    m.dictation.cfg.SilenceAutoStopEnabled(),
+		WindowsAudioDevice: m.dictation.cfg.WindowsAudioDevice,
+	})
+
+	base := m.ctx
+	if base == nil {
+		base = context.Background()
+	}
+	ctx, cancel := context.WithCancel(base)
+
+	m.dictation.recorder = rec
+	m.dictation.transcriber = transcriber
+	m.dictation.ctx = ctx
+	m.dictation.cancel = cancel
+	m.dictation.streaming = streaming
+	m.dictation.phase = dictStarting
+
+	if streaming {
+		return m.startStreamingDictation()
+	}
+	return m, startBatchRecordingCmd(rec)
+}
+
+// stopDictation ends a recording. For batch it triggers Stop()+Transcribe(); for
+// streaming it stops the recorder, which closes the chunk channel and lets the
+// in-flight StreamTranscribe return its final text.
+func (m model) stopDictation() (model, tea.Cmd) {
+	m.dictation.phase = dictTranscribing
+	if m.dictation.streaming {
+		if m.dictation.streamStop != nil {
+			_ = m.dictation.streamStop()
+		}
+		return m, nil // final text arrives via the streaming command already running
+	}
+	return m, transcribeBatchCmd(m.dictation.ctx, m.dictation.recorder, m.dictation.transcriber, m.dictation.cfg.AutoSubmitEnabled())
+}
+
+// cancelDictation aborts an in-flight recording without transcribing. Bound to
+// Esc while a session is active.
+func (m model) cancelDictation() (model, tea.Cmd) {
+	if m.dictation.cancel != nil {
+		m.dictation.cancel()
+	}
+	if m.dictation.streaming && m.dictation.streamStop != nil {
+		_ = m.dictation.streamStop()
+	} else if m.dictation.recorder != nil && m.dictation.phase != dictTranscribing {
+		// Best-effort: stop the capture tool so the microphone is released.
+		go func(r Recorder) { _, _ = r.Stop() }(m.dictation.recorder)
+	}
+	m = m.discardDictationRegion()
+	m.dictation.reset()
+	return m.appendSystemNotice("Dictation cancelled."), nil
+}
+
+// wantStreaming decides whether this recording uses the streaming pipeline:
+// enabled in config and supported on this platform (desktop only — Termux's mic
+// tool has no stdout mode).
+func (d dictationController) wantStreaming() bool {
+	return d.cfg.StreamingEnabled() && d.platform.StreamingSupported()
+}
+
+func (d dictationController) maxDuration() time.Duration {
+	if d.cfg.MaxDurationSeconds > 0 {
+		return time.Duration(d.cfg.MaxDurationSeconds) * time.Second
+	}
+	return dictation.DefaultMaxDuration
+}
+
+func (d *dictationController) reset() {
+	d.phase = dictIdle
+	d.recorder = nil
+	d.transcriber = nil
+	d.ctx = nil
+	d.cancel = nil
+	d.streaming = false
+	d.streamStop = nil
+	d.regionActive = false
+	d.regionPrefix = ""
+	d.waveBars = nil
+	d.waveTick = 0
+}
+
+// startBatchRecordingCmd starts the record-to-file capture off the UI goroutine
+// (Start spawns a subprocess and may briefly block or fail on a missing tool).
+func startBatchRecordingCmd(rec Recorder) tea.Cmd {
+	return func() tea.Msg {
+		return dictationStartedMsg{err: rec.Start()}
+	}
+}
+
+// transcribeBatchCmd stops the recording, transcribes the audio, and reports the
+// final text. Runs off the UI goroutine — Stop waits on the capture tool and
+// Transcribe does a network round-trip or a local exec.
+func transcribeBatchCmd(ctx context.Context, rec Recorder, transcriber Transcriber, submit bool) tea.Cmd {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return func() tea.Msg {
+		audio, err := rec.Stop()
+		if err != nil {
+			return dictationTranscribedMsg{err: err}
+		}
+		text, err := transcriber.Transcribe(ctx, audio)
+		return dictationTranscribedMsg{text: text, err: err, submit: submit}
+	}
+}
+
+// handleDictationStarted transitions to recording (or reports a start failure).
+func (m model) handleDictationStarted(msg dictationStartedMsg) (model, tea.Cmd) {
+	if msg.err != nil {
+		m = m.discardDictationRegion()
+		m.dictation.reset()
+		text := dictationErrorText(msg.err)
+		return m.appendDictationNotice("dicterr:"+text, text), nil
+	}
+	// A stop or cancel may have already advanced the phase; only arm recording if
+	// we are still starting.
+	if m.dictation.phase == dictStarting {
+		m.dictation.phase = dictRecording
+	}
+	// A voice-mode Space release that arrived mid-startup asked us to stop as soon
+	// as recording began.
+	if m.dictation.voiceStopPending && m.dictation.phase == dictRecording {
+		m.dictation.voiceStopPending = false
+		return m.stopDictation()
+	}
+	// Kick off the recording waveform animation.
+	return m, recTickCmd()
+}
+
+// handleDictationTranscribed inserts the final transcript into the composer (or
+// submits it when stt.autoSubmit is on), then returns to idle.
+func (m model) handleDictationTranscribed(msg dictationTranscribedMsg) (tea.Model, tea.Cmd) {
+	streaming := m.dictation.streaming || msg.streaming
+	m = m.commitDictationRegion()
+	// A streaming session can end via a transcriber error (not just a user stop), so
+	// tear the capture down here BEFORE reset() drops the handles: stop the recorder
+	// (kills the mic subprocess) and cancel the context (unblocks the audio tap).
+	// Without this, an error path leaves the mic running and the next attempt hits
+	// "already recording". Both are idempotent, so this is safe on the happy path.
+	if streaming {
+		if m.dictation.streamStop != nil {
+			_ = m.dictation.streamStop()
+		}
+		if m.dictation.cancel != nil {
+			m.dictation.cancel()
+		}
+	}
+	m.dictation.reset()
+
+	if msg.err != nil && !errors.Is(msg.err, context.Canceled) {
+		// A cloud auth failure (missing/invalid key) is fixable in place: reopen the
+		// API-key prompt for the current provider so the user can paste a key and
+		// retry, instead of hitting a dead-end "run zero auth" line.
+		if next, handled := m.maybeOfferKeyOnAuthError(msg.err); handled {
+			return next, nil
+		}
+		// Partial text may still be worth keeping on a mid-stream failure (§6).
+		if strings.TrimSpace(msg.text) != "" && !streaming {
+			m = m.insertDictatedText(msg.text)
+			return m.appendSystemNotice("Dictation interrupted; kept the partial transcript. " + dictationErrorText(msg.err)), nil
+		}
+		// Keyed so hammering the dictation gesture against the same unusable model doesn't spam the
+		// identical error line over and over.
+		text := dictationErrorText(msg.err)
+		return m.appendDictationNotice("dicterr:"+text, text), nil
+	}
+	if strings.TrimSpace(msg.text) == "" {
+		if streaming {
+			return m, nil // streaming already rendered live; nothing to add
+		}
+		return m.appendSystemNotice("No speech detected."), nil
+	}
+	if !streaming {
+		m = m.insertDictatedText(msg.text)
+	}
+	if msg.submit {
+		// stt.autoSubmit fires the transcript straight at the agent (off by
+		// default — insert-for-review is the safety net for a misheard prompt).
+		return m.handleSubmit()
+	}
+	return m, nil
+}
+
+// insertDictatedText inserts transcribed text at the composer cursor, adding a
+// separating space when the existing text would otherwise run into it.
+func (m model) insertDictatedText(text string) model {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return m
+	}
+	state := m.currentComposerState()
+	if needsLeadingSpace(state) {
+		text = " " + text
+	}
+	m.setComposerState(insertComposerText(state, text))
+	return m
+}
+
+func needsLeadingSpace(state composerState) bool {
+	runes := []rune(state.text)
+	if state.cursor <= 0 || state.cursor > len(runes) {
+		return false
+	}
+	prev := runes[state.cursor-1]
+	return prev != ' ' && prev != '\n' && prev != '\t'
+}
+
+// dictationStatusChip renders the active-recording indicator for the status
+// line: a live animated waveform plus how to stop. Empty when idle.
+func (m model) dictationStatusChip() string {
+	switch m.dictation.phase {
+	case dictStarting, dictRecording:
+		stop := "release Space to stop"
+		if !m.dictation.eventTypesSupported {
+			stop = "press Space to stop" // press-to-toggle fallback
+		}
+		wave := zeroTheme.amber.Render("● " + renderWaveBars(m.dictation.waveBars) + " REC")
+		return wave + zeroTheme.muted.Render(" · "+stop+", Esc to cancel")
+	case dictTranscribing:
+		return zeroTheme.accent.Render("●") + " " + zeroTheme.muted.Render("transcribing…")
+	}
+	return ""
+}
+
+const (
+	waveBarCount    = 14
+	recTickInterval = 90 * time.Millisecond
+)
+
+// waveRunes maps a 0..8 bar height to a block glyph.
+var waveRunes = []rune(" ▁▂▃▄▅▆▇█")
+
+// renderWaveBars draws the scrolling bar heights as block glyphs.
+func renderWaveBars(bars []int) string {
+	if len(bars) == 0 {
+		return strings.Repeat(" ", waveBarCount)
+	}
+	out := make([]rune, len(bars))
+	for i, h := range bars {
+		if h < 0 {
+			h = 0
+		}
+		if h > 8 {
+			h = 8
+		}
+		out[i] = waveRunes[h]
+	}
+	return string(out)
+}
+
+// pushLevel appends a new bar height on the right and scrolls the ring left.
+func (d *dictationController) pushLevel(height int) {
+	nb := make([]int, waveBarCount)
+	if len(d.waveBars) == waveBarCount {
+		copy(nb, d.waveBars[1:])
+	}
+	nb[waveBarCount-1] = height
+	d.waveBars = nb
+}
+
+// levelHeight maps a 0..1 audio level to a 0..8 bar height.
+func levelHeight(level float64) int {
+	h := int(level*8 + 0.5)
+	if h < 0 {
+		h = 0
+	}
+	if h > 8 {
+		h = 8
+	}
+	return h
+}
+
+// sttLevelMsg carries a live microphone level (0..1) from the streaming audio
+// tap, driving the real audio-reactive waveform.
+type sttLevelMsg struct{ level float64 }
+
+// handleDictationLevel pushes a real mic level onto the waveform.
+func (m model) handleDictationLevel(msg sttLevelMsg) model {
+	if m.dictation.active() {
+		m.dictation.pushLevel(levelHeight(msg.level))
+	}
+	return m
+}
+
+// recTickMsg drives the BATCH synthetic waveform (batch records to a file, so
+// there is no live audio to react to). The streaming path animates from real
+// levels instead (sttLevelMsg) and does not tick.
+type recTickMsg struct{}
+
+func recTickCmd() tea.Cmd {
+	return tea.Tick(recTickInterval, func(time.Time) tea.Msg { return recTickMsg{} })
+}
+
+// syntheticWaveLevel synthesizes an organic 0..8 bar height for the batch
+// recording animation (batch records to a file, so there is no live signal to
+// react to). Rather than loop a fixed pulse — which reads as mechanical — it
+// layers a few incommensurate sinusoids so the envelope wanders and doesn't
+// obviously repeat, plus a hash-based per-frame jitter for texture and an
+// occasional near-silent dip so it breathes like real speech.
+func syntheticWaveLevel(tick int) int {
+	t := float64(tick)
+	amp := 0.5 +
+		0.24*math.Sin(t*0.33) +
+		0.15*math.Sin(t*0.12+1.7) +
+		0.12*math.Sin(t*0.71+0.4) +
+		0.08*math.Sin(t*1.30+2.2) // faster wiggle so it never flatlines
+	// Deterministic jitter in ~[-0.09, 0.09] from a cheap integer hash of the tick.
+	h := uint32(tick)*2654435761 + 1013904223
+	amp += (float64(h>>16&0xffff)/0xffff - 0.5) * 0.18
+	// A slow, shallow gate occasionally eases the level down (a spoken pause) without
+	// ever flatlining, so the wave keeps breathing instead of humming a fixed shape.
+	if gate := math.Sin(t*0.09 + 0.6); gate < -0.5 {
+		amp *= 0.55
+	}
+	switch {
+	case amp < 0:
+		amp = 0
+	case amp > 1:
+		amp = 1
+	}
+	return levelHeight(amp)
+}
+
+// handleRecTick advances the batch synthetic waveform and stops when recording ends.
+func (m model) handleRecTick() (model, tea.Cmd) {
+	if m.dictation.phase == dictRecording || m.dictation.phase == dictStarting {
+		m.dictation.waveTick++
+		m.dictation.pushLevel(syntheticWaveLevel(m.dictation.waveTick))
+		return m, recTickCmd()
+	}
+	return m, nil
+}
+
+// voiceModeIndicator renders the persistent "voice mode on" hint shown while
+// idle so the user knows Space is repurposed to hold-to-record (§10).
+func (m model) voiceModeIndicator() string {
+	if !m.dictation.voiceModeEnabled {
+		return ""
+	}
+	return zeroTheme.accent.Render("🎙 voice") + zeroTheme.muted.Render(" · "+m.dictation.currentModelLabel())
+}
+
+// dictationErrorText renders a dictation error for the transcript: a missing-
+// tool setup error becomes actionable guidance, everything else is shown plainly.
+func dictationErrorText(err error) string {
+	var setupErr *dictation.SetupError
+	if errors.As(err, &setupErr) {
+		return "Dictation unavailable: " + setupErr.Error()
+	}
+	return fmt.Sprintf("Dictation failed: %v", err)
+}

--- a/internal/tui/dictation.go
+++ b/internal/tui/dictation.go
@@ -76,6 +76,10 @@ type dictationController struct {
 	regionStart  int
 	regionEnd    int
 	regionPrefix string
+	// regionAnchor snapshots the text BEFORE the live region, so the next
+	// partial can detect external edits (typing, paste) and shift [start,end)
+	// to stay aligned. Updated alongside regionStart on each render.
+	regionAnchor string
 
 	// waveBars is the recording waveform's recent bar heights (a scrolling ring):
 	// audio-reactive from live mic levels on the streaming path, synthetic on the

--- a/internal/tui/dictation_download.go
+++ b/internal/tui/dictation_download.go
@@ -41,6 +41,9 @@ func (d dictationController) canOfferDownload(err error) bool {
 // startVariantDownload fetches the sherpa-onnx engine + the chosen model
 // variant, reporting progress live, then persists and applies the resolved paths.
 func (m model) startVariantDownload(v dictation.ModelVariant) (model, tea.Cmd) {
+	if m.dictation.downloading {
+		return m.appendSystemNotice("A dictation download is already in progress — please wait for it to finish."), nil
+	}
 	m.dictation.downloading = true
 	sink := m.runtimeMessageSink
 	root := m.dictation.downloadRoot

--- a/internal/tui/dictation_download.go
+++ b/internal/tui/dictation_download.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/dictation"
+)
+
+// sttDownloadProgressMsg carries a live download-status line (with a
+// percentage) into the TUI, injected from the download goroutine via
+// runtimeMessageSink.
+type sttDownloadProgressMsg struct{ status string }
+
+// dictationDownloadedMsg reports the outcome of an auto-download.
+type dictationDownloadedMsg struct {
+	components dictation.EngineComponents
+	err        error
+	// streaming is the chosen variant's pipeline (a streaming transducer vs a
+	// batch model), applied to the config after a successful download.
+	streaming bool
+}
+
+// canOfferDownload reports whether a failed build should point the user at the
+// /stt-model download chooser: the failure is a missing-setup error, the user is
+// on the local provider, this platform has a prebuilt engine, and a download
+// root is configured.
+func (d dictationController) canOfferDownload(err error) bool {
+	var setupErr *dictation.SetupError
+	return d.downloadRoot != "" && !d.downloading &&
+		d.cfg.STTProvider() == config.STTProviderLocal &&
+		dictation.AutoDownloadSupported() &&
+		errors.As(err, &setupErr)
+}
+
+// startVariantDownload fetches the sherpa-onnx engine + the chosen model
+// variant, reporting progress live, then persists and applies the resolved paths.
+func (m model) startVariantDownload(v dictation.ModelVariant) (model, tea.Cmd) {
+	m.dictation.downloading = true
+	sink := m.runtimeMessageSink
+	root := m.dictation.downloadRoot
+	version := m.dictation.cfg.EngineVersion
+	base := m.ctx
+	if base == nil {
+		base = context.Background()
+	}
+	m.dictation.downloadStatus = "Starting download…"
+	m = m.appendSystemNotice(fmt.Sprintf("Setting up local dictation — downloading the offline engine and %s (~%d MB). This runs once; progress is shown in the status bar below.", v.Label, (v.Bytes>>20)+(engineDownloadBytes>>20)))
+	return m, func() tea.Msg {
+		comp, err := dictation.EnsureLocalEngine(base, dictation.DownloadOptions{
+			DestRoot:          root,
+			EngineVersion:     version,
+			ModelAssetName:    v.AssetName,
+			ModelPinnedDigest: v.Digest,
+			ModelDirName:      v.DirName,
+			ModelLabel:        v.Label,
+			Progress: func(status string) {
+				if sink != nil {
+					sink(sttDownloadProgressMsg{status: status})
+				}
+			},
+		})
+		return dictationDownloadedMsg{components: comp, err: err, streaming: v.Streaming}
+	}
+}
+
+// handleDictationDownloadProgress updates the single live status line (shown in
+// the status bar) — not a new transcript line per update.
+func (m model) handleDictationDownloadProgress(msg sttDownloadProgressMsg) model {
+	if m.dictation.downloading {
+		m.dictation.downloadStatus = msg.status
+	}
+	return m
+}
+
+// handleDictationDownloaded persists and applies the downloaded engine, or
+// reports the failure.
+func (m model) handleDictationDownloaded(msg dictationDownloadedMsg) (model, tea.Cmd) {
+	m.dictation.downloading = false
+	m.dictation.downloadStatus = ""
+	if msg.err != nil {
+		return m.appendSystemNotice("Dictation setup failed: " + dictationErrorText(msg.err)), nil
+	}
+	m, err := m.applyEngineComponents(msg.components, msg.streaming)
+	if err != nil {
+		return m.appendSystemNotice("Downloaded the engine, but couldn't save the config: " + err.Error()), nil
+	}
+	return m.appendSystemNotice("Local dictation is ready. Run /voice, then hold Space to dictate."), nil
+}
+
+// applyEngineComponents persists and applies resolved engine/model paths to the
+// live config (shared by a fresh download and the already-installed fast path).
+func (m model) applyEngineComponents(comp dictation.EngineComponents, streaming bool) (model, error) {
+	if path := m.dictation.userConfigPath; path != "" {
+		if _, err := config.SetSTTLocalEngine(path, comp.BinaryPath, comp.ServerPath, comp.ModelPath, streaming); err != nil {
+			return m, err
+		}
+	}
+	m.dictation.cfg.Provider = config.STTProviderLocal
+	m.dictation.cfg.LocalBinary = comp.BinaryPath
+	m.dictation.cfg.LocalServerBinary = comp.ServerPath
+	m.dictation.cfg.LocalModelPath = comp.ModelPath
+	s := streaming
+	m.dictation.cfg.Streaming = &s
+	return m, nil
+}
+
+// appendDictationNotice appends a transcript notice, suppressing an immediate
+// repeat of the same message — the fix for hammering the dictation gesture against an unusable
+// model (or in voice mode) spamming the identical line on every keypress. It is
+// stateless: it simply skips the append when the message equals the most recent
+// transcript line, so an unrelated line in between lets it show again.
+func (m model) appendDictationNotice(key, text string) model {
+	_ = key
+	if n := len(m.transcript); n > 0 && strings.TrimSpace(m.transcript[n-1].text) == strings.TrimSpace(text) {
+		return m
+	}
+	return m.appendSystemNotice(text)
+}

--- a/internal/tui/dictation_download_test.go
+++ b/internal/tui/dictation_download_test.go
@@ -1,0 +1,177 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/dictation"
+)
+
+// buildFails returns a controller whose build always fails with a setup error,
+// as if the local engine/model were missing.
+func setupErrController(downloadRoot string) dictationController {
+	return dictationController{
+		cfg:          config.STTConfig{Provider: config.STTProviderLocal},
+		platform:     dictation.DetectPlatform(),
+		downloadRoot: downloadRoot,
+		build: func(config.STTConfig, bool) (Transcriber, bool, error) {
+			return nil, false, &dictation.SetupError{Tool: "local STT model", Hint: "set stt.localModelPath"}
+		},
+	}
+}
+
+func TestF9PointsToSTTModelWhenLocalMissing(t *testing.T) {
+	if !dictation.AutoDownloadSupported() {
+		t.Skip("no prebuilt engine for this platform")
+	}
+	m := model{dictation: setupErrController("/tmp/zero-stt")}
+	next, _ := m.toggleDictation()
+	if !transcriptHasText(next, "/stt-model") {
+		t.Error("F9 with a missing local engine should point at /stt-model to download")
+	}
+}
+
+func TestF9PlainSetupErrorWithoutDownloadRoot(t *testing.T) {
+	m := model{dictation: setupErrController("")} // no download root
+	next, _ := m.toggleDictation()
+	if !transcriptHasText(next, "set stt.localModelPath") {
+		t.Error("without a download root, expected the plain setup error")
+	}
+}
+
+func TestDictationNoticeDedupe(t *testing.T) {
+	m := model{}
+	m = m.appendDictationNotice("k", "same message")
+	m = m.appendDictationNotice("k", "same message")
+	m = m.appendDictationNotice("k", "same message")
+	n := 0
+	for _, row := range m.transcript {
+		if row.text == "same message" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("consecutive identical notices should dedupe to 1, got %d", n)
+	}
+	// A different key breaks the dedupe.
+	m = m.appendDictationNotice("other", "another")
+	if !transcriptHasText(m, "another") {
+		t.Error("a different-keyed notice should still show")
+	}
+}
+
+func TestDownloadedBatchModelAppliedToConfig(t *testing.T) {
+	m := model{dictation: dictationController{cfg: config.STTConfig{Provider: config.STTProviderLocal}}}
+	m.dictation.downloading = true
+	comp := dictation.EngineComponents{
+		BinaryPath: "/x/bin/sherpa-onnx-offline",
+		ServerPath: "/x/bin/sherpa-onnx-online-websocket-server",
+		ModelPath:  "/x/model",
+	}
+	got, _ := m.handleDictationDownloaded(dictationDownloadedMsg{components: comp, streaming: false})
+	if got.dictation.downloading {
+		t.Error("downloading flag should clear")
+	}
+	if got.dictation.cfg.LocalBinary != comp.BinaryPath || got.dictation.cfg.LocalModelPath != comp.ModelPath {
+		t.Errorf("engine paths not applied: %+v", got.dictation.cfg)
+	}
+	if got.dictation.cfg.StreamingEnabled() {
+		t.Error("a batch variant should set streaming off")
+	}
+	if !transcriptHasText(got, "ready") {
+		t.Error("expected a ready notice")
+	}
+}
+
+func TestDownloadedStreamingModelSetsStreamingOn(t *testing.T) {
+	m := model{dictation: dictationController{cfg: config.STTConfig{Provider: config.STTProviderLocal}}}
+	comp := dictation.EngineComponents{BinaryPath: "/x/bin/sherpa-onnx-offline", ModelPath: "/x/model"}
+	got, _ := m.handleDictationDownloaded(dictationDownloadedMsg{components: comp, streaming: true})
+	if !got.dictation.cfg.StreamingEnabled() {
+		t.Error("a streaming variant should set streaming on")
+	}
+}
+
+func TestSTTDownloadLoadingPickerThenFilled(t *testing.T) {
+	// The chooser opens in a single loading state (no curated-then-swap flicker),
+	// then handleSTTModelsFetched fills it with the fetched list.
+	loading := newSTTDownloadLoadingPicker()
+	if loading.kind != pickerSTTDownload || !loading.loading || len(loading.items) != 0 {
+		t.Fatalf("loading picker = %+v, want an empty, loading STT-download picker", loading)
+	}
+
+	m := model{dictation: dictationController{downloadRoot: "/tmp/x"}}
+	m.picker = loading
+	fetched := dictation.ModelVariants()
+	m = m.handleSTTModelsFetched(sttModelsFetchedMsg{variants: fetched})
+	if m.dictation.browseLoading {
+		t.Error("browseLoading should clear once the list arrives")
+	}
+	if m.picker.loading {
+		t.Error("the filled picker should no longer be loading")
+	}
+	if len(m.picker.items) != len(fetched) {
+		t.Errorf("filled picker has %d items, want %d", len(m.picker.items), len(fetched))
+	}
+}
+
+func TestSTTModelsFetchFailureFallsBackToCurated(t *testing.T) {
+	// A failed fetch with nothing cached falls back to the curated shortlist so the
+	// picker still works offline (never a permanently-empty loading box).
+	m := model{dictation: dictationController{downloadRoot: "/tmp/x"}}
+	m.picker = newSTTDownloadLoadingPicker()
+	m = m.handleSTTModelsFetched(sttModelsFetchedMsg{err: errors.New("offline")})
+	if m.picker.loading {
+		t.Error("picker should stop loading even on fetch failure")
+	}
+	if len(m.picker.items) != len(dictation.ModelVariants()) {
+		t.Errorf("fallback picker has %d items, want the %d curated variants",
+			len(m.picker.items), len(dictation.ModelVariants()))
+	}
+}
+
+func TestSTTDownloadPickerListsVariants(t *testing.T) {
+	m := model{dictation: dictationController{downloadRoot: "/tmp/x"}}
+	p := m.newSTTDownloadPicker()
+	if p == nil || p.kind != pickerSTTDownload {
+		t.Fatal("expected an STT download picker")
+	}
+	// Exactly the curated download variants — no dead-end "manual" row.
+	if len(p.items) != len(dictation.ModelVariants()) {
+		t.Errorf("picker has %d items, want %d variants", len(p.items), len(dictation.ModelVariants()))
+	}
+	for _, it := range p.items {
+		if it.Value == "manual" {
+			t.Error("the dead-end manual row should be gone")
+		}
+	}
+}
+
+func TestSTTDownloadSelectionStartsDownload(t *testing.T) {
+	m := model{dictation: dictationController{downloadRoot: "/tmp/x", cfg: config.STTConfig{Provider: config.STTProviderLocal}}}
+	variant := dictation.ModelVariants()[0]
+	next, cmd := m.handleSTTDownloadSelection(variant.ID)
+	if !next.dictation.downloading {
+		t.Error("selecting a variant should start a download")
+	}
+	if cmd == nil {
+		t.Error("expected a download command")
+	}
+	if !transcriptHasText(next, variant.Label) {
+		t.Error("expected the download-starting notice to name the variant")
+	}
+}
+
+func TestDownloadFailureReported(t *testing.T) {
+	m := model{dictation: dictationController{}}
+	m.dictation.downloading = true
+	next, _ := m.handleDictationDownloaded(dictationDownloadedMsg{err: errors.New("network down")})
+	got := next
+	if got.dictation.downloading {
+		t.Error("downloading flag should clear on failure")
+	}
+	if !transcriptHasText(got, "network down") {
+		t.Error("expected the failure reported")
+	}
+}

--- a/internal/tui/dictation_stream.go
+++ b/internal/tui/dictation_stream.go
@@ -1,0 +1,128 @@
+package tui
+
+import (
+	"context"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/dictation"
+)
+
+// sttPartialMsg carries an incremental streaming transcript into the TUI. It is
+// injected from the streaming goroutine via runtimeMessageSink — the same
+// mechanism agent text deltas use (§6). text is the cumulative best transcript
+// so far (not a delta); final marks a settled segment.
+type sttPartialMsg struct {
+	text  string
+	final bool
+}
+
+// startStreamingDictation begins continuous capture and launches the streaming
+// transcription command. StartStreaming spawns the capture process
+// synchronously, so a failure here is immediate; on success we are already
+// recording (no separate "started" round-trip).
+func (m model) startStreamingDictation() (model, tea.Cmd) {
+	chunks, stop, err := m.dictation.recorder.StartStreaming()
+	if err != nil {
+		m.dictation.reset()
+		return m.appendSystemNotice(dictationErrorText(err)), nil
+	}
+	m.dictation.streamStop = stop
+	m.dictation.phase = dictRecording
+
+	sink := m.runtimeMessageSink
+	ctx := m.dictation.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	transcriber := m.dictation.transcriber
+	submit := m.dictation.cfg.AutoSubmitEnabled()
+
+	// Tap the audio: compute a mic level per chunk for the live waveform, then
+	// forward the chunk to the transcriber. A small buffer keeps the tap from
+	// stalling capture if the transcriber briefly lags.
+	tapped := make(chan []byte, 16)
+	go func() {
+		defer close(tapped)
+		for chunk := range chunks {
+			if sink != nil {
+				sink(sttLevelMsg{level: dictation.ChunkLevel(chunk)})
+			}
+			// Also select on ctx.Done so this goroutine can't block forever on the
+			// send if StreamTranscribe exits early (e.g. a sherpa startup failure) and
+			// stops draining `tapped` — the session's cancel unblocks and drains it.
+			select {
+			case tapped <- chunk:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	streamCmd := func() tea.Msg {
+		onPartial := func(text string, final bool) {
+			if sink != nil {
+				sink(sttPartialMsg{text: text, final: final})
+			}
+		}
+		text, err := transcriber.StreamTranscribe(ctx, tapped, onPartial)
+		return dictationTranscribedMsg{text: text, err: err, submit: submit, streaming: true}
+	}
+	// Streaming drives the waveform from real levels (no synthetic tick needed).
+	return m, streamCmd
+}
+
+// handleDictationPartial renders a cumulative partial transcript into the
+// composer, replacing the previously-rendered live region wholesale so the text
+// builds up in place as the user keeps talking.
+func (m model) handleDictationPartial(msg sttPartialMsg) model {
+	// Ignore stragglers that arrive after the session ended (cancel/final).
+	if m.dictation.phase != dictRecording && m.dictation.phase != dictTranscribing {
+		return m
+	}
+	m.applyStreamingText(msg.text)
+	return m
+}
+
+// applyStreamingText replaces the current live region with text, tracking the
+// region's rune bounds so the next partial can overwrite it. The first partial
+// records the region start at the cursor and (if needed) a separating space.
+func (m *model) applyStreamingText(text string) {
+	state := m.currentComposerState()
+	if !m.dictation.regionActive {
+		m.dictation.regionActive = true
+		m.dictation.regionStart = state.cursor
+		m.dictation.regionEnd = state.cursor
+		m.dictation.regionPrefix = ""
+		if needsLeadingSpace(state) {
+			// Fold the separator into the region so a cancel removes it too.
+			m.dictation.regionPrefix = " "
+		}
+	}
+	// Replace [regionStart, regionEnd) with prefix + the new cumulative text.
+	rendered := m.dictation.regionPrefix + text
+	cleared := deleteComposerRange(state, m.dictation.regionStart, m.dictation.regionEnd)
+	cleared.cursor = m.dictation.regionStart
+	updated := insertComposerText(cleared, rendered)
+	m.dictation.regionEnd = m.dictation.regionStart + len([]rune(rendered))
+	m.setComposerState(updated)
+}
+
+// commitDictationRegion keeps the streamed text in the composer and stops
+// tracking it as a live region (used on successful completion — the final
+// transcript equals the last partial already rendered).
+func (m model) commitDictationRegion() model {
+	m.dictation.regionActive = false
+	return m
+}
+
+// discardDictationRegion removes the live streamed text from the composer (used
+// on cancel — the user aborted, so the half-formed transcript is dropped).
+func (m model) discardDictationRegion() model {
+	if m.dictation.regionActive {
+		state := m.currentComposerState()
+		m.setComposerState(deleteComposerRange(state, m.dictation.regionStart, m.dictation.regionEnd))
+		m.dictation.regionActive = false
+	}
+	return m
+}

--- a/internal/tui/dictation_stream.go
+++ b/internal/tui/dictation_stream.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -84,9 +85,6 @@ func (m model) handleDictationPartial(msg sttPartialMsg) model {
 	return m
 }
 
-// applyStreamingText replaces the current live region with text, tracking the
-// region's rune bounds so the next partial can overwrite it. The first partial
-// records the region start at the cursor and (if needed) a separating space.
 func (m *model) applyStreamingText(text string) {
 	state := m.currentComposerState()
 	if !m.dictation.regionActive {
@@ -94,15 +92,60 @@ func (m *model) applyStreamingText(text string) {
 		m.dictation.regionStart = state.cursor
 		m.dictation.regionEnd = state.cursor
 		m.dictation.regionPrefix = ""
+		// Anchor the prefix text BEFORE the live region. If the user types or
+		// pastes outside the region, the next partial can detect the change in
+		// this prefix and shift [start,end) to stay aligned.
+		m.dictation.regionAnchor = state.text
 		if needsLeadingSpace(state) {
 			// Fold the separator into the region so a cancel removes it too.
 			m.dictation.regionPrefix = " "
+		}
+	} else {
+		// Compare the prefix before the live region. If it changed (the user
+		// typed/pasted there) shift [start,end) by the length delta so the
+		// next partial's slice targets the right span. If the user edited
+		// INSIDE the region, drop the live region and re-anchor at the
+		// current cursor — we can't tell the partial from the user's text
+		// after that point.
+		prefix := string([]rune(state.text)[:m.dictation.regionStart])
+		anchor := m.dictation.regionAnchor
+		switch {
+		case prefix == anchor:
+			// External edit at or after the region — no shift needed.
+		case len(prefix) > len(anchor) && strings.HasPrefix(prefix, anchor):
+			// External edit inserted text just before the region (i.e. at
+			// position regionStart, pushing the region right).
+			delta := len([]rune(prefix)) - len([]rune(anchor))
+			m.dictation.regionStart += delta
+			m.dictation.regionEnd += delta
+			m.dictation.regionAnchor = prefix
+		case len(anchor) > len(prefix) && strings.HasPrefix(anchor, prefix):
+			// External delete just before the region.
+			delta := len([]rune(anchor)) - len([]rune(prefix))
+			m.dictation.regionStart -= delta
+			m.dictation.regionEnd -= delta
+			m.dictation.regionAnchor = prefix
+		default:
+			// User edited inside or across the region — can't safely
+			// overwrite. Drop the live region and re-anchor at the cursor
+			// so the next partial inserts as a fresh span.
+			m.dictation.regionStart = state.cursor
+			m.dictation.regionEnd = state.cursor
+			m.dictation.regionPrefix = ""
+			m.dictation.regionAnchor = string([]rune(state.text)[:state.cursor])
 		}
 	}
 	// Replace [regionStart, regionEnd) with prefix + the new cumulative text.
 	rendered := m.dictation.regionPrefix + text
 	cleared := deleteComposerRange(state, m.dictation.regionStart, m.dictation.regionEnd)
-	cleared.cursor = m.dictation.regionStart
+	// Preserve the user's cursor if they moved it outside the live region
+	// (e.g. to edit elsewhere in the composer) — yanking it to regionStart on
+	// every partial would steal their focus mid-edit.
+	if cleared.cursor < m.dictation.regionStart || cleared.cursor > m.dictation.regionEnd {
+		// keep cleared.cursor
+	} else {
+		cleared.cursor = m.dictation.regionStart
+	}
 	updated := insertComposerText(cleared, rendered)
 	m.dictation.regionEnd = m.dictation.regionStart + len([]rune(rendered))
 	m.setComposerState(updated)

--- a/internal/tui/dictation_test.go
+++ b/internal/tui/dictation_test.go
@@ -1,0 +1,304 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/dictation"
+)
+
+func TestDictationTranscribedInsertsIntoComposer(t *testing.T) {
+	m := model{}
+	m.setComposerState(composerState{text: "hello", cursor: 5})
+	m.dictation.phase = dictTranscribing
+
+	next, _ := m.handleDictationTranscribed(dictationTranscribedMsg{text: "world"})
+	got := next.(model)
+	if got.composer.text != "hello world" {
+		t.Errorf("composer = %q, want 'hello world'", got.composer.text)
+	}
+	if got.dictation.active() {
+		t.Error("dictation should be idle after transcription")
+	}
+}
+
+func TestDictationTranscribedEmptyIsNoticed(t *testing.T) {
+	m := model{}
+	m.dictation.phase = dictTranscribing
+	next, _ := m.handleDictationTranscribed(dictationTranscribedMsg{text: "   "})
+	got := next.(model)
+	if got.composer.text != "" {
+		t.Errorf("composer should stay empty, got %q", got.composer.text)
+	}
+	if !transcriptHasText(got, "No speech detected") {
+		t.Error("expected a 'no speech' notice")
+	}
+}
+
+func TestDictationTranscribedSetupErrorGuides(t *testing.T) {
+	m := model{}
+	m.dictation.phase = dictTranscribing
+	err := &dictation.SetupError{Tool: "arecord", Hint: "install alsa-utils"}
+	next, _ := m.handleDictationTranscribed(dictationTranscribedMsg{err: err})
+	got := next.(model)
+	if !transcriptHasText(got, "install alsa-utils") {
+		t.Error("expected setup guidance in the transcript")
+	}
+}
+
+func TestDictationAuthErrorReopensKeyPrompt(t *testing.T) {
+	// A cloud auth failure should offer an inline key prompt for the current
+	// provider (preserving its model), not dead-end on "run zero auth".
+	m := model{}
+	m.dictation.cfg = config.STTConfig{Provider: config.STTProviderGroq, Model: "whisper-large-v3-turbo"}
+	m.dictation.saveKey = func(string, string) error { return nil }
+	m.dictation.phase = dictTranscribing
+
+	err := &dictation.AuthError{Provider: "groq", Message: "auth error: your API key is missing or invalid"}
+	next, _ := m.handleDictationTranscribed(dictationTranscribedMsg{err: err})
+	got := next.(model)
+	if got.sttKeyPrompt == nil {
+		t.Fatal("an auth failure should reopen the API-key prompt")
+	}
+	if got.sttKeyPrompt.provider != "groq" || got.sttKeyPrompt.modelValue != "groq:whisper-large-v3-turbo" {
+		t.Errorf("key prompt = %+v, want groq / groq:whisper-large-v3-turbo", got.sttKeyPrompt)
+	}
+}
+
+func TestDictationNonAuthErrorDoesNotPrompt(t *testing.T) {
+	m := model{}
+	m.dictation.cfg = config.STTConfig{Provider: config.STTProviderGroq}
+	m.dictation.saveKey = func(string, string) error { return nil }
+	m.dictation.phase = dictTranscribing
+
+	next, _ := m.handleDictationTranscribed(dictationTranscribedMsg{err: errors.New("network unreachable")})
+	got := next.(model)
+	if got.sttKeyPrompt != nil {
+		t.Error("a non-auth error must not open the key prompt")
+	}
+	if !transcriptHasText(got, "network unreachable") {
+		t.Error("expected the raw error in the transcript")
+	}
+}
+
+func TestDictationStartedFailureResets(t *testing.T) {
+	m := model{}
+	m.dictation.phase = dictStarting
+	m.dictation.streaming = false
+	got, _ := m.handleDictationStarted(dictationStartedMsg{err: errors.New("mic busy")})
+	if got.dictation.active() {
+		t.Error("a start failure should reset to idle")
+	}
+	if !transcriptHasText(got, "mic busy") {
+		t.Error("expected the start error in the transcript")
+	}
+}
+
+func TestDictationStartedArmsRecording(t *testing.T) {
+	m := model{}
+	m.dictation.phase = dictStarting
+	got, _ := m.handleDictationStarted(dictationStartedMsg{})
+	if got.dictation.phase != dictRecording {
+		t.Error("a successful start should advance to recording")
+	}
+}
+
+func TestDictationUnavailableShowsHint(t *testing.T) {
+	m := model{} // no build factory
+	next, _ := m.toggleDictation()
+	if !transcriptHasText(next, "not configured") {
+		t.Error("expected a 'not configured' hint when dictation is unavailable")
+	}
+}
+
+func TestDictationStreamingPartialReplacesRegion(t *testing.T) {
+	m := model{}
+	m.setComposerState(composerState{text: "note:", cursor: 5})
+	m.dictation.phase = dictRecording
+	m.dictation.streaming = true
+
+	m = m.handleDictationPartial(sttPartialMsg{text: "the quick"})
+	if m.composer.text != "note: the quick" {
+		t.Fatalf("after first partial: %q", m.composer.text)
+	}
+	// A longer cumulative partial replaces the previous region wholesale.
+	m = m.handleDictationPartial(sttPartialMsg{text: "the quick brown fox"})
+	if m.composer.text != "note: the quick brown fox" {
+		t.Fatalf("after second partial: %q", m.composer.text)
+	}
+	// Cancel discards the streamed region.
+	m2 := m.discardDictationRegion()
+	if m2.composer.text != "note:" {
+		t.Errorf("discard should restore original text, got %q", m2.composer.text)
+	}
+}
+
+func TestDictationCommitKeepsStreamedText(t *testing.T) {
+	m := model{}
+	m.setComposerState(composerState{text: "", cursor: 0})
+	m.dictation.phase = dictRecording
+	m.dictation.streaming = true
+	m = m.handleDictationPartial(sttPartialMsg{text: "final words"})
+	got, _ := m.handleDictationTranscribed(dictationTranscribedMsg{text: "final words", streaming: true})
+	if got.(model).composer.text != "final words" {
+		t.Errorf("committed streamed text lost: %q", got.(model).composer.text)
+	}
+}
+
+func TestVoiceOffReleasesWarmServer(t *testing.T) {
+	shutdownCalls := 0
+	m := model{}
+	m.dictation.build = func(config.STTConfig, bool) (Transcriber, bool, error) { return nil, false, nil } // makes available()
+	m.dictation.shutdownServer = func(context.Context) error { shutdownCalls++; return nil }
+
+	on, _ := m.toggleVoiceMode()
+	if !on.dictation.voiceModeEnabled {
+		t.Fatal("voice should be on after first toggle")
+	}
+	off, cmd := on.toggleVoiceMode()
+	if off.dictation.voiceModeEnabled {
+		t.Fatal("voice should be off after second toggle")
+	}
+	if cmd == nil {
+		t.Fatal("turning voice off should return a server-release command")
+	}
+	cmd() // run it
+	if shutdownCalls != 1 {
+		t.Errorf("shutdown called %d times, want 1", shutdownCalls)
+	}
+}
+
+func TestVoiceOffMidRecordingKeepsServer(t *testing.T) {
+	m := model{}
+	m.dictation.build = func(config.STTConfig, bool) (Transcriber, bool, error) { return nil, false, nil }
+	m.dictation.shutdownServer = func(context.Context) error {
+		t.Error("must not tear down the server while a recording is in flight")
+		return nil
+	}
+	m.dictation.voiceModeEnabled = true
+	m.dictation.phase = dictRecording
+	if _, cmd := m.toggleVoiceMode(); cmd != nil {
+		t.Error("no server-release command should be issued mid-recording")
+	}
+}
+
+func TestWantStreamingGatedByConfigAndPlatform(t *testing.T) {
+	streamOff := false
+	d := dictationController{cfg: config.STTConfig{Streaming: &streamOff}, platform: dictation.PlatformLinux}
+	if d.wantStreaming() {
+		t.Error("streaming:false in config should disable streaming")
+	}
+	d = dictationController{platform: dictation.PlatformTermux}
+	if d.wantStreaming() {
+		t.Error("Termux has no streaming capture, wantStreaming must be false")
+	}
+	d = dictationController{platform: dictation.PlatformLinux}
+	if !d.wantStreaming() {
+		t.Error("desktop default should want streaming")
+	}
+}
+
+func TestNeedsLeadingSpace(t *testing.T) {
+	if needsLeadingSpace(composerState{text: "hi", cursor: 2}) != true {
+		t.Error("cursor after non-space should need a leading space")
+	}
+	if needsLeadingSpace(composerState{text: "hi ", cursor: 3}) != false {
+		t.Error("cursor after a space should not need one")
+	}
+	if needsLeadingSpace(composerState{text: "", cursor: 0}) != false {
+		t.Error("empty composer should not need a leading space")
+	}
+}
+
+func TestDictationBatchCtxNonNil(t *testing.T) {
+	d := dictationController{}
+	if got := transcribeBatchCtx(d.ctx); got == nil {
+		t.Error("batch ctx should never be nil")
+	}
+}
+
+// transcribeBatchCtx mirrors the nil-guard in transcribeBatchCmd for testing.
+func transcribeBatchCtx(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+func transcriptHasText(m model, substr string) bool {
+	for _, row := range m.transcript {
+		if strings.Contains(row.text, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWaveformRendersLevels(t *testing.T) {
+	// Higher levels render taller bars; the ring scrolls left as levels arrive.
+	var d dictationController
+	d.pushLevel(levelHeight(1.0)) // loud → tall
+	d.pushLevel(levelHeight(0.0)) // silent → short
+	bars := renderWaveBars(d.waveBars)
+	if len([]rune(bars)) != waveBarCount {
+		t.Errorf("waveform width = %d, want %d", len([]rune(bars)), waveBarCount)
+	}
+	// The newest (rightmost) bar reflects the last pushed level (silent → space/low).
+	runes := []rune(bars)
+	if runes[waveBarCount-1] != waveRunes[0] {
+		t.Errorf("last bar should be the silent level, got %q", string(runes[waveBarCount-1]))
+	}
+}
+
+func TestDictationLevelDrivesWave(t *testing.T) {
+	m := model{}
+	m.dictation.phase = dictRecording
+	m = m.handleDictationLevel(sttLevelMsg{level: 0.9})
+	if len(m.dictation.waveBars) != waveBarCount {
+		t.Fatalf("a mic level should populate the waveform ring")
+	}
+	if m.dictation.waveBars[waveBarCount-1] != levelHeight(0.9) {
+		t.Error("the newest bar should match the received mic level")
+	}
+}
+
+func TestHandleRecTickOnlyAnimatesWhileRecording(t *testing.T) {
+	m := model{}
+	m.dictation.phase = dictRecording
+	next, cmd := m.handleRecTick()
+	if next.dictation.waveTick != 1 || cmd == nil {
+		t.Error("recording should advance the batch synthetic wave and reschedule")
+	}
+	m.dictation.phase = dictIdle
+	_, cmd = m.handleRecTick()
+	if cmd != nil {
+		t.Error("idle should stop ticking")
+	}
+}
+
+func TestCurrentModelLabel(t *testing.T) {
+	// Cloud provider + model.
+	d := dictationController{cfg: config.STTConfig{Provider: config.STTProviderGroq, Model: "whisper-large-v3-turbo"}}
+	if got := d.currentModelLabel(); got != "Groq whisper-large-v3-turbo" {
+		t.Errorf("groq label = %q", got)
+	}
+	// Cloud provider with default model.
+	d = dictationController{cfg: config.STTConfig{Provider: config.STTProviderOpenAI}}
+	if got := d.currentModelLabel(); got != "OpenAI whisper-1" {
+		t.Errorf("openai default label = %q", got)
+	}
+	// Local with a downloaded curated variant → "Local · <friendly name>".
+	kroko := dictation.ModelVariants()[0] // Kroko streaming
+	d = dictationController{cfg: config.STTConfig{Provider: config.STTProviderLocal, LocalModelPath: "/home/x/.config/zero/stt/" + kroko.DirName + "/sherpa-onnx-...-kroko"}}
+	if got := d.currentModelLabel(); got != "Local · "+kroko.Label {
+		t.Errorf("local kroko label = %q, want %q", got, "Local · "+kroko.Label)
+	}
+	// Local with no model.
+	d = dictationController{cfg: config.STTConfig{Provider: config.STTProviderLocal}}
+	if got := d.currentModelLabel(); got != "Local (no model set)" {
+		t.Errorf("no-model label = %q", got)
+	}
+}

--- a/internal/tui/dictation_voice.go
+++ b/internal/tui/dictation_voice.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+// Voice mode's Space-hold gesture — the (only) dictation trigger. Two terminal
+// tiers:
+//
+//  1. The terminal confirms key-release reporting (Ghostty/Kitty/WezTerm, …):
+//     Space press starts recording, Space release stops it — true hold-to-record,
+//     no ambiguity.
+//  2. The terminal does not confirm release events: Space falls back to
+//     press-to-toggle (press to start, press again to stop) — a deliberately
+//     simpler, robust fallback than inferring release from key-repeat timing
+//     (racy in a terminal). This works on ANY terminal, so voice mode is always
+//     usable once enabled.
+//
+// Only active while voice mode is on; the rest of dispatch is built on
+// KeyPressMsg and is untouched.
+
+// handleKeyboardEnhancements records the terminal's confirmed keyboard
+// capabilities, so voice mode knows whether hold-to-record is available.
+func (m model) handleKeyboardEnhancements(msg tea.KeyboardEnhancementsMsg) model {
+	m.dictation.eventTypesKnown = true
+	m.dictation.eventTypesSupported = msg.SupportsEventTypes()
+	return m
+}
+
+// handleVoiceSpacePress handles a Space press while voice mode is on.
+func (m model) handleVoiceSpacePress(msg tea.KeyMsg) (model, tea.Cmd) {
+	if !m.dictation.eventTypesSupported {
+		// Tier 2: no release events — press-to-toggle.
+		return m.toggleDictation()
+	}
+	// Tier 1: hold-to-record. Ignore auto-repeat presses while the key is held.
+	if msg.Key().IsRepeat {
+		return m, nil
+	}
+	if m.dictation.phase == dictIdle {
+		m.dictation.spaceHeld = true
+		m.dictation.voiceStopPending = false
+		return m.startDictation()
+	}
+	return m, nil // already recording; the release will stop it
+}
+
+// handleVoiceSpaceRelease stops a hold-to-record session when Space is released.
+func (m model) handleVoiceSpaceRelease() (model, tea.Cmd) {
+	if !m.dictation.spaceHeld {
+		return m, nil
+	}
+	m.dictation.spaceHeld = false
+	switch m.dictation.phase {
+	case dictRecording:
+		return m.stopDictation()
+	case dictStarting:
+		// Released before the recording finished starting; stop as soon as it does.
+		m.dictation.voiceStopPending = true
+		return m, nil
+	}
+	return m, nil
+}

--- a/internal/tui/dictation_voice_test.go
+++ b/internal/tui/dictation_voice_test.go
@@ -1,0 +1,144 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+type fakeTUITranscriber struct{}
+
+func (fakeTUITranscriber) Transcribe(context.Context, []byte) (string, error) { return "", nil }
+func (fakeTUITranscriber) StreamTranscribe(context.Context, <-chan []byte, func(string, bool)) (string, error) {
+	return "", nil
+}
+
+// batchOnlyController builds a controller whose recordings take the batch path
+// (streaming disabled), so startDictation returns an unexecuted command instead
+// of exec'ing a real capture tool.
+func batchOnlyController() dictationController {
+	streamOff := false
+	return dictationController{
+		cfg:      config.STTConfig{Streaming: &streamOff},
+		platform: "linux",
+		build: func(config.STTConfig, bool) (Transcriber, bool, error) {
+			return fakeTUITranscriber{}, false, nil
+		},
+	}
+}
+
+func TestToggleVoiceModeFlips(t *testing.T) {
+	m := model{dictation: batchOnlyController()}
+	next, _ := m.toggleVoiceMode()
+	if !next.dictation.voiceModeEnabled {
+		t.Fatal("first /voice should enable voice mode")
+	}
+	if !transcriptHasText(next, "Voice mode on") {
+		t.Error("expected voice-mode-on notice")
+	}
+	off, _ := next.toggleVoiceMode()
+	if off.dictation.voiceModeEnabled {
+		t.Error("second /voice should disable voice mode")
+	}
+}
+
+func TestVoiceModeUnavailableWithoutFactory(t *testing.T) {
+	m := model{} // no build factory
+	next, _ := m.toggleVoiceMode()
+	if next.dictation.voiceModeEnabled {
+		t.Error("voice mode must not enable when dictation is unavailable")
+	}
+	if !transcriptHasText(next, "not configured") {
+		t.Error("expected a not-configured hint")
+	}
+}
+
+func TestKeyboardEnhancementsRecorded(t *testing.T) {
+	m := model{dictation: batchOnlyController()}
+	// Flags with the event-types bit unset → not supported.
+	m = m.handleKeyboardEnhancements(tea.KeyboardEnhancementsMsg{Flags: 0})
+	if !m.dictation.eventTypesKnown || m.dictation.eventTypesSupported {
+		t.Error("Flags=0 should be known-but-unsupported")
+	}
+}
+
+func TestVoiceSpaceHoldStartsRecording(t *testing.T) {
+	m := model{dictation: batchOnlyController()}
+	m.dictation.voiceModeEnabled = true
+	m.dictation.eventTypesSupported = true
+
+	press := tea.KeyPressMsg(tea.Key{Code: tea.KeySpace})
+	next, cmd := m.handleVoiceSpacePress(press)
+	if next.dictation.phase != dictStarting {
+		t.Fatalf("Space press should start recording (phase=%d)", next.dictation.phase)
+	}
+	if !next.dictation.spaceHeld {
+		t.Error("spaceHeld should be set in hold mode")
+	}
+	if cmd == nil {
+		t.Error("expected a start command")
+	}
+}
+
+func TestVoiceSpaceHoldIgnoresRepeat(t *testing.T) {
+	m := model{dictation: batchOnlyController()}
+	m.dictation.voiceModeEnabled = true
+	m.dictation.eventTypesSupported = true
+	m.dictation.phase = dictRecording
+	m.dictation.spaceHeld = true
+
+	repeat := tea.KeyPressMsg(tea.Key{Code: tea.KeySpace, IsRepeat: true})
+	next, _ := m.handleVoiceSpacePress(repeat)
+	if next.dictation.phase != dictRecording {
+		t.Error("auto-repeat while held must not restart or change phase")
+	}
+}
+
+func TestVoiceSpaceReleaseStops(t *testing.T) {
+	m := model{dictation: batchOnlyController()}
+	m.dictation.voiceModeEnabled = true
+	m.dictation.eventTypesSupported = true
+	m.dictation.phase = dictRecording
+	m.dictation.spaceHeld = true
+
+	next, _ := m.handleVoiceSpaceRelease()
+	if next.dictation.phase != dictTranscribing {
+		t.Errorf("release should stop recording → transcribing (phase=%d)", next.dictation.phase)
+	}
+	if next.dictation.spaceHeld {
+		t.Error("spaceHeld should clear on release")
+	}
+}
+
+func TestVoiceReleaseDuringStartupDefersStop(t *testing.T) {
+	m := model{dictation: batchOnlyController()}
+	m.dictation.voiceModeEnabled = true
+	m.dictation.eventTypesSupported = true
+	m.dictation.phase = dictStarting
+	m.dictation.spaceHeld = true
+
+	next, _ := m.handleVoiceSpaceRelease()
+	if !next.dictation.voiceStopPending {
+		t.Error("a release during startup should defer the stop")
+	}
+	// When the recording finishes starting, the deferred stop fires.
+	after, _ := next.handleDictationStarted(dictationStartedMsg{})
+	if after.dictation.phase != dictTranscribing {
+		t.Errorf("deferred stop should transition to transcribing (phase=%d)", after.dictation.phase)
+	}
+}
+
+func TestVoiceSpaceToggleFallback(t *testing.T) {
+	m := model{dictation: batchOnlyController()}
+	m.dictation.voiceModeEnabled = true
+	m.dictation.eventTypesSupported = false // no release events → toggle fallback
+
+	press := tea.KeyPressMsg(tea.Key{Code: tea.KeySpace})
+	next, _ := m.handleVoiceSpacePress(press)
+	if next.dictation.phase != dictStarting {
+		t.Errorf("toggle-mode Space should start recording (phase=%d)", next.dictation.phase)
+	}
+}

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -78,6 +79,9 @@ func (p parsedBinding) Label() string {
 			b.WriteString("PgUp")
 		case tea.KeyPgDown:
 			b.WriteString("PgDn")
+		case tea.KeyF1, tea.KeyF2, tea.KeyF3, tea.KeyF4, tea.KeyF5, tea.KeyF6,
+			tea.KeyF7, tea.KeyF8, tea.KeyF9, tea.KeyF10, tea.KeyF11, tea.KeyF12:
+			b.WriteString(fKeyLabel(p.code))
 		default:
 			// Printable character — uppercase for display
 			if p.code >= 'a' && p.code <= 'z' {
@@ -207,6 +211,30 @@ func parseBinding(s string) parsedBinding {
 		p.code = tea.KeyPgUp
 	case "pgdown", "pagedown":
 		p.code = tea.KeyPgDown
+	case "f1":
+		p.code = tea.KeyF1
+	case "f2":
+		p.code = tea.KeyF2
+	case "f3":
+		p.code = tea.KeyF3
+	case "f4":
+		p.code = tea.KeyF4
+	case "f5":
+		p.code = tea.KeyF5
+	case "f6":
+		p.code = tea.KeyF6
+	case "f7":
+		p.code = tea.KeyF7
+	case "f8":
+		p.code = tea.KeyF8
+	case "f9":
+		p.code = tea.KeyF9
+	case "f10":
+		p.code = tea.KeyF10
+	case "f11":
+		p.code = tea.KeyF11
+	case "f12":
+		p.code = tea.KeyF12
 	case "?":
 		p.text = "?"
 		p.code = 0
@@ -241,6 +269,13 @@ type keyBindings struct {
 	cycleReasoning parsedBinding
 	togglePlan     parsedBinding
 	toggleSidebar  parsedBinding
+}
+
+// fKeyLabel renders a function-key code as "F9" etc. tea.KeyF1..KeyF12 are
+// sequential, so the offset from KeyF1 gives the number.
+func fKeyLabel(code rune) string {
+	n := int(code-tea.KeyF1) + 1
+	return "F" + strconv.Itoa(n)
 }
 
 // resolveKeyBindings converts a user-facing KeyBindingsConfig into the

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -157,6 +157,8 @@ type model struct {
 	composerCursorVisible bool
 	composerPastePreviews []composerPastePreview
 	composerSelection     composerSelectionState
+	dictation             dictationController
+	sttKeyPrompt          *sttKeyPromptState
 	// plan holds the sticky plan panel state (steps, expansion, timings)
 	// synced from the update_plan tool. See plan_panel.go.
 	plan            planPanelState
@@ -803,6 +805,7 @@ func newModel(ctx context.Context, options Options) model {
 		swarmSessionMap:             map[string]string{},
 		setup:                       newSetupState(options.Setup),
 		setupSave:                   options.Setup.Save,
+		dictation:                   newDictationController(options),
 	}
 	// Apply an explicit theme immediately; auto stays on the dark default until
 	// Init's terminal background probe resolves it (see Init / BackgroundColorMsg).
@@ -946,7 +949,8 @@ func (m *model) stopPRWatcher() {
 // by every shortcut that should defer to whichever modal is focused.
 func (m model) noBlockingModal() bool {
 	return m.pendingPermission == nil && m.pendingAskUser == nil && m.pendingSpecReview == nil &&
-		m.providerWizard == nil && m.mcpAddWizard == nil && m.mcpManager == nil && m.picker == nil
+		m.providerWizard == nil && m.mcpAddWizard == nil && m.mcpManager == nil && m.picker == nil &&
+		m.sttKeyPrompt == nil
 }
 
 func (m model) quit() (tea.Model, tea.Cmd) {
@@ -960,12 +964,16 @@ func (m model) quit() (tea.Model, tea.Cmd) {
 // Best-effort with a short deadline so a slow server can't hang the quit; the
 // servers are our child processes and would be reaped on exit regardless.
 func (m model) shutdownLSPManager() {
-	if m.lspManager == nil {
-		return
-	}
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_ = m.lspManager.Shutdown(shutdownCtx)
+	if m.lspManager != nil {
+		_ = m.lspManager.Shutdown(shutdownCtx)
+	}
+	// The warm sherpa-onnx streaming server is a session-long child process too;
+	// tear it down alongside the language servers (§6a).
+	if m.dictation.shutdownServer != nil {
+		_ = m.dictation.shutdownServer(shutdownCtx)
+	}
 }
 
 func (m model) handleCtrlC() (tea.Model, tea.Cmd) {
@@ -1130,10 +1138,46 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m.attachClipboardImage(msg.data, msg.mediaType), nil
 	case tea.PasteMsg:
+		// A paste into the cloud-STT key prompt fills the key (the common way to
+		// enter an API key), not the composer.
+		if m.sttKeyPrompt != nil {
+			m.sttKeyPrompt.input += strings.TrimSpace(msg.Content)
+			return m, nil
+		}
 		return m.routePaste(msg.Content)
+	case dictationStartedMsg:
+		return m.handleDictationStarted(msg)
+	case dictationTranscribedMsg:
+		return m.handleDictationTranscribed(msg)
+	case sttPartialMsg:
+		return m.handleDictationPartial(msg), nil
+	case sttDownloadProgressMsg:
+		return m.handleDictationDownloadProgress(msg), nil
+	case dictationDownloadedMsg:
+		return m.handleDictationDownloaded(msg)
+	case sttModelsFetchedMsg:
+		return m.handleSTTModelsFetched(msg), nil
+	case recTickMsg:
+		return m.handleRecTick()
+	case sttLevelMsg:
+		return m.handleDictationLevel(msg), nil
+	case tea.KeyboardEnhancementsMsg:
+		return m.handleKeyboardEnhancements(msg), nil
+	case tea.KeyReleaseMsg:
+		// Voice mode's hold-to-record ends on Space release; every other release
+		// event is ignored (dispatch elsewhere is press-based).
+		if m.dictation.voiceModeEnabled && keyIs(msg, tea.KeySpace) {
+			return m.handleVoiceSpaceRelease()
+		}
+		return m, nil
 	case tea.KeyPressMsg:
 		if m.setup.visible {
 			return m.handleSetupKey(msg)
+		}
+		// The cloud-STT API-key prompt is modal: it owns every keystroke (masked
+		// input) until Enter saves or Esc cancels.
+		if m.sttKeyPrompt != nil {
+			return m.handleSTTKeyPromptKey(msg)
 		}
 		m.transcriptSelection = transcriptSelectionState{}
 		m.composerSelection = composerSelectionState{}
@@ -1178,6 +1222,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.appendSystemNotice(fmt.Sprintf("Mouse released — drag to select and copy text. Press %s again to re-enable mouse interaction (clicks, right-click paste).", mouseKey)), nil
 			}
 			return m.appendSystemNotice("Mouse interaction re-enabled."), nil
+		case m.dictation.voiceModeEnabled && !m.transcriptDetailed && keyIs(msg, tea.KeySpace) && !keyHasMod(msg, tea.ModCtrl) && !keyAlt(msg) && m.noBlockingModal():
+			// Voice mode (/voice) repurposes Space into the record gesture — the only
+			// dictation trigger — so it must not also type a space. Turn voice mode
+			// off (/voice) to type normally.
+			return m.handleVoiceSpacePress(msg)
 		case keyIs(msg, tea.KeyEsc):
 			// Esc is heavily overloaded below (subchat exit, MCP cancel, ask-user,
 			// permission deny, wizard/picker/suggestions dismiss, ...) before ever
@@ -1188,6 +1237,12 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// armed for some later, unrelated Esc to silently act on.
 			wasConfirmingCancel := m.pending && m.cancelConfirmActive
 			m = m.disarmCancelConfirmation()
+			// An active dictation recording cancels on Esc (releases the mic, drops
+			// the audio) before any other Esc consumer — a recording in progress is
+			// the most immediate thing the user would want Esc to stop.
+			if m.dictation.active() {
+				return m.cancelDictation()
+			}
 			// Subchat view exits on Esc (returns to main chat).
 			if m.subchat.active {
 				m.chatScrollOffset = m.subchat.exit()
@@ -2369,6 +2424,10 @@ func (m model) View() tea.View {
 		view.BackgroundColor = zeroTheme.bgPanel
 	}
 	view.ReportFocus = m.notifier != nil
+	// Voice mode's Space-hold gesture needs key-release events (Kitty protocol).
+	// Request them only while voice mode is on — the renderer re-sends the request
+	// only when the value changes, so gating this costs nothing (§10).
+	view.KeyboardEnhancements.ReportEventTypes = m.dictation.voiceModeEnabled
 	if m.wantsMouseCapture() {
 		if isRunningUnderPRoot() {
 			// Under PRoot the AllMotion (1003) sequence doesn't work
@@ -2442,8 +2501,11 @@ func (m model) transcriptView() string {
 	mcpAddOverlay := m.mcpAddWizardOverlay(width)
 	mcpOverlay := m.mcpManagerOverlay(width)
 	pickerOverlay := m.pickerOverlay(width)
+	sttKeyOverlay := m.sttKeyPromptOverlay(width)
 	viewportOverlay := ""
 	switch {
+	case sttKeyOverlay != "":
+		viewportOverlay = sttKeyOverlay
 	case helpOverlayContent != "":
 		viewportOverlay = helpOverlayContent
 	case providerOverlay != "":
@@ -3784,6 +3846,19 @@ func (m model) choosePicker() (tea.Model, tea.Cmd) {
 		// submitting (a bare second Enter runs it without one); names the slash
 		// path cannot reach run immediately instead.
 		m, cmd = m.chooseSkillFromPicker(item)
+	case pickerSTTModel:
+		// Selecting the local engine with no model (and auto-download available)
+		// chains into the variant-download picker instead of finalizing.
+		if next, fetchCmd, opened := m.maybeOpenSTTDownloadPicker(item.Value); opened {
+			return next, fetchCmd
+		}
+		text := ""
+		m, text = m.handleSTTModelSelection(item.Value)
+		if text != "" { // empty when a key prompt opened instead of finalizing
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		}
+	case pickerSTTDownload:
+		return m.handleSTTDownloadSelection(item.Value)
 	case pickerTheme:
 		// The hovered palette is already live from the preview; handleThemeCommand
 		// records the choice (m.themeMode) and re-applies it, and reports the switch.
@@ -3981,6 +4056,14 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m, text = m.handleModelCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
+	case commandSTTModel:
+		if m.pending {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: pickerBusyText(command.name)})
+			return m, nil
+		}
+		return m.openSTTModelPicker()
+	case commandVoice:
+		return m.toggleVoiceMode()
 	case commandContext:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.contextText()})
 		return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1238,9 +1238,12 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			wasConfirmingCancel := m.pending && m.cancelConfirmActive
 			m = m.disarmCancelConfirmation()
 			// An active dictation recording cancels on Esc (releases the mic, drops
-			// the audio) before any other Esc consumer — a recording in progress is
-			// the most immediate thing the user would want Esc to stop.
-			if m.dictation.active() {
+			// the audio) — but only if this Esc isn't a confirming run-cancel
+			// press. Without this guard, a user mid-recording who double-Esc's
+			// to kill the run finds the first Esc swallowed by dictation and
+			// the run still going. The pending run cancel happens further
+			// down at the bottom of the Esc branch.
+			if m.dictation.active() && !wasConfirmingCancel {
 				return m.cancelDictation()
 			}
 			// Subchat view exits on Esc (returns to main chat).

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -467,7 +467,8 @@ func (m *model) selectGenericPickerAtMouse(msg tea.MouseMsg) (mouseSelectionTarg
 	selected := clampInt(m.picker.selected, 0, len(m.picker.items)-1)
 	start := selectableListStart(len(m.picker.items), maxVisible, selected)
 	visible := m.picker.items[start : start+maxVisible]
-	line := 2
+	// y=0 titled top border, y=1 search line, y=2 separator; rows begin at y=3.
+	line := 3
 	lastGroup := ""
 	for offset, item := range visible {
 		if item.Group != "" && item.Group != lastGroup {

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -62,7 +62,8 @@ func TestMouseClickSelectsThenAppliesPickerRow(t *testing.T) {
 
 	width := m.chatColumnWidth()
 	top := m.overlayMouseTop(len(viewLines(m.pickerOverlay(width))), width)
-	click := testMouseClick(tea.MouseLeft, width/2, top+3)
+	// Rows: y=0 titled border, y=1 search, y=2 separator, y=3 "auto", y=4 "high".
+	click := testMouseClick(tea.MouseLeft, width/2, top+4)
 	updated, cmd := m.Update(click)
 	next := updated.(model)
 	if cmd != nil {

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -76,6 +76,37 @@ type Options struct {
 	// KeyBindingsConfig means "use built-in defaults" for each action.
 	KeyBindings config.KeyBindingsConfig
 
+	// STT configures speech-to-text dictation (§ docs/dictation.md).
+	STT config.STTConfig
+	// BuildDictationTranscriber constructs the transcriber for the current STT
+	// config. It lives in the CLI layer because it resolves provider API keys
+	// (credstore + env) and base URLs; the TUI only calls it when a recording
+	// starts. preferStreaming asks for the streaming backend; the returned
+	// `streaming` bool reports whether streaming is actually available (false
+	// falls the caller back to the batch pipeline). Nil disables dictation (the
+	// keybinding shows a "not configured" hint). cfg is passed each call (not
+	// captured) so a mid-session config change — e.g. the auto-download writing
+	// localModelPath — takes effect on the next recording.
+	BuildDictationTranscriber func(cfg config.STTConfig, preferStreaming bool) (t Transcriber, streaming bool, err error)
+
+	// ShutdownDictationServer tears down the warm sherpa-onnx streaming server (if
+	// one was started), called alongside the LSP manager's shutdown on exit. Nil
+	// when dictation is not wired.
+	ShutdownDictationServer func(context.Context) error
+
+	// STTDownloadRoot is where the auto-download stores the sherpa-onnx engine
+	// and model (e.g. ~/.config/zero/stt). Empty disables auto-download (the F9
+	// setup message then only points at manual setup / cloud providers).
+	STTDownloadRoot string
+
+	// STTKeyStatus reports whether an API key is already resolvable for a cloud
+	// STT provider ("groq"/"openai"/"deepgram"). Nil disables the inline key
+	// prompt (dictation then just shows the "run zero auth" setup error).
+	STTKeyStatus func(provider string) bool
+	// SaveSTTKey stores an API key for a cloud STT provider in the credential
+	// store, so the inline prompt can capture and persist it.
+	SaveSTTKey func(provider, key string) error
+
 	// AltScreen tells the model it is running inside Bubble Tea's alternate
 	// screen. Run sets this for the interactive app; tests can leave it false
 	// to exercise the native scrollback renderer.

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -25,6 +25,8 @@ const (
 	pickerSession
 	pickerTheme
 	pickerSkill
+	pickerSTTModel
+	pickerSTTDownload
 )
 
 // pickerItem is one selectable row: Label is shown, Value is passed to the
@@ -56,6 +58,9 @@ type commandPicker struct {
 	allItems []pickerItem
 	query    string
 	selected int
+	// loading marks a picker still fetching its rows (e.g. the STT model list from
+	// GitHub): the overlay shows a "fetching…" line instead of "no matching items".
+	loading bool
 }
 
 func (p *commandPicker) move(delta int) {

--- a/internal/tui/stt_key_prompt.go
+++ b/internal/tui/stt_key_prompt.go
@@ -1,0 +1,163 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/dictation"
+)
+
+// sttKeyPromptState is the inline API-key prompt shown when a cloud dictation
+// provider is chosen. On submit the key is saved to the credential store and the
+// model selection is finalized. When optional is set a key is already on file, so
+// Esc/empty-Enter keeps it and still applies the model (this is the proactive path
+// for replacing a key that turned out to be invalid — you don't have to trigger a
+// failed recording first).
+type sttKeyPromptState struct {
+	provider   string // "groq" / "openai"
+	label      string // "Groq" / "OpenAI"
+	modelValue string // the picker value to finalize, e.g. "groq:whisper-large-v3-turbo"
+	input      string
+	optional   bool // a key already resolves; entering a new one just replaces it
+}
+
+// maybeOfferKeyOnAuthError, when err is a cloud AuthError, reopens the API-key
+// prompt for the currently-selected cloud provider (preserving its model) so the
+// user can fix a missing/invalid key and retry. Returns handled=false for any
+// other error (or when no key can be saved / the provider is local).
+func (m model) maybeOfferKeyOnAuthError(err error) (model, bool) {
+	var authErr *dictation.AuthError
+	if !errors.As(err, &authErr) || m.dictation.saveKey == nil {
+		return m, false
+	}
+	provider := string(m.dictation.cfg.Provider)
+	if provider == "" || m.dictation.cfg.STTProvider() == config.STTProviderLocal {
+		return m, false
+	}
+	value := provider + sttValueSep + m.dictation.cfg.Model
+	m = m.appendSystemNotice(dictationErrorText(err) + " — paste your " + titleCase(provider) + " API key below to fix it and retry.")
+	// The existing key is invalid, so a new one is required here (Esc cancels).
+	return m.openSTTKeyPrompt(provider, value, false), true
+}
+
+// openSTTKeyPrompt begins collecting the API key for a cloud provider. optional
+// marks that a key already resolves, so the prompt can be dismissed to keep it.
+func (m model) openSTTKeyPrompt(provider, modelValue string, optional bool) model {
+	m.sttKeyPrompt = &sttKeyPromptState{
+		provider:   provider,
+		label:      titleCase(provider),
+		modelValue: modelValue,
+		optional:   optional,
+	}
+	m.clearSuggestions()
+	return m
+}
+
+// handleSTTKeyPromptKey captures typing for the API-key prompt. It fully owns
+// the keystroke while the prompt is open (masked input, Enter saves, Esc cancels).
+func (m model) handleSTTKeyPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	p := m.sttKeyPrompt
+	switch {
+	case keyIs(msg, tea.KeyEsc), keyCtrl(msg, 'c'):
+		if p.optional {
+			// A key is already on file — keep it and apply the model selection.
+			return m.finalizeSTTModelFromKey(p, "Kept your saved "+p.label+" API key. ")
+		}
+		m.sttKeyPrompt = nil
+		return m.appendSystemNotice("Cancelled — no " + p.label + " API key saved."), nil
+	case keyIs(msg, tea.KeyEnter):
+		return m.submitSTTKey()
+	case keyBackspace(msg):
+		if r := []rune(p.input); len(r) > 0 {
+			p.input = string(r[:len(r)-1])
+		}
+		return m, nil
+	case keyCtrl(msg, 'u'):
+		p.input = ""
+		return m, nil
+	default:
+		if t := keyText(msg); t != "" && !keyAlt(msg) && !keyHasMod(msg, tea.ModCtrl) {
+			p.input += t
+		}
+		return m, nil
+	}
+}
+
+// submitSTTKey saves the entered key and finalizes the pending model selection.
+func (m model) submitSTTKey() (tea.Model, tea.Cmd) {
+	p := m.sttKeyPrompt
+	key := strings.TrimSpace(p.input)
+	if key == "" {
+		if p.optional {
+			// Nothing typed but a key is already on file — keep it and apply the model.
+			return m.finalizeSTTModelFromKey(p, "Kept your saved "+p.label+" API key. ")
+		}
+		m.sttKeyPrompt = nil
+		return m.appendSystemNotice("No key entered — nothing saved."), nil
+	}
+	if m.dictation.saveKey != nil {
+		if err := m.dictation.saveKey(p.provider, key); err != nil {
+			m.sttKeyPrompt = nil
+			return m.appendSystemNotice("Couldn't save the " + p.label + " API key: " + err.Error()), nil
+		}
+	}
+	return m.finalizeSTTModelFromKey(p, "Saved your "+p.label+" API key. ")
+}
+
+// finalizeSTTModelFromKey closes the prompt and commits the pending cloud model
+// selection, prefixing the confirmation with a key-status note.
+func (m model) finalizeSTTModelFromKey(p *sttKeyPromptState, prefix string) (tea.Model, tea.Cmd) {
+	m.sttKeyPrompt = nil
+	provider, modelID, _ := strings.Cut(p.modelValue, sttValueSep)
+	kind := config.STTProviderKind(provider)
+	m.dictation.cfg.Provider = kind
+	m.dictation.cfg.Model = modelID
+	if _, err := config.SetSTTModel(m.userConfigPath, kind, modelID); err != nil {
+		return m.appendSystemNotice(prefix + "But couldn't save the model: " + err.Error()), nil
+	}
+	label := p.label
+	if modelID != "" {
+		label += " " + modelID
+	}
+	return m.appendSystemNotice(prefix + "Dictation model set to " + label + ". Run /voice, then hold Space to dictate."), nil
+}
+
+// sttKeyPromptOverlay renders the API-key prompt as a centered modal, matching
+// the picker's box styling. The key is masked as it is typed.
+func (m model) sttKeyPromptOverlay(width int) string {
+	if m.sttKeyPrompt == nil {
+		return ""
+	}
+	p := m.sttKeyPrompt
+	overlayWidth := minInt(width, pickerOverlayMaxWidth)
+	if overlayWidth < pickerOverlayMinWidth {
+		overlayWidth = width
+	}
+	// Input line mirrors the provider wizard's credential step (renderCredentialStep):
+	// an "api key > " prompt, cursor-before-placeholder when empty, masked key with a
+	// trailing cursor once typing starts — so both key prompts read the same.
+	value := zeroTheme.accent.Render("▌") + zeroTheme.faint.Render("paste key here")
+	if p.input != "" {
+		value = zeroTheme.ink.Render(maskedProviderWizardKey(p.input)) + zeroTheme.accent.Render("▌")
+	}
+	input := zeroTheme.userPrompt.Render("api key > ") + value
+	intro := p.label + " isn't set up yet. Paste or type your " + p.label + " API key:"
+	footer := "⏎ save · Esc cancel · stored in Zero's credential store"
+	if p.optional {
+		// A key already resolves — this pass is for replacing an invalid/old one.
+		intro = p.label + " already has an API key. Paste a new one to replace it, or press Esc to keep it:"
+		footer = "⏎ replace · Esc keep saved key · stored in Zero's credential store"
+	}
+	lines := []string{
+		zeroTheme.ink.Render(intro),
+		"",
+		input,
+		"",
+		zeroTheme.faint.Render(footer),
+	}
+	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, p.label+" API key", lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
+}

--- a/internal/tui/stt_key_prompt_test.go
+++ b/internal/tui/stt_key_prompt_test.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestCloudKeyPromptOpensWhenNoKey(t *testing.T) {
+	m := model{}
+	m.dictation.keyAvailable = func(string) bool { return false } // not authenticated
+	m.dictation.saveKey = func(string, string) error { return nil }
+
+	next, text := m.handleSTTModelSelection("groq:whisper-large-v3-turbo")
+	if next.sttKeyPrompt == nil {
+		t.Fatal("selecting a keyless cloud provider should open the API-key prompt")
+	}
+	if next.sttKeyPrompt.provider != "groq" || next.sttKeyPrompt.label != "Groq" {
+		t.Errorf("prompt = %+v", next.sttKeyPrompt)
+	}
+	if text != "" {
+		t.Errorf("no notice should be appended when the prompt opens, got %q", text)
+	}
+}
+
+func TestCloudKeyPromptCancelKeepsPreviousProvider(t *testing.T) {
+	// Regression: selecting a keyless cloud provider must NOT switch the active
+	// provider until the key is actually saved — otherwise cancelling the prompt
+	// strands the session on a half-chosen provider carrying the old model.
+	m := model{}
+	m.dictation.cfg = config.STTConfig{Provider: config.STTProviderGroq, Model: "whisper-large-v3-turbo"}
+	m.dictation.keyAvailable = func(string) bool { return false } // OpenAI has no key
+	m.dictation.saveKey = func(string, string) error { return nil }
+
+	next, _ := m.handleSTTModelSelection("openai:whisper-1")
+	if next.sttKeyPrompt == nil {
+		t.Fatal("selecting a keyless cloud provider should open the key prompt")
+	}
+	if next.dictation.cfg.Provider != config.STTProviderGroq || next.dictation.cfg.Model != "whisper-large-v3-turbo" {
+		t.Fatalf("active provider/model changed before commit: %q/%q",
+			next.dictation.cfg.Provider, next.dictation.cfg.Model)
+	}
+
+	esc, _ := next.handleSTTKeyPromptKey(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
+	got := esc.(model)
+	if got.sttKeyPrompt != nil {
+		t.Error("Esc should close the prompt")
+	}
+	if got.dictation.cfg.Provider != config.STTProviderGroq || got.dictation.cfg.Model != "whisper-large-v3-turbo" {
+		t.Errorf("after cancel, provider/model = %q/%q; want the working Groq selection preserved",
+			got.dictation.cfg.Provider, got.dictation.cfg.Model)
+	}
+}
+
+func TestCloudKeyPromptOptionalWhenAuthenticated(t *testing.T) {
+	// Selecting a provider that already has a key still opens the prompt — but as an
+	// OPTIONAL pass, so an invalid/old key can be replaced proactively (without first
+	// suffering a failed recording). Esc keeps the saved key and applies the model.
+	dir := t.TempDir()
+	m := model{userConfigPath: dir + "/config.json"}
+	m.dictation.keyAvailable = func(string) bool { return true }
+	m.dictation.saveKey = func(string, string) error { return nil }
+
+	next, _ := m.handleSTTModelSelection("groq:whisper-large-v3-turbo")
+	if next.sttKeyPrompt == nil || !next.sttKeyPrompt.optional {
+		t.Fatalf("expected an optional key prompt, got %+v", next.sttKeyPrompt)
+	}
+
+	esc, _ := next.handleSTTKeyPromptKey(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
+	got := esc.(model)
+	if got.sttKeyPrompt != nil {
+		t.Error("Esc should close the optional prompt")
+	}
+	if got.dictation.cfg.Provider != config.STTProviderGroq || got.dictation.cfg.Model != "whisper-large-v3-turbo" {
+		t.Errorf("model not applied on keep: %q/%q", got.dictation.cfg.Provider, got.dictation.cfg.Model)
+	}
+	if !transcriptHasText(got, "Kept your saved Groq API key") {
+		t.Error("expected a kept-key notice")
+	}
+}
+
+func TestCloudKeyPromptOptionalReplaceSavesNewKey(t *testing.T) {
+	// Typing a new key in the optional prompt replaces the saved one and applies the model.
+	dir := t.TempDir()
+	var savedKey string
+	m := model{userConfigPath: dir + "/config.json"}
+	m.dictation.keyAvailable = func(string) bool { return true }
+	m.dictation.saveKey = func(_, k string) error { savedKey = k; return nil }
+
+	next, _ := m.handleSTTModelSelection("groq:whisper-large-v3-turbo")
+	m2 := next
+	for _, r := range []string{"g", "s", "k", "-", "n", "e", "w"} {
+		u, _ := m2.handleSTTKeyPromptKey(tea.KeyPressMsg(tea.Key{Text: r}))
+		m2 = u.(model)
+	}
+	done, _ := m2.handleSTTKeyPromptKey(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	got := done.(model)
+	if savedKey != "gsk-new" {
+		t.Errorf("replacement key = %q, want gsk-new", savedKey)
+	}
+	if got.dictation.cfg.Model != "whisper-large-v3-turbo" {
+		t.Errorf("model not applied after replace: %q", got.dictation.cfg.Model)
+	}
+	if !transcriptHasText(got, "Saved your Groq API key") {
+		t.Error("expected a saved-key notice")
+	}
+}
+
+func TestCloudKeySavedAndModelApplied(t *testing.T) {
+	dir := t.TempDir()
+	var savedProvider, savedKey string
+	m := model{userConfigPath: dir + "/config.json"}
+	m.dictation.saveKey = func(p, k string) error { savedProvider, savedKey = p, k; return nil }
+	m.sttKeyPrompt = &sttKeyPromptState{provider: "groq", label: "Groq", modelValue: "groq:whisper-large-v3-turbo", input: "gsk-secret"}
+
+	next, _ := m.submitSTTKey()
+	got := next.(model)
+	if savedProvider != "groq" || savedKey != "gsk-secret" {
+		t.Errorf("saved key = %q/%q", savedProvider, savedKey)
+	}
+	if got.sttKeyPrompt != nil {
+		t.Error("prompt should close after submit")
+	}
+	if got.dictation.cfg.Model != "whisper-large-v3-turbo" {
+		t.Errorf("model not applied: %q", got.dictation.cfg.Model)
+	}
+	if !transcriptHasText(got, "Saved your Groq API key") {
+		t.Error("expected a saved-key notice")
+	}
+}
+
+func TestCloudKeyPromptTypingBackspaceAndCancel(t *testing.T) {
+	m := model{sttKeyPrompt: &sttKeyPromptState{provider: "groq", label: "Groq"}}
+	for _, r := range []string{"a", "b", "c"} {
+		next, _ := m.handleSTTKeyPromptKey(tea.KeyPressMsg(tea.Key{Text: r}))
+		m = next.(model)
+	}
+	if m.sttKeyPrompt.input != "abc" {
+		t.Fatalf("input = %q, want abc", m.sttKeyPrompt.input)
+	}
+	back, _ := m.handleSTTKeyPromptKey(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+	m = back.(model)
+	if m.sttKeyPrompt.input != "ab" {
+		t.Errorf("after backspace: %q", m.sttKeyPrompt.input)
+	}
+	esc, _ := m.handleSTTKeyPromptKey(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
+	if esc.(model).sttKeyPrompt != nil {
+		t.Error("Esc should cancel the prompt")
+	}
+}

--- a/internal/tui/stt_model_picker.go
+++ b/internal/tui/stt_model_picker.go
@@ -3,8 +3,11 @@ package tui
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -124,10 +127,11 @@ func (m model) maybeOpenSTTDownloadPicker(value string) (model, tea.Cmd, bool) {
 	}
 	// Always open the chooser when Local is picked — so you can select a model the
 	// first time AND switch models later (even with one already configured).
-	m.dictation.cfg.Provider = config.STTProviderLocal
-	if m.userConfigPath != "" {
-		_, _ = config.SetSTTProvider(m.userConfigPath, config.STTProviderLocal)
-	}
+	// Don't persist Provider=local here — applyEngineComponents (called on both
+	// the download-completion and the already-installed fast path) is the sole
+	// place that commits the provider/model. Persisting now would silently
+	// strand the user on an unconfigured local provider if they press Esc
+	// out of the picker.
 	m.clearSuggestions()
 	if len(m.dictation.browseVariants) > 0 {
 		// Full list already fetched this session — show it straight away.
@@ -163,7 +167,13 @@ type sttModelsFetchedMsg struct {
 // off the UI goroutine (a GitHub API round-trip).
 func fetchSTTModelsCmd() tea.Cmd {
 	return func() tea.Msg {
-		variants, err := dictation.ListModels(context.Background(), nil, "")
+		// A stalled GitHub response would otherwise hang the picker loading
+		// state forever (http.DefaultClient has no timeout). 30s is enough
+		// headroom for the release + assets round-trips on a slow link.
+		client := &http.Client{Timeout: 30 * time.Second}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		variants, err := dictation.ListModels(ctx, client, "")
 		return sttModelsFetchedMsg{variants: variants, err: err}
 	}
 }
@@ -261,7 +271,10 @@ func (m model) engineDownloaded() bool {
 // the per-model total once it is on disk.
 func newSTTDownloadPickerFrom(variants []dictation.ModelVariant, loading bool, downloadRoot string, engineHave bool, currentPath string) *commandPicker {
 	isCurrent := func(v dictation.ModelVariant) bool {
-		return currentPath != "" && v.DirName != "" && strings.Contains(currentPath, v.DirName)
+		// Substring match false-positives when one variant's DirName is a
+		// substring of another's ("tiny" inside "tiny-en"). Compare the
+		// last path segment only.
+		return currentPath != "" && v.DirName != "" && filepath.Base(currentPath) == v.DirName
 	}
 	sorted := append([]dictation.ModelVariant(nil), variants...)
 	installed := func(v dictation.ModelVariant) bool {

--- a/internal/tui/stt_model_picker.go
+++ b/internal/tui/stt_model_picker.go
@@ -1,0 +1,389 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/dictation"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/providermodelcatalog"
+)
+
+// sttModelValue encodes a picker selection as "provider:model" (model may be
+// empty for the local engine, whose model is configured via stt.localModelPath).
+const sttValueSep = ":"
+
+// baselineSTTModels are the known transcription models per cloud provider (§7/§8).
+// Used as a stable floor so the picker always offers sensible options even when
+// the live catalog has not surfaced them (models.dev lists Groq's Whisper models
+// without cost fields; OpenAI's transcription models are absent there entirely —
+// see §8). Any additional IsSTTModel entries the catalog does surface are merged
+// in on top.
+var baselineSTTModels = map[string][]string{
+	string(config.STTProviderGroq):   {"whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en"},
+	string(config.STTProviderOpenAI): {"whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe"},
+}
+
+// newSTTModelPicker builds the /stt-model overlay: a local-engine row plus the
+// transcription models offered by Groq and OpenAI.
+func (m model) newSTTModelPicker() *commandPicker {
+	current := m.dictation.cfg
+	var items []pickerItem
+
+	// Local engine row — its model is a filesystem path set separately.
+	localMeta := "sherpa-onnx offline engine"
+	if current.STTProvider() == config.STTProviderLocal {
+		localMeta = "current · " + localMeta
+	}
+	items = append(items, pickerItem{
+		Group: "Local",
+		Label: "Local (sherpa-onnx)",
+		Value: string(config.STTProviderLocal) + sttValueSep,
+		Meta:  localMeta,
+		// No locality dot: the Local/Groq/OpenAI section headers already say which is
+		// which, so the marker was redundant.
+	})
+
+	for _, prov := range []string{string(config.STTProviderGroq), string(config.STTProviderOpenAI)} {
+		group := titleCase(prov)
+		for _, id := range sttModelsForProvider(prov) {
+			meta := ""
+			if current.STTProvider() == config.STTProviderKind(prov) && current.Model == id {
+				meta = "current"
+			}
+			items = append(items, pickerItem{
+				Group: group,
+				Label: id,
+				Value: prov + sttValueSep + id,
+				Meta:  meta,
+			})
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	return &commandPicker{
+		kind:     pickerSTTModel,
+		title:    "Choose a dictation (speech-to-text) model",
+		items:    items,
+		allItems: append([]pickerItem{}, items...),
+	}
+}
+
+// sttModelsForProvider returns the transcription model ids for a cloud provider:
+// the stable baseline, plus any additional IsSTTModel entries the live catalog
+// surfaces, de-duplicated and baseline-first.
+func sttModelsForProvider(provider string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, id := range baselineSTTModels[provider] {
+		if !seen[id] {
+			seen[id] = true
+			out = append(out, id)
+		}
+	}
+	if descriptor, ok := providercatalog.Get(provider); ok {
+		for _, model := range providermodelcatalog.Models(descriptor) {
+			id := strings.TrimSpace(model.ID)
+			if id == "" || seen[id] || !providermodelcatalog.IsSTTModel(model) {
+				continue
+			}
+			seen[id] = true
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func (m model) openSTTModelPicker() (model, tea.Cmd) {
+	picker := m.newSTTModelPicker()
+	if picker == nil {
+		return m, nil
+	}
+	m.picker = picker
+	m.clearSuggestions()
+	return m, nil
+}
+
+// maybeOpenSTTDownloadPicker opens the model-download chooser when the user
+// picked the local engine, no model is configured yet, and this platform can
+// auto-download. It persists the local-provider choice first so a later manual
+// setup is still honored. Returns (model, true) when it opened the picker.
+func (m model) maybeOpenSTTDownloadPicker(value string) (model, tea.Cmd, bool) {
+	provider, _, _ := strings.Cut(value, sttValueSep)
+	if config.STTProviderKind(provider) != config.STTProviderLocal {
+		return m, nil, false
+	}
+	if m.dictation.downloadRoot == "" || !dictation.AutoDownloadSupported() {
+		return m, nil, false // manual/cloud only on this platform
+	}
+	// Always open the chooser when Local is picked — so you can select a model the
+	// first time AND switch models later (even with one already configured).
+	m.dictation.cfg.Provider = config.STTProviderLocal
+	if m.userConfigPath != "" {
+		_, _ = config.SetSTTProvider(m.userConfigPath, config.STTProviderLocal)
+	}
+	m.clearSuggestions()
+	if len(m.dictation.browseVariants) > 0 {
+		// Full list already fetched this session — show it straight away.
+		m.picker = newSTTDownloadPickerFrom(m.dictation.browseVariants, false, m.dictation.downloadRoot, m.engineDownloaded(), m.dictation.cfg.LocalModelPath)
+		return m, nil, true
+	}
+	// Show a single loading state while the full list is fetched — no curated-then-
+	// swap flicker. handleSTTModelsFetched fills it in (or falls back to the curated
+	// shortlist if the fetch fails, so the picker still works offline).
+	m.dictation.browseLoading = true
+	m.picker = newSTTDownloadLoadingPicker()
+	return m, fetchSTTModelsCmd(), true
+}
+
+// newSTTDownloadLoadingPicker is the placeholder chooser shown while the full
+// model list is being fetched — an empty, loading-marked picker so the overlay
+// renders a "fetching…" line and its footer, matching the /model loading UX.
+func newSTTDownloadLoadingPicker() *commandPicker {
+	return &commandPicker{
+		kind:    pickerSTTDownload,
+		title:   "Download a local dictation model — loading…",
+		loading: true,
+	}
+}
+
+// sttModelsFetchedMsg carries the full model list fetched from the release.
+type sttModelsFetchedMsg struct {
+	variants []dictation.ModelVariant
+	err      error
+}
+
+// fetchSTTModelsCmd lists every downloadable transcription model in the release,
+// off the UI goroutine (a GitHub API round-trip).
+func fetchSTTModelsCmd() tea.Cmd {
+	return func() tea.Msg {
+		variants, err := dictation.ListModels(context.Background(), nil, "")
+		return sttModelsFetchedMsg{variants: variants, err: err}
+	}
+}
+
+// handleSTTModelsFetched fills the loading download picker with the fetched full
+// model list (preserving any filter the user typed while it loaded). If the fetch
+// failed and nothing is cached, it falls back to the curated shortlist so the
+// picker still works offline.
+func (m model) handleSTTModelsFetched(msg sttModelsFetchedMsg) model {
+	m.dictation.browseLoading = false
+	if msg.err == nil && len(msg.variants) > 0 {
+		m.dictation.browseVariants = msg.variants
+	}
+	if m.picker == nil || m.picker.kind != pickerSTTDownload {
+		return m // the chooser was already closed
+	}
+	variants := m.dictation.browseVariants
+	if len(variants) == 0 {
+		variants = dictation.ModelVariants() // fetch failed → offline curated fallback
+	}
+	// Preserve the query AND the highlighted row across the fill-in.
+	query := m.picker.query
+	selectedValue := ""
+	if item, ok := m.picker.current(); ok {
+		selectedValue = item.Value
+	}
+	m.picker = newSTTDownloadPickerFrom(variants, false, m.dictation.downloadRoot, m.engineDownloaded(), m.dictation.cfg.LocalModelPath)
+	m.picker.query = query
+	m.picker.applyQuery()
+	m.selectPickerValue(selectedValue)
+	return m
+}
+
+// handleSTTModelSelection persists the chosen dictation provider+model and
+// updates the live controller so the next recording uses it (§11a — a switch
+// takes effect for the next recording, never mid-utterance).
+func (m model) handleSTTModelSelection(value string) (model, string) {
+	provider, modelID, _ := strings.Cut(value, sttValueSep)
+	kind := config.STTProviderKind(provider)
+
+	if kind == config.STTProviderLocal {
+		m.dictation.cfg.Provider = kind
+		// Leave localModelPath as-is; the local model is a path, not chosen here.
+		if _, err := config.SetSTTProvider(m.userConfigPath, kind); err != nil {
+			return m, "Could not save dictation provider: " + err.Error()
+		}
+		hint := "Dictation set to the local sherpa-onnx engine."
+		if strings.TrimSpace(m.dictation.cfg.LocalModelPath) == "" {
+			// Auto-download platforms never reach here (the download chooser opens
+			// instead); this is the manual-setup path (e.g. Termux).
+			hint += " Set stt.localModelPath to a model directory (see docs/dictation.md)."
+		} else {
+			hint += " Run /voice, then hold Space to dictate."
+		}
+		return m, hint
+	}
+
+	// Cloud provider. Route through the key prompt so a missing OR invalid key can be
+	// set/replaced here, proactively — not only after a failed dictation (a saved key
+	// can be present but invalid, and we can't tell until it's used). When a key
+	// already resolves the prompt is optional: Esc keeps it and just applies the model.
+	// Crucially, the active provider/model are only switched on commit, so cancelling
+	// leaves a previously-working provider (e.g. Groq) untouched.
+	if m.dictation.saveKey == nil {
+		// No credential store wired on this platform — just apply the model.
+		m.dictation.cfg.Provider = kind
+		m.dictation.cfg.Model = modelID
+		if _, err := config.SetSTTModel(m.userConfigPath, kind, modelID); err != nil {
+			return m, "Could not save dictation model: " + err.Error()
+		}
+		return m, "Dictation model set to " + titleCase(provider) + " " + modelID + "."
+	}
+	hasKey := m.dictation.keyAvailable != nil && m.dictation.keyAvailable(provider)
+	return m.openSTTKeyPrompt(provider, value, hasKey), ""
+}
+
+// newSTTDownloadPicker builds the model-download chooser, seeded with the
+// curated shortlist. The full model list from the release is fetched
+// asynchronously and merged in (see fetchSTTModelsCmd / handleSTTModelsFetched).
+func (m model) newSTTDownloadPicker() *commandPicker {
+	return newSTTDownloadPickerFrom(dictation.ModelVariants(), true, m.dictation.downloadRoot, m.engineDownloaded(), m.dictation.cfg.LocalModelPath)
+}
+
+// engineDownloaded reports whether the shared engine is already on disk.
+func (m model) engineDownloaded() bool {
+	return dictation.EngineDownloaded(m.dictation.downloadRoot, m.dictation.cfg.EngineVersion)
+}
+
+// newSTTDownloadPickerFrom builds the chooser from any variant list as a flat,
+// un-grouped list — the Live/Batch pipeline is shown as a right-hand tag on each
+// row (leading the meta) rather than as section headers, which read as cluttered
+// and could even repeat a header when installed models sorted to the top. loading
+// appends a hint that more models are still being fetched. downloadRoot lets it
+// mark already-installed models; engineHave drops the shared engine's size from
+// the per-model total once it is on disk.
+func newSTTDownloadPickerFrom(variants []dictation.ModelVariant, loading bool, downloadRoot string, engineHave bool, currentPath string) *commandPicker {
+	isCurrent := func(v dictation.ModelVariant) bool {
+		return currentPath != "" && v.DirName != "" && strings.Contains(currentPath, v.DirName)
+	}
+	sorted := append([]dictation.ModelVariant(nil), variants...)
+	installed := func(v dictation.ModelVariant) bool {
+		return dictation.ModelDownloaded(downloadRoot, v.DirName)
+	}
+	sort.SliceStable(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+		// Rank by quality, pipeline-agnostic: the curated "good" picks — live AND batch
+		// alike — rise together to the top (the Live/Batch tag on each row tells them
+		// apart, so there's no separate live section). Then already-installed, then
+		// smallest/fastest first.
+		if a.Recommended != b.Recommended {
+			return a.Recommended
+		}
+		if ia, ib := installed(a), installed(b); ia != ib {
+			return ia
+		}
+		return a.Bytes < b.Bytes
+	})
+	var items []pickerItem
+	for _, v := range sorted {
+		label := v.Label
+		if v.Recommended {
+			label = "★ " + label
+		}
+		totalMB := v.Bytes >> 20
+		if !engineHave {
+			totalMB += engineDownloadBytes >> 20 // engine is downloaded once, shared by all models
+		}
+		// Meta reads: pipeline tag · [description] · size · [state].
+		tag := "Batch"
+		if v.Streaming {
+			tag = "Live"
+		}
+		parts := []string{tag}
+		if v.Description != "" {
+			parts = append(parts, v.Description)
+		}
+		parts = append(parts, fmt.Sprintf("%d MB", totalMB))
+		switch {
+		case isCurrent(v):
+			parts = append(parts, "● current")
+		case installed(v):
+			parts = append(parts, "✓ downloaded") // selecting re-applies it, no re-download
+		}
+		items = append(items, pickerItem{
+			Label: label,
+			Value: v.ID,
+			Meta:  strings.Join(parts, " · "),
+			// No Local dot: every row here is a local model, so the marker only added
+			// noise. The Live/Batch tag in the meta is the meaningful distinction.
+		})
+	}
+	// The search line and footer already convey "type to filter" and "Esc", so the
+	// title stays just the name.
+	title := "Download a local dictation model"
+	if loading {
+		title = "Download a local dictation model — loading full list…"
+	}
+	return &commandPicker{
+		kind:     pickerSTTDownload,
+		title:    title,
+		items:    items,
+		allItems: append([]pickerItem{}, items...),
+	}
+}
+
+// engineDownloadBytes is the approximate size of the shared sherpa-onnx engine
+// bundle, added to each model's size for the total-download display.
+const engineDownloadBytes = 23 << 20
+
+// handleSTTDownloadSelection starts downloading the chosen model variant (engine
+// + that model). It resolves the variant from the picker's current items so any
+// browse-listed model (not just the curated shortlist) is downloadable.
+func (m model) handleSTTDownloadSelection(value string) (model, tea.Cmd) {
+	for _, v := range m.sttDownloadVariants() {
+		if v.ID == value {
+			// Already on disk (engine + this model): apply instantly, no download UI.
+			if m.engineDownloaded() && dictation.ModelDownloaded(m.dictation.downloadRoot, v.DirName) {
+				return m.applyInstalledModel(v)
+			}
+			return m.startVariantDownload(v)
+		}
+	}
+	return m, nil
+}
+
+// applyInstalledModel resolves the paths of an already-downloaded model (a fast,
+// network-free EnsureLocalEngine) and applies them, with no download animation.
+func (m model) applyInstalledModel(v dictation.ModelVariant) (model, tea.Cmd) {
+	comp, err := dictation.EnsureLocalEngine(context.Background(), dictation.DownloadOptions{
+		DestRoot:          m.dictation.downloadRoot,
+		EngineVersion:     m.dictation.cfg.EngineVersion,
+		ModelAssetName:    v.AssetName,
+		ModelPinnedDigest: v.Digest,
+		ModelDirName:      v.DirName,
+		ModelLabel:        v.Label,
+	})
+	if err != nil {
+		return m.startVariantDownload(v) // fell out of cache somehow — download it
+	}
+	m, aerr := m.applyEngineComponents(comp, v.Streaming)
+	if aerr != nil {
+		return m.appendSystemNotice("Couldn't save the config: " + aerr.Error()), nil
+	}
+	return m.appendSystemNotice(v.Label + " is already downloaded — dictation ready. Run /voice, then hold Space to dictate."), nil
+}
+
+// sttDownloadVariants returns the variants currently offered — the full fetched
+// list when available, else the curated shortlist.
+func (m model) sttDownloadVariants() []dictation.ModelVariant {
+	if len(m.dictation.browseVariants) > 0 {
+		return m.dictation.browseVariants
+	}
+	return dictation.ModelVariants()
+}
+
+// titleCase capitalizes the first letter of a lowercase provider id for display
+// ("groq" → "Groq"), avoiding the deprecated strings.Title.
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -204,6 +204,9 @@ func (m model) statusLine(width int) string {
 		if m.cancelConfirmActive {
 			return fitStyledLine(prefix+zeroTheme.amber.Render("●")+" "+zeroTheme.amber.Render(escCancelConfirmText), width)
 		}
+		if dictation := m.dictationStatusChip(); dictation != "" {
+			return fitStyledLine(prefix+dictation, width)
+		}
 		return fitStyledLine(left, width)
 	}
 
@@ -215,8 +218,20 @@ func (m model) statusLine(width int) string {
 		left = prefix + zeroTheme.amber.Render("●") + " " + zeroTheme.amber.Render(ctrlCExitConfirmText)
 	} else if m.cancelConfirmActive {
 		left = prefix + zeroTheme.amber.Render("●") + " " + zeroTheme.amber.Render(escCancelConfirmText)
-	} else if summary := m.backgroundTerminalSummary(); summary != "" {
-		left += separator + zeroTheme.muted.Render(summary)
+	} else if m.dictation.downloading && m.dictation.downloadStatus != "" {
+		// A model download in progress takes over the left chip with a live percentage.
+		left = prefix + zeroTheme.accent.Render("⬇ ") + zeroTheme.muted.Render(m.dictation.downloadStatus)
+	} else if dictation := m.dictationStatusChip(); dictation != "" && m.dictation.active() {
+		// An active recording/transcription takes over the left chip — it is the
+		// most time-sensitive thing on screen (the mic is live).
+		left = prefix + dictation
+	} else {
+		if voice := m.voiceModeIndicator(); voice != "" {
+			left += zeroTheme.muted.Render(" · ") + voice
+		}
+		if summary := m.backgroundTerminalSummary(); summary != "" {
+			left += separator + zeroTheme.muted.Render(summary)
+		}
 	}
 	// Active loops surface a persistent "↻ N loops · next 3:05pm" segment so a
 	// running loop is always visible (hidden during an exit/cancel confirm above).
@@ -727,10 +742,12 @@ func (m model) pickerOverlay(width int) string {
 		visible = m.picker.items[start : start+maxVisible]
 	}
 
-	lines := make([]string, 0, len(visible)+5)
+	lines := make([]string, 0, len(visible)+7)
 	title := strings.TrimSpace(m.picker.title)
-	hint := "↑/↓ · ⏎ · esc"
-	lines = append(lines, zeroTheme.faint.Render(hint))
+	// A visible "search > …" line so typing to filter shows what you've typed,
+	// matching the /model picker. Followed by a separator, then the rows.
+	lines = append(lines, renderPickerSearchLine(m.picker.query, "type to filter…", innerWidth))
+	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
 	lastGroup := ""
 	for index, item := range visible {
 		absoluteIndex := start + index
@@ -766,8 +783,16 @@ func (m model) pickerOverlay(width int) string {
 		lines = append(lines, fitStyledLine(line, innerWidth))
 	}
 	if len(visible) == 0 {
-		lines = append(lines, zeroTheme.faint.Render("  no matching items"))
+		if m.picker.loading {
+			lines = append(lines, zeroTheme.faint.Render("Fetching available models…"))
+		} else {
+			lines = append(lines, zeroTheme.faint.Render("  no matching items"))
+		}
 	}
+	// Hints live in the footer (a separator + faint keys), matching the /model
+	// picker and the other bordered boxes.
+	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+	lines = append(lines, zeroTheme.faint.Render("↑/↓ move   Enter select   Esc close"))
 	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, title, lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
 }
 
@@ -884,11 +909,18 @@ func modelPickerOverlayWidth(terminalWidth int, picker *commandPicker) int {
 }
 
 func renderModelPickerSearchLine(query string, width int) string {
+	return renderPickerSearchLine(query, "model name...", width)
+}
+
+// renderPickerSearchLine renders the "search > <query>▌" input line shared by the
+// popup pickers, so what you type while filtering is always visible. placeholder
+// is the faint hint shown when the query is empty.
+func renderPickerSearchLine(query, placeholder string, width int) string {
 	query = strings.TrimSpace(query)
 	prompt := zeroTheme.userPrompt.Render("search > ")
 	cursor := zeroTheme.accent.Render("▌")
 	if query == "" {
-		return fitStyledLine(prompt+cursor+zeroTheme.faint.Render("model name..."), width)
+		return fitStyledLine(prompt+cursor+zeroTheme.faint.Render(placeholder), width)
 	}
 	return fitStyledLine(prompt+zeroTheme.ink.Render(query)+cursor, width)
 }


### PR DESCRIPTION
## Speech-to-text dictation

Adds voice dictation to Zero. Run `/voice` to enter hold-to-record mode, then hold **Space** to dictate and release to transcribe (run `/voice` again to turn it off so Space types normally). Pick a backend with `/stt-model`.

### Backends
- **Local (sherpa-onnx)** — offline, no API key. Auto-downloads a model via `/stt-model`; the engine binary is fetched once and shared across models. Family auto-detection covers the mainstream offline families (Whisper, transducer/Zipformer, Moonshine, Paraformer, SenseVoice, and the CTC families FireRedASR, NeMo, TeleSpeech, WeNet, Zipformer-CTC, Dolphin, Omnilingual — plus the encoder/decoder families Canary and FireRedASR-AED).
- **Cloud batch** — Groq and OpenAI Whisper. Keys resolve from a configured provider, the encrypted credential store, or the env var; a missing/invalid key is entered inline.
- **Streaming** — a warm local sherpa-onnx websocket server (live transcript as you speak) on desktop, or Deepgram / OpenAI Realtime.

### Highlights
- Live audio-reactive waveform while recording (real mic levels when streaming; a synthesized wave for batch).
- `/stt-model` download chooser: recommended models first, Live/Batch tag per row, size + download state, and a search filter.
- Streaming transcript is inserted live into the composer and committed on stop; batch inserts on stop. Insert-for-review by default (`stt.autoSubmit` to fire straight at the agent).
- The warm streaming server is released when `/voice` is turned off and on exit.

### Implementation notes
- No CGO and no bundled runtimes — every OS integration shells out via `exec.Command` with discrete argv (never a shell string).
- The streaming server manager mirrors the LSP manager's warm-subprocess lifecycle.
- OS-boundary code (recorders, transcribers, server) is unit-tested via injected fakes; real microphone / websocket behavior is covered by env-gated smoke tests.

### Testing
- `go build ./...`, `go vet ./...`, and the config / dictation / cli / tui suites pass.
- Verified end-to-end against real downloaded binaries + models (offline batch, streaming websocket server, and the model auto-download), including the FireRedASR-CTC and NeMo streaming transducer families.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added speech-to-text dictation with local offline transcription, cloud batch transcription, and cloud streaming options.
  * Introduced an in-TUI STT model picker with local (sherpa-onnx) download, deterministic progress/status, and installed-state awareness.
  * Added voice mode for Space press/hold recording plus an inline cloud API-key prompt with saved-key persistence.
* **Bug Fixes**
  * Strengthened STT configuration validation and merging so invalid providers/stream providers and out-of-range settings are rejected early with clearer guidance.
  * Improved dictation streaming partial/region handling and safer STT server warm-up/shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
