### PR TITLE
fix: warn about untracked scratch files left behind after a run

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -729,6 +729,8 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		Scope:         scope,
 	})
 	lastKnownMCPConfig := mcpConfig
+	fileTracker := tools.NewFileTracker()
+	scratchBaseline := scratchFileSnapshot(workspaceRoot)
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:                  workspaceRoot,
 		Version:              version,
@@ -747,12 +749,15 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		NewProvider:          deps.newProvider,
 		ProbeProviderHealth:  deps.probeProviderHealth,
 		UserAgent:            userAgent(),
-		Registry:             registry,
-		SessionStore:         deps.newSessionStore(),
-		SandboxStore:         sandboxStore,
-		MCPConfig:            mcpConfig,
-		MCPPermissionStore:   mcpPermissionStore,
-		MCPTokenStore:        mcpTokenStore,
+		RunCompletionWarning: func() string {
+			return scratchFileWarning(workspaceRoot, scratchBaseline)
+		},
+		Registry:           registry,
+		SessionStore:       deps.newSessionStore(),
+		SandboxStore:       sandboxStore,
+		MCPConfig:          mcpConfig,
+		MCPPermissionStore: mcpPermissionStore,
+		MCPTokenStore:      mcpTokenStore,
 		MCPCommand: func(ctx context.Context, args []string) tui.MCPCommandResult {
 			if ctx == nil {
 				ctx = context.Background()
@@ -778,7 +783,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 			PermissionMode: permissionMode,
 			Autonomy:       "low",
 			Sandbox:        sandboxEngine,
-			FileTracker:    tools.NewFileTracker(),
+			FileTracker:    fileTracker,
 			Hooks:          newHookDispatcherWithExtra(workspaceRoot, pluginActivation.hooks),
 			DeferThreshold: resolved.Tools.DeferThreshold,
 			Specialists:    specialistRuntime.specialists,

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -736,7 +736,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	})
 	lastKnownMCPConfig := mcpConfig
 	fileTracker := tools.NewFileTracker()
-	scratchBaseline := scratchFileSnapshot(workspaceRoot)
+	var scratchBaseline scratchFileBaseline
 	sttServerManager := newDictationServerManager(resolved.STT)
 	// Keep STT downloads in the SAME config tree the rest of the TUI uses. Deriving
 	// from userConfigPath (rather than config.UserConfigDir()) matters when the config
@@ -766,6 +766,9 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		NewProvider:          deps.newProvider,
 		ProbeProviderHealth:  deps.probeProviderHealth,
 		UserAgent:            userAgent(),
+		PrepareRunCompletionWarning: func() {
+			scratchBaseline = scratchFileSnapshot(workspaceRoot)
+		},
 		RunCompletionWarning: func() string {
 			return scratchFileWarning(workspaceRoot, scratchBaseline)
 		},

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -510,10 +510,10 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	// lspShutdown tears down any language-server sessions either half spawned.
 	selfCorrector, fileDiagnostics, lspShutdown := newExecSelfCorrector(options.selfCorrect, workspaceRoot, options.autonomy)
 	defer lspShutdown()
-	// Kept as a named variable (rather than inlined into Options below) so its
-	// CreatedFiles() can be inspected after the run for the scratch-file
-	// completion warning (issue #551).
+	// Kept as a named variable (rather than inlined into Options below) because
+	// the write tools also use it for conflict checks across a run.
 	fileTracker := tools.NewFileTracker()
+	scratchBaseline := scratchFileSnapshot(workspaceRoot)
 	result, err := agent.Run(runCtx, agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
 		ContextWindow:    resolveAgentContextWindow(runCtx, modelRegistry, resolved.Provider),
@@ -652,11 +652,10 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if notice := result.TruncationNotice(); notice != "" {
 		writer.warning(notice)
 	}
-	// Surface any brand-new files the model wrote this run that are still
-	// untracked in git when we finish — a debug/scratch file left in the
-	// working tree is otherwise invisible until `git status` is checked by
-	// hand (issue #551).
-	if notice := scratchFileWarning(workspaceRoot, fileTracker.CreatedFiles()); notice != "" {
+	// Surface new scratch/debug-like files left untracked in git when we finish —
+	// including files created by shell commands that bypass the file tools (issue
+	// #551). Normal new deliverable files stay quiet to avoid warning fatigue.
+	if notice := scratchFileWarning(workspaceRoot, scratchBaseline); notice != "" {
 		writer.warning(notice)
 	}
 	// A headless run the completion gate marked INCOMPLETE (no-tool-call stall,

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -514,6 +514,11 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	// the write tools also use it for conflict checks across a run.
 	fileTracker := tools.NewFileTracker()
 	scratchBaseline := scratchFileSnapshot(workspaceRoot)
+	emitScratchWarning := func() {
+		if notice := scratchFileWarning(workspaceRoot, scratchBaseline); notice != "" {
+			writer.warning(notice)
+		}
+	}
 	result, err := agent.Run(runCtx, agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
 		ContextWindow:    resolveAgentContextWindow(runCtx, modelRegistry, resolved.Provider),
@@ -602,6 +607,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return exitCrash
 	}
 	if err != nil {
+		emitScratchWarning()
 		// A Ctrl+C / SIGTERM cancellation is a clean shutdown, not a provider error.
 		if errors.Is(err, context.Canceled) || runCtx.Err() != nil {
 			sessionRecorder.append(sessions.EventError, map[string]any{"message": "interrupted"})
@@ -655,9 +661,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	// Surface new scratch/debug-like files left untracked in git when we finish —
 	// including files created by shell commands that bypass the file tools (issue
 	// #551). Normal new deliverable files stay quiet to avoid warning fatigue.
-	if notice := scratchFileWarning(workspaceRoot, scratchBaseline); notice != "" {
-		writer.warning(notice)
-	}
+	emitScratchWarning()
 	// A headless run the completion gate marked INCOMPLETE (no-tool-call stall,
 	// self-reported non-completion, or max-turns cutoff) must NOT be reported as a
 	// success: exit 4 AND a machine-readable terminal event saying so. Handled per

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -510,6 +510,10 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	// lspShutdown tears down any language-server sessions either half spawned.
 	selfCorrector, fileDiagnostics, lspShutdown := newExecSelfCorrector(options.selfCorrect, workspaceRoot, options.autonomy)
 	defer lspShutdown()
+	// Kept as a named variable (rather than inlined into Options below) so its
+	// CreatedFiles() can be inspected after the run for the scratch-file
+	// completion warning (issue #551).
+	fileTracker := tools.NewFileTracker()
 	result, err := agent.Run(runCtx, agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
 		ContextWindow:    resolveAgentContextWindow(runCtx, modelRegistry, resolved.Provider),
@@ -539,7 +543,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		// if the model keeps stalling. The interactive TUI leaves this off.
 		RequireCompletionSignal: true,
 		Sandbox:                 sandboxEngine,
-		FileTracker:             tools.NewFileTracker(),
+		FileTracker:             fileTracker,
 		Hooks:                   newHookDispatcherWithExtra(workspaceRoot, pluginActivation.hooks),
 		EnabledTools:            options.enabledTools,
 		DisabledTools:           options.disabledTools,
@@ -646,6 +650,13 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	})
 
 	if notice := result.TruncationNotice(); notice != "" {
+		writer.warning(notice)
+	}
+	// Surface any brand-new files the model wrote this run that are still
+	// untracked in git when we finish — a debug/scratch file left in the
+	// working tree is otherwise invisible until `git status` is checked by
+	// hand (issue #551).
+	if notice := scratchFileWarning(workspaceRoot, fileTracker.CreatedFiles()); notice != "" {
 		writer.warning(notice)
 	}
 	// A headless run the completion gate marked INCOMPLETE (no-tool-call stall,

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -712,6 +713,48 @@ func TestRunExecJSONInterruptedEmitsTerminalEvents(t *testing.T) {
 	}
 }
 
+func TestRunExecWarnsAboutScratchFileWhenProviderErrors(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+	runGitForScratchTest(t, cwd, "init")
+	if err := os.WriteFile(filepath.Join(cwd, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForScratchTest(t, cwd, "add", "README.md")
+	runGitForScratchTest(t, cwd, "commit", "-m", "init")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"exec", "--output-format", "stream-json", "write scratch then fail"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveConfig: func(_ string, _ config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return toolThenErrorExecProvider{
+				toolCallID: "call_scratch",
+				toolName:   "write_file",
+				arguments:  `{"path":"_debug.py","content":"print('debug')"}`,
+				err:        errors.New("provider failed after tool"),
+			}, nil
+		},
+		newSandboxStore: func() (*sandbox.GrantStore, error) {
+			return sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+		},
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider exit %d, got %d: stdout=%q stderr=%q", exitProvider, exitCode, stdout.String(), stderr.String())
+	}
+	events := decodeJSONLines(t, stdout.String())
+	warning := findJSONEvent(t, events, "warning")
+	message, _ := warning["message"].(string)
+	if !strings.Contains(message, "_debug.py") {
+		t.Fatalf("expected scratch warning to mention _debug.py, got %#v", warning)
+	}
+}
+
 func TestRunExecReadsStreamJSONPromptFromStdin(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	cwd := t.TempDir()
@@ -790,6 +833,13 @@ type toolCallingExecProvider struct {
 	answer     string
 }
 
+type toolThenErrorExecProvider struct {
+	toolCallID string
+	toolName   string
+	arguments  string
+	err        error
+}
+
 type reasoningExecProvider struct{}
 
 func (reasoningExecProvider) StreamCompletion(context.Context, zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
@@ -809,6 +859,26 @@ func (provider toolCallingExecProvider) StreamCompletion(ctx context.Context, re
 			ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
 			close(ch)
 			return ch, nil
+		}
+	}
+	ch := make(chan zeroruntime.StreamEvent, 4)
+	select {
+	case <-ctx.Done():
+		close(ch)
+		return ch, ctx.Err()
+	case ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: provider.toolCallID, ToolName: provider.toolName}:
+	}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: provider.toolCallID, ArgumentsFragment: provider.arguments}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: provider.toolCallID}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+func (provider toolThenErrorExecProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	for _, message := range request.Messages {
+		if message.Role == zeroruntime.MessageRoleTool {
+			return nil, provider.err
 		}
 	}
 	ch := make(chan zeroruntime.StreamEvent, 4)

--- a/internal/cli/scratch_files.go
+++ b/internal/cli/scratch_files.go
@@ -44,7 +44,7 @@ func scratchFileWarning(workspaceRoot string, createdFiles []string) string {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	args := append([]string{"-C", workspaceRoot, "status", "--porcelain", "--untracked-files=all", "--"}, existing...)
+	args := append([]string{"-C", workspaceRoot, "status", "--porcelain", "-z", "--untracked-files=all", "--"}, existing...)
 	output, err := exec.CommandContext(ctx, "git", args...).Output()
 	if err != nil {
 		// Not a git repo (or git failed for some other reason) — nothing
@@ -53,12 +53,11 @@ func scratchFileWarning(workspaceRoot string, createdFiles []string) string {
 	}
 
 	var untracked []string
-	for _, line := range strings.Split(string(output), "\n") {
-		if !strings.HasPrefix(line, "?? ") {
+	for _, entry := range strings.Split(string(output), "\x00") {
+		if !strings.HasPrefix(entry, "?? ") {
 			continue
 		}
-		relative := strings.TrimSpace(strings.TrimPrefix(line, "??"))
-		relative = strings.Trim(relative, "\"")
+		relative := strings.TrimPrefix(entry, "?? ")
 		untracked = append(untracked, relative)
 	}
 	if len(untracked) == 0 {

--- a/internal/cli/scratch_files.go
+++ b/internal/cli/scratch_files.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -10,46 +9,80 @@ import (
 	"time"
 )
 
-// scratchFileWarning builds a completion-time warning listing brand-new files
-// the model created during this run (via write_file) that are still sitting in
-// the workspace, untracked by git, when the run ends. This is the safest fix
-// for https://github.com/Gitlawb/zero/issues/551 — Zero never guesses which
-// files are "scratch" and deletes them (a wrong guess would destroy real
-// work), it just surfaces what git would otherwise silently let `git add -A`
-// sweep up, so a leftover `_debug.py` is caught before it is committed instead
-// of after.
+type scratchFileBaseline map[string]bool
+
+// scratchFileSnapshot records the untracked scratch-like files that already
+// existed before a run starts. Completion warnings compare against this baseline
+// so Zero only reports files newly left behind by the run, including files made
+// by shell commands that bypass the file tools.
+func scratchFileSnapshot(workspaceRoot string) scratchFileBaseline {
+	untracked, ok := gitUntrackedFiles(workspaceRoot)
+	if !ok {
+		return nil
+	}
+	baseline := make(scratchFileBaseline, len(untracked))
+	for _, path := range untracked {
+		if scratchLikePath(path) {
+			baseline[path] = true
+		}
+	}
+	return baseline
+}
+
+// scratchFileWarning builds a completion-time warning listing scratch/debug-like
+// files that became untracked during this run. It deliberately does not warn for
+// every new untracked file: brand-new deliverables are a normal coding-task
+// result, while names such as `_debug.py`, `_fix_test.py`, or `scratch.js` are
+// the class of throwaway artifacts called out in issue #551.
 //
-// Returns "" when there is nothing to report: no files were created, git is
-// unavailable, workspaceRoot isn't a git repo, or every created file was
-// either removed again or already tracked/staged by the model itself.
-func scratchFileWarning(workspaceRoot string, createdFiles []string) string {
-	if len(createdFiles) == 0 {
+// Returns "" when there is nothing to report: git is unavailable,
+// workspaceRoot isn't a git repo, no baseline was captured, or no new
+// scratch-like untracked files remain.
+func scratchFileWarning(workspaceRoot string, baseline scratchFileBaseline) string {
+	if baseline == nil {
 		return ""
 	}
-	if _, err := exec.LookPath("git"); err != nil {
+	untracked, ok := gitUntrackedFiles(workspaceRoot)
+	if !ok {
 		return ""
 	}
 
-	// Filter to files that still exist; the model may have deleted its own
-	// scratch work already, which needs no warning.
-	existing := make([]string, 0, len(createdFiles))
-	for _, path := range createdFiles {
-		if _, err := os.Stat(path); err == nil {
-			existing = append(existing, path)
+	var scratchFiles []string
+	for _, path := range untracked {
+		if baseline[path] || !scratchLikePath(path) {
+			continue
 		}
+		baseline[path] = true
+		scratchFiles = append(scratchFiles, path)
 	}
-	if len(existing) == 0 {
+	if len(scratchFiles) == 0 {
 		return ""
+	}
+
+	displayPaths := make([]string, len(scratchFiles))
+	for i, path := range scratchFiles {
+		displayPaths[i] = filepath.ToSlash(path)
+	}
+	plural := "s"
+	if len(displayPaths) == 1 {
+		plural = ""
+	}
+	return "This run left " + strconv.Itoa(len(displayPaths)) + " new scratch/debug-like file" + plural + " untracked in git: " +
+		strings.Join(displayPaths, ", ") + ". Review before committing/staging."
+}
+
+func gitUntrackedFiles(workspaceRoot string) ([]string, bool) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, false
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	args := append([]string{"-C", workspaceRoot, "status", "--porcelain", "-z", "--untracked-files=all", "--"}, existing...)
-	output, err := exec.CommandContext(ctx, "git", args...).Output()
+	output, err := exec.CommandContext(ctx, "git", "-C", workspaceRoot, "status", "--porcelain", "-z", "--untracked-files=all").Output()
 	if err != nil {
 		// Not a git repo (or git failed for some other reason) — nothing
 		// reliable to report against, so stay silent rather than guess.
-		return ""
+		return nil, false
 	}
 
 	var untracked []string
@@ -60,21 +93,22 @@ func scratchFileWarning(workspaceRoot string, createdFiles []string) string {
 		relative := strings.TrimPrefix(entry, "?? ")
 		untracked = append(untracked, relative)
 	}
-	if len(untracked) == 0 {
-		return ""
-	}
+	return untracked, true
+}
 
-	displayPaths := make([]string, len(untracked))
-	for i, path := range untracked {
-		displayPaths[i] = filepath.ToSlash(path)
+func scratchLikePath(path string) bool {
+	name := strings.ToLower(filepath.Base(filepath.ToSlash(path)))
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
 	}
-	plural := "s"
-	verb := "are"
-	if len(displayPaths) == 1 {
-		plural = ""
-		verb = "is"
+	if strings.HasPrefix(name, "scratch") || strings.HasPrefix(name, "debug") || strings.HasPrefix(name, "tmp") || strings.HasPrefix(name, "temp") || strings.HasPrefix(name, "repro") {
+		return true
 	}
-	return "This run created " + strconv.Itoa(len(displayPaths)) + " new file" + plural + " that " + verb +
-		" still untracked in git and may be scratch/debug output left behind: " +
-		strings.Join(displayPaths, ", ") + ". Review before committing/staging."
+	for _, marker := range []string{"scratch", "debug", "tmp", "temp", "repro", "fix_test"} {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/scratch_files.go
+++ b/internal/cli/scratch_files.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// scratchFileWarning builds a completion-time warning listing brand-new files
+// the model created during this run (via write_file) that are still sitting in
+// the workspace, untracked by git, when the run ends. This is the safest fix
+// for https://github.com/Gitlawb/zero/issues/551 — Zero never guesses which
+// files are "scratch" and deletes them (a wrong guess would destroy real
+// work), it just surfaces what git would otherwise silently let `git add -A`
+// sweep up, so a leftover `_debug.py` is caught before it is committed instead
+// of after.
+//
+// Returns "" when there is nothing to report: no files were created, git is
+// unavailable, workspaceRoot isn't a git repo, or every created file was
+// either removed again or already tracked/staged by the model itself.
+func scratchFileWarning(workspaceRoot string, createdFiles []string) string {
+	if len(createdFiles) == 0 {
+		return ""
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return ""
+	}
+
+	// Filter to files that still exist; the model may have deleted its own
+	// scratch work already, which needs no warning.
+	existing := make([]string, 0, len(createdFiles))
+	for _, path := range createdFiles {
+		if _, err := os.Stat(path); err == nil {
+			existing = append(existing, path)
+		}
+	}
+	if len(existing) == 0 {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	args := append([]string{"-C", workspaceRoot, "status", "--porcelain", "--untracked-files=all", "--"}, existing...)
+	output, err := exec.CommandContext(ctx, "git", args...).Output()
+	if err != nil {
+		// Not a git repo (or git failed for some other reason) — nothing
+		// reliable to report against, so stay silent rather than guess.
+		return ""
+	}
+
+	var untracked []string
+	for _, line := range strings.Split(string(output), "\n") {
+		if !strings.HasPrefix(line, "?? ") {
+			continue
+		}
+		relative := strings.TrimSpace(strings.TrimPrefix(line, "??"))
+		relative = strings.Trim(relative, "\"")
+		untracked = append(untracked, relative)
+	}
+	if len(untracked) == 0 {
+		return ""
+	}
+
+	displayPaths := make([]string, len(untracked))
+	for i, path := range untracked {
+		displayPaths[i] = filepath.ToSlash(path)
+	}
+	plural := "s"
+	verb := "are"
+	if len(displayPaths) == 1 {
+		plural = ""
+		verb = "is"
+	}
+	return "This run created " + strconv.Itoa(len(displayPaths)) + " new file" + plural + " that " + verb +
+		" still untracked in git and may be scratch/debug output left behind: " +
+		strings.Join(displayPaths, ", ") + ". Review before committing/staging."
+}

--- a/internal/cli/scratch_files_test.go
+++ b/internal/cli/scratch_files_test.go
@@ -31,34 +31,94 @@ func TestScratchFileWarningFlagsUntrackedCreatedFile(t *testing.T) {
 	}
 	runGitForScratchTest(t, root, "add", "README.md")
 	runGitForScratchTest(t, root, "commit", "-m", "init")
+	baseline := scratchFileSnapshot(root)
 
-	scratchPath := filepath.Join(root, "scratch file.py")
+	scratchPath := filepath.Join(root, "_debug file.py")
 	if err := os.WriteFile(scratchPath, []byte("print('debug')"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	warning := scratchFileWarning(root, []string{scratchPath})
+	warning := scratchFileWarning(root, baseline)
 	if warning == "" {
 		t.Fatal("expected a warning about the untracked scratch file")
 	}
-	if !strings.Contains(warning, "scratch file.py") {
-		t.Fatalf("expected warning to mention scratch file.py, got %q", warning)
+	if !strings.Contains(warning, "_debug file.py") {
+		t.Fatalf("expected warning to mention _debug file.py, got %q", warning)
+	}
+}
+
+func TestScratchFileWarningDetectsShellCreatedScratchFile(t *testing.T) {
+	root := t.TempDir()
+	runGitForScratchTest(t, root, "init")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForScratchTest(t, root, "add", "README.md")
+	runGitForScratchTest(t, root, "commit", "-m", "init")
+	baseline := scratchFileSnapshot(root)
+
+	// Simulate a shell heredoc/redirect creating a scratch file. The warning is
+	// based on the git before/after state, not only FileTracker-created paths.
+	if err := os.WriteFile(filepath.Join(root, "_fix_test.py"), []byte("print('debug')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	warning := scratchFileWarning(root, baseline)
+	if !strings.Contains(warning, "_fix_test.py") {
+		t.Fatalf("expected warning to mention shell-created _fix_test.py, got %q", warning)
+	}
+}
+
+func TestScratchFileWarningSilentForNormalDeliverableFile(t *testing.T) {
+	root := t.TempDir()
+	runGitForScratchTest(t, root, "init")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForScratchTest(t, root, "add", "README.md")
+	runGitForScratchTest(t, root, "commit", "-m", "init")
+	baseline := scratchFileSnapshot(root)
+
+	if err := os.WriteFile(filepath.Join(root, "app.py"), []byte("print('app')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warning := scratchFileWarning(root, baseline); warning != "" {
+		t.Fatalf("expected no warning for a normal new deliverable file, got %q", warning)
+	}
+}
+
+func TestScratchFileWarningSilentForUnderscoreDeliverableFile(t *testing.T) {
+	root := t.TempDir()
+	runGitForScratchTest(t, root, "init")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForScratchTest(t, root, "add", "README.md")
+	runGitForScratchTest(t, root, "commit", "-m", "init")
+	baseline := scratchFileSnapshot(root)
+
+	if err := os.WriteFile(filepath.Join(root, "_generated.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warning := scratchFileWarning(root, baseline); warning != "" {
+		t.Fatalf("expected no warning for an underscore-prefixed deliverable file, got %q", warning)
 	}
 }
 
 func TestScratchFileWarningSilentWhenFileIsTracked(t *testing.T) {
 	root := t.TempDir()
 	runGitForScratchTest(t, root, "init")
-	trackedPath := filepath.Join(root, "app.py")
+	baseline := scratchFileSnapshot(root)
+	trackedPath := filepath.Join(root, "_debug.py")
 	if err := os.WriteFile(trackedPath, []byte("print('app')"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	runGitForScratchTest(t, root, "add", "app.py")
+	runGitForScratchTest(t, root, "add", "_debug.py")
 	runGitForScratchTest(t, root, "commit", "-m", "init")
 
-	// A file created by write_file but subsequently staged/committed by the
+	// A scratch-like file subsequently staged/committed by the
 	// model itself is no longer a loose scratch file, so no warning.
-	if warning := scratchFileWarning(root, []string{trackedPath}); warning != "" {
+	if warning := scratchFileWarning(root, baseline); warning != "" {
 		t.Fatalf("expected no warning for a tracked file, got %q", warning)
 	}
 }
@@ -66,7 +126,8 @@ func TestScratchFileWarningSilentWhenFileIsTracked(t *testing.T) {
 func TestScratchFileWarningSilentWhenNoFilesCreated(t *testing.T) {
 	root := t.TempDir()
 	runGitForScratchTest(t, root, "init")
-	if warning := scratchFileWarning(root, nil); warning != "" {
+	baseline := scratchFileSnapshot(root)
+	if warning := scratchFileWarning(root, baseline); warning != "" {
 		t.Fatalf("expected no warning when nothing was created, got %q", warning)
 	}
 }
@@ -74,6 +135,7 @@ func TestScratchFileWarningSilentWhenNoFilesCreated(t *testing.T) {
 func TestScratchFileWarningSilentWhenFileWasRemovedAgain(t *testing.T) {
 	root := t.TempDir()
 	runGitForScratchTest(t, root, "init")
+	baseline := scratchFileSnapshot(root)
 	scratchPath := filepath.Join(root, "_debug.py")
 	if err := os.WriteFile(scratchPath, []byte("print('debug')"), 0o644); err != nil {
 		t.Fatal(err)
@@ -82,8 +144,21 @@ func TestScratchFileWarningSilentWhenFileWasRemovedAgain(t *testing.T) {
 		t.Fatal(err)
 	}
 	// The model created and then cleaned up its own scratch file — nothing to warn about.
-	if warning := scratchFileWarning(root, []string{scratchPath}); warning != "" {
+	if warning := scratchFileWarning(root, baseline); warning != "" {
 		t.Fatalf("expected no warning for a removed file, got %q", warning)
+	}
+}
+
+func TestScratchFileWarningSilentForPreexistingScratchFile(t *testing.T) {
+	root := t.TempDir()
+	runGitForScratchTest(t, root, "init")
+	if err := os.WriteFile(filepath.Join(root, "_debug.py"), []byte("print('debug')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	baseline := scratchFileSnapshot(root)
+
+	if warning := scratchFileWarning(root, baseline); warning != "" {
+		t.Fatalf("expected no warning for a pre-existing scratch file, got %q", warning)
 	}
 }
 
@@ -93,7 +168,7 @@ func TestScratchFileWarningSilentWhenNotAGitRepo(t *testing.T) {
 	if err := os.WriteFile(scratchPath, []byte("print('debug')"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if warning := scratchFileWarning(root, []string{scratchPath}); warning != "" {
+	if warning := scratchFileWarning(root, scratchFileSnapshot(root)); warning != "" {
 		t.Fatalf("expected no warning outside a git repo, got %q", warning)
 	}
 }

--- a/internal/cli/scratch_files_test.go
+++ b/internal/cli/scratch_files_test.go
@@ -10,6 +10,9 @@ import (
 
 func runGitForScratchTest(t *testing.T, dir string, args ...string) {
 	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	cmd.Env = append(os.Environ(),
 		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
@@ -29,7 +32,7 @@ func TestScratchFileWarningFlagsUntrackedCreatedFile(t *testing.T) {
 	runGitForScratchTest(t, root, "add", "README.md")
 	runGitForScratchTest(t, root, "commit", "-m", "init")
 
-	scratchPath := filepath.Join(root, "_debug.py")
+	scratchPath := filepath.Join(root, "scratch file.py")
 	if err := os.WriteFile(scratchPath, []byte("print('debug')"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -38,8 +41,8 @@ func TestScratchFileWarningFlagsUntrackedCreatedFile(t *testing.T) {
 	if warning == "" {
 		t.Fatal("expected a warning about the untracked scratch file")
 	}
-	if !strings.Contains(warning, "_debug.py") {
-		t.Fatalf("expected warning to mention _debug.py, got %q", warning)
+	if !strings.Contains(warning, "scratch file.py") {
+		t.Fatalf("expected warning to mention scratch file.py, got %q", warning)
 	}
 }
 

--- a/internal/cli/scratch_files_test.go
+++ b/internal/cli/scratch_files_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runGitForScratchTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}
+
+func TestScratchFileWarningFlagsUntrackedCreatedFile(t *testing.T) {
+	root := t.TempDir()
+	runGitForScratchTest(t, root, "init")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForScratchTest(t, root, "add", "README.md")
+	runGitForScratchTest(t, root, "commit", "-m", "init")
+
+	scratchPath := filepath.Join(root, "_debug.py")
+	if err := os.WriteFile(scratchPath, []byte("print('debug')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	warning := scratchFileWarning(root, []string{scratchPath})
+	if warning == "" {
+		t.Fatal("expected a warning about the untracked scratch file")
+	}
+	if !strings.Contains(warning, "_debug.py") {
+		t.Fatalf("expected warning to mention _debug.py, got %q", warning)
+	}
+}
+
+func TestScratchFileWarningSilentWhenFileIsTracked(t *testing.T) {
+	root := t.TempDir()
+	runGitForScratchTest(t, root, "init")
+	trackedPath := filepath.Join(root, "app.py")
+	if err := os.WriteFile(trackedPath, []byte("print('app')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForScratchTest(t, root, "add", "app.py")
+	runGitForScratchTest(t, root, "commit", "-m", "init")
+
+	// A file created by write_file but subsequently staged/committed by the
+	// model itself is no longer a loose scratch file, so no warning.
+	if warning := scratchFileWarning(root, []string{trackedPath}); warning != "" {
+		t.Fatalf("expected no warning for a tracked file, got %q", warning)
+	}
+}
+
+func TestScratchFileWarningSilentWhenNoFilesCreated(t *testing.T) {
+	root := t.TempDir()
+	runGitForScratchTest(t, root, "init")
+	if warning := scratchFileWarning(root, nil); warning != "" {
+		t.Fatalf("expected no warning when nothing was created, got %q", warning)
+	}
+}
+
+func TestScratchFileWarningSilentWhenFileWasRemovedAgain(t *testing.T) {
+	root := t.TempDir()
+	runGitForScratchTest(t, root, "init")
+	scratchPath := filepath.Join(root, "_debug.py")
+	if err := os.WriteFile(scratchPath, []byte("print('debug')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(scratchPath); err != nil {
+		t.Fatal(err)
+	}
+	// The model created and then cleaned up its own scratch file — nothing to warn about.
+	if warning := scratchFileWarning(root, []string{scratchPath}); warning != "" {
+		t.Fatalf("expected no warning for a removed file, got %q", warning)
+	}
+}
+
+func TestScratchFileWarningSilentWhenNotAGitRepo(t *testing.T) {
+	root := t.TempDir()
+	scratchPath := filepath.Join(root, "_debug.py")
+	if err := os.WriteFile(scratchPath, []byte("print('debug')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warning := scratchFileWarning(root, []string{scratchPath}); warning != "" {
+		t.Fatalf("expected no warning outside a git repo, got %q", warning)
+	}
+}

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -82,6 +82,10 @@ func (tool applyPatchTool) RunWithOptions(ctx context.Context, args map[string]a
 	if err := recheckPatchWriteTargets(applyRoot, patch); err != nil {
 		return errorResult("Error applying patch: " + err.Error())
 	}
+	var createdTargets []string
+	if options.FileTracker != nil {
+		createdTargets = missingPatchTargets(applyRoot, patch)
+	}
 
 	command := exec.CommandContext(ctx, "git", "apply", "--whitespace=nowarn", patchPath)
 	command.Dir = applyRoot
@@ -110,7 +114,42 @@ func (tool applyPatchTool) RunWithOptions(ctx context.Context, args map[string]a
 			options.FileTracker.Forget(absolute)
 		}
 	}
+	recordCreatedPatchTargets(options.FileTracker, createdTargets)
 	return result
+}
+
+func missingPatchTargets(root string, patch string) []string {
+	seen := map[string]bool{}
+	var missing []string
+	for _, path := range patchHeaderPaths(patch) {
+		if path == "" || path == "/dev/null" {
+			continue
+		}
+		absolute, _, err := resolveWorkspaceTargetPath(root, path)
+		if err != nil || seen[absolute] {
+			continue
+		}
+		seen[absolute] = true
+		if _, err := os.Stat(absolute); os.IsNotExist(err) {
+			missing = append(missing, absolute)
+		}
+	}
+	return missing
+}
+
+func recordCreatedPatchTargets(tracker *FileTracker, missingBefore []string) {
+	if tracker == nil {
+		return
+	}
+	for _, absolute := range missingBefore {
+		if _, err := os.Stat(absolute); err != nil {
+			continue
+		}
+		if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+			absolute = resolved
+		}
+		tracker.RecordCreated(absolute)
+	}
 }
 
 // changedFilesFromPatch extracts the unique, WORKSPACE-relative paths a patch

--- a/internal/tools/file_tracker.go
+++ b/internal/tools/file_tracker.go
@@ -76,7 +76,7 @@ func (tracker *FileTracker) Version(absPath string) (FileVersion, bool) {
 // this session (as opposed to an overwrite of something that already existed).
 // Zero surfaces this list at the end of a headless run so a scratch/debug file
 // left behind by the model (e.g. `_fix_test.py`) is caught before it can be
-// committed by accident — see the completion summary in cli.scratchFileWarning.
+// committed by accident in the completion summary.
 func (tracker *FileTracker) RecordCreated(absPath string) {
 	if tracker == nil {
 		return

--- a/internal/tools/file_tracker.go
+++ b/internal/tools/file_tracker.go
@@ -74,9 +74,6 @@ func (tracker *FileTracker) Version(absPath string) (FileVersion, bool) {
 
 // RecordCreated notes that absPath is a brand-new file a tool just created in
 // this session (as opposed to an overwrite of something that already existed).
-// Zero surfaces this list at the end of a headless run so a scratch/debug file
-// left behind by the model (e.g. `_fix_test.py`) is caught before it can be
-// committed by accident in the completion summary.
 func (tracker *FileTracker) RecordCreated(absPath string) {
 	if tracker == nil {
 		return

--- a/internal/tools/file_tracker.go
+++ b/internal/tools/file_tracker.go
@@ -34,6 +34,12 @@ type FileVersion struct {
 type FileTracker struct {
 	mu       sync.Mutex
 	versions map[string]FileVersion
+	// created preserves the order in which brand-new files (paths that did not
+	// exist before a write tool created them) were first written this session.
+	// A map would lose that order and complicates de-duplication, so a slice
+	// plus a seen-set is used instead.
+	created     []string
+	createdSeen map[string]bool
 }
 
 func NewFileTracker() *FileTracker {
@@ -64,6 +70,41 @@ func (tracker *FileTracker) Version(absPath string) (FileVersion, bool) {
 	defer tracker.mu.Unlock()
 	version, ok := tracker.versions[absPath]
 	return version, ok
+}
+
+// RecordCreated notes that absPath is a brand-new file a tool just created in
+// this session (as opposed to an overwrite of something that already existed).
+// Zero surfaces this list at the end of a headless run so a scratch/debug file
+// left behind by the model (e.g. `_fix_test.py`) is caught before it can be
+// committed by accident — see the completion summary in cli.scratchFileWarning.
+func (tracker *FileTracker) RecordCreated(absPath string) {
+	if tracker == nil {
+		return
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if tracker.createdSeen == nil {
+		tracker.createdSeen = make(map[string]bool)
+	}
+	if tracker.createdSeen[absPath] {
+		return
+	}
+	tracker.createdSeen[absPath] = true
+	tracker.created = append(tracker.created, absPath)
+}
+
+// CreatedFiles returns the absolute paths of every brand-new file recorded via
+// RecordCreated during this session, in first-created order. The caller owns
+// the returned slice.
+func (tracker *FileTracker) CreatedFiles() []string {
+	if tracker == nil {
+		return nil
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	out := make([]string, len(tracker.created))
+	copy(out, tracker.created)
+	return out
 }
 
 // Forget drops any recorded version for absPath, so the next read re-establishes

--- a/internal/tools/file_tracker_test.go
+++ b/internal/tools/file_tracker_test.go
@@ -108,3 +108,36 @@ func TestHashContentIsStableAndDistinguishing(t *testing.T) {
 		t.Fatal("hash must differ for different content")
 	}
 }
+
+func TestRecordCreatedTracksNewFilesInOrder(t *testing.T) {
+	tracker := NewFileTracker()
+	tracker.RecordCreated("/repo/b.txt")
+	tracker.RecordCreated("/repo/a.txt")
+	got := tracker.CreatedFiles()
+	want := []string{"/repo/b.txt", "/repo/a.txt"}
+	if len(got) != len(want) {
+		t.Fatalf("CreatedFiles() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("CreatedFiles() = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestRecordCreatedDeduplicates(t *testing.T) {
+	tracker := NewFileTracker()
+	tracker.RecordCreated("/repo/a.txt")
+	tracker.RecordCreated("/repo/a.txt")
+	if got := tracker.CreatedFiles(); len(got) != 1 {
+		t.Fatalf("CreatedFiles() = %v, want a single entry", got)
+	}
+}
+
+func TestNilFileTrackerCreatedFilesIsANoop(t *testing.T) {
+	var tracker *FileTracker
+	tracker.RecordCreated("/repo/a.txt") // must not panic
+	if got := tracker.CreatedFiles(); got != nil {
+		t.Fatalf("CreatedFiles() on nil tracker = %v, want nil", got)
+	}
+}

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -118,6 +118,9 @@ func (tool writeFileTool) RunWithOptions(ctx context.Context, args map[string]an
 	// session compares against what is now on disk.
 	newInfo, _ := os.Stat(absolutePath)
 	options.FileTracker.Record(absolutePath, []byte(content), newInfo)
+	if !existed {
+		options.FileTracker.RecordCreated(absolutePath)
+	}
 
 	verb := "Created"
 	if existed {

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -142,6 +142,10 @@ func TestWriteFileToolRecordsCreatedFileButNotOverwrite(t *testing.T) {
 		t.Fatalf("expected create ok, got %s: %s", created.Status, created.Output)
 	}
 	absPath := filepath.Join(root, "scratch.txt")
+	absPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", absPath, err)
+	}
 	if got := tracker.CreatedFiles(); len(got) != 1 || got[0] != absPath {
 		t.Fatalf("CreatedFiles() = %v, want [%s]", got, absPath)
 	}

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -165,6 +165,50 @@ func TestWriteFileToolRecordsCreatedFileButNotOverwrite(t *testing.T) {
 	}
 }
 
+func TestApplyPatchRecordsCreatedFileButNotExistingEdits(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "existing.txt"), []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	registry := NewRegistry()
+	registry.Register(NewApplyPatchTool(root))
+	tracker := NewFileTracker()
+	patch := strings.Join([]string{
+		"diff --git a/scratch.txt b/scratch.txt",
+		"new file mode 100644",
+		"index 0000000..e965047",
+		"--- /dev/null",
+		"+++ b/scratch.txt",
+		"@@ -0,0 +1 @@",
+		"+hello",
+		"diff --git a/existing.txt b/existing.txt",
+		"--- a/existing.txt",
+		"+++ b/existing.txt",
+		"@@ -1 +1 @@",
+		"-old",
+		"+new",
+		"",
+	}, "\n")
+
+	result := registry.RunWithOptions(context.Background(), "apply_patch", map[string]any{
+		"patch": patch,
+	}, RunOptions{PermissionGranted: true, FileTracker: tracker})
+	if result.Status != StatusOK {
+		if gitApplyUnavailable(result.Output) {
+			t.Skipf("git binary unavailable: %s", result.Output)
+		}
+		t.Fatalf("expected apply_patch ok, got %s: %s", result.Status, result.Output)
+	}
+	absPath := filepath.Join(root, "scratch.txt")
+	absPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", absPath, err)
+	}
+	if got := tracker.CreatedFiles(); len(got) != 1 || got[0] != absPath {
+		t.Fatalf("CreatedFiles() = %v, want [%s]", got, absPath)
+	}
+}
+
 func TestWriteFileSummaryReportsLineCount(t *testing.T) {
 	root := t.TempDir()
 	tool := NewWriteFileTool(root)

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -128,6 +128,39 @@ func TestWriteFileToolCreatesAndProtectsExistingFiles(t *testing.T) {
 	}
 }
 
+func TestWriteFileToolRecordsCreatedFileButNotOverwrite(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry()
+	registry.Register(NewWriteFileTool(root))
+	tracker := NewFileTracker()
+
+	created := registry.RunWithOptions(context.Background(), "write_file", map[string]any{
+		"path":    "scratch.txt",
+		"content": "first",
+	}, RunOptions{PermissionGranted: true, FileTracker: tracker})
+	if created.Status != StatusOK {
+		t.Fatalf("expected create ok, got %s: %s", created.Status, created.Output)
+	}
+	absPath := filepath.Join(root, "scratch.txt")
+	if got := tracker.CreatedFiles(); len(got) != 1 || got[0] != absPath {
+		t.Fatalf("CreatedFiles() = %v, want [%s]", got, absPath)
+	}
+
+	overwrote := registry.RunWithOptions(context.Background(), "write_file", map[string]any{
+		"path":      "scratch.txt",
+		"content":   "second",
+		"overwrite": true,
+	}, RunOptions{PermissionGranted: true, FileTracker: tracker})
+	if overwrote.Status != StatusOK {
+		t.Fatalf("expected overwrite ok, got %s: %s", overwrote.Status, overwrote.Output)
+	}
+	// Overwriting an existing file is not a "new" creation, so CreatedFiles
+	// must not gain a second (duplicate) entry for it.
+	if got := tracker.CreatedFiles(); len(got) != 1 || got[0] != absPath {
+		t.Fatalf("CreatedFiles() after overwrite = %v, want unchanged [%s]", got, absPath)
+	}
+}
+
 func TestWriteFileSummaryReportsLineCount(t *testing.T) {
 	root := t.TempDir()
 	tool := NewWriteFileTool(root)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -110,37 +110,38 @@ type model struct {
 	titledSessions map[string]bool
 	// retitle* drive the sequential /retitle backfill: queued session ids still
 	// awaiting a title, whether a backfill is running, and its progress counters.
-	retitleQueue         []string
-	retitleActive        bool
-	retitleTotal         int
-	retitleDone          int
-	retitleOK            int
-	usageTracker         *usage.Tracker
-	sessionCompactor     SessionCompactor
-	prService            *PrService
-	prState              PrState
-	prWatcherStop        func()
-	runtimeMessageSink   func(tea.Msg)
-	runCompletionWarning func() string
-	agentOptions         agent.Options
-	notifier             *notify.Notifier
-	permissionMode       agent.PermissionMode
-	selfCorrectTests     bool
-	reasoningEffort      modelregistry.ReasoningEffort
-	responseStyle        string
-	keyBindings          keyBindings
-	themeMode            themeMode // palette preference: auto (default), dark, light
-	hasDarkBg            bool      // last terminal background-detection result (auto mode)
-	userAgent            string
-	compactRequests      int
-	compactInFlight      bool
-	compactFrame         int
-	lastCompactResult    *CompactResult
-	lastCompactError     string
-	unpricedRequests     int
-	unpricedTokens       int
-	lastUsage            usage.Normalized
-	lastUsageSeen        bool
+	retitleQueue                []string
+	retitleActive               bool
+	retitleTotal                int
+	retitleDone                 int
+	retitleOK                   int
+	usageTracker                *usage.Tracker
+	sessionCompactor            SessionCompactor
+	prService                   *PrService
+	prState                     PrState
+	prWatcherStop               func()
+	runtimeMessageSink          func(tea.Msg)
+	prepareRunCompletionWarning func()
+	runCompletionWarning        func() string
+	agentOptions                agent.Options
+	notifier                    *notify.Notifier
+	permissionMode              agent.PermissionMode
+	selfCorrectTests            bool
+	reasoningEffort             modelregistry.ReasoningEffort
+	responseStyle               string
+	keyBindings                 keyBindings
+	themeMode                   themeMode // palette preference: auto (default), dark, light
+	hasDarkBg                   bool      // last terminal background-detection result (auto mode)
+	userAgent                   string
+	compactRequests             int
+	compactInFlight             bool
+	compactFrame                int
+	lastCompactResult           *CompactResult
+	lastCompactError            string
+	unpricedRequests            int
+	unpricedTokens              int
+	lastUsage                   usage.Normalized
+	lastUsageSeen               bool
 	// turnLatencySum / turnLatencyCount accumulate completed-run wall time so
 	// /context can show a rolling average turn latency (the "is it slow?" signal).
 	// Reset by /new.
@@ -805,6 +806,7 @@ func newModel(ctx context.Context, options Options) model {
 		prState:                     prService.GetState(),
 		input:                       input,
 		spinner:                     runSpinner,
+		prepareRunCompletionWarning: options.PrepareRunCompletionWarning,
 		runCompletionWarning:        options.RunCompletionWarning,
 		now:                         time.Now,
 		notifier:                    notifier,
@@ -4440,6 +4442,9 @@ func (m model) launchPrompt(prompt string) (model, tea.Cmd) {
 // (normal prompt + spec draft/impl) keeps these in sync — a missing
 // turnStartedAt previously dropped the elapsed timer on spec-mode runs.
 func (m model) beginRun(cancel context.CancelFunc) model {
+	if m.prepareRunCompletionWarning != nil {
+		m.prepareRunCompletionWarning()
+	}
 	m.runID++
 	m.activeRunID = m.runID
 	m.runCancel = cancel

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -110,36 +110,37 @@ type model struct {
 	titledSessions map[string]bool
 	// retitle* drive the sequential /retitle backfill: queued session ids still
 	// awaiting a title, whether a backfill is running, and its progress counters.
-	retitleQueue       []string
-	retitleActive      bool
-	retitleTotal       int
-	retitleDone        int
-	retitleOK          int
-	usageTracker       *usage.Tracker
-	sessionCompactor   SessionCompactor
-	prService          *PrService
-	prState            PrState
-	prWatcherStop      func()
-	runtimeMessageSink func(tea.Msg)
-	agentOptions       agent.Options
-	notifier           *notify.Notifier
-	permissionMode     agent.PermissionMode
-	selfCorrectTests   bool
-	reasoningEffort    modelregistry.ReasoningEffort
-	responseStyle      string
-	keyBindings        keyBindings
-	themeMode          themeMode // palette preference: auto (default), dark, light
-	hasDarkBg          bool      // last terminal background-detection result (auto mode)
-	userAgent          string
-	compactRequests    int
-	compactInFlight    bool
-	compactFrame       int
-	lastCompactResult  *CompactResult
-	lastCompactError   string
-	unpricedRequests   int
-	unpricedTokens     int
-	lastUsage          usage.Normalized
-	lastUsageSeen      bool
+	retitleQueue         []string
+	retitleActive        bool
+	retitleTotal         int
+	retitleDone          int
+	retitleOK            int
+	usageTracker         *usage.Tracker
+	sessionCompactor     SessionCompactor
+	prService            *PrService
+	prState              PrState
+	prWatcherStop        func()
+	runtimeMessageSink   func(tea.Msg)
+	runCompletionWarning func() string
+	agentOptions         agent.Options
+	notifier             *notify.Notifier
+	permissionMode       agent.PermissionMode
+	selfCorrectTests     bool
+	reasoningEffort      modelregistry.ReasoningEffort
+	responseStyle        string
+	keyBindings          keyBindings
+	themeMode            themeMode // palette preference: auto (default), dark, light
+	hasDarkBg            bool      // last terminal background-detection result (auto mode)
+	userAgent            string
+	compactRequests      int
+	compactInFlight      bool
+	compactFrame         int
+	lastCompactResult    *CompactResult
+	lastCompactError     string
+	unpricedRequests     int
+	unpricedTokens       int
+	lastUsage            usage.Normalized
+	lastUsageSeen        bool
 	// turnLatencySum / turnLatencyCount accumulate completed-run wall time so
 	// /context can show a rolling average turn latency (the "is it slow?" signal).
 	// Reset by /new.
@@ -796,6 +797,7 @@ func newModel(ctx context.Context, options Options) model {
 		prState:                     prService.GetState(),
 		input:                       input,
 		spinner:                     runSpinner,
+		runCompletionWarning:        options.RunCompletionWarning,
 		now:                         time.Now,
 		notifier:                    notifier,
 		altScreen:                   options.AltScreen,
@@ -2053,6 +2055,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				turnTools:   msg.turnTools,
 				turnElapsed: msg.turnElapsed,
 			})
+		}
+		if m.runCompletionWarning != nil {
+			if notice := strings.TrimSpace(m.runCompletionWarning()); notice != "" {
+				m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, text: notice})
+			}
 		}
 		m.streamingText = nil
 		m.streamingReasoning = ""

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1387,6 +1387,20 @@ func TestAgentResponseSurfacesRunCompletionWarning(t *testing.T) {
 	}
 }
 
+func TestBeginRunPreparesRunCompletionWarningEachTurn(t *testing.T) {
+	prepares := 0
+	m := newModel(context.Background(), Options{
+		PrepareRunCompletionWarning: func() { prepares++ },
+	})
+
+	m = m.beginRun(nil)
+	m = m.beginRun(nil)
+
+	if prepares != 2 {
+		t.Fatalf("PrepareRunCompletionWarning called %d times, want once per run", prepares)
+	}
+}
+
 // TestToolResultDetailPrefersPreview: the card body uses the rich card-only
 // Display.Preview on a successful result, falls back to Output when there's no
 // preview, and always uses Output (the failure) on an error.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1374,6 +1374,19 @@ func TestAgentResponseCompletesStuckPlan(t *testing.T) {
 	})
 }
 
+func TestAgentResponseSurfacesRunCompletionWarning(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		RunCompletionWarning: func() string { return "scratch warning" },
+	})
+	m.pending = true
+	m.activeRunID = 7
+	updated, _ := m.Update(agentResponseMsg{runID: 7, rows: []transcriptRow{{kind: rowAssistant, text: "done", final: true}}})
+	next := updated.(model)
+	if !transcriptContains(next.transcript, "scratch warning") {
+		t.Fatalf("expected run completion warning in transcript, got %#v", next.transcript)
+	}
+}
+
 // TestToolResultDetailPrefersPreview: the card body uses the rich card-only
 // Display.Preview on a successful result, falls back to Output when there's no
 // preview, and always uses Output (the failure) on an error.

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -39,6 +39,7 @@ type Options struct {
 	DiscoverProviderModels      func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	DiscoverOllamaContextWindow func(ctx context.Context, baseURL string, model string) (int, error)
 	RuntimeMessageSink          func(tea.Msg)
+	PrepareRunCompletionWarning func()
 	RunCompletionWarning        func() string
 	Registry                    *tools.Registry
 	SessionStore                *sessions.Store

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	DiscoverProviderModels      func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	DiscoverOllamaContextWindow func(ctx context.Context, baseURL string, model string) (int, error)
 	RuntimeMessageSink          func(tea.Msg)
+	RunCompletionWarning        func() string
 	Registry                    *tools.Registry
 	SessionStore                *sessions.Store
 	SandboxStore                *sandbox.GrantStore


### PR DESCRIPTION
Fixes #551.

## Problem
A headless \zero exec\ run could leave behind debug/scratch files the model created while iterating (e.g. \_fix_test.py\, \_debug.py\) sitting untracked in the repo. These would then be silently swept up by a later \git add -A\ and committed by accident.

## Fix
Rather than guessing which files are 'scratch' and deleting them (risky — a wrong guess destroys real work), Zero now surfaces a completion-time warning listing any brand-new file it created this run that is still present and untracked by git when the run ends, so it's caught before staging/committing instead of after.

- \FileTracker\ gains \RecordCreated\/\CreatedFiles\, tracking brand-new files distinct from its existing version-baseline (used for external-modification conflict detection).
- \write_file\ records a path as created only the first time it writes a file that didn't already exist — an overwrite of an existing file is not counted.
- After a headless run completes, \xec.go\ checks \git status\ for any created file that's still present and untracked, and surfaces a warning via the existing \writer.warning()\ (works across text / \-o json\ / stream-json output).

Silent (no-op) when: nothing was created, git isn't available, the workspace isn't a git repo, or the created file was removed or already tracked/committed by the model itself.

## Testing
- \go build ./...\
- \go test ./internal/tools/... ./internal/cli/...\ (all pass, including new tests for \FileTracker.RecordCreated\/\CreatedFiles\, \write_file\'s create-vs-overwrite tracking, and \scratchFileWarning\'s git-status behavior across tracked/untracked/removed/non-repo cases)
- Full \go test ./...\ — all green except a pre-existing, unrelated TUI scroll-rendering test failure (\internal/tui\) that reproduces identically on a clean checkout with none of this PR's files touched.