### PR TITLE
Stream tool file IO

### DIFF
--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -76,6 +76,45 @@ func TestReadFileToolAppliesByteBudget(t *testing.T) {
 	}
 }
 
+func TestReadFileToolTracksWholeFileHashWhenReadingSmallRange(t *testing.T) {
+	root := t.TempDir()
+	var builder strings.Builder
+	for i := 1; i <= 2000; i++ {
+		builder.WriteString("line ")
+		builder.WriteString(strings.Repeat("x", 16))
+		builder.WriteString("\n")
+	}
+	content := builder.String()
+	path := filepath.Join(root, "large.txt")
+	writeTestFile(t, path, content)
+
+	tracker := NewFileTracker()
+	tool := NewReadFileTool(root).(optionsAwareTool)
+	result := tool.RunWithOptions(context.Background(), map[string]any{
+		"path":       "large.txt",
+		"start_line": 1000,
+		"max_lines":  2,
+	}, RunOptions{FileTracker: tracker})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	version, ok := tracker.Version(resolved)
+	if !ok {
+		t.Fatal("expected read_file to record a file version")
+	}
+	if version.Hash != HashContent([]byte(content)) {
+		t.Fatalf("hash = %q, want %q", version.Hash, HashContent([]byte(content)))
+	}
+	if err := tracker.CheckConflict(resolved, []byte(content+"changed")); err != ErrFileChangedOnDisk {
+		t.Fatalf("changed content should conflict, got %v", err)
+	}
+}
+
 func TestReadFileToolRejectsOutsideWorkspace(t *testing.T) {
 	root := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "secret.txt")
@@ -205,6 +244,33 @@ func TestGrepToolMakesHeadLimitTruncationVisible(t *testing.T) {
 	}
 }
 
+func TestGrepToolCountsAllLinesWhileKeepingHeadLimitSmall(t *testing.T) {
+	root := t.TempDir()
+	var builder strings.Builder
+	for i := 0; i < 100; i++ {
+		builder.WriteString("needle ")
+		builder.WriteString(strings.Repeat("x", 8))
+		builder.WriteString("\n")
+	}
+	writeTestFile(t, filepath.Join(root, "notes.txt"), builder.String())
+
+	result := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":    "needle",
+		"path":       ".",
+		"head_limit": 3,
+	})
+
+	if result.Status != StatusOK || !result.Truncated {
+		t.Fatalf("expected ok+truncated, got status=%s truncated=%v output=%q", result.Status, result.Truncated, result.Output)
+	}
+	if !strings.Contains(result.Output, "[truncated: showing first 3 of 100 matches") {
+		t.Fatalf("expected exact total match count, got %q", result.Output)
+	}
+	if strings.Contains(result.Output, "notes.txt:4:") {
+		t.Fatalf("head_limit leaked fourth result: %q", result.Output)
+	}
+}
+
 // A glob is matched relative to the search directory, not the workspace root, so
 // `path=subdir glob=*.go` finds subdir/a.go (as "a.go"). Previously the glob was
 // matched against the workspace-relative "subdir/a.go", so a non-recursive "*.go"
@@ -242,6 +308,22 @@ func TestGrepToolSupportsFilesAndCountModes(t *testing.T) {
 	if !strings.Contains(files.Output, "a.txt") || !strings.Contains(files.Output, "b.txt") {
 		t.Fatalf("expected both files, got %q", files.Output)
 	}
+
+	count := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":     "needle",
+		"output_mode": "count",
+	})
+	if count.Status != StatusOK {
+		t.Fatalf("expected count result, got %s: %s", count.Status, count.Output)
+	}
+	if count.Output != "3 matches found" {
+		t.Fatalf("expected count output, got %q", count.Output)
+	}
+}
+
+func TestGrepCountModeCountsMultipleHitsPerLine(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "notes.txt"), "needle needle\nneedle\n")
 
 	count := NewGrepTool(root).Run(context.Background(), map[string]any{
 		"pattern":     "needle",

--- a/internal/tools/file_tracker.go
+++ b/internal/tools/file_tracker.go
@@ -42,10 +42,16 @@ func NewFileTracker() *FileTracker {
 
 // Record stores the version of absPath given its content and optional stat info.
 func (tracker *FileTracker) Record(absPath string, content []byte, info os.FileInfo) {
+	tracker.RecordHash(absPath, HashContent(content), info)
+}
+
+// RecordHash stores the version of absPath when the caller already computed
+// the same HashContent-compatible SHA-256 while reading the file.
+func (tracker *FileTracker) RecordHash(absPath string, hash string, info os.FileInfo) {
 	if tracker == nil {
 		return
 	}
-	version := FileVersion{Hash: HashContent(content)}
+	version := FileVersion{Hash: hash}
 	if info != nil {
 		version.Size = info.Size()
 		version.MTime = info.ModTime()

--- a/internal/tools/file_tracker_test.go
+++ b/internal/tools/file_tracker_test.go
@@ -34,6 +34,18 @@ func TestFileTrackerRecordsAndReadsBackVersion(t *testing.T) {
 	}
 }
 
+func TestFileTrackerRecordHashMatchesRecord(t *testing.T) {
+	tracker := NewFileTracker()
+	content := []byte("streamed content")
+	tracker.RecordHash("/repo/x.txt", HashContent(content), nil)
+	if err := tracker.CheckConflict("/repo/x.txt", content); err != nil {
+		t.Fatalf("recorded hash should match content, got %v", err)
+	}
+	if err := tracker.CheckConflict("/repo/x.txt", []byte("changed")); err != ErrFileChangedOnDisk {
+		t.Fatalf("changed content should conflict, got %v", err)
+	}
+}
+
 func TestCheckConflictAllowsUntrackedPath(t *testing.T) {
 	tracker := NewFileTracker()
 	// No Record call: a first-touch write has no baseline to conflict against.

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -1,8 +1,10 @@
 package tools
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -138,84 +140,35 @@ func (tool grepTool) runWith(ctx context.Context, args map[string]any, exclude r
 		}
 	}
 
-	files, err := grepFiles(ctx, resolvedRoot, target, globMatcher, exclude)
-	if err != nil {
-		if res, ok := searchCancelledResult("grep", err); ok {
-			return res
-		}
-		return errorResult("Error running grep: " + err.Error())
-	}
-
-	// resolveScopedPath returns an absolute displayRoot when the target resolved
-	// to an extra (non-workspace) granted root; emit absolute match paths there so
-	// they survive a round-trip through read_file/edit_file (mirrors glob).
-	matches, err := collectGrepMatches(ctx, resolvedRoot, filepath.IsAbs(displayRoot), files, compiled)
-	if err != nil {
-		if res, ok := searchCancelledResult("grep", err); ok {
-			return res
-		}
-		return errorResult("Error running grep: " + err.Error())
-	}
-	if len(matches) == 0 {
-		if outputMode == "count" {
-			return okResult("0 matches found")
-		}
-		return okResult("No matches found.")
-	}
-
+	absolutePaths := filepath.IsAbs(displayRoot)
 	switch outputMode {
 	case "count":
-		total := 0
-		for _, match := range matches {
-			total += match.hits
+		collector := &grepCountCollector{}
+		if err := scanGrepMatches(ctx, resolvedRoot, target, globMatcher, exclude, absolutePaths, exactGrepLineMatcher(compiled), collector.collect); err != nil {
+			if res, ok := searchCancelledResult("grep", err); ok {
+				return res
+			}
+			return errorResult("Error running grep: " + err.Error())
 		}
-		return okResult(fmt.Sprintf("%d matches found", total))
+		return collector.result()
 	case "files_with_matches":
-		seen := map[string]bool{}
-		files := []string{}
-		for _, match := range matches {
-			if !seen[match.file] {
-				seen[match.file] = true
-				files = append(files, match.file)
+		collector := &grepFileListCollector{}
+		if err := scanGrepMatches(ctx, resolvedRoot, target, globMatcher, exclude, absolutePaths, presenceGrepLineMatcher(compiled), collector.collect); err != nil {
+			if res, ok := searchCancelledResult("grep", err); ok {
+				return res
 			}
+			return errorResult("Error running grep: " + err.Error())
 		}
-		sort.Strings(files)
-		budgeted := applyOutputBudget(strings.Join(files, "\n"), searchOutputBudgetBytes, "narrow path/glob/pattern to continue")
-		meta := outputBudgetMeta(budgeted)
-		if budgeted.Truncated {
-			meta["truncated"] = "true"
-			meta["truncation_reason"] = "byte_budget"
-		}
-		return Result{Status: StatusOK, Output: budgeted.Output, Truncated: budgeted.Truncated, Meta: meta}
+		return collector.result()
 	default:
-		lines := make([]string, 0, len(matches))
-		for _, match := range matches {
-			if len(lines) >= headLimit {
-				break
+		collector := &grepContentCollector{headLimit: headLimit}
+		if err := scanGrepMatches(ctx, resolvedRoot, target, globMatcher, exclude, absolutePaths, presenceGrepLineMatcher(compiled), collector.collect); err != nil {
+			if res, ok := searchCancelledResult("grep", err); ok {
+				return res
 			}
-			lines = append(lines, fmt.Sprintf("%s:%d: %s", match.file, match.line, match.text))
+			return errorResult("Error running grep: " + err.Error())
 		}
-		truncated := len(matches) > headLimit
-		output := strings.Join(lines, "\n")
-		if truncated {
-			output += fmt.Sprintf("\n\n[truncated: showing first %d of %d matches; narrow path/glob/pattern or increase head_limit]", len(lines), len(matches))
-		}
-		budgeted := applyOutputBudget(output, searchOutputBudgetBytes, "narrow path/glob/pattern or increase head_limit")
-		meta := outputBudgetMeta(budgeted)
-		if truncated || budgeted.Truncated {
-			meta["truncated"] = "true"
-			if budgeted.Truncated {
-				meta["truncation_reason"] = "byte_budget"
-			} else {
-				meta["truncation_reason"] = "head_limit"
-			}
-		}
-		return Result{
-			Status:    StatusOK,
-			Output:    budgeted.Output,
-			Truncated: truncated || budgeted.Truncated,
-			Meta:      meta,
-		}
+		return collector.result()
 	}
 }
 
@@ -270,33 +223,32 @@ func confineGrepFile(resolvedRoot string, path string) (string, string, bool) {
 	return filepath.ToSlash(relative), resolved, true
 }
 
-func grepFiles(ctx context.Context, resolvedRoot string, target string, globMatcher *regexp.Regexp, exclude readExcluder) ([]string, error) {
+func walkGrepFiles(ctx context.Context, resolvedRoot string, target string, globMatcher *regexp.Regexp, exclude readExcluder, visit func(string) error) error {
 	info, err := os.Stat(target)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if !info.IsDir() {
 		relative, _, ok := confineGrepFile(resolvedRoot, target)
 		if !ok {
-			return []string{}, nil
+			return nil
 		}
 		if shouldSkipWorkspaceFile(relative) {
-			return []string{}, nil
+			return nil
 		}
 		if exclude.fileExcluded(target) {
-			return []string{}, nil
+			return nil
 		}
 		// A single explicit file is matched by its base name so a pattern like
 		// "*.go" applies regardless of how deep the file sits under the workspace.
 		if globMatcher == nil || globMatcher.MatchString(filepath.Base(target)) {
-			return []string{target}, nil
+			return visit(target)
 		}
-		return []string{}, nil
+		return nil
 	}
 
-	files := []string{}
-	err = filepath.WalkDir(target, func(path string, entry os.DirEntry, walkErr error) error {
+	return filepath.WalkDir(target, func(path string, entry os.DirEntry, walkErr error) error {
 		// Checked first, ahead of walkErr: an unscoped search over a large tree
 		// (e.g. a broad parent directory, not just the workspace) can run long
 		// enough that cancelling the run must stop the walk promptly rather than
@@ -347,62 +299,189 @@ func grepFiles(ctx context.Context, resolvedRoot string, target string, globMatc
 			globPath = filepath.ToSlash(rel)
 		}
 		if globMatcher == nil || globMatcher.MatchString(globPath) {
-			files = append(files, path)
+			if err := visit(path); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	sort.Strings(files)
-	return files, nil
 }
 
-func collectGrepMatches(ctx context.Context, resolvedRoot string, absolutePaths bool, files []string, compiled *regexp.Regexp) ([]grepMatch, error) {
-	matches := []grepMatch{}
-	for _, file := range files {
-		// Checked per file, matching the walk's per-entry check in grepFiles: a
-		// broad search can already have collected many files before the run is
-		// cancelled, and reading/regex-scanning each one is real work that must
-		// stop promptly rather than running to completion.
+type grepLineMatcher func(string) (int, bool)
+
+func presenceGrepLineMatcher(compiled *regexp.Regexp) grepLineMatcher {
+	return func(line string) (int, bool) {
+		if !compiled.MatchString(line) {
+			return 0, false
+		}
+		return 1, true
+	}
+}
+
+func exactGrepLineMatcher(compiled *regexp.Regexp) grepLineMatcher {
+	return func(line string) (int, bool) {
+		matches := compiled.FindAllStringIndex(line, -1)
+		if len(matches) == 0 {
+			return 0, false
+		}
+		return len(matches), true
+	}
+}
+
+func scanGrepMatches(ctx context.Context, resolvedRoot string, target string, globMatcher *regexp.Regexp, exclude readExcluder, absolutePaths bool, matcher grepLineMatcher, emit func(grepMatch)) error {
+	return walkGrepFiles(ctx, resolvedRoot, target, globMatcher, exclude, func(file string) error {
+		return scanGrepFile(ctx, resolvedRoot, absolutePaths, file, matcher, emit)
+	})
+}
+
+func scanGrepFile(ctx context.Context, resolvedRoot string, absolutePaths bool, file string, matcher grepLineMatcher, emit func(grepMatch)) error {
+	// Re-confine at read time (defense-in-depth) AND to compute the clean
+	// workspace-relative path used in output.
+	relative, resolvedPath, ok := confineGrepFile(resolvedRoot, file)
+	if !ok {
+		return nil
+	}
+	if shouldSkipWorkspaceFile(relative) {
+		return nil
+	}
+	fileLabel := relative
+	if absolutePaths {
+		// Extra-root search: report the absolute, symlink-resolved path
+		// confineGrepFile already validated, so a bare workspace-relative
+		// name can't resolve under the workspace and hit the wrong file when
+		// the same name exists in both roots.
+		fileLabel = filepath.ToSlash(resolvedPath)
+	}
+
+	// Read the symlink-RESOLVED path that confineGrepFile validated, not the
+	// raw candidate, so a symlink swapped in after the check can't escape.
+	handle, err := os.Open(resolvedPath)
+	if err != nil {
+		return nil
+	}
+	defer handle.Close()
+
+	reader := bufio.NewReader(handle)
+	lineNumber := 1
+	sawLine := false
+	lastEnded := false
+	for {
 		if err := ctx.Err(); err != nil {
-			return matches, err
+			return err
 		}
-		// Re-confine at read time (defense-in-depth) AND to compute the clean
-		// workspace-relative path used in output.
-		relative, resolvedPath, ok := confineGrepFile(resolvedRoot, file)
-		if !ok {
-			continue
+		raw, ended, err := readRawLine(reader)
+		if err == io.EOF {
+			if !sawLine || lastEnded {
+				emitGrepLine(matcher, fileLabel, lineNumber, "", emit)
+			}
+			return nil
 		}
-		if shouldSkipWorkspaceFile(relative) {
-			continue
-		}
-		// Read the symlink-RESOLVED path that confineGrepFile validated, not the
-		// raw candidate, so a symlink swapped in after the check can't escape.
-		content, err := os.ReadFile(resolvedPath)
 		if err != nil {
-			continue
+			return nil
 		}
-		for index, line := range strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n") {
-			lineMatches := compiled.FindAllStringIndex(line, -1)
-			if len(lineMatches) == 0 {
-				continue
-			}
-			fileLabel := relative
-			if absolutePaths {
-				// Extra-root search: report the absolute, symlink-resolved path
-				// confineGrepFile already validated, so a bare workspace-relative
-				// name can't resolve under the workspace and hit the wrong file when
-				// the same name exists in both roots.
-				fileLabel = filepath.ToSlash(resolvedPath)
-			}
-			matches = append(matches, grepMatch{
-				file: fileLabel,
-				line: index + 1,
-				text: strings.TrimRight(line, "\r"),
-				hits: len(lineMatches),
-			})
+		sawLine = true
+		lastEnded = ended
+		line := strings.TrimRight(string(trimLineBreak(raw, ended)), "\r")
+		emitGrepLine(matcher, fileLabel, lineNumber, line, emit)
+		lineNumber++
+	}
+}
+
+func emitGrepLine(matcher grepLineMatcher, fileLabel string, lineNumber int, line string, emit func(grepMatch)) {
+	hits, ok := matcher(line)
+	if !ok {
+		return
+	}
+	emit(grepMatch{
+		file: fileLabel,
+		line: lineNumber,
+		text: line,
+		hits: hits,
+	})
+}
+
+type grepCountCollector struct {
+	hits int
+}
+
+func (collector *grepCountCollector) collect(match grepMatch) {
+	collector.hits += match.hits
+}
+
+func (collector *grepCountCollector) result() Result {
+	return okResult(fmt.Sprintf("%d matches found", collector.hits))
+}
+
+type grepFileListCollector struct {
+	files []string
+	seen  map[string]bool
+}
+
+func (collector *grepFileListCollector) collect(match grepMatch) {
+	if collector.seen == nil {
+		collector.seen = map[string]bool{}
+	}
+	if collector.seen[match.file] {
+		return
+	}
+	collector.seen[match.file] = true
+	collector.files = append(collector.files, match.file)
+}
+
+func (collector *grepFileListCollector) result() Result {
+	if len(collector.files) == 0 {
+		return okResult("No matches found.")
+	}
+	sort.Strings(collector.files)
+	budgeted := applyOutputBudget(strings.Join(collector.files, "\n"), searchOutputBudgetBytes, "narrow path/glob/pattern to continue")
+	meta := outputBudgetMeta(budgeted)
+	if budgeted.Truncated {
+		meta["truncated"] = "true"
+		meta["truncation_reason"] = "byte_budget"
+	}
+	return Result{Status: StatusOK, Output: budgeted.Output, Truncated: budgeted.Truncated, Meta: meta}
+}
+
+type grepContentCollector struct {
+	headLimit     int
+	matches       []grepMatch
+	matchingLines int
+}
+
+func (collector *grepContentCollector) collect(match grepMatch) {
+	collector.matchingLines++
+	if len(collector.matches) < collector.headLimit {
+		collector.matches = append(collector.matches, match)
+	}
+}
+
+func (collector *grepContentCollector) result() Result {
+	if collector.matchingLines == 0 {
+		return okResult("No matches found.")
+	}
+	lines := make([]string, 0, len(collector.matches))
+	for _, match := range collector.matches {
+		lines = append(lines, fmt.Sprintf("%s:%d: %s", match.file, match.line, match.text))
+	}
+	truncated := collector.matchingLines > collector.headLimit
+	output := strings.Join(lines, "\n")
+	if truncated {
+		output += fmt.Sprintf("\n\n[truncated: showing first %d of %d matches; narrow path/glob/pattern or increase head_limit]", len(lines), collector.matchingLines)
+	}
+	budgeted := applyOutputBudget(output, searchOutputBudgetBytes, "narrow path/glob/pattern or increase head_limit")
+	meta := outputBudgetMeta(budgeted)
+	if truncated || budgeted.Truncated {
+		meta["truncated"] = "true"
+		if budgeted.Truncated {
+			meta["truncation_reason"] = "byte_budget"
+		} else {
+			meta["truncation_reason"] = "head_limit"
 		}
 	}
-	return matches, nil
+	return Result{
+		Status:    StatusOK,
+		Output:    budgeted.Output,
+		Truncated: truncated || budgeted.Truncated,
+		Meta:      meta,
+	}
 }

--- a/internal/tools/line_reader.go
+++ b/internal/tools/line_reader.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"bufio"
+	"io"
+)
+
+func readRawLine(reader *bufio.Reader) ([]byte, bool, error) {
+	var line []byte
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if len(fragment) > 0 {
+			if line != nil || err == bufio.ErrBufferFull {
+				line = append(line, fragment...)
+			} else {
+				line = fragment
+			}
+		}
+		switch err {
+		case nil:
+			return line, true, nil
+		case bufio.ErrBufferFull:
+			continue
+		case io.EOF:
+			if len(line) > 0 {
+				return line, false, nil
+			}
+			return nil, false, io.EOF
+		default:
+			return nil, false, err
+		}
+	}
+}
+
+func trimLineBreak(raw []byte, ended bool) []byte {
+	if !ended || len(raw) == 0 || raw[len(raw)-1] != '\n' {
+		return raw
+	}
+	raw = raw[:len(raw)-1]
+	if len(raw) > 0 && raw[len(raw)-1] == '\r' {
+		raw = raw[:len(raw)-1]
+	}
+	return raw
+}

--- a/internal/tools/output_budget.go
+++ b/internal/tools/output_budget.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -51,4 +52,46 @@ func estimatedTokensFromBytes(bytes int) int {
 		return 0
 	}
 	return (bytes + 3) / 4
+}
+
+type outputBudgetBuilder struct {
+	builder  strings.Builder
+	rawBytes int
+	maxBytes int
+	hint     string
+}
+
+func newOutputBudgetBuilder(maxBytes int, hint string) *outputBudgetBuilder {
+	return &outputBudgetBuilder{maxBytes: maxBytes, hint: hint}
+}
+
+func (builder *outputBudgetBuilder) WriteString(value string) {
+	builder.rawBytes += len(value)
+	if builder.maxBytes <= 0 || builder.builder.Len() >= builder.maxBytes {
+		return
+	}
+	remaining := builder.maxBytes - builder.builder.Len()
+	builder.builder.WriteString(utf8Prefix(value, remaining))
+}
+
+func (builder *outputBudgetBuilder) Result() outputBudgetResult {
+	output := builder.builder.String()
+	result := outputBudgetResult{
+		Output:       output,
+		RawBytes:     builder.rawBytes,
+		EmittedBytes: len(output),
+	}
+	if builder.maxBytes <= 0 || builder.rawBytes <= builder.maxBytes {
+		return result
+	}
+
+	marker := fmt.Sprintf("\n\n[truncated: output exceeded %d bytes; %s]", builder.maxBytes, builder.hint)
+	budget := builder.maxBytes - len(marker)
+	if budget < 0 {
+		budget = 0
+	}
+	result.Output = utf8Prefix(output, budget) + marker
+	result.Truncated = true
+	result.EmittedBytes = len(result.Output)
+	return result
 }

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -1,8 +1,12 @@
 package tools
 
 import (
+	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -68,7 +72,7 @@ func (tool readFileTool) RunWithOptions(_ context.Context, args map[string]any, 
 		return errorResult("Error reading file " + requestedPath + ": " + err.Error())
 	}
 
-	content, err := os.ReadFile(absolutePath)
+	stats, err := scanReadFileStats(absolutePath)
 	if err != nil {
 		return errorResult("Error reading file " + relativePath + ": " + err.Error())
 	}
@@ -76,17 +80,15 @@ func (tool readFileTool) RunWithOptions(_ context.Context, args map[string]any, 
 	// write_file read) so a later write can detect an out-of-Zero modification.
 	// Stat is best-effort: a missing FileInfo only drops the diagnostic size/mtime,
 	// not the authoritative content hash.
-	info, _ := os.Stat(absolutePath)
-	options.FileTracker.Record(absolutePath, content, info)
+	options.FileTracker.RecordHash(absolutePath, stats.hash, stats.info)
 
-	normalizedContent := strings.ReplaceAll(string(content), "\r\n", "\n")
-	normalizedContent = strings.TrimSuffix(normalizedContent, "\n")
-	lines := strings.Split(normalizedContent, "\n")
-	total := len(lines)
+	return renderReadFileRange(absolutePath, relativePath, stats.lines, startLine, endLine, maxLines)
+}
+
+func renderReadFileRange(absolutePath string, relativePath string, total int, startLine int, endLine int, maxLines int) Result {
 	if startLine > total {
 		return okResult(fmt.Sprintf("File: %s\n(start_line %d is past the end of the file, which has %d lines)", relativePath, startLine, total))
 	}
-
 	if endLine == 0 || endLine > total {
 		endLine = total
 	}
@@ -94,46 +96,117 @@ func (tool readFileTool) RunWithOptions(_ context.Context, args map[string]any, 
 		return errorResult("Error: Invalid arguments for read_file: end_line must be greater than or equal to start_line")
 	}
 
-	selected := lines[startLine-1 : endLine]
 	truncated := false
-	if maxLines > 0 && len(selected) > maxLines {
-		selected = selected[:maxLines]
+	selectedLines := endLine - startLine + 1
+	if maxLines > 0 && selectedLines > maxLines {
+		selectedLines = maxLines
 		truncated = true
 	}
 
-	lastLine := startLine + len(selected) - 1
+	lastLine := startLine + selectedLines - 1
 	width := len(strconv.Itoa(lastLine))
-	numbered := make([]string, 0, len(selected))
-	for index, line := range selected {
-		lineNumber := strconv.Itoa(startLine + index)
-		numbered = append(numbered, strings.Repeat(" ", width-len(lineNumber))+lineNumber+" | "+line)
-	}
-
 	header := fmt.Sprintf("File: %s (%d lines)", relativePath, total)
 	if startLine != 1 || endLine != total || maxLines > 0 {
 		header = fmt.Sprintf("File: %s (lines %d-%d of %d)", relativePath, startLine, lastLine, total)
 	}
 
-	body := strings.Join(numbered, "\n")
+	budgetedOutput := newOutputBudgetBuilder(readOutputBudgetBytes, "use start_line/end_line or max_lines to continue with a smaller range")
+	budgetedOutput.WriteString(header)
+	budgetedOutput.WriteString("\n\n")
+	if err := appendReadFileRange(budgetedOutput, absolutePath, startLine, selectedLines, width); err != nil {
+		return errorResult("Error reading file " + relativePath + ": " + err.Error())
+	}
 	if truncated {
 		// The Truncated flag alone is invisible to the model in the rendered
 		// output, so it cannot tell a max_lines cut from a complete read. Make the
 		// cut explicit and tell it how to continue.
-		body += fmt.Sprintf("\n\n[truncated: %d more line(s) in the requested range not shown; set start_line=%d to continue]", endLine-lastLine, lastLine+1)
+		budgetedOutput.WriteString(fmt.Sprintf("\n\n[truncated: %d more line(s) in the requested range not shown; set start_line=%d to continue]", endLine-lastLine, lastLine+1))
 	}
 
-	output := header + "\n\n" + body
-	budgeted := applyOutputBudget(output, readOutputBudgetBytes, "use start_line/end_line or max_lines to continue with a smaller range")
+	budgeted := budgetedOutput.Result()
 	meta := outputBudgetMeta(budgeted)
 	if budgeted.Truncated {
 		meta["truncated"] = "true"
 		meta["truncation_reason"] = "byte_budget"
 	}
-
 	return Result{
 		Status:    StatusOK,
 		Output:    budgeted.Output,
 		Truncated: truncated || budgeted.Truncated,
 		Meta:      meta,
 	}
+}
+
+type readFileStats struct {
+	lines int
+	hash  string
+	info  os.FileInfo
+}
+
+func scanReadFileStats(path string) (readFileStats, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return readFileStats{}, err
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	reader := bufio.NewReader(file)
+	lines := 0
+	for {
+		raw, _, err := readRawLine(reader)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return readFileStats{}, err
+		}
+		if _, err := hasher.Write(raw); err != nil {
+			return readFileStats{}, err
+		}
+		lines++
+	}
+	if lines == 0 {
+		lines = 1
+	}
+	info, _ := file.Stat()
+	return readFileStats{lines: lines, hash: hex.EncodeToString(hasher.Sum(nil)), info: info}, nil
+}
+
+func appendReadFileRange(output *outputBudgetBuilder, path string, startLine int, selectedLines int, width int) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	lineNumber := 1
+	emitted := 0
+	for emitted < selectedLines {
+		raw, ended, err := readRawLine(reader)
+		if err == io.EOF {
+			raw = nil
+			ended = false
+		} else if err != nil {
+			return err
+		}
+
+		if lineNumber >= startLine {
+			if emitted > 0 {
+				output.WriteString("\n")
+			}
+			number := strconv.Itoa(lineNumber)
+			output.WriteString(strings.Repeat(" ", width-len(number)))
+			output.WriteString(number)
+			output.WriteString(" | ")
+			output.WriteString(string(trimLineBreak(raw, ended)))
+			emitted++
+		}
+		if err == io.EOF {
+			break
+		}
+		lineNumber++
+	}
+	return nil
 }

--- a/internal/tools/search_cancellation_test.go
+++ b/internal/tools/search_cancellation_test.go
@@ -96,14 +96,12 @@ func TestGrepStillMatchesWithLiveContext(t *testing.T) {
 	}
 }
 
-// Before this fix, only grepFiles' walk checked ctx: once the walk had
-// finished discovering candidate files, collectGrepMatches read and
-// regex-scanned every one of them to completion regardless of cancellation.
-// This proves the match-collection phase itself stops partway through,
-// not only when the context was already cancelled before the walk started.
-// grepFiles must stop mid-walk once ctx is cancelled, not only when the
+// Before this fix, only grep's walk checked ctx: once the walk had discovered
+// candidate files, match scanning could run to completion regardless of
+// cancellation. These tests cover both phases directly.
+// The walker must stop mid-walk once ctx is cancelled, not only when the
 // context was already cancelled before WalkDir starts.
-func TestGrepFilesStopsMidWalkOnCancelledContext(t *testing.T) {
+func TestGrepWalkStopsMidWalkOnCancelledContext(t *testing.T) {
 	root := buildLargeSearchTree(t, 50)
 	resolvedRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
@@ -112,21 +110,27 @@ func TestGrepFilesStopsMidWalkOnCancelledContext(t *testing.T) {
 
 	const allowed = 5
 	ctx := &countingCancelContext{Context: context.Background(), remaining: allowed}
-	files, err := grepFiles(ctx, resolvedRoot, root, nil, readExcluder{})
+	files := 0
+	err = walkGrepFiles(ctx, resolvedRoot, root, nil, readExcluder{}, func(string) error {
+		files++
+		return nil
+	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want context.Canceled", err)
 	}
-	if len(files) >= 50 {
-		t.Fatalf("files = %d; walk should stop mid-traversal instead of visiting every entry", len(files))
+	if files >= 50 {
+		t.Fatalf("files = %d; walk should stop mid-traversal instead of visiting every entry", files)
 	}
 }
 
-func TestGrepCollectMatchesStopsMidCollectionOnCancelledContext(t *testing.T) {
-	root := buildLargeSearchTree(t, 50)
-	files := make([]string, 50)
-	for i := range files {
-		files[i] = filepath.Join(root, "file"+strconv.Itoa(i)+".txt")
+func TestGrepScanStopsMidFileOnCancelledContext(t *testing.T) {
+	root := t.TempDir()
+	var body string
+	for i := 0; i < 50; i++ {
+		body += "needle\n"
 	}
+	file := filepath.Join(root, "file.txt")
+	writeTestFile(t, file, body)
 	resolvedRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		t.Fatalf("EvalSymlinks: %v", err)
@@ -135,12 +139,15 @@ func TestGrepCollectMatchesStopsMidCollectionOnCancelledContext(t *testing.T) {
 
 	const allowed = 5
 	ctx := &countingCancelContext{Context: context.Background(), remaining: allowed}
-	matches, err := collectGrepMatches(ctx, resolvedRoot, false, files, compiled)
+	matches := 0
+	err = scanGrepFile(ctx, resolvedRoot, false, file, presenceGrepLineMatcher(compiled), func(grepMatch) {
+		matches++
+	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want context.Canceled", err)
 	}
-	if len(matches) != allowed {
-		t.Fatalf("matches = %d, want exactly %d collected before cancellation stopped the loop", len(matches), allowed)
+	if matches != allowed {
+		t.Fatalf("matches = %d, want exactly %d collected before cancellation stopped the loop", matches, allowed)
 	}
 }
 

--- a/internal/tools/tool_io_bench_test.go
+++ b/internal/tools/tool_io_bench_test.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func BenchmarkReadFileLargeRangeSmall(b *testing.B) {
+	root := b.TempDir()
+	const lines = 200_000
+	writeBenchLines(b, filepath.Join(root, "large.txt"), lines, func(i int) string {
+		return fmt.Sprintf("line-%06d abcdefghijklmnopqrstuvwxyz 0123456789\n", i)
+	})
+
+	tool := NewReadFileTool(root)
+	args := map[string]any{
+		"path":       "large.txt",
+		"start_line": lines / 2,
+		"max_lines":  5,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := tool.Run(context.Background(), args)
+		if result.Status != StatusOK {
+			b.Fatalf("status=%s output=%s", result.Status, result.Output)
+		}
+	}
+}
+
+func BenchmarkGrepLargeTreeHeadLimit(b *testing.B) {
+	root := b.TempDir()
+	const files = 80
+	const linesPerFile = 500
+	for fileIndex := 0; fileIndex < files; fileIndex++ {
+		path := filepath.Join(root, "pkg", fmt.Sprintf("file-%03d.txt", fileIndex))
+		writeBenchLines(b, path, linesPerFile, func(lineIndex int) string {
+			return fmt.Sprintf("needle file=%03d line=%03d payload=%s\n", fileIndex, lineIndex, strings.Repeat("x", 32))
+		})
+	}
+
+	tool := NewGrepTool(root)
+	args := map[string]any{
+		"pattern":    "needle",
+		"path":       ".",
+		"head_limit": 10,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := tool.Run(context.Background(), args)
+		if result.Status != StatusOK {
+			b.Fatalf("status=%s output=%s", result.Status, result.Output)
+		}
+	}
+}
+
+func writeBenchLines(tb testing.TB, path string, lines int, line func(int) string) {
+	tb.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			tb.Fatal(err)
+		}
+	}()
+	for i := 0; i < lines; i++ {
+		if _, err := file.WriteString(line(i)); err != nil {
+			tb.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #564.

Streams `read_file` and `grep` IO. Preserves guards, budgets, cancellation, file tracking.

Benchmem on Apple M4, `-count=5` avg:
- `ReadFileLargeRangeSmall`: 23.2 MB/op -> 18.3 KB/op
- `GrepLargeTreeHeadLimit`: 29.8 MB/op -> 4.27 MB/op

