### PR TITLE
fix(mcp): silence startup warning for unconfigured default servers

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -686,8 +686,14 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	defer closeMCPRuntime(stderr, mcpRuntime)
 	// A server that could not be reached or validated is skipped, not fatal (one
 	// bad MCP server must not abort startup) — surface each so a missing tool set is
-	// explained rather than silently absent.
+	// explained rather than silently absent. A built-in default the user never
+	// configured (e.g. keyless Firecrawl with no credentials) is the exception: it
+	// was never asked for, so its failure is not worth a startup warning — only
+	// servers the user actually configured warn on failure (issue #552).
 	for _, skipped := range mcpRuntime.Skipped() {
+		if skipped.UnconfiguredDefault {
+			continue
+		}
 		fmt.Fprintf(stderr, "warning: MCP server %s unavailable, skipped: %s\n", skipped.Name, redaction.ErrorMessage(skipped.Err, redaction.Options{}))
 	}
 	// Make local plugins live: register their declared tools into the registry and

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -158,6 +158,86 @@ func TestRunNoArgsLaunchesSetupTUIWithNilProviderWhenNoProviderConfigured(t *tes
 	assertAgentOptions(t, launchedOptions, 12, agent.PermissionModeAsk)
 }
 
+type fakeMCPRuntimeWithSkips struct {
+	skipped []mcp.SkippedServer
+}
+
+func (r fakeMCPRuntimeWithSkips) Close() error { return nil }
+
+func (r fakeMCPRuntimeWithSkips) Skipped() []mcp.SkippedServer { return r.skipped }
+
+func TestTUIStartupSuppressesWarningForUnconfiguredDefaultServer(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	setCLIUserConfigRoot(t)
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 8}, nil
+		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"firecrawl": config.DefaultMCPServers()["firecrawl"],
+			}}, nil
+		},
+		registerMCPTools: func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return fakeMCPRuntimeWithSkips{skipped: []mcp.SkippedServer{
+				{Name: "firecrawl", Err: errors.New("returned HTTP 401"), UnconfiguredDefault: true},
+			}}, nil
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "firecrawl") {
+		t.Fatalf("stderr = %q, want no warning for an unconfigured default server", stderr.String())
+	}
+}
+
+func TestTUIStartupWarnsForUserConfiguredServerSkip(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	setCLIUserConfigRoot(t)
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 8}, nil
+		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"custom": {Type: "stdio", Command: "custom-mcp"},
+			}}, nil
+		},
+		registerMCPTools: func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return fakeMCPRuntimeWithSkips{skipped: []mcp.SkippedServer{
+				{Name: "custom", Err: errors.New("connect failed"), UnconfiguredDefault: false},
+			}}, nil
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "warning: MCP server custom unavailable") {
+		t.Fatalf("stderr = %q, want a warning for a user-configured server that failed", stderr.String())
+	}
+}
+
 func TestRunNoArgsEntersSetupWhenResolveReportsNoActiveProvider(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/config/mcp_defaults.go
+++ b/internal/config/mcp_defaults.go
@@ -33,18 +33,28 @@ func IsDefaultMCPServer(name string) bool {
 	return ok
 }
 
-// IsUnconfiguredDefault reports whether server is exactly the built-in default
-// for name — i.e. the user never wrote anything for this server into their
-// config, so it is running with whatever Zero ships (e.g. keyless Firecrawl,
-// no credentials). mergeMCPServer only overwrites fields the user actually set,
-// so an untouched default survives merge byte-identical to DefaultMCPServers();
-// even a disabled/enabled toggle (e.g. `zero mcp enable firecrawl`) marks the
-// merged disabledSet field, which breaks the equality below, so an explicit
-// toggle counts as "configured" even though the resolved value is unchanged.
+// IsUnconfiguredDefault reports whether server is one of Zero's built-in
+// defaults that the user never wrote an entry for in their config — i.e. it is
+// running with whatever Zero ships (e.g. keyless Firecrawl, no credentials).
+//
+// Both conditions below must hold:
+//   - !server.configured: the user's JSON never declared an object for this
+//     server key at all (set by MCPServerConfig.UnmarshalJSON only when it
+//     actually ran for this key). Any explicit action — including a
+//     disable/enable toggle like `zero mcp enable firecrawl` that leaves the
+//     resolved value unchanged — sets configured, so it always counts as
+//     user-configured, even though the value comparison below could not tell
+//     the difference on its own.
+//   - reflect.DeepEqual(def, server): the value still matches the default.
+//     This is the fallback for callers that construct MCPServerConfig
+//     directly rather than through the JSON/merge pipeline (server.configured
+//     is then always false) — without it, any hand-built config with
+//     different field values would be misreported as unconfigured.
+//
 // Callers use this to tell "server we turned on for the user" apart from
 // "server the user configured themselves," e.g. to avoid warning loudly when
 // an out-of-the-box default that was never given credentials fails to connect.
 func IsUnconfiguredDefault(name string, server MCPServerConfig) bool {
 	def, ok := DefaultMCPServers()[strings.TrimSpace(name)]
-	return ok && reflect.DeepEqual(def, server)
+	return ok && !server.configured && reflect.DeepEqual(def, server)
 }

--- a/internal/config/mcp_defaults.go
+++ b/internal/config/mcp_defaults.go
@@ -1,6 +1,9 @@
 package config
 
-import "strings"
+import (
+	"reflect"
+	"strings"
+)
 
 // DefaultMCPServers returns the MCP servers Zero ships ENABLED by default so web
 // search and scraping work out of the box with no setup and no API key. They are
@@ -28,4 +31,17 @@ func DefaultMCPServers() map[string]MCPServerConfig {
 func IsDefaultMCPServer(name string) bool {
 	_, ok := DefaultMCPServers()[strings.TrimSpace(name)]
 	return ok
+}
+
+// IsUnconfiguredDefault reports whether server is exactly the built-in default
+// for name — i.e. the user never wrote anything for this server into their
+// config, so it is running with whatever Zero ships (e.g. keyless Firecrawl,
+// no credentials). mergeMCPServer only overwrites fields the user actually set,
+// so an untouched default survives merge byte-identical to DefaultMCPServers().
+// Callers use this to tell "server we turned on for the user" apart from
+// "server the user configured themselves," e.g. to avoid warning loudly when
+// an out-of-the-box default that was never given credentials fails to connect.
+func IsUnconfiguredDefault(name string, server MCPServerConfig) bool {
+	def, ok := DefaultMCPServers()[strings.TrimSpace(name)]
+	return ok && reflect.DeepEqual(def, server)
 }

--- a/internal/config/mcp_defaults.go
+++ b/internal/config/mcp_defaults.go
@@ -37,7 +37,10 @@ func IsDefaultMCPServer(name string) bool {
 // for name — i.e. the user never wrote anything for this server into their
 // config, so it is running with whatever Zero ships (e.g. keyless Firecrawl,
 // no credentials). mergeMCPServer only overwrites fields the user actually set,
-// so an untouched default survives merge byte-identical to DefaultMCPServers().
+// so an untouched default survives merge byte-identical to DefaultMCPServers();
+// even a disabled/enabled toggle (e.g. `zero mcp enable firecrawl`) marks the
+// merged disabledSet field, which breaks the equality below, so an explicit
+// toggle counts as "configured" even though the resolved value is unchanged.
 // Callers use this to tell "server we turned on for the user" apart from
 // "server the user configured themselves," e.g. to avoid warning loudly when
 // an out-of-the-box default that was never given credentials fails to connect.

--- a/internal/config/mcp_defaults_test.go
+++ b/internal/config/mcp_defaults_test.go
@@ -86,6 +86,32 @@ func TestResolveMCPExplicitReenableIsNotUnconfiguredDefault(t *testing.T) {
 	}
 }
 
+func TestResolveMCPExplicitRedeclareOfDefaultValuesIsNotUnconfiguredDefault(t *testing.T) {
+	// A user who copies firecrawl's exact default type/url into their config
+	// (e.g. from an example file, planning to add credentials later) produces a
+	// resolved value byte-identical to DefaultMCPServers()["firecrawl"] — the
+	// same trap TestResolveMCPExplicitReenableIsNotUnconfiguredDefault covers for
+	// the disabled toggle. IsUnconfiguredDefault must still treat this as
+	// user-configured because the user's JSON declared an entry for it, even
+	// though a plain resolved-value comparison could not tell the difference.
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"type":"http","url":"https://mcp.firecrawl.dev/v2/mcp"}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	firecrawl := cfg.Servers["firecrawl"]
+	want := DefaultMCPServers()["firecrawl"]
+	if firecrawl.Type != want.Type || firecrawl.URL != want.URL || firecrawl.Disabled != want.Disabled {
+		t.Fatalf("expected the resolved value to match the default's fields exactly: %#v", firecrawl)
+	}
+	if IsUnconfiguredDefault("firecrawl", firecrawl) {
+		t.Fatal("redeclaring the default's exact values is still an explicit user configuration, not an untouched default")
+	}
+}
+
 func TestResolveMCPUserCanOverrideDefaultURLKeepingOtherFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	// Point firecrawl at a self-hosted instance; the default's Type must survive.

--- a/internal/config/mcp_defaults_test.go
+++ b/internal/config/mcp_defaults_test.go
@@ -64,6 +64,28 @@ func TestIsUnconfiguredDefault(t *testing.T) {
 	}
 }
 
