### PR TITLE
feat(tui): remember recent provider+model selections in /model picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .cache
 *.tsbuildinfo
 
+# Go build/module caches (GOCACHE/GOMODCACHE pointed here for local runs)
+.gocache/
+.gomodcache/
+
 # IntelliJ based IDEs
 .idea
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -742,6 +742,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		ProviderProfile:      resolved.Provider,
 		SavedProviders:       usableSavedProviders(resolved.Providers),
 		FavoriteModels:       resolved.Preferences.FavoriteModels,
+		RecentModels:         resolved.Preferences.RecentModels,
 		RecapsEnabled:        resolved.Preferences.RecapsEnabled(),
 		Provider:             provider,
 		NewProvider:          deps.newProvider,

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -223,6 +223,9 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	if src.Preferences.FavoriteModels != nil {
 		dst.Preferences.FavoriteModels = normalizeFavoriteModels(src.Preferences.FavoriteModels)
 	}
+	if src.Preferences.RecentModels != nil {
+		dst.Preferences.RecentModels = normalizeRecentModels(src.Preferences.RecentModels)
+	}
 	if src.Preferences.Recaps != nil {
 		dst.Preferences.Recaps = src.Preferences.Recaps
 	}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -224,7 +224,7 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 		dst.Preferences.FavoriteModels = normalizeFavoriteModels(src.Preferences.FavoriteModels)
 	}
 	if src.Preferences.RecentModels != nil {
-		dst.Preferences.RecentModels = normalizeRecentModels(src.Preferences.RecentModels)
+		dst.Preferences.RecentModels = NormalizeRecentModels(src.Preferences.RecentModels)
 	}
 	if src.Preferences.Recaps != nil {
 		dst.Preferences.Recaps = src.Preferences.Recaps

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -127,6 +127,46 @@ func TestResolveLoadsFavoriteModelsFromUserConfigOnly(t *testing.T) {
 	}
 }
 
+func TestResolveLoadsRecentModelsFromUserConfigOnly(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"activeProvider": "user",
+		"providers": [{
+			"name": "user",
+			"provider": "openai",
+			"apiKey": "sk-user",
+			"model": "gpt-user"
+		}],
+		"preferences": {
+			"recentModels": [
+				{"provider": "openrouter", "model": " google/gemini-2.5-pro "},
+				{"provider": "openrouter", "model": "minimax/minimax-m2.1"}
+			]
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"preferences": {
+			"recentModels": [{"provider": "project", "model": "project-model"}]
+		}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env:               map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	want := []RecentModelEntry{
+		{Provider: "openrouter", Model: "google/gemini-2.5-pro"},
+		{Provider: "openrouter", Model: "minimax/minimax-m2.1"},
+	}
+	if !reflect.DeepEqual(resolved.Preferences.RecentModels, want) {
+		t.Fatalf("RecentModels = %#v, want %#v", resolved.Preferences.RecentModels, want)
+	}
+}
+
 func TestResolveLoadsProviderCatalogSnakeAndCamelJSONFields(t *testing.T) {
 	path := writeConfig(t, `{
 		"activeProvider": "snake",

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -167,6 +167,39 @@ func TestResolveLoadsRecentModelsFromUserConfigOnly(t *testing.T) {
 	}
 }
 
+// recentModels must never be merged from project config (same posture as
+// favoriteModels): a project setting it with no corresponding user setting
+// should leave the resolved value empty, not pick up the project's list.
+func TestResolveIgnoresProjectOnlyRecentModels(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"activeProvider": "user",
+		"providers": [{
+			"name": "user",
+			"provider": "openai",
+			"apiKey": "sk-user",
+			"model": "gpt-user"
+		}]
+	}`)
+	projectPath := writeConfig(t, `{
+		"preferences": {
+			"recentModels": [{"provider": "project", "model": "project-model"}]
+		}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env:               map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if len(resolved.Preferences.RecentModels) != 0 {
+		t.Fatalf("RecentModels = %#v, want empty (project-only recentModels must not be merged)", resolved.Preferences.RecentModels)
+	}
+}
+
 func TestResolveLoadsProviderCatalogSnakeAndCamelJSONFields(t *testing.T) {
 	path := writeConfig(t, `{
 		"activeProvider": "snake",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -97,6 +97,11 @@ type ToolsConfig struct {
 
 type PreferencesConfig struct {
 	FavoriteModels []string `json:"favoriteModels,omitempty"`
+	// RecentModels is the short automatic history of provider+model pairs the
+	// user has switched to via /model, newest first. Unlike FavoriteModels
+	// (manual pins), this list is maintained automatically on every switch and
+	// capped to MaxRecentModels entries. See RecentModelEntry.
+	RecentModels []RecentModelEntry `json:"recentModels,omitempty"`
 	// Theme is the persisted TUI palette preference — "auto" or a registered theme
 	// name (e.g. "dracula"). Applied at startup below the --theme flag and
 	// ZERO_THEME, so a /theme choice survives restart. Empty = unset (defaults auto).
@@ -106,6 +111,18 @@ type PreferencesConfig struct {
 	// custom unmarshal is needed (unlike ToolsConfig.DeferThreshold's int).
 	Recaps *bool `json:"recaps,omitempty"`
 }
+
+// RecentModelEntry is one provider-qualified model selection recorded in
+// Preferences.RecentModels. Provider is the saved provider profile's Name (not
+// a display label), so a recent entry can be resolved back to a concrete
+// profile the same way the /model picker's cross-provider rows are.
+type RecentModelEntry struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+// MaxRecentModels caps the persisted/displayed recent-selection history.
+const MaxRecentModels = 5
 
 // RecapsEnabled reports whether post-turn recaps are on. Unset defaults to ON.
 func (p PreferencesConfig) RecapsEnabled() bool {

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -150,7 +150,7 @@ func SetRecentModels(path string, entries []RecentModelEntry) (FileConfig, error
 		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
 	}
 
-	cfg.Preferences.RecentModels = normalizeRecentModels(entries)
+	cfg.Preferences.RecentModels = NormalizeRecentModels(entries)
 	if err := writeConfigFile(path, cfg); err != nil {
 		return FileConfig{}, err
 	}
@@ -217,11 +217,14 @@ func normalizeFavoriteModels(models []string) []string {
 	return favorites
 }
 
-// normalizeRecentModels trims, drops entries with no model id, de-duplicates
+// NormalizeRecentModels trims, drops entries with no model id, de-duplicates
 // by provider+model pair (keeping the first/newest occurrence), and caps the
 // result to MaxRecentModels. Order is preserved — the caller is responsible
-// for passing entries newest-first.
-func normalizeRecentModels(entries []RecentModelEntry) []RecentModelEntry {
+// for passing entries newest-first. Exported so callers outside this package
+// (e.g. the TUI, which keeps its own in-memory copy of recent history) apply
+// the exact same normalization rules as the persisted config, instead of
+// maintaining a second, independently-drifting copy of this logic.
+func NormalizeRecentModels(entries []RecentModelEntry) []RecentModelEntry {
 	seen := map[string]bool{}
 	recent := make([]RecentModelEntry, 0, len(entries))
 	for _, entry := range entries {

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -131,6 +131,32 @@ func SetFavoriteModels(path string, models []string) (FileConfig, error) {
 	return cfg, nil
 }
 
+// SetRecentModels persists the automatic recent-model-switch history,
+// mirroring SetFavoriteModels (read-modify-atomic-write). Unlike favorites,
+// order is preserved (newest first) rather than sorted, since it reflects
+// switch recency, not an alphabetical preference list.
+func SetRecentModels(path string, entries []RecentModelEntry) (FileConfig, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return FileConfig{}, fmt.Errorf("config path is required")
+	}
+
+	cfg := FileConfig{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+
+	cfg.Preferences.RecentModels = normalizeRecentModels(entries)
+	if err := writeConfigFile(path, cfg); err != nil {
+		return FileConfig{}, err
+	}
+	return cfg, nil
+}
+
 // SetRecapsEnabled persists the post-turn recap preference, mirroring
 // SetFavoriteModels (read-modify-atomic-write).
 func SetRecapsEnabled(path string, enabled bool) (FileConfig, error) {
@@ -189,6 +215,32 @@ func normalizeFavoriteModels(models []string) []string {
 	}
 	sort.Strings(favorites)
 	return favorites
+}
+
+// normalizeRecentModels trims, drops entries with no model id, de-duplicates
+// by provider+model pair (keeping the first/newest occurrence), and caps the
+// result to MaxRecentModels. Order is preserved — the caller is responsible
+// for passing entries newest-first.
+func normalizeRecentModels(entries []RecentModelEntry) []RecentModelEntry {
+	seen := map[string]bool{}
+	recent := make([]RecentModelEntry, 0, len(entries))
+	for _, entry := range entries {
+		provider := strings.TrimSpace(entry.Provider)
+		model := strings.TrimSpace(entry.Model)
+		if model == "" {
+			continue
+		}
+		key := strings.ToLower(provider) + "\x00" + model
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		recent = append(recent, RecentModelEntry{Provider: provider, Model: model})
+		if len(recent) >= MaxRecentModels {
+			break
+		}
+	}
+	return recent
 }
 
 func writeConfigFile(path string, cfg FileConfig) error {

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -272,6 +272,69 @@ func TestSetFavoriteModelsPersistsUserPreferences(t *testing.T) {
 	}
 }
 
+func TestSetRecentModelsPersistsOrderDedupesAndCaps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "openai",
+		Providers: []ProviderProfile{
+			{Name: "openai", ProviderKind: ProviderKindOpenAI, Model: "gpt-4.1"},
+		},
+	}, 0o600)
+
+	cfg, err := SetRecentModels(path, []RecentModelEntry{
+		{Provider: " openrouter ", Model: " google/gemini-2.5-pro "},
+		{Provider: "openrouter", Model: "minimax/minimax-m2.1"},
+		{Provider: "openrouter", Model: "google/gemini-2.5-pro"}, // duplicate pair, older: dropped
+		{Provider: "", Model: ""},                                // blank model: dropped
+		{Provider: "openrouter", Model: "a"},
+		{Provider: "openrouter", Model: "b"},
+		{Provider: "openrouter", Model: "c"},
+		{Provider: "openrouter", Model: "d"}, // beyond MaxRecentModels (5): dropped
+	})
+	if err != nil {
+		t.Fatalf("SetRecentModels() error = %v", err)
+	}
+
+	want := []RecentModelEntry{
+		{Provider: "openrouter", Model: "google/gemini-2.5-pro"},
+		{Provider: "openrouter", Model: "minimax/minimax-m2.1"},
+		{Provider: "openrouter", Model: "a"},
+		{Provider: "openrouter", Model: "b"},
+		{Provider: "openrouter", Model: "c"},
+	}
+	if !reflect.DeepEqual(cfg.Preferences.RecentModels, want) {
+		t.Fatalf("RecentModels = %#v, want %#v", cfg.Preferences.RecentModels, want)
+	}
+	persisted := readConfigFixture(t, path)
+	if !reflect.DeepEqual(persisted.Preferences.RecentModels, want) {
+		t.Fatalf("persisted RecentModels = %#v, want %#v", persisted.Preferences.RecentModels, want)
+	}
+	if persisted.ActiveProvider != "openai" || len(persisted.Providers) != 1 {
+		t.Fatalf("provider config was not preserved: %#v", persisted)
+	}
+}
+
+// Two providers offering the same model id must both survive normalization —
+// recent history de-duplicates by provider+model pair, not model id alone.
+func TestSetRecentModelsDedupesByProviderAndModelPair(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+
+	cfg, err := SetRecentModels(path, []RecentModelEntry{
+		{Provider: "provider-a", Model: "shared-model"},
+		{Provider: "provider-b", Model: "shared-model"},
+	})
+	if err != nil {
+		t.Fatalf("SetRecentModels() error = %v", err)
+	}
+	want := []RecentModelEntry{
+		{Provider: "provider-a", Model: "shared-model"},
+		{Provider: "provider-b", Model: "shared-model"},
+	}
+	if !reflect.DeepEqual(cfg.Preferences.RecentModels, want) {
+		t.Fatalf("RecentModels = %#v, want both providers preserved: %#v", cfg.Preferences.RecentModels, want)
+	}
+}
+
 func TestSetThemePersistsUserPreference(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "zero.json")
 	writeConfigFixture(t, path, FileConfig{

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -411,7 +411,7 @@ func (m model) handleModelCommand(args string) (model, string) {
 		return m, "Model\nProvider rebuild is not available for this TUI session."
 	}
 
-	previousProviderName := m.providerProfile.Name
+	previousProviderName := m.providerName
 	previousModel := m.modelName
 
 	nextProfile := m.providerProfile
@@ -455,7 +455,11 @@ func (m model) handleModelCommand(args string) (model, string) {
 	// instead of two separate disk writes for this one switch.
 	m = m.recordRecentModels(
 		config.RecentModelEntry{Provider: previousProviderName, Model: previousModel},
-		config.RecentModelEntry{Provider: nextProfile.Name, Model: target.modelID},
+		// Record under m.providerName (the same resolved value recentModelPairsForPicker
+		// pins the active row with), not the raw nextProfile.Name: for a provider profile
+		// with no Name set, those two diverge and the pinned active row would fail to
+		// dedupe against the entry just persisted here, showing the same switch twice.
+		config.RecentModelEntry{Provider: m.providerName, Model: target.modelID},
 	)
 	resetEffort := false
 	if m.reasoningEffort != "" && !reasoningEffortAllowed(target.reasoningEfforts, m.reasoningEffort) {
@@ -517,7 +521,7 @@ func (m model) switchProviderModel(providerName, modelID string) (model, string,
 	if !ok {
 		return m, "Model\nunknown provider " + strconv.Quote(providerName), nil
 	}
-	previousProviderName := m.providerProfile.Name
+	previousProviderName := m.providerName
 	previousModel := m.modelName
 	target = m.profileWithCredential(target)
 	target.Model = strings.TrimSpace(modelID)

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -450,10 +450,13 @@ func (m model) handleModelCommand(args string) (model, string) {
 	// Record the outgoing pair too, not just the destination: otherwise the
 	// model a session started on (never itself the target of a recordRecentModel
 	// call) would silently drop out of "Recent" the moment you switch away from
-	// it once. Recording old-then-new leaves new at the front (recordRecentModel
-	// prepends), with old right behind it.
-	m = m.recordRecentModel(previousProviderName, previousModel)
-	m = m.recordRecentModel(nextProfile.Name, target.modelID)
+	// it once. Recording old-then-new leaves new at the front, with old right
+	// behind it. recordRecentModels batches both into a single normalize+persist
+	// instead of two separate disk writes for this one switch.
+	m = m.recordRecentModels(
+		config.RecentModelEntry{Provider: previousProviderName, Model: previousModel},
+		config.RecentModelEntry{Provider: nextProfile.Name, Model: target.modelID},
+	)
 	resetEffort := false
 	if m.reasoningEffort != "" && !reasoningEffortAllowed(target.reasoningEfforts, m.reasoningEffort) {
 		// Drop an unsupported carry-over preference and fall back to the
@@ -536,8 +539,12 @@ func (m model) switchProviderModel(providerName, modelID string) (model, string,
 	// Record the outgoing pair too — see the matching comment in
 	// handleModelCommand for why (keeps the session's starting model from
 	// silently dropping out of "Recent" on the first switch away from it).
-	m = m.recordRecentModel(previousProviderName, previousModel)
-	m = m.recordRecentModel(target.Name, target.Model)
+	// recordRecentModels batches both into a single normalize+persist instead
+	// of two separate disk writes for this one switch.
+	m = m.recordRecentModels(
+		config.RecentModelEntry{Provider: previousProviderName, Model: previousModel},
+		config.RecentModelEntry{Provider: target.Name, Model: target.Model},
+	)
 	// Keep sub-agent child processes on the same provider we just switched to.
 	config.SetActiveProviderEnv(target.Name)
 	if strings.TrimSpace(m.userConfigPath) != "" {

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -411,6 +411,9 @@ func (m model) handleModelCommand(args string) (model, string) {
 		return m, "Model\nProvider rebuild is not available for this TUI session."
 	}
 
+	previousProviderName := m.providerProfile.Name
+	previousModel := m.modelName
+
 	nextProfile := m.providerProfile
 	if provider, ok := m.activeProviderDescriptor(); ok {
 		nextProfile = m.normalizeProfileForProvider(provider)
@@ -444,6 +447,13 @@ func (m model) handleModelCommand(args string) (model, string) {
 	// Keep sub-agent child processes on the same provider we just switched to.
 	config.SetActiveProviderEnv(nextProfile.Name)
 	m.modelName = target.modelID
+	// Record the outgoing pair too, not just the destination: otherwise the
+	// model a session started on (never itself the target of a recordRecentModel
+	// call) would silently drop out of "Recent" the moment you switch away from
+	// it once. Recording old-then-new leaves new at the front (recordRecentModel
+	// prepends), with old right behind it.
+	m = m.recordRecentModel(previousProviderName, previousModel)
+	m = m.recordRecentModel(nextProfile.Name, target.modelID)
 	resetEffort := false
 	if m.reasoningEffort != "" && !reasoningEffortAllowed(target.reasoningEfforts, m.reasoningEffort) {
 		// Drop an unsupported carry-over preference and fall back to the
@@ -504,6 +514,8 @@ func (m model) switchProviderModel(providerName, modelID string) (model, string,
 	if !ok {
 		return m, "Model\nunknown provider " + strconv.Quote(providerName), nil
 	}
+	previousProviderName := m.providerProfile.Name
+	previousModel := m.modelName
 	target = m.profileWithCredential(target)
 	target.Model = strings.TrimSpace(modelID)
 	descriptor, hasDescriptor := m.descriptorForProfile(target)
@@ -521,6 +533,11 @@ func (m model) switchProviderModel(providerName, modelID string) (model, string,
 	m.providerProfile = target
 	m.providerName = target.Name
 	m.modelName = target.Model
+	// Record the outgoing pair too — see the matching comment in
+	// handleModelCommand for why (keeps the session's starting model from
+	// silently dropping out of "Recent" on the first switch away from it).
+	m = m.recordRecentModel(previousProviderName, previousModel)
+	m = m.recordRecentModel(target.Name, target.Model)
 	// Keep sub-agent child processes on the same provider we just switched to.
 	config.SetActiveProviderEnv(target.Name)
 	if strings.TrimSpace(m.userConfigPath) != "" {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -398,16 +398,16 @@ type model struct {
 	// picker, when non-nil, is an open interactive selector overlay (/model,
 	// /effort with no argument). It captures ↑/↓/Enter/Esc and applies
 	// the chosen value through the existing command handlers.
-	picker                       *commandPicker
-	providerWizard               *providerWizardState
-	mcpManager                   *mcpManagerState
-	mcpAddWizard                 *mcpAddWizardState
-	favoriteModels               map[string]bool
+	picker         *commandPicker
+	providerWizard *providerWizardState
+	mcpManager     *mcpManagerState
+	mcpAddWizard   *mcpAddWizardState
+	favoriteModels map[string]bool
 	// recentModels is the automatic history of provider+model switches, newest
 	// first, capped to config.MaxRecentModels. Unlike favoriteModels (manual
 	// pins), this is maintained by recordRecentModel on every successful
 	// switch and persisted via config.SetRecentModels.
-	recentModels []config.RecentModelEntry
+	recentModels                 []config.RecentModelEntry
 	recapsEnabled                bool         // post-turn "※ recap:" line (config: recaps on|off)
 	recappedRuns                 map[int]bool // per-run guard so a recap fires at most once per turn
 	modelPickerLoading           bool

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -403,6 +403,11 @@ type model struct {
 	mcpManager                   *mcpManagerState
 	mcpAddWizard                 *mcpAddWizardState
 	favoriteModels               map[string]bool
+	// recentModels is the automatic history of provider+model switches, newest
+	// first, capped to config.MaxRecentModels. Unlike favoriteModels (manual
+	// pins), this is maintained by recordRecentModel on every successful
+	// switch and persisted via config.SetRecentModels.
+	recentModels []config.RecentModelEntry
 	recapsEnabled                bool         // post-turn "※ recap:" line (config: recaps on|off)
 	recappedRuns                 map[int]bool // per-run guard so a recap fires at most once per turn
 	modelPickerLoading           bool
@@ -765,6 +770,7 @@ func newModel(ctx context.Context, options Options) model {
 		modelCatalog:                modelCatalog,
 		providerProfile:             options.ProviderProfile,
 		favoriteModels:              favoriteModelSet(options.FavoriteModels),
+		recentModels:                normalizeRecentModelEntries(options.RecentModels),
 		recapsEnabled:               options.RecapsEnabled,
 		provider:                    options.Provider,
 		newProvider:                 options.NewProvider,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3766,10 +3766,15 @@ func (m model) choosePicker() (tea.Model, tea.Cmd) {
 	switch picker.kind {
 	case pickerModel:
 		text := ""
-		if owner := strings.TrimSpace(item.OwnerProvider); owner != "" && !strings.EqualFold(owner, strings.TrimSpace(m.providerName)) {
+		owner := strings.TrimSpace(item.OwnerProvider)
+		_, ownerIsSavedProvider := m.savedProviderByName(owner)
+		if owner != "" && !strings.EqualFold(owner, strings.TrimSpace(m.providerName)) && ownerIsSavedProvider {
 			// A model from another saved provider: switch provider + model together.
 			m, text, cmd = m.switchProviderModel(owner, item.Value)
 		} else {
+			// OwnerProvider is blank, matches the active provider, or (registry-fallback
+			// / stale-history rows) doesn't resolve to any saved provider: apply against
+			// the active provider instead of attempting an unresolvable provider switch.
 			m, text = m.handleModelCommand(item.Value)
 		}
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -31,6 +31,7 @@ type Options struct {
 	ProviderProfile             config.ProviderProfile
 	SavedProviders              []config.ProviderProfile // all configured providers, for the /model multi-provider list
 	FavoriteModels              []string
+	RecentModels                []config.RecentModelEntry
 	RecapsEnabled               bool
 	Provider                    zeroruntime.Provider
 	NewProvider                 func(config.ProviderProfile) (zeroruntime.Provider, error)

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -211,8 +211,12 @@ func (m model) newModelPicker() *commandPicker {
 	}
 	if len(catalog) == 0 {
 		// No saved providers resolved any models: fall back to the full registry.
+		// Only skip the active model when the entry's own provider also matches the
+		// active provider — a different provider offering the same model id is a
+		// distinct, independently selectable row (same provider-aware de-dup this
+		// PR applies everywhere else), not a duplicate of the pinned "Recent" row.
 		for _, entry := range registry.List(modelregistry.ListOptions{}) {
-			if entry.ID == activeModel {
+			if entry.ID == activeModel && (activeProvider == "" || strings.EqualFold(string(entry.Provider), activeProvider)) {
 				continue
 			}
 			catalog = append(catalog, registryModelPickerItem(entry, "Catalog"))
@@ -445,16 +449,19 @@ func (m model) assembleModelPickerItems(recent []pickerItem, catalog []pickerIte
 	// model IDs by Value alone so a model favorited once doesn't surface twice
 	// just because it's in multiple provider catalogs.
 	favoriteSeen := map[string]bool{}
-	all := append(append([]pickerItem{}, recent...), catalog...)
-	for _, item := range all {
-		if item.Value == "" || !m.favoriteModels[item.Value] || favoriteSeen[item.Value] {
-			continue
+	addFavorites := func(items []pickerItem) {
+		for _, item := range items {
+			if item.Value == "" || !m.favoriteModels[item.Value] || favoriteSeen[item.Value] {
+				continue
+			}
+			item.Group = "Favorites"
+			item.Favorite = true
+			result = append(result, item)
+			favoriteSeen[item.Value] = true
 		}
-		item.Group = "Favorites"
-		item.Favorite = true
-		result = append(result, item)
-		favoriteSeen[item.Value] = true
 	}
+	addFavorites(recent)
+	addFavorites(catalog)
 	// Recent and Catalog use the provider-aware de-dup key so the same model ID
 	// offered by different providers shows as distinct, independently selectable
 	// rows. They still skip any model ID already surfaced under Favorites, so a
@@ -495,26 +502,10 @@ func (m model) assembleModelPickerItems(recent []pickerItem, catalog []pickerIte
 // history, de-duplicated by provider+model pair and capped to
 // config.MaxRecentModels.
 func (m model) recentModelPairsForPicker() []config.RecentModelEntry {
-	pairs := make([]config.RecentModelEntry, 0, config.MaxRecentModels)
-	seen := map[string]bool{}
-	add := func(provider, modelID string) {
-		modelID = strings.TrimSpace(modelID)
-		if modelID == "" || len(pairs) >= config.MaxRecentModels {
-			return
-		}
-		provider = strings.TrimSpace(provider)
-		key := strings.ToLower(provider) + "\x00" + modelID
-		if seen[key] {
-			return
-		}
-		seen[key] = true
-		pairs = append(pairs, config.RecentModelEntry{Provider: provider, Model: modelID})
-	}
-	add(m.providerName, m.modelName)
-	for _, entry := range m.recentModels {
-		add(entry.Provider, entry.Model)
-	}
-	return pairs
+	pairs := make([]config.RecentModelEntry, 0, len(m.recentModels)+1)
+	pairs = append(pairs, config.RecentModelEntry{Provider: m.providerName, Model: m.modelName})
+	pairs = append(pairs, m.recentModels...)
+	return config.NormalizeRecentModels(pairs)
 }
 
 // modelPickerRecentItem resolves one "Recent" row for a provider+model pair,
@@ -889,34 +880,19 @@ func (m model) persistFavoriteModels() error {
 	return err
 }
 
-// recordRecentModel prepends provider+model to the in-memory recent-selection
-// history, de-duplicates by provider+model pair (moving a re-selected pair
-// back to the front rather than leaving a stale older copy), caps the result,
-// and persists it. Called after every successful /model switch (typed command
-// or picker), so the "Recent" section reflects real switching history even
-// across sessions. Returns the receiver unchanged when modelID is blank.
+// recordRecentModels prepends the given provider+model pairs (in order, so the
+// last pair ends up frontmost) to the in-memory recent-selection history,
+// de-duplicates by provider+model pair (moving a re-selected pair back to the
+// front rather than leaving a stale older copy), caps the result, and persists
+// it in a single normalize+write regardless of how many pairs are given. Model
+// switches record both the outgoing and incoming pair for one logical switch —
+// otherwise the model a session started on would silently drop out of "Recent"
+// the moment you switch away from it once — and batching avoids two
+// synchronous read-modify-write disk operations for a single user action.
 // Persistence is skipped when there is no user config path, but the in-memory
 // history is still updated so the picker reflects the selection for the rest
-// of the session — note that such in-memory-only history will not survive a
-// restart, which is why a missing config path is logged separately rather than
-// silently diverging from the persisted list.
-func (m model) recordRecentModel(provider, modelID string) model {
-	return m.recordRecentModels(config.RecentModelEntry{Provider: provider, Model: modelID})
-}
-
-// recordRecentModels is the batched form of recordRecentModel: it behaves as
-// if recordRecentModel were called once per pair in order (earlier pairs end
-// up further back in history, the last pair ends up frontmost — same result
-// as calling recordRecentModel that many times in sequence), but normalizes
-// and persists exactly once regardless of how many pairs are given. Model
-// switches need to record both the outgoing and incoming pair for one logical
-// switch (see the package comment above recordRecentModel's call sites for
-// why the outgoing pair matters too); doing that with two separate
-// recordRecentModel calls meant two synchronous read-modify-write disk
-// operations for a single user action, where a failure on the first write
-// would append a spurious error line before the second write silently
-// succeeded. Returns the receiver unchanged (no re-normalization, no write)
-// when every pair has a blank model id.
+// of the session. Returns the receiver unchanged (no re-normalization, no
+// write) when every pair has a blank model id.
 func (m model) recordRecentModels(pairs ...config.RecentModelEntry) model {
 	entries := append([]config.RecentModelEntry{}, m.recentModels...)
 	changed := false

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -901,14 +901,36 @@ func (m model) persistFavoriteModels() error {
 // restart, which is why a missing config path is logged separately rather than
 // silently diverging from the persisted list.
 func (m model) recordRecentModel(provider, modelID string) model {
-	provider = strings.TrimSpace(provider)
-	modelID = strings.TrimSpace(modelID)
-	if modelID == "" {
+	return m.recordRecentModels(config.RecentModelEntry{Provider: provider, Model: modelID})
+}
+
+// recordRecentModels is the batched form of recordRecentModel: it behaves as
+// if recordRecentModel were called once per pair in order (earlier pairs end
+// up further back in history, the last pair ends up frontmost — same result
+// as calling recordRecentModel that many times in sequence), but normalizes
+// and persists exactly once regardless of how many pairs are given. Model
+// switches need to record both the outgoing and incoming pair for one logical
+// switch (see the package comment above recordRecentModel's call sites for
+// why the outgoing pair matters too); doing that with two separate
+// recordRecentModel calls meant two synchronous read-modify-write disk
+// operations for a single user action, where a failure on the first write
+// would append a spurious error line before the second write silently
+// succeeded. Returns the receiver unchanged (no re-normalization, no write)
+// when every pair has a blank model id.
+func (m model) recordRecentModels(pairs ...config.RecentModelEntry) model {
+	entries := append([]config.RecentModelEntry{}, m.recentModels...)
+	changed := false
+	for _, pair := range pairs {
+		modelID := strings.TrimSpace(pair.Model)
+		if modelID == "" {
+			continue
+		}
+		changed = true
+		entries = append([]config.RecentModelEntry{{Provider: strings.TrimSpace(pair.Provider), Model: modelID}}, entries...)
+	}
+	if !changed {
 		return m
 	}
-	entries := make([]config.RecentModelEntry, 0, len(m.recentModels)+1)
-	entries = append(entries, config.RecentModelEntry{Provider: provider, Model: modelID})
-	entries = append(entries, m.recentModels...)
 	m.recentModels = normalizeRecentModelEntries(entries)
 	if path := strings.TrimSpace(m.userConfigPath); path != "" {
 		if _, err := config.SetRecentModels(path, m.recentModels); err != nil {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -440,23 +440,29 @@ func pickerItemDedupKey(item pickerItem) string {
 
 func (m model) assembleModelPickerItems(recent []pickerItem, catalog []pickerItem) []pickerItem {
 	result := []pickerItem{}
-	seen := map[string]bool{}
+	// Favorites keep the pre-provider-aware semantics: one row per favorited
+	// model ID, regardless of how many providers offer it. Track seen favorite
+	// model IDs by Value alone so a model favorited once doesn't surface twice
+	// just because it's in multiple provider catalogs.
+	favoriteSeen := map[string]bool{}
 	all := append(append([]pickerItem{}, recent...), catalog...)
 	for _, item := range all {
-		if item.Value == "" || !m.favoriteModels[item.Value] {
-			continue
-		}
-		key := pickerItemDedupKey(item)
-		if seen[key] {
+		if item.Value == "" || !m.favoriteModels[item.Value] || favoriteSeen[item.Value] {
 			continue
 		}
 		item.Group = "Favorites"
 		item.Favorite = true
 		result = append(result, item)
-		seen[key] = true
+		favoriteSeen[item.Value] = true
 	}
+	// Recent and Catalog use the provider-aware de-dup key so the same model ID
+	// offered by different providers shows as distinct, independently selectable
+	// rows. They still skip any model ID already surfaced under Favorites, so a
+	// favorited model doesn't appear in a second group (preserving the prior
+	// "favorited models are hidden from the rest" behavior).
+	seen := map[string]bool{}
 	for _, item := range recent {
-		if item.Value == "" {
+		if item.Value == "" || favoriteSeen[item.Value] {
 			continue
 		}
 		key := pickerItemDedupKey(item)
@@ -469,7 +475,7 @@ func (m model) assembleModelPickerItems(recent []pickerItem, catalog []pickerIte
 		seen[key] = true
 	}
 	for _, item := range catalog {
-		if item.Value == "" {
+		if item.Value == "" || favoriteSeen[item.Value] {
 			continue
 		}
 		key := pickerItemDedupKey(item)
@@ -881,9 +887,12 @@ func (m model) persistFavoriteModels() error {
 // back to the front rather than leaving a stale older copy), caps the result,
 // and persists it. Called after every successful /model switch (typed command
 // or picker), so the "Recent" section reflects real switching history even
-// across sessions. A no-op when modelID is blank or there is no user config
-// path to persist to (in-memory history alone would not survive restart, and
-// silently diverging from the persisted list would be confusing).
+// across sessions. Returns the receiver unchanged when modelID is blank.
+// Persistence is skipped when there is no user config path, but the in-memory
+// history is still updated so the picker reflects the selection for the rest
+// of the session — note that such in-memory-only history will not survive a
+// restart, which is why a missing config path is logged separately rather than
+// silently diverging from the persisted list.
 func (m model) recordRecentModel(provider, modelID string) model {
 	provider = strings.TrimSpace(provider)
 	modelID = strings.TrimSpace(modelID)

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -552,6 +552,13 @@ func registryModelPickerItem(entry modelregistry.ModelEntry, group string) picke
 		Group: group,
 		Label: firstProviderDisplayValue(entry.DisplayName, entry.ID),
 		Value: entry.ID,
+		// OwnerProvider defaults to the registry entry's canonical provider so
+		// cross-group de-dup (pickerItemDedupKey) can distinguish the same model
+		// id offered by different providers even in the plain-registry fallback
+		// path (no saved providers resolved any models). Callers that resolve a
+		// specific provider profile (e.g. modelPickerRecentItem) overwrite this
+		// with the profile name right after calling this constructor.
+		OwnerProvider: string(entry.Provider),
 	}
 	item.Meta = registryModelPickerMeta(entry)
 	if descriptor, ok := providercatalog.Get(string(entry.Provider)); ok {
@@ -913,29 +920,12 @@ func (m model) recordRecentModel(provider, modelID string) model {
 
 // normalizeRecentModelEntries trims, drops entries with no model id,
 // de-duplicates by provider+model pair (keeping the first/newest occurrence),
-// and caps the result to config.MaxRecentModels. Mirrors the config package's
-// own normalization so options loaded outside of config.Resolve (e.g. tests
-// constructing Options directly) get the same guarantees.
+// and caps the result to config.MaxRecentModels. Delegates to
+// config.NormalizeRecentModels so options loaded outside of config.Resolve
+// (e.g. tests constructing Options directly) can never drift from the
+// persisted-config normalization rules.
 func normalizeRecentModelEntries(entries []config.RecentModelEntry) []config.RecentModelEntry {
-	seen := map[string]bool{}
-	out := make([]config.RecentModelEntry, 0, len(entries))
-	for _, entry := range entries {
-		provider := strings.TrimSpace(entry.Provider)
-		modelID := strings.TrimSpace(entry.Model)
-		if modelID == "" {
-			continue
-		}
-		key := strings.ToLower(provider) + "\x00" + modelID
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		out = append(out, config.RecentModelEntry{Provider: provider, Model: modelID})
-		if len(out) >= config.MaxRecentModels {
-			break
-		}
-	}
-	return out
+	return config.NormalizeRecentModels(entries)
 }
 
 func favoriteModelSet(models []string) map[string]bool {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -189,12 +189,11 @@ func (m model) newModelPicker() *commandPicker {
 		return nil
 	}
 	activeModel := strings.TrimSpace(m.modelName)
-	recent := []pickerItem{}
-	if activeModel != "" {
-		recent = append(recent, m.modelPickerRecentItem(registry, activeModel))
-	}
-
 	activeProvider := strings.TrimSpace(m.providerName)
+	recent := []pickerItem{}
+	for _, pair := range m.recentModelPairsForPicker() {
+		recent = append(recent, m.modelPickerRecentItem(registry, pair.Provider, pair.Model))
+	}
 	catalog := []pickerItem{}
 	// List every saved provider's models, grouped per provider (one contiguous
 	// section each), so /model shows all configured providers and you can switch
@@ -427,56 +426,119 @@ func (m *model) clearModelPickerLoadState() {
 	m.modelPickerLoadError = ""
 }
 
+// pickerItemDedupKey identifies a picker row for cross-group de-duplication.
+// Rows tagged with an owning provider are keyed by provider+model, not model
+// id alone — the same model id can be offered by multiple providers (e.g. a
+// model name available from both a direct provider and an OpenAI-compatible
+// gateway), and those are distinct, independently selectable rows.
+func pickerItemDedupKey(item pickerItem) string {
+	if owner := strings.TrimSpace(item.OwnerProvider); owner != "" {
+		return strings.ToLower(owner) + "\x00" + item.Value
+	}
+	return item.Value
+}
+
 func (m model) assembleModelPickerItems(recent []pickerItem, catalog []pickerItem) []pickerItem {
 	result := []pickerItem{}
 	seen := map[string]bool{}
 	all := append(append([]pickerItem{}, recent...), catalog...)
 	for _, item := range all {
-		if item.Value == "" || !m.favoriteModels[item.Value] || seen[item.Value] {
+		if item.Value == "" || !m.favoriteModels[item.Value] {
+			continue
+		}
+		key := pickerItemDedupKey(item)
+		if seen[key] {
 			continue
 		}
 		item.Group = "Favorites"
 		item.Favorite = true
 		result = append(result, item)
-		seen[item.Value] = true
+		seen[key] = true
 	}
 	for _, item := range recent {
-		if item.Value == "" || seen[item.Value] {
+		if item.Value == "" {
+			continue
+		}
+		key := pickerItemDedupKey(item)
+		if seen[key] {
 			continue
 		}
 		item.Group = "Recent"
 		item.Favorite = m.favoriteModels[item.Value]
 		result = append(result, item)
-		seen[item.Value] = true
+		seen[key] = true
 	}
 	for _, item := range catalog {
-		if item.Value == "" || seen[item.Value] {
+		if item.Value == "" {
+			continue
+		}
+		key := pickerItemDedupKey(item)
+		if seen[key] {
 			continue
 		}
 		item.Favorite = m.favoriteModels[item.Value]
 		result = append(result, item)
-		seen[item.Value] = true
+		seen[key] = true
 	}
 	return result
 }
 
-func (m model) modelPickerRecentItem(registry modelregistry.Registry, modelID string) pickerItem {
+// recentModelPairsForPicker returns the provider+model pairs to show under
+// "Recent", newest first: the active provider/model is always pinned first
+// (even before it has been recorded to history), followed by persisted
+// history, de-duplicated by provider+model pair and capped to
+// config.MaxRecentModels.
+func (m model) recentModelPairsForPicker() []config.RecentModelEntry {
+	pairs := make([]config.RecentModelEntry, 0, config.MaxRecentModels)
+	seen := map[string]bool{}
+	add := func(provider, modelID string) {
+		modelID = strings.TrimSpace(modelID)
+		if modelID == "" || len(pairs) >= config.MaxRecentModels {
+			return
+		}
+		provider = strings.TrimSpace(provider)
+		key := strings.ToLower(provider) + "\x00" + modelID
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		pairs = append(pairs, config.RecentModelEntry{Provider: provider, Model: modelID})
+	}
+	add(m.providerName, m.modelName)
+	for _, entry := range m.recentModels {
+		add(entry.Provider, entry.Model)
+	}
+	return pairs
+}
+
+// modelPickerRecentItem resolves one "Recent" row for a provider+model pair,
+// tagging it with OwnerProvider so choosing it can switch providers (like any
+// other cross-provider picker row) even when it isn't the active provider.
+func (m model) modelPickerRecentItem(registry modelregistry.Registry, providerName, modelID string) pickerItem {
+	providerName = strings.TrimSpace(providerName)
 	if entry, ok := registry.Resolve(modelID); ok {
 		item := registryModelPickerItem(entry, "Recent")
 		item.Value = modelID
+		item.OwnerProvider = providerName
 		return item
 	}
-	if provider, ok := m.activeProviderDescriptor(); ok {
-		for _, model := range providermodelcatalog.Models(provider) {
-			if model.ID == modelID {
-				item := providerModelPickerItem(provider, model, "Recent")
-				item.Value = modelID
-				return item
+	if profile, ok := m.savedProviderByName(providerName); ok {
+		if descriptor, hasDescriptor := m.descriptorForProfile(profile); hasDescriptor {
+			for _, model := range providermodelcatalog.Models(descriptor) {
+				if model.ID == modelID {
+					item := providerModelPickerItem(descriptor, model, "Recent")
+					item.Value = modelID
+					item.OwnerProvider = profile.Name
+					return item
+				}
 			}
+			item := providerModelPickerItem(descriptor, providermodelcatalog.Model{ID: modelID}, "Recent")
+			item.Value = modelID
+			item.OwnerProvider = profile.Name
+			return item
 		}
-		return providerModelPickerItem(provider, providermodelcatalog.Model{ID: modelID}, "Recent")
 	}
-	return pickerItem{Group: "Recent", Label: modelPickerDisplayName(modelID, ""), Value: modelID}
+	return pickerItem{Group: "Recent", Label: modelPickerDisplayName(modelID, ""), Value: modelID, OwnerProvider: providerName}
 }
 
 func registryModelPickerItem(entry modelregistry.ModelEntry, group string) pickerItem {
@@ -812,6 +874,59 @@ func (m model) persistFavoriteModels() error {
 	}
 	_, err := config.SetFavoriteModels(m.userConfigPath, favoriteModelValues(m.favoriteModels))
 	return err
+}
+
+// recordRecentModel prepends provider+model to the in-memory recent-selection
+// history, de-duplicates by provider+model pair (moving a re-selected pair
+// back to the front rather than leaving a stale older copy), caps the result,
+// and persists it. Called after every successful /model switch (typed command
+// or picker), so the "Recent" section reflects real switching history even
+// across sessions. A no-op when modelID is blank or there is no user config
+// path to persist to (in-memory history alone would not survive restart, and
+// silently diverging from the persisted list would be confusing).
+func (m model) recordRecentModel(provider, modelID string) model {
+	provider = strings.TrimSpace(provider)
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return m
+	}
+	entries := make([]config.RecentModelEntry, 0, len(m.recentModels)+1)
+	entries = append(entries, config.RecentModelEntry{Provider: provider, Model: modelID})
+	entries = append(entries, m.recentModels...)
+	m.recentModels = normalizeRecentModelEntries(entries)
+	if path := strings.TrimSpace(m.userConfigPath); path != "" {
+		if _, err := config.SetRecentModels(path, m.recentModels); err != nil {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "recent model save error: " + err.Error()})
+		}
+	}
+	return m
+}
+
+// normalizeRecentModelEntries trims, drops entries with no model id,
+// de-duplicates by provider+model pair (keeping the first/newest occurrence),
+// and caps the result to config.MaxRecentModels. Mirrors the config package's
+// own normalization so options loaded outside of config.Resolve (e.g. tests
+// constructing Options directly) get the same guarantees.
+func normalizeRecentModelEntries(entries []config.RecentModelEntry) []config.RecentModelEntry {
+	seen := map[string]bool{}
+	out := make([]config.RecentModelEntry, 0, len(entries))
+	for _, entry := range entries {
+		provider := strings.TrimSpace(entry.Provider)
+		modelID := strings.TrimSpace(entry.Model)
+		if modelID == "" {
+			continue
+		}
+		key := strings.ToLower(provider) + "\x00" + modelID
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, config.RecentModelEntry{Provider: provider, Model: modelID})
+		if len(out) >= config.MaxRecentModels {
+			break
+		}
+	}
+	return out
 }
 
 func favoriteModelSet(models []string) map[string]bool {

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -585,19 +585,16 @@ func TestAssembleModelPickerItemsFavoritesDedupByModelIDAndHideFromOtherGroups(t
 	if len(favorites) != 1 {
 		t.Fatalf("expected exactly one Favorites row for shared-model, got %#v", favorites)
 	}
+	// The deduped Favorites row keeps whichever occurrence comes first in
+	// recent+catalog order — here provider-a from recent[0]. Pin that down
+	// explicitly rather than leaving it implicit.
+	if favorites[0].OwnerProvider != "provider-a" {
+		t.Fatalf("expected surviving favorite to keep first-seen provider %q, got %#v", "provider-a", favorites[0])
+	}
 	for _, item := range items {
 		if item.Group != "Favorites" && item.Value == "shared-model" {
 			t.Fatalf("favorited model id leaked into %s: %#v", item.Group, item)
 		}
-	}
-	var otherRecent []pickerItem
-	for _, item := range items {
-		if item.Group == "Recent" && item.Value == "other-model" {
-			otherRecent = append(otherRecent, item)
-		}
-	}
-	if len(otherRecent) != 0 {
-		t.Fatalf("other-model is not in recent; got %#v", items)
 	}
 	var otherCatalog []pickerItem
 	for _, item := range items {
@@ -741,6 +738,14 @@ func TestModelCommandRecordsAndPersistsRecentHistory(t *testing.T) {
 	if !reflect.DeepEqual(m.recentModels, want) {
 		t.Fatalf("recentModels after re-selecting = %#v, want %#v", m.recentModels, want)
 	}
+	// Also check the persisted copy for this reorder/dedupe case (the trickiest
+	// path): if recordRecentModel(s)'s in-memory reordering ever diverges from
+	// SetRecentModels/NormalizeRecentModels' disk-write semantics, this is the
+	// case most likely to expose it.
+	persisted = readTUIConfigFixture(t, configPath)
+	if !reflect.DeepEqual(persisted.Preferences.RecentModels, want) {
+		t.Fatalf("persisted RecentModels after re-selecting = %#v, want %#v", persisted.Preferences.RecentModels, want)
+	}
 }
 
 // switchProviderModel (the picker's cross-provider path) must also record
@@ -762,7 +767,11 @@ func TestSwitchProviderModelRecordsRecentHistory(t *testing.T) {
 		},
 	})
 
-	next, _, _ := m.switchProviderModel("ollama", "kimi-k2.7-code:cloud")
+	next, status, _ := m.switchProviderModel("ollama", "kimi-k2.7-code:cloud")
+	wantStatus := "Model\nSwitched to ollama · kimi-k2.7-code:cloud"
+	if status != wantStatus {
+		t.Fatalf("switchProviderModel() status = %q, want %q (a mismatch here means the switch itself failed, not the recentModels assertion below)", status, wantStatus)
+	}
 
 	want := []config.RecentModelEntry{
 		{Provider: "ollama", Model: "kimi-k2.7-code:cloud"},

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -497,6 +498,197 @@ func TestModelPickerAppliesActiveProviderCatalogModelID(t *testing.T) {
 	}
 	if !transcriptContains(next.transcript, "openai/gpt-4.1 ·") {
 		t.Fatalf("expected model switch status, got %#v", next.transcript)
+	}
+}
+
+// recentModelPairsForPicker pins the active provider+model first (even before
+// it is recorded to history), then follows persisted history in order,
+// de-duplicating by provider+model pair and capping to config.MaxRecentModels
+// (issue: /model picker's "Recent" section only ever showed the active model).
+func TestRecentModelPairsForPickerPinsActiveDedupesAndCaps(t *testing.T) {
+	m := model{
+		providerName: "openrouter",
+		modelName:    "google/gemini-2.5-pro",
+		recentModels: []config.RecentModelEntry{
+			{Provider: "openrouter", Model: "google/gemini-2.5-pro"}, // dup of active: collapses
+			{Provider: "openrouter", Model: "a"},
+			{Provider: "openrouter", Model: "b"},
+			{Provider: "openrouter", Model: "c"},
+			{Provider: "openrouter", Model: "d"},
+			{Provider: "openrouter", Model: "e"}, // beyond the cap: dropped
+		},
+	}
+	got := m.recentModelPairsForPicker()
+	want := []config.RecentModelEntry{
+		{Provider: "openrouter", Model: "google/gemini-2.5-pro"},
+		{Provider: "openrouter", Model: "a"},
+		{Provider: "openrouter", Model: "b"},
+		{Provider: "openrouter", Model: "c"},
+		{Provider: "openrouter", Model: "d"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("recentModelPairsForPicker() = %#v, want %#v", got, want)
+	}
+	if len(got) != config.MaxRecentModels {
+		t.Fatalf("len = %d, want config.MaxRecentModels (%d)", len(got), config.MaxRecentModels)
+	}
+}
+
+// The picker's cross-group de-dup must key on provider+model, not model id
+// alone: the same model id can be offered by two different providers, and
+// those are distinct, independently selectable rows (issue: recents should
+// "de-duplicate by provider+model pair, not model name alone").
+func TestAssembleModelPickerItemsDedupesByProviderAndModelPairNotModelIDAlone(t *testing.T) {
+	m := model{}
+	recent := []pickerItem{
+		{Value: "shared-model", OwnerProvider: "provider-a"},
+		{Value: "shared-model", OwnerProvider: "provider-b"},
+	}
+	items := m.assembleModelPickerItems(recent, nil)
+	if len(items) != 2 {
+		t.Fatalf("expected both provider-a and provider-b rows to survive de-dup, got %#v", items)
+	}
+	owners := map[string]bool{}
+	for _, item := range items {
+		owners[item.OwnerProvider] = true
+	}
+	if !owners["provider-a"] || !owners["provider-b"] {
+		t.Fatalf("expected rows from both providers, got %#v", items)
+	}
+}
+
+// End-to-end: the picker's "Recent" section shows the active model plus prior
+// history, newest first, with the active entry deduped against a stale copy
+// already present in history.
+func TestModelPickerRecentSectionShowsHistoryPastTheActiveModel(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "openrouter",
+		ModelName:    "google/gemini-2.5-pro",
+		ProviderProfile: config.ProviderProfile{
+			Name:      "openrouter",
+			CatalogID: "openrouter",
+			Model:     "google/gemini-2.5-pro",
+			APIKeyEnv: "OPENROUTER_API_KEY",
+			Provider:  string(config.ProviderKindOpenAICompatible),
+			BaseURL:   "https://openrouter.ai/api/v1",
+			APIFormat: "chat-completions",
+		},
+		RecentModels: []config.RecentModelEntry{
+			{Provider: "openrouter", Model: "minimax/minimax-m2.1"},
+			{Provider: "openrouter", Model: "google/gemini-2.5-pro"},
+		},
+	})
+
+	picker := m.newModelPicker()
+	if picker == nil {
+		t.Fatal("expected a model picker")
+	}
+	recentValues := []string{}
+	for _, item := range picker.items {
+		if item.Group != "Recent" {
+			break
+		}
+		recentValues = append(recentValues, item.Value)
+	}
+	want := []string{"google/gemini-2.5-pro", "minimax/minimax-m2.1"}
+	if !reflect.DeepEqual(recentValues, want) {
+		t.Fatalf("Recent section values = %#v, want %#v (active pinned first, history deduped)", recentValues, want)
+	}
+}
+
+// Typed /model switches must record + persist recent history, moving a
+// re-selected pair back to the front rather than leaving a stale duplicate.
+func TestModelCommandRecordsAndPersistsRecentHistory(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	m := newModel(context.Background(), Options{
+		UserConfigPath: configPath,
+		ProviderName:   "openrouter",
+		ModelName:      "google/gemini-2.5-pro",
+		Provider:       &fakeProvider{},
+		ProviderProfile: config.ProviderProfile{
+			Name:      "openrouter",
+			CatalogID: "openrouter",
+			Model:     "google/gemini-2.5-pro",
+			APIKeyEnv: "OPENROUTER_API_KEY",
+			Provider:  string(config.ProviderKindOpenAICompatible),
+			BaseURL:   "https://openrouter.ai/api/v1",
+			APIFormat: "chat-completions",
+		},
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			return &fakeProvider{}, nil
+		},
+	})
+
+	m.input.SetValue("/model anthropic/claude-sonnet-4.5")
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	m = updated.(model)
+	if m.modelName != "anthropic/claude-sonnet-4.5" {
+		t.Fatalf("modelName = %q, want the switch to apply", m.modelName)
+	}
+
+	m.input.SetValue("/model minimax/minimax-m2.1")
+	updated, _ = m.Update(testKey(tea.KeyEnter))
+	m = updated.(model)
+
+	want := []config.RecentModelEntry{
+		{Provider: "openrouter", Model: "minimax/minimax-m2.1"},
+		{Provider: "openrouter", Model: "anthropic/claude-sonnet-4.5"},
+		{Provider: "openrouter", Model: "google/gemini-2.5-pro"},
+	}
+	if !reflect.DeepEqual(m.recentModels, want) {
+		t.Fatalf("recentModels = %#v, want %#v", m.recentModels, want)
+	}
+	persisted := readTUIConfigFixture(t, configPath)
+	if !reflect.DeepEqual(persisted.Preferences.RecentModels, want) {
+		t.Fatalf("persisted RecentModels = %#v, want %#v", persisted.Preferences.RecentModels, want)
+	}
+
+	// Re-selecting the oldest pair moves it to the front instead of leaving a
+	// stale duplicate further down the list.
+	m.input.SetValue("/model google/gemini-2.5-pro")
+	updated, _ = m.Update(testKey(tea.KeyEnter))
+	m = updated.(model)
+	want = []config.RecentModelEntry{
+		{Provider: "openrouter", Model: "google/gemini-2.5-pro"},
+		{Provider: "openrouter", Model: "minimax/minimax-m2.1"},
+		{Provider: "openrouter", Model: "anthropic/claude-sonnet-4.5"},
+	}
+	if !reflect.DeepEqual(m.recentModels, want) {
+		t.Fatalf("recentModels after re-selecting = %#v, want %#v", m.recentModels, want)
+	}
+}
+
+// switchProviderModel (the picker's cross-provider path) must also record
+// history, tagged with the provider actually switched to.
+func TestSwitchProviderModelRecordsRecentHistory(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	m := newModel(context.Background(), Options{
+		UserConfigPath: configPath,
+		ProviderName:   "openai",
+		ModelName:      "gpt-5.1",
+		Provider:       &fakeProvider{},
+		ProviderProfile: config.ProviderProfile{Name: "openai", CatalogID: "openai", Model: "gpt-5.1"},
+		SavedProviders: []config.ProviderProfile{
+			{Name: "openai", CatalogID: "openai", Model: "gpt-5.1"},
+			{Name: "ollama", CatalogID: "ollama", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "http://localhost:11434/v1", Model: "kimi-k2.7-code:cloud"},
+		},
+		NewProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return &fakeProvider{}, nil
+		},
+	})
+
+	next, _, _ := m.switchProviderModel("ollama", "kimi-k2.7-code:cloud")
+
+	want := []config.RecentModelEntry{
+		{Provider: "ollama", Model: "kimi-k2.7-code:cloud"},
+		{Provider: "openai", Model: "gpt-5.1"},
+	}
+	if !reflect.DeepEqual(next.recentModels, want) {
+		t.Fatalf("recentModels = %#v, want %#v", next.recentModels, want)
+	}
+	persisted := readTUIConfigFixture(t, configPath)
+	if !reflect.DeepEqual(persisted.Preferences.RecentModels, want) {
+		t.Fatalf("persisted RecentModels = %#v, want %#v", persisted.Preferences.RecentModels, want)
 	}
 }
 

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -557,6 +557,59 @@ func TestAssembleModelPickerItemsDedupesByProviderAndModelPairNotModelIDAlone(t 
 	}
 }
 
+// Favorites keep the pre-provider-aware semantics: one row per favorited
+// model ID, even when that model ID is offered by multiple providers. Recent
+// and Catalog must also skip any model ID already surfaced under Favorites,
+// so a favorited model doesn't reappear in a second group. Recent/Catalog
+// still de-dup among themselves by provider+model so cross-provider rows stay
+// distinct.
+func TestAssembleModelPickerItemsFavoritesDedupByModelIDAndHideFromOtherGroups(t *testing.T) {
+	m := model{favoriteModels: map[string]bool{"shared-model": true}}
+	recent := []pickerItem{
+		{Value: "shared-model", OwnerProvider: "provider-a"},
+		{Value: "shared-model", OwnerProvider: "provider-b"},
+	}
+	catalog := []pickerItem{
+		{Value: "shared-model", OwnerProvider: "provider-a"},
+		{Value: "shared-model", OwnerProvider: "provider-c"},
+		{Value: "other-model", OwnerProvider: "provider-a"},
+	}
+	items := m.assembleModelPickerItems(recent, catalog)
+
+	var favorites []pickerItem
+	for _, item := range items {
+		if item.Group == "Favorites" {
+			favorites = append(favorites, item)
+		}
+	}
+	if len(favorites) != 1 {
+		t.Fatalf("expected exactly one Favorites row for shared-model, got %#v", favorites)
+	}
+	for _, item := range items {
+		if item.Group != "Favorites" && item.Value == "shared-model" {
+			t.Fatalf("favorited model id leaked into %s: %#v", item.Group, item)
+		}
+	}
+	var otherRecent []pickerItem
+	for _, item := range items {
+		if item.Group == "Recent" && item.Value == "other-model" {
+			otherRecent = append(otherRecent, item)
+		}
+	}
+	if len(otherRecent) != 0 {
+		t.Fatalf("other-model is not in recent; got %#v", items)
+	}
+	var otherCatalog []pickerItem
+	for _, item := range items {
+		if item.Group != "Favorites" && item.Group != "Recent" && item.Value == "other-model" {
+			otherCatalog = append(otherCatalog, item)
+		}
+	}
+	if len(otherCatalog) != 1 {
+		t.Fatalf("expected other-model to appear once in Catalog, got %#v", items)
+	}
+}
+
 // End-to-end: the picker's "Recent" section shows the active model plus prior
 // history, newest first, with the active entry deduped against a stale copy
 // already present in history.

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -610,6 +610,38 @@ func TestAssembleModelPickerItemsFavoritesDedupByModelIDAndHideFromOtherGroups(t
 	}
 }
 
+// registryModelPickerItem must tag rows with OwnerProvider so
+// pickerItemDedupKey keys them by provider+model instead of falling back to
+// Value alone. This matters most for the plain-registry fallback path (no
+// saved providers resolved any models — newModelPicker lists the full
+// registry directly via registryModelPickerItem), where two registry entries
+// sharing a model id but offered by different providers would otherwise
+// collide and silently drop one row.
+func TestRegistryModelPickerItemSetsOwnerProvider(t *testing.T) {
+	entry := testModelEntry("shared-model", 128000, nil)
+	entry.Provider = modelregistry.ProviderAnthropic
+	item := registryModelPickerItem(entry, "Catalog")
+	if item.OwnerProvider != string(modelregistry.ProviderAnthropic) {
+		t.Fatalf("expected OwnerProvider %q, got %q", modelregistry.ProviderAnthropic, item.OwnerProvider)
+	}
+
+	// Two catalog rows for the same model id from different providers must
+	// survive assembleModelPickerItems as distinct rows, not collide on Value.
+	entryA := testModelEntry("shared-model", 128000, nil)
+	entryA.Provider = modelregistry.ProviderAnthropic
+	entryB := testModelEntry("shared-model", 128000, nil)
+	entryB.Provider = modelregistry.ProviderOpenAI
+	catalog := []pickerItem{
+		registryModelPickerItem(entryA, "Catalog"),
+		registryModelPickerItem(entryB, "Catalog"),
+	}
+	m := model{}
+	items := m.assembleModelPickerItems(nil, catalog)
+	if len(items) != 2 {
+		t.Fatalf("expected both provider rows to survive de-dup, got %#v", items)
+	}
+}
+
 // End-to-end: the picker's "Recent" section shows the active model plus prior
 // history, newest first, with the active entry deduped against a stale copy
 // already present in history.

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -663,10 +663,10 @@ func TestModelCommandRecordsAndPersistsRecentHistory(t *testing.T) {
 func TestSwitchProviderModelRecordsRecentHistory(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 	m := newModel(context.Background(), Options{
-		UserConfigPath: configPath,
-		ProviderName:   "openai",
-		ModelName:      "gpt-5.1",
-		Provider:       &fakeProvider{},
+		UserConfigPath:  configPath,
+		ProviderName:    "openai",
+		ModelName:       "gpt-5.1",
+		Provider:        &fakeProvider{},
 		ProviderProfile: config.ProviderProfile{Name: "openai", CatalogID: "openai", Model: "gpt-5.1"},
 		SavedProviders: []config.ProviderProfile{
 			{Name: "openai", CatalogID: "openai", Model: "gpt-5.1"},


### PR DESCRIPTION
## Summary

Closes #562.

The `/model` picker's "Recent" section only ever showed the currently active model. This made it hard to switch back to a previously used provider+model pair once you'd moved on to something else — especially confusing when the same model name exists across multiple providers (the picker's cross-group de-dup keyed on model id alone, so two providers offering the same id would collide).

This adds a short automatic history of provider-qualified selections:

- Newest first, capped to 5 entries (`config.MaxRecentModels`)
- Stored as provider-qualified pairs (`{provider, model}`), not bare model names
- De-duplicated by provider+model pair, not model name alone (fixes a latent cross-provider collision in the picker's row de-dup along the way)
- Selecting an older recent entry switches both provider and model, same as any other cross-provider picker row
- Existing favorites behavior is unchanged
- Persisted to user config only (`preferences.recentModels`), never merged from project config — same posture as `favoriteModels`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/config/...` — new tests for `SetRecentModels` normalization (order preservation, dedup by provider+model pair, cap to 5), and a resolver test confirming `recentModels` loads from user config only (not merged from project config)
- [x] `go test ./internal/tui/...` — new tests: `Recent` section pins the active model first and shows history past it; picker row de-dup keys on provider+model, not model id alone; `/model <id>` and cross-provider picker switches both record and persist history, moving a re-selected pair back to the front
- [x] `go test ./internal/cli/...`
- Pre-existing, unrelated failure noted: `TestProviderWizardAdvancesProviderAPIKeyAndModelSteps` also fails on `main` at the base commit (rendering-width assertion), not touched by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-aware “Recent” model history that records recently used provider/model combinations (newest first, capped at 5) and persists across sessions.
  * The interactive model picker now renders “Recent” with provider context and keeps the history ordering consistent across provider/model switches.
* **Bug Fixes**
  * Recent history now loads correctly from the intended user setting only, trims whitespace, removes invalid entries, and deduplicates by provider+model (case-insensitive), including correct behavior when switching providers.
* **Chores**
  * Updated ignore rules to exclude Go build and module cache directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->