### PR TITLE
fix(keyring): pass generic password via stdin on macOS

### DIFF
--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -3,11 +3,12 @@
 // macOS and `secret-tool` (libsecret) on Linux. It stores a single secret string
 // per (service, account). Windows and other platforms report unsupported.
 //
-// It shells out to the OS tools rather than taking a third-party dependency. On
-// macOS the secret is passed to `security` as an argument, so it is briefly
-// visible to other processes via the process list; on Linux the secret is passed
-// over stdin and is not exposed in the argument vector. Callers that need to keep
-// a secret out of the process list on macOS should prefer the file backend.
+// It shells out to the OS tools rather than taking a third-party dependency.
+// On both macOS and Linux the secret is passed over stdin, never the argument
+// vector, so it is not exposed via the process list. On macOS this relies on
+// `security`'s interactive password+retype prompt, which is line-based, so a
+// secret containing a newline is rejected by Set rather than silently
+// truncated; Linux's secret-tool has no such restriction.
 package keyring
 
 import (
@@ -67,6 +68,13 @@ func (k *Keyring) Set(service, account, secret string) error {
 		// Pass the secret via stdin to prevent leaking it in the process list.
 		// A trailing -w without a value makes security prompt for password + retype,
 		// reading both from stdin, so we write the secret twice separated by a newline.
+		// That prompt is line-based (getpass-style), so a secret containing its own
+		// newline cannot be told apart from the password/retype separator: the first
+		// line read back would silently truncate the stored value. Reject it instead
+		// of storing a corrupted secret.
+		if strings.ContainsAny(secret, "\r\n") {
+			return wrap("set", errors.New("secret must not contain newlines on macOS (security's password+retype prompt is line-based)"))
+		}
 		stdinPayload := []byte(secret + "\n" + secret + "\n")
 		_, err := k.exec(stdinPayload, "security", "add-generic-password", "-U", "-s", service, "-a", account, "-w")
 		return wrap("set", err)

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -5,10 +5,11 @@
 //
 // It shells out to the OS tools rather than taking a third-party dependency.
 // On both macOS and Linux the secret is passed over stdin, never the argument
-// vector, so it is not exposed via the process list. On macOS this relies on
-// `security`'s interactive password+retype prompt, which is line-based, so a
-// secret containing a newline is rejected by Set rather than silently
-// truncated; Linux's secret-tool has no such restriction.
+// vector, so it is not exposed via the process list. On macOS the write goes
+// through `security -i` (interactive mode), whose command parser is line-based
+// with a fixed 4096-byte line buffer, so Set rejects secrets containing
+// newlines or exceeding that budget rather than silently corrupting them;
+// Linux's secret-tool has no such restriction.
 package keyring
 
 import (
@@ -64,19 +65,28 @@ func (k *Keyring) Set(service, account, secret string) error {
 	}
 	switch k.goos {
 	case "darwin":
-		// -U updates the item if it already exists rather than failing.
-		// Pass the secret via stdin to prevent leaking it in the process list.
-		// A trailing -w without a value makes security prompt for password + retype,
-		// reading both from stdin, so we write the secret twice separated by a newline.
-		// That prompt is line-based (getpass-style), so a secret containing its own
-		// newline cannot be told apart from the password/retype separator: the first
-		// line read back would silently truncate the stored value. Reject it instead
-		// of storing a corrupted secret.
-		if strings.ContainsAny(secret, "\r\n") {
-			return wrap("set", errors.New("secret must not contain newlines on macOS (security's password+retype prompt is line-based)"))
+		// The secret must stay out of the argument vector (visible to every
+		// process via `ps`), but a trailing -w prompt is not a substitute:
+		// security prompts with getpass(3), which reads from /dev/tty whenever
+		// the process has a controlling terminal (ignoring a piped stdin) and
+		// truncates at getpass's small fixed buffer otherwise. Instead drive
+		// `security -i`: interactive mode reads whole commands from stdin, so
+		// argv is just ["-i"] and the secret rides inside the command line.
+		// That parser is line-based with a fixed 4096-byte buffer, so reject
+		// newlines and oversized payloads up front; an overlong line would be
+		// split and executed as two garbage commands, silently corrupting the
+		// stored value.
+		for _, s := range []string{service, account, secret} {
+			if strings.ContainsAny(s, "\r\n") {
+				return wrap("set", errors.New("service, account, and secret must not contain newlines on macOS (security -i is line-based)"))
+			}
 		}
-		stdinPayload := []byte(secret + "\n" + secret + "\n")
-		_, err := k.exec(stdinPayload, "security", "add-generic-password", "-U", "-s", service, "-a", account, "-w")
+		// -U updates the item if it already exists rather than failing.
+		line := "add-generic-password -U -s " + securityQuote(service) + " -a " + securityQuote(account) + " -w " + securityQuote(secret) + "\n"
+		if len(line) > securityMaxLine {
+			return wrap("set", fmt.Errorf("secret too large for the macOS security tool's %d-byte command line; use the file backend instead", securityMaxLine))
+		}
+		_, err := k.exec([]byte(line), "security", "-i")
 		return wrap("set", err)
 	case "linux":
 		// secret-tool reads the secret from stdin, keeping it out of the argv.
@@ -150,6 +160,19 @@ func (k *Keyring) Delete(service, account string) (bool, error) {
 	default:
 		return false, ErrUnsupported
 	}
+}
+
+// securityMaxLine is the most `security -i` can read as one command: its line
+// buffer is MAX_LINE_LEN (4096) bytes in Apple's SecurityTool, one of which the
+// terminating NUL consumes.
+const securityMaxLine = 4095
+
+// securityQuote wraps s for one argument of a `security -i` command line. The
+// tool's parser (split_line in Apple's SecurityTool) treats a backslash inside
+// double quotes as escaping the next character and the matching quote as the
+// argument terminator, so those two characters are all that needs escaping.
+func securityQuote(s string) string {
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s) + `"`
 }
 
 func (k *Keyring) exec(stdin []byte, name string, args ...string) ([]byte, error) {

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -65,7 +65,10 @@ func (k *Keyring) Set(service, account, secret string) error {
 	case "darwin":
 		// -U updates the item if it already exists rather than failing.
 		// Pass the secret via stdin to prevent leaking it in the process list.
-		_, err := k.exec([]byte(secret), "security", "add-generic-password", "-U", "-s", service, "-a", account, "-w")
+		// A trailing -w without a value makes security prompt for password + retype,
+		// reading both from stdin, so we write the secret twice separated by a newline.
+		stdinPayload := []byte(secret + "\n" + secret + "\n")
+		_, err := k.exec(stdinPayload, "security", "add-generic-password", "-U", "-s", service, "-a", account, "-w")
 		return wrap("set", err)
 	case "linux":
 		// secret-tool reads the secret from stdin, keeping it out of the argv.

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -64,7 +64,8 @@ func (k *Keyring) Set(service, account, secret string) error {
 	switch k.goos {
 	case "darwin":
 		// -U updates the item if it already exists rather than failing.
-		_, err := k.exec(nil, "security", "add-generic-password", "-U", "-s", service, "-a", account, "-w", secret)
+		// Pass the secret via stdin to prevent leaking it in the process list.
+		_, err := k.exec([]byte(secret), "security", "add-generic-password", "-U", "-s", service, "-a", account, "-w")
 		return wrap("set", err)
 	case "linux":
 		// secret-tool reads the secret from stdin, keeping it out of the argv.

--- a/internal/keyring/keyring_test.go
+++ b/internal/keyring/keyring_test.go
@@ -63,7 +63,10 @@ func (f *fakeKeyring) run(_ context.Context, name string, stdin []byte, args ...
 		case "add-generic-password":
 			password := flagValue(args, "-w")
 			if password == "" && len(args) > 0 && args[len(args)-1] == "-w" {
-				password = string(stdin)
+				// Mirror real security behavior: read the first line as
+				// the password (the second line is the retype confirmation).
+				lines := strings.SplitN(string(stdin), "\n", 2)
+				password = lines[0]
 			}
 			f.data[key(svc, acct)] = password
 			return nil, nil
@@ -140,8 +143,11 @@ func TestKeyringRoundTripDarwinUsesStdin(t *testing.T) {
 		t.Fatalf("Set: %v", err)
 	}
 	// The secret must travel via stdin, never the argument vector.
-	if f.lastStdin != "blob-CCC" {
-		t.Fatalf("secret not sent via stdin: stdin=%q", f.lastStdin)
+	// The payload contains the secret twice (password + retype confirmation)
+	// separated by newlines, matching the real security prompt behavior.
+	wantStdin := "blob-CCC\nblob-CCC\n"
+	if f.lastStdin != wantStdin {
+		t.Fatalf("secret not sent via stdin correctly: stdin=%q, want=%q", f.lastStdin, wantStdin)
 	}
 	for _, a := range f.lastArgs {
 		if strings.Contains(a, "blob-CCC") {

--- a/internal/keyring/keyring_test.go
+++ b/internal/keyring/keyring_test.go
@@ -61,7 +61,11 @@ func (f *fakeKeyring) run(_ context.Context, name string, stdin []byte, args ...
 		svc, acct := flagValue(args, "-s"), flagValue(args, "-a")
 		switch args[0] {
 		case "add-generic-password":
-			f.data[key(svc, acct)] = flagValue(args, "-w")
+			password := flagValue(args, "-w")
+			if password == "" && len(args) > 0 && args[len(args)-1] == "-w" {
+				password = string(stdin)
+			}
+			f.data[key(svc, acct)] = password
 			return nil, nil
 		case "find-generic-password":
 			if v, ok := f.data[key(svc, acct)]; ok {
@@ -126,6 +130,31 @@ func TestKeyringRoundTripDarwin(t *testing.T) {
 	}
 	if _, ok, _ := k.Get("zero", "tokens"); ok {
 		t.Fatal("token should be gone after delete")
+	}
+}
+
+func TestKeyringRoundTripDarwinUsesStdin(t *testing.T) {
+	f := newFake("darwin")
+	k := f.keyring()
+	if err := k.Set("zero", "tokens", "blob-CCC"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	// The secret must travel via stdin, never the argument vector.
+	if f.lastStdin != "blob-CCC" {
+		t.Fatalf("secret not sent via stdin: stdin=%q", f.lastStdin)
+	}
+	for _, a := range f.lastArgs {
+		if strings.Contains(a, "blob-CCC") {
+			t.Fatalf("secret leaked into argv: %v", f.lastArgs)
+		}
+	}
+	got, ok, err := k.Get("zero", "tokens")
+	if err != nil || !ok || got != "blob-CCC" {
+		t.Fatalf("Get = %q ok=%v err=%v", got, ok, err)
+	}
+	existed, err := k.Delete("zero", "tokens")
+	if err != nil || !existed {
+		t.Fatalf("Delete: existed=%v err=%v", existed, err)
 	}
 }
 

--- a/internal/keyring/keyring_test.go
+++ b/internal/keyring/keyring_test.go
@@ -50,6 +50,52 @@ func attrValue(args []string, attr string) string {
 
 func key(service, account string) string { return service + "\x00" + account }
 
+// splitSecurityLine mirrors split_line in Apple's SecurityTool so the fake
+// parses `security -i` command lines the way the real tool does: whitespace
+// separates arguments, double or single quotes group one, and a backslash
+// escapes the next character both inside and outside quotes.
+func splitSecurityLine(line string) []string {
+	var args []string
+	var cur strings.Builder
+	inArg, escaped := false, false
+	quote := byte(0)
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case escaped:
+			cur.WriteByte(c)
+			escaped = false
+		case c == '\\':
+			escaped = true
+			inArg = true
+		case quote != 0:
+			if c != quote {
+				cur.WriteByte(c)
+				continue
+			}
+			args = append(args, cur.String())
+			cur.Reset()
+			inArg, quote = false, 0
+		case c == '"' || c == '\'':
+			quote = c
+			inArg = true
+		case c == ' ' || c == '\t':
+			if inArg {
+				args = append(args, cur.String())
+				cur.Reset()
+				inArg = false
+			}
+		default:
+			cur.WriteByte(c)
+			inArg = true
+		}
+	}
+	if inArg {
+		args = append(args, cur.String())
+	}
+	return args
+}
+
 func (f *fakeKeyring) run(_ context.Context, name string, stdin []byte, args ...string) ([]byte, error) {
 	f.lastStdin = string(stdin)
 	f.lastArgs = append([]string{name}, args...)
@@ -58,17 +104,19 @@ func (f *fakeKeyring) run(_ context.Context, name string, stdin []byte, args ...
 	}
 	switch f.goos {
 	case "darwin":
-		svc, acct := flagValue(args, "-s"), flagValue(args, "-a")
-		switch args[0] {
-		case "add-generic-password":
-			password := flagValue(args, "-w")
-			if password == "" && len(args) > 0 && args[len(args)-1] == "-w" {
-				// Mirror real security behavior: read the first line as
-				// the password (the second line is the retype confirmation).
-				lines := strings.SplitN(string(stdin), "\n", 2)
-				password = lines[0]
+		cmdArgs := args
+		if args[0] == "-i" {
+			// Interactive mode: the command arrives as one line on stdin.
+			line, _, _ := strings.Cut(string(stdin), "\n")
+			cmdArgs = splitSecurityLine(line)
+			if len(cmdArgs) == 0 {
+				return nil, fakeExit{1}
 			}
-			f.data[key(svc, acct)] = password
+		}
+		svc, acct := flagValue(cmdArgs, "-s"), flagValue(cmdArgs, "-a")
+		switch cmdArgs[0] {
+		case "add-generic-password":
+			f.data[key(svc, acct)] = flagValue(cmdArgs, "-w")
 			return nil, nil
 		case "find-generic-password":
 			if v, ok := f.data[key(svc, acct)]; ok {
@@ -142,17 +190,16 @@ func TestKeyringRoundTripDarwinUsesStdin(t *testing.T) {
 	if err := k.Set("zero", "tokens", "blob-CCC"); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
-	// The secret must travel via stdin, never the argument vector.
-	// The payload contains the secret twice (password + retype confirmation)
-	// separated by newlines, matching the real security prompt behavior.
-	wantStdin := "blob-CCC\nblob-CCC\n"
+	// The secret must travel via stdin, never the argument vector: the write
+	// goes through `security -i`, whose whole command line (secret included)
+	// arrives on stdin while argv carries only the -i flag.
+	wantStdin := "add-generic-password -U -s \"zero\" -a \"tokens\" -w \"blob-CCC\"\n"
 	if f.lastStdin != wantStdin {
 		t.Fatalf("secret not sent via stdin correctly: stdin=%q, want=%q", f.lastStdin, wantStdin)
 	}
-	for _, a := range f.lastArgs {
-		if strings.Contains(a, "blob-CCC") {
-			t.Fatalf("secret leaked into argv: %v", f.lastArgs)
-		}
+	wantArgs := []string{"security", "-i"}
+	if len(f.lastArgs) != len(wantArgs) || f.lastArgs[0] != wantArgs[0] || f.lastArgs[1] != wantArgs[1] {
+		t.Fatalf("argv = %v, want %v", f.lastArgs, wantArgs)
 	}
 	got, ok, err := k.Get("zero", "tokens")
 	if err != nil || !ok || got != "blob-CCC" {
@@ -165,10 +212,10 @@ func TestKeyringRoundTripDarwinUsesStdin(t *testing.T) {
 }
 
 // TestKeyringSetRejectsMultilineSecretOnDarwin guards against silently
-// truncating a secret containing a newline: security's -w password+retype
-// prompt is line-based, so writing "secret\nsecret\n" to stdin reads only the
-// text up to the first newline as the password. Set must reject this before
-// ever invoking security, not store a corrupted value.
+// truncating a secret containing a newline: `security -i` reads one command
+// per line, so an embedded newline would split the write into two garbage
+// commands. Set must reject this before ever invoking security, not store a
+// corrupted value.
 func TestKeyringSetRejectsMultilineSecretOnDarwin(t *testing.T) {
 	for _, secret := range []string{"line1\nline2", "line1\r\nline2", "trailing\n"} {
 		f := newFake("darwin")
@@ -179,6 +226,51 @@ func TestKeyringSetRejectsMultilineSecretOnDarwin(t *testing.T) {
 		if f.lastArgs != nil {
 			t.Fatalf("Set(%q) should be rejected before invoking security, got args=%v", secret, f.lastArgs)
 		}
+	}
+}
+
+// TestKeyringDarwinQuotesSpecialCharacters proves the quoting survives the
+// real tool's parser: the fake tokenizes stdin with a faithful mirror of
+// SecurityTool's split_line, so a secret full of quotes, backslashes, and
+// spaces must round-trip unchanged.
+func TestKeyringDarwinQuotesSpecialCharacters(t *testing.T) {
+	for _, secret := range []string{
+		`spa ced`,
+		`quo"te`,
+		`back\slash`,
+		`sin'gle`,
+		`mi"x'ed \" \\ end\`,
+		` leading and trailing `,
+	} {
+		f := newFake("darwin")
+		k := f.keyring()
+		if err := k.Set("zero", "tokens", secret); err != nil {
+			t.Fatalf("Set(%q): %v", secret, err)
+		}
+		got, ok, err := k.Get("zero", "tokens")
+		if err != nil || !ok || got != secret {
+			t.Fatalf("Get after Set(%q) = %q ok=%v err=%v", secret, got, ok, err)
+		}
+	}
+}
+
+// TestKeyringSetRejectsOversizedSecretOnDarwin guards the `security -i` line
+// budget: MAX_LINE_LEN is 4096 bytes, and an overlong line would be split and
+// executed as two garbage commands. A payload comfortably under the budget
+// must succeed; one over it must be rejected before invoking security.
+func TestKeyringSetRejectsOversizedSecretOnDarwin(t *testing.T) {
+	f := newFake("darwin")
+	k := f.keyring()
+	if err := k.Set("zero", "tokens", strings.Repeat("a", 4000)); err != nil {
+		t.Fatalf("Set(4000 bytes): %v", err)
+	}
+	f = newFake("darwin")
+	k = f.keyring()
+	if err := k.Set("zero", "tokens", strings.Repeat("a", 5000)); err == nil {
+		t.Fatal("Set(5000 bytes) = nil error, want rejection of the oversized line")
+	}
+	if f.lastArgs != nil {
+		t.Fatalf("oversized Set should be rejected before invoking security, got args=%v", f.lastArgs)
 	}
 }
 

--- a/internal/keyring/keyring_test.go
+++ b/internal/keyring/keyring_test.go
@@ -164,6 +164,40 @@ func TestKeyringRoundTripDarwinUsesStdin(t *testing.T) {
 	}
 }
 
+// TestKeyringSetRejectsMultilineSecretOnDarwin guards against silently
+// truncating a secret containing a newline: security's -w password+retype
+// prompt is line-based, so writing "secret\nsecret\n" to stdin reads only the
+// text up to the first newline as the password. Set must reject this before
+// ever invoking security, not store a corrupted value.
+func TestKeyringSetRejectsMultilineSecretOnDarwin(t *testing.T) {
+	for _, secret := range []string{"line1\nline2", "line1\r\nline2", "trailing\n"} {
+		f := newFake("darwin")
+		k := f.keyring()
+		if err := k.Set("zero", "tokens", secret); err == nil {
+			t.Fatalf("Set(%q) = nil error, want rejection of the embedded newline", secret)
+		}
+		if f.lastArgs != nil {
+			t.Fatalf("Set(%q) should be rejected before invoking security, got args=%v", secret, f.lastArgs)
+		}
+	}
+}
+
+// TestKeyringSetAllowsMultilineSecretOnLinux confirms the newline restriction
+// is macOS-specific: secret-tool reads the whole stdin payload as the secret,
+// with no line-based prompt to corrupt an embedded newline.
+func TestKeyringSetAllowsMultilineSecretOnLinux(t *testing.T) {
+	f := newFake("linux")
+	k := f.keyring()
+	secret := "line1\nline2"
+	if err := k.Set("zero", "tokens", secret); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, ok, err := k.Get("zero", "tokens")
+	if err != nil || !ok || got != secret {
+		t.Fatalf("Get = %q ok=%v err=%v, want %q", got, ok, err, secret)
+	}
+}
+
 func TestKeyringRoundTripLinuxUsesStdin(t *testing.T) {
 	f := newFake("linux")
 	k := f.keyring()


### PR DESCRIPTION
## Summary

Addresses a credentials leak vulnerability on macOS. When writing generic passwords to the Keychain, Zero previously passed the password via the command-line argument `-w <secret>`. This exposed the secret in plain text to the local process list (e.g. visible via `ps`), making it readable by any other running process. This fix pipes the secret to standard input of the `security` command instead.

## Changes

**`internal/keyring/keyring.go`**
- Modify `Set` for macOS (`darwin` case) to drive `security -i` (interactive mode), writing the full `add-generic-password` command over stdin so argv carries only the `-i` flag. A trailing bare `-w` prompt was not viable: it goes through `getpass(3)`, which reads from `/dev/tty` whenever a controlling terminal exists and truncates at a small fixed buffer otherwise.
- Quote arguments for SecurityTool's `split_line` parser (backslash and double quote escaped inside double quotes), verified against apple-oss-distributions/Security.
- Reject secrets containing newlines and command lines over the parser's 4096-byte buffer with clear errors instead of corrupting the stored value.

**`internal/keyring/keyring_test.go`**
- Update `fakeKeyring.run` to tokenize `security -i` stdin with a faithful mirror of `split_line`.
- Add tests covering stdin transport (no secret in argv), special-character quoting round-trips, newline rejection, and oversized-payload rejection.

## Test plan

- `go test ./internal/keyring/...`: ok
- Automated: unit tests verify the secret travels only via stdin, argv is exactly `security -i`, and quoting survives a faithful mirror of the real parser.

---

> [!NOTE]
> I have read `SECURITY.md`, but I believe it is more important to get this patched in `main` ASAP rather than worrying about bureaucracy. The window of exposure exists only as long as this remains unpatched and we don't release a 0.3.0 update pronto. Furthermore, exploiting this requires a local compromise (i.e., a malicious user/attacker must already have local access to the system, see your process tree, and specifically watch the process list during execution).