+func TestResolveMCPExplicitReenableIsNotUnconfiguredDefault(t *testing.T) {
+	// `zero mcp enable firecrawl` after a prior disable writes {"disabled":false}
+	// explicitly. The resolved value is identical to the untouched default (both
+	// enabled, no credentials), but the user DID take an explicit action here, so
+	// IsUnconfiguredDefault must not treat it as untouched (issue #563 review).
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":false}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	firecrawl := cfg.Servers["firecrawl"]
+	if firecrawl.Disabled {
+		t.Fatalf("explicit re-enable should leave the server enabled: %#v", firecrawl)
+	}
+	if IsUnconfiguredDefault("firecrawl", firecrawl) {
+		t.Fatal("an explicit enable/disable toggle must count as user-configured, even though the resolved value matches the default")
+	}
+}
+
 func TestResolveMCPUserCanOverrideDefaultURLKeepingOtherFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	// Point firecrawl at a self-hosted instance; the default's Type must survive.

--- a/internal/config/mcp_defaults_test.go
+++ b/internal/config/mcp_defaults_test.go
@@ -49,6 +49,21 @@ func TestResolveMCPUserCanDisableDefault(t *testing.T) {
 	}
 }
 
+func TestIsUnconfiguredDefault(t *testing.T) {
+	if !IsUnconfiguredDefault("firecrawl", DefaultMCPServers()["firecrawl"]) {
+		t.Fatal("an untouched firecrawl default should be reported as unconfigured")
+	}
+	if IsUnconfiguredDefault("firecrawl", MCPServerConfig{Type: "http", URL: "http://localhost:3002/mcp"}) {
+		t.Fatal("a server overriding the default URL is no longer unconfigured")
+	}
+	if IsUnconfiguredDefault("firecrawl", MCPServerConfig{Type: "http", URL: "https://mcp.firecrawl.dev/v2/mcp", Auth: "bearer"}) {
+		t.Fatal("a server with credentials added is no longer unconfigured")
+	}
+	if IsUnconfiguredDefault("not-a-default", MCPServerConfig{}) {
+		t.Fatal("a server with no matching default can never be unconfigured-default")
+	}
+}
+
 func TestResolveMCPUserCanOverrideDefaultURLKeepingOtherFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	// Point firecrawl at a self-hosted instance; the default's Type must survive.

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -773,12 +773,9 @@ func mergeMCPServer(base MCPServerConfig, next MCPServerConfig) MCPServerConfig 
 	}
 	if next.disabledSet || next.Disabled {
 		base.Disabled = next.Disabled
-		// Mark the merged result itself as explicitly touched (not just Disabled),
-		// so a user who writes {"disabled": false} to re-enable a built-in default
-		// (e.g. `zero mcp enable firecrawl`) produces a config that IsUnconfiguredDefault
-		// can tell apart from the untouched default it started from, even though the
-		// resolved value ends up identical — the toggle itself is the "configured" signal.
-		base.disabledSet = true
+	}
+	if next.configured {
+		base.configured = true
 	}
 	return base
 }

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -773,6 +773,12 @@ func mergeMCPServer(base MCPServerConfig, next MCPServerConfig) MCPServerConfig 
 	}
 	if next.disabledSet || next.Disabled {
 		base.Disabled = next.Disabled
+		// Mark the merged result itself as explicitly touched (not just Disabled),
+		// so a user who writes {"disabled": false} to re-enable a built-in default
+		// (e.g. `zero mcp enable firecrawl`) produces a config that IsUnconfiguredDefault
+		// can tell apart from the untouched default it started from, even though the
+		// resolved value ends up identical — the toggle itself is the "configured" signal.
+		base.disabledSet = true
 	}
 	return base
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -312,6 +312,16 @@ type MCPServerConfig struct {
 	OAuth       *MCPOAuthConfig   `json:"oauth,omitempty"`
 	Disabled    bool              `json:"disabled,omitempty"`
 	disabledSet bool
+	// configured is true when the user's config JSON declared an object for
+	// this server at all (i.e. UnmarshalJSON ran for it), regardless of which
+	// fields it set or what values they hold. A built-in default seeded by
+	// DefaultMCPServers() is never unmarshaled from JSON, so it starts false;
+	// any explicit entry in the user/project file — even one that happens to
+	// repeat a default's exact field values (e.g. re-declaring firecrawl's
+	// default URL) — sets it true. IsUnconfiguredDefault checks this alongside
+	// a resolved-value comparison, so redeclaring default values verbatim still
+	// counts as user-configured.
+	configured bool
 }
 
 // MCPOAuthConfig describes how to authenticate to a remote MCP server using an
@@ -503,6 +513,10 @@ func (server *MCPServerConfig) UnmarshalJSON(data []byte) error {
 		server.Disabled = *raw.Disabled
 		server.disabledSet = true
 	}
+	// This method only runs when the user's JSON actually has an object for this
+	// server key (built-in defaults are seeded as Go struct literals, never
+	// unmarshaled), so reaching here at all means the user configured it.
+	server.configured = true
 	return nil
 }
 

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -31,6 +31,11 @@ type Server struct {
 	Auth     string
 	OAuth    *OAuthConfig
 	Identity string
+	// UnconfiguredDefault is true when this server is one of Zero's built-in
+	// defaults (e.g. keyless Firecrawl) that the user never touched in their
+	// config — no credentials, no overrides. Callers use it to avoid warning
+	// loudly when a server nobody configured fails to connect.
+	UnconfiguredDefault bool
 }
 
 func NormalizeConfig(cfg config.MCPConfig) ([]Server, error) {
@@ -74,15 +79,16 @@ func normalizeServer(name string, raw config.MCPServerConfig) (Server, error) {
 
 	auth := strings.ToLower(strings.TrimSpace(raw.Auth))
 	server := Server{
-		Name:    name,
-		Type:    serverType,
-		Command: strings.TrimSpace(raw.Command),
-		Args:    trimStringSlice(raw.Args),
-		Env:     copyStringMap(raw.Env),
-		URL:     strings.TrimSpace(raw.URL),
-		Headers: copyStringMap(raw.Headers),
-		Auth:    auth,
-		OAuth:   normalizeOAuthConfig(raw.OAuth),
+		Name:                name,
+		Type:                serverType,
+		Command:             strings.TrimSpace(raw.Command),
+		Args:                trimStringSlice(raw.Args),
+		Env:                 copyStringMap(raw.Env),
+		URL:                 strings.TrimSpace(raw.URL),
+		Headers:             copyStringMap(raw.Headers),
+		Auth:                auth,
+		OAuth:               normalizeOAuthConfig(raw.OAuth),
+		UnconfiguredDefault: config.IsUnconfiguredDefault(name, raw),
 	}
 
 	switch server.Type {

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -88,6 +88,33 @@ func TestNormalizeConfigValidatesTransportBoundaries(t *testing.T) {
 	}
 }
 
+func TestNormalizeConfigFlagsUnconfiguredDefault(t *testing.T) {
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"firecrawl": config.DefaultMCPServers()["firecrawl"],
+		"web": {
+			Type: "http",
+			URL:  "https://example.com/mcp",
+		},
+	}}
+
+	servers, err := NormalizeConfig(cfg)
+	if err != nil {
+		t.Fatalf("NormalizeConfig() error = %v", err)
+	}
+
+	byName := make(map[string]Server, len(servers))
+	for _, server := range servers {
+		byName[server.Name] = server
+	}
+
+	if !byName["firecrawl"].UnconfiguredDefault {
+		t.Fatal("an untouched firecrawl default should be flagged UnconfiguredDefault")
+	}
+	if byName["web"].UnconfiguredDefault {
+		t.Fatal("a server the user configured must not be flagged UnconfiguredDefault")
+	}
+}
+
 func TestServerIdentityChangesWithTransportFields(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -35,6 +35,10 @@ type RegisterOptions struct {
 type SkippedServer struct {
 	Name string
 	Err  error
+	// UnconfiguredDefault mirrors Server.UnconfiguredDefault: true when this
+	// server is an out-of-the-box default the user never configured, so a
+	// caller can skip warning loudly about it.
+	UnconfiguredDefault bool
 }
 
 type Runtime struct {
@@ -148,7 +152,7 @@ func RegisterTools(ctx context.Context, registry *tools.Registry, cfg config.MCP
 	for index, server := range servers {
 		res := results[index]
 		if res.err != nil {
-			runtime.skipped = append(runtime.skipped, SkippedServer{Name: server.Name, Err: res.err})
+			runtime.skipped = append(runtime.skipped, SkippedServer{Name: server.Name, Err: res.err, UnconfiguredDefault: server.UnconfiguredDefault})
 			continue
 		}
 		serverTools, validateErr := buildServerTools(registry, server, res.remote, res.client, options, stagedNames)
@@ -157,7 +161,7 @@ func RegisterTools(ctx context.Context, registry *tools.Registry, cfg config.MCP
 				res.cancel()
 			}
 			_ = res.client.Close()
-			runtime.skipped = append(runtime.skipped, SkippedServer{Name: server.Name, Err: validateErr})
+			runtime.skipped = append(runtime.skipped, SkippedServer{Name: server.Name, Err: validateErr, UnconfiguredDefault: server.UnconfiguredDefault})
 			continue
 		}
 		runtime.clients = append(runtime.clients, res.client)

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -153,6 +153,39 @@ func TestRegisterToolsSkipsUnreachableServerAndKeepsOthers(t *testing.T) {
 	}
 }
 
+func TestRegisterToolsFlagsUnconfiguredDefaultOnSkip(t *testing.T) {
+	// firecrawl is seeded by config.DefaultMCPServers with no credentials; when a
+	// user never configures it, a connect failure (e.g. the real HTTP 401 from
+	// issue #552) must be recorded as UnconfiguredDefault so callers can avoid
+	// warning about a server the user never asked for. "custom" is configured by
+	// the user and must NOT be flagged even though it also fails to connect.
+	registry := tools.NewRegistry()
+
+	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"firecrawl": config.DefaultMCPServers()["firecrawl"],
+		"custom":    {Type: "stdio", Command: "custom-mcp"},
+	}}, RegisterOptions{
+		ClientFactory: func(_ context.Context, server Server) (ToolClient, error) {
+			return nil, errors.New(server.Name + " connect failed")
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTools returned error, want a skip: %v", err)
+	}
+	defer runtime.Close()
+
+	byName := make(map[string]SkippedServer)
+	for _, skipped := range runtime.Skipped() {
+		byName[skipped.Name] = skipped
+	}
+	if !byName["firecrawl"].UnconfiguredDefault {
+		t.Fatalf("Skipped()[firecrawl] = %#v, want UnconfiguredDefault", byName["firecrawl"])
+	}
+	if byName["custom"].UnconfiguredDefault {
+		t.Fatalf("Skipped()[custom] = %#v, want a user-configured server not flagged", byName["custom"])
+	}
+}
+
 func TestRegisterToolsKeepsPriorStateAndReachableServersWhenOneIsSkipped(t *testing.T) {
 	// A tool that predates registration must survive, the reachable server's tools
 	// must register, and the unreachable server is skipped (recorded), not fatal.

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -178,11 +178,19 @@ func TestRegisterToolsFlagsUnconfiguredDefaultOnSkip(t *testing.T) {
 	for _, skipped := range runtime.Skipped() {
 		byName[skipped.Name] = skipped
 	}
-	if !byName["firecrawl"].UnconfiguredDefault {
-		t.Fatalf("Skipped()[firecrawl] = %#v, want UnconfiguredDefault", byName["firecrawl"])
+	firecrawl, ok := byName["firecrawl"]
+	if !ok {
+		t.Fatalf("Skipped() = %#v, want an entry for firecrawl", runtime.Skipped())
 	}
-	if byName["custom"].UnconfiguredDefault {
-		t.Fatalf("Skipped()[custom] = %#v, want a user-configured server not flagged", byName["custom"])
+	if !firecrawl.UnconfiguredDefault {
+		t.Fatalf("Skipped()[firecrawl] = %#v, want UnconfiguredDefault", firecrawl)
+	}
+	custom, ok := byName["custom"]
+	if !ok {
+		t.Fatalf("Skipped() = %#v, want an entry for custom", runtime.Skipped())
+	}
+	if custom.UnconfiguredDefault {
+		t.Fatalf("Skipped()[custom] = %#v, want a user-configured server not flagged", custom)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Firecrawl is seeded as an always-on default MCP server with no credentials (`config.DefaultMCPServers`), so every fresh install prints a loud `warning: MCP server firecrawl unavailable, skipped: ... HTTP 401` line on first launch, even though the user never configured or touched it — it reads like something is broken.
- Adds `config.IsUnconfiguredDefault(name, server)`, which reports whether a resolved server config is byte-identical to its built-in default (i.e. the user never wrote anything for it), threaded through `mcp.Server.UnconfiguredDefault` and `mcp.SkippedServer.UnconfiguredDefault`.
- `internal/cli/app.go`'s startup warning loop now skips printing when a skipped server is an untouched default. Servers the user actually configured still warn loudly on failure, so a real misconfiguration is never hidden.
- Scoped to the interactive TUI launch path (`internal/cli/app.go`); the headless exec path never surfaced `Skipped()` and is unaffected.

Fixes #552

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/config/... ./internal/mcp/... ./internal/cli/...` — all pass, including new coverage:
  - `TestIsUnconfiguredDefault` (config)
  - `TestNormalizeConfigFlagsUnconfiguredDefault` (mcp)
  - `TestRegisterToolsFlagsUnconfiguredDefaultOnSkip` (mcp)
  - `TestTUIStartupSuppressesWarningForUnconfiguredDefaultServer` / `TestTUIStartupWarnsForUserConfiguredServerSkip` (cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy startup warnings by suppressing “MCP server unavailable, skipped” messages for built-in servers the user never customized.
  * Startup warnings now appear only for MCP servers that are explicitly configured by the user, even when defaults are re-enabled or redeclared.
* **Tests**
  * Added test coverage to ensure warning suppression for unconfigured-default skips and warnings for user-configured server failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->