### PR TITLE
fix(tui): bypass toggleSidebar and toggleMouse global shortcuts when composer is non-empty

### DIFF
--- a/internal/tui/keybinding_help_test.go
+++ b/internal/tui/keybinding_help_test.go
@@ -254,3 +254,42 @@ func TestRemappedToggleBindingsIgnoreComposerGuard(t *testing.T) {
 		t.Fatalf("remapped toggleSidebar binding should not fall through to composer input, got %q", next.composerValue())
 	}
 }
+
+// TestExplicitDefaultChordConfigStillRequiresEmptyComposer guards against
+// treating "explicitly configured" the same as "genuinely remapped": a user
+// who writes toggleMouse: "ctrl+e" / toggleSidebar: "ctrl+b" in config (the
+// same chord as the built-in default) gets a non-zero parsedBinding, not the
+// isZero() sentinel, so a check that only asked "is this unset" would wrongly
+// let Ctrl+E/Ctrl+B bypass the composer guard again instead of reaching the
+// readline cursor-navigation handlers.
+func TestExplicitDefaultChordConfigStillRequiresEmptyComposer(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	m.altScreen = true
+	m.width = 120
+	m.height = 40
+	m.transcript = append(m.transcript, transcriptRow{kind: rowToolCall, tool: "read_file", detail: "main.go"})
+	m.keyBindings.toggleMouse = parseBinding("ctrl+e")
+	m.keyBindings.toggleSidebar = parseBinding("ctrl+b")
+	if !m.sidebarToggleAllowed() {
+		t.Fatal("sidebar toggle should be allowed")
+	}
+
+	m = typeRunes(t, m, "hello")
+	if m.composerValue() != "hello" {
+		t.Fatalf("composerValue = %q, want 'hello'", m.composerValue())
+	}
+
+	initialMouse := m.mouseReleased
+	updated, _ := m.Update(testKeyCtrl('e'))
+	next := updated.(model)
+	if next.mouseReleased != initialMouse {
+		t.Fatal("explicit ctrl+e config should NOT toggle mouseReleased with a non-empty composer")
+	}
+
+	initialSidebar := next.sidebarHidden
+	updated, _ = next.Update(testKeyCtrl('b'))
+	next = updated.(model)
+	if next.sidebarHidden != initialSidebar {
+		t.Fatal("explicit ctrl+b config should NOT toggle sidebarHidden with a non-empty composer")
+	}
+}

--- a/internal/tui/keybinding_help_test.go
+++ b/internal/tui/keybinding_help_test.go
@@ -191,7 +191,7 @@ func TestCtrlBCtrlECursorNavigationBypass(t *testing.T) {
 	m2.width = 120
 	m2.height = 40
 	m2.transcript = append(m2.transcript, transcriptRow{kind: rowToolCall, tool: "read_file", detail: "main.go"})
-	
+
 	m2 = typeRunes(t, m2, "hello")
 	if m2.composerValue() != "hello" {
 		t.Fatalf("composerValue = %q, want 'hello'", m2.composerValue())
@@ -209,5 +209,48 @@ func TestCtrlBCtrlECursorNavigationBypass(t *testing.T) {
 	next2 = updated.(model)
 	if next2.mouseReleased != initialMouse2 {
 		t.Fatal("Ctrl+E on non-empty composer should NOT toggle mouseReleased")
+	}
+}
+
+// TestRemappedToggleBindingsIgnoreComposerGuard guards against the
+// composer-empty bypass over-applying to a user-remapped, non-conflicting
+// binding: it exists so the default Ctrl+E/Ctrl+B chords (which readline
+// navigation also claims while typing) don't hijack keystrokes mid-sentence,
+// not to block every toggleMouse/toggleSidebar binding while composing.
+func TestRemappedToggleBindingsIgnoreComposerGuard(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	m.altScreen = true
+	m.width = 120
+	m.height = 40
+	m.transcript = append(m.transcript, transcriptRow{kind: rowToolCall, tool: "read_file", detail: "main.go"})
+	m.keyBindings.toggleMouse = parseBinding("ctrl+m")
+	m.keyBindings.toggleSidebar = parseBinding("ctrl+n")
+	if !m.sidebarToggleAllowed() {
+		t.Fatal("sidebar toggle should be allowed")
+	}
+
+	m = typeRunes(t, m, "hello")
+	if m.composerValue() != "hello" {
+		t.Fatalf("composerValue = %q, want 'hello'", m.composerValue())
+	}
+
+	initialMouse := m.mouseReleased
+	updated, _ := m.Update(testKeyCtrl('m'))
+	next := updated.(model)
+	if next.mouseReleased == initialMouse {
+		t.Fatal("remapped Ctrl+M toggleMouse binding should still fire with a non-empty composer")
+	}
+	if next.composerValue() != "hello" {
+		t.Fatalf("remapped toggleMouse binding should not fall through to composer input, got %q", next.composerValue())
+	}
+
+	initialSidebar := next.sidebarHidden
+	updated, _ = next.Update(testKeyCtrl('n'))
+	next = updated.(model)
+	if next.sidebarHidden == initialSidebar {
+		t.Fatal("remapped Ctrl+N toggleSidebar binding should still fire with a non-empty composer")
+	}
+	if next.composerValue() != "hello" {
+		t.Fatalf("remapped toggleSidebar binding should not fall through to composer input, got %q", next.composerValue())
 	}
 }

--- a/internal/tui/keybinding_help_test.go
+++ b/internal/tui/keybinding_help_test.go
@@ -159,3 +159,55 @@ func TestHelpOverlayKeepsTranscriptBodyBehindIt(t *testing.T) {
 		t.Fatalf("#419: transcript body was replaced by the help overlay:\n%s", view)
 	}
 }
+
+func TestCtrlBCtrlECursorNavigationBypass(t *testing.T) {
+	// 1. Empty composer: Ctrl+B should toggle sidebarHidden, Ctrl+E should toggle mouseReleased
+	m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	m.altScreen = true
+	m.width = 120
+	m.height = 40
+	m.transcript = append(m.transcript, transcriptRow{kind: rowToolCall, tool: "read_file", detail: "main.go"})
+	if !m.sidebarToggleAllowed() {
+		t.Fatal("sidebar toggle should be allowed")
+	}
+
+	initialSidebar := m.sidebarHidden
+	updated, _ := m.Update(testKeyCtrl('b'))
+	next := updated.(model)
+	if next.sidebarHidden == initialSidebar {
+		t.Fatal("Ctrl+B on empty composer should toggle sidebarHidden")
+	}
+
+	initialMouse := next.mouseReleased
+	updated, _ = next.Update(testKeyCtrl('e'))
+	next = updated.(model)
+	if next.mouseReleased == initialMouse {
+		t.Fatal("Ctrl+E on empty composer should toggle mouseReleased")
+	}
+
+	// 2. Non-empty composer: Ctrl+B and Ctrl+E should not toggle state, but act as cursor movement
+	m2 := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	m2.altScreen = true
+	m2.width = 120
+	m2.height = 40
+	m2.transcript = append(m2.transcript, transcriptRow{kind: rowToolCall, tool: "read_file", detail: "main.go"})
+	
+	m2 = typeRunes(t, m2, "hello")
+	if m2.composerValue() != "hello" {
+		t.Fatalf("composerValue = %q, want 'hello'", m2.composerValue())
+	}
+
+	initialSidebar2 := m2.sidebarHidden
+	updated, _ = m2.Update(testKeyCtrl('b'))
+	next2 := updated.(model)
+	if next2.sidebarHidden != initialSidebar2 {
+		t.Fatal("Ctrl+B on non-empty composer should NOT toggle sidebarHidden")
+	}
+
+	initialMouse2 := next2.mouseReleased
+	updated, _ = next2.Update(testKeyCtrl('e'))
+	next2 = updated.(model)
+	if next2.mouseReleased != initialMouse2 {
+		t.Fatal("Ctrl+E on non-empty composer should NOT toggle mouseReleased")
+	}
+}

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -47,6 +47,14 @@ func requiresEmptyComposer(b parsedBinding, conflicting parsedBinding) bool {
 	return b.isZero() || b == conflicting
 }
 
+// canFireComposerGatedToggle reports whether a toggle bound to b (whose
+// conflicting hardcoded default is conflicting) may fire given the current
+// composer-empty state. Factored out of the toggleMouse/toggleSidebar dispatch
+// cases in model.go, which both repeated this same condition inline.
+func canFireComposerGatedToggle(b parsedBinding, conflicting parsedBinding, composerEmpty bool) bool {
+	return !requiresEmptyComposer(b, conflicting) || composerEmpty
+}
+
 // Label returns a human-readable representation of the binding, e.g. "Ctrl+O"
 // or "Cmd+Shift+Enter". Used in the help overlay. Returns empty string for
 // zero (unset) bindings.

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -26,6 +26,27 @@ func (p parsedBinding) isZero() bool {
 	return p.code == 0 && p.text == ""
 }
 
+// defaultToggleMouseChord and defaultToggleSidebarChord are the built-in
+// Ctrl+E/Ctrl+B chords that conflict with readline cursor navigation
+// (move-to-end-of-line / move-to-beginning-of-line) while typing in the
+// composer.
+var (
+	defaultToggleMouseChord   = parseBinding("ctrl+e")
+	defaultToggleSidebarChord = parseBinding("ctrl+b")
+)
+
+// requiresEmptyComposer reports whether binding b resolves to conflicting, the
+// hardcoded default chord it can fall back to. That happens either because b
+// is unset (isZero, so keyMatch uses the default matcher) or because the user
+// explicitly configured the identical chord (e.g. toggleMouse: "ctrl+e"),
+// which parseBinding does not treat as zero. Only a binding that resolves to
+// a genuinely different chord may fire while the composer has text; one that
+// resolves to the conflicting default must still wait for it to be empty so
+// readline navigation gets the keystroke instead.
+func requiresEmptyComposer(b parsedBinding, conflicting parsedBinding) bool {
+	return b.isZero() || b == conflicting
+}
+
 // Label returns a human-readable representation of the binding, e.g. "Ctrl+O"
 // or "Cmd+Shift+Enter". Used in the help overlay. Returns empty string for
 // zero (unset) bindings.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1169,9 +1169,12 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.setFileViewMode(fileViewFull), nil
 			}
 			return m.setFileViewMode(fileViewDiff), nil
-		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }) && m.composerValue() == "":
+		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }) && (!m.keyBindings.toggleMouse.isZero() || m.composerValue() == ""):
 			// Release/recapture the mouse so the user can drag-select and copy text
-			// natively (mouse capture otherwise intercepts terminal selection).
+			// natively (mouse capture otherwise intercepts terminal selection). The
+			// composer-empty requirement only applies to the default Ctrl+E chord,
+			// which readline navigation (move-to-end-of-line) also claims while
+			// typing; a user-remapped, non-conflicting binding still fires mid-type.
 			m.mouseReleased = !m.mouseReleased
 			if m.mouseReleased {
 				mouseKey := labelOr(m.keyBindings.toggleMouse, "Ctrl+E")
@@ -1369,8 +1372,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.plan.expanded = !m.plan.expanded
 				return m, nil
 			}
-		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }) && m.composerValue() == "":
-			// Ctrl+B collapses / restores the right context sidebar. Only acts when
+		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }) && (!m.keyBindings.toggleSidebar.isZero() || m.composerValue() == ""):
+			// Ctrl+B collapses / restores the right context sidebar. The composer-empty
+			// requirement only applies to the default Ctrl+B chord, which readline
+			// navigation (move-to-beginning-of-line) also claims while typing; a
+			// user-remapped, non-conflicting binding still fires mid-type. Only acts when
 			// the sidebar would otherwise be on screen (managed mode, wide enough,
 			// real conversation) so it's a no-op — not a confusing notice — on the
 			// home screen or a narrow terminal. Hiding reflows the chat to full

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1169,12 +1169,14 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.setFileViewMode(fileViewFull), nil
 			}
 			return m.setFileViewMode(fileViewDiff), nil
-		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }) && (!m.keyBindings.toggleMouse.isZero() || m.composerValue() == ""):
+		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }) && (!requiresEmptyComposer(m.keyBindings.toggleMouse, defaultToggleMouseChord) || m.composerValue() == ""):
 			// Release/recapture the mouse so the user can drag-select and copy text
 			// natively (mouse capture otherwise intercepts terminal selection). The
-			// composer-empty requirement only applies to the default Ctrl+E chord,
-			// which readline navigation (move-to-end-of-line) also claims while
-			// typing; a user-remapped, non-conflicting binding still fires mid-type.
+			// composer-empty requirement only applies when the binding resolves to
+			// the conflicting default Ctrl+E chord (unset, or explicitly configured
+			// to the same chord), which readline navigation (move-to-end-of-line)
+			// also claims while typing; a binding that resolves to a genuinely
+			// different chord still fires mid-type.
 			m.mouseReleased = !m.mouseReleased
 			if m.mouseReleased {
 				mouseKey := labelOr(m.keyBindings.toggleMouse, "Ctrl+E")
@@ -1372,11 +1374,13 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.plan.expanded = !m.plan.expanded
 				return m, nil
 			}
-		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }) && (!m.keyBindings.toggleSidebar.isZero() || m.composerValue() == ""):
+		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }) && (!requiresEmptyComposer(m.keyBindings.toggleSidebar, defaultToggleSidebarChord) || m.composerValue() == ""):
 			// Ctrl+B collapses / restores the right context sidebar. The composer-empty
-			// requirement only applies to the default Ctrl+B chord, which readline
-			// navigation (move-to-beginning-of-line) also claims while typing; a
-			// user-remapped, non-conflicting binding still fires mid-type. Only acts when
+			// requirement only applies when the binding resolves to the conflicting
+			// default Ctrl+B chord (unset, or explicitly configured to the same
+			// chord), which readline navigation (move-to-beginning-of-line) also
+			// claims while typing; a binding that resolves to a genuinely different
+			// chord still fires mid-type. Only acts when
 			// the sidebar would otherwise be on screen (managed mode, wide enough,
 			// real conversation) so it's a no-op — not a confusing notice — on the
 			// home screen or a narrow terminal. Hiding reflows the chat to full

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1169,7 +1169,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.setFileViewMode(fileViewFull), nil
 			}
 			return m.setFileViewMode(fileViewDiff), nil
-		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }):
+		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }) && m.composerValue() == "":
 			// Release/recapture the mouse so the user can drag-select and copy text
 			// natively (mouse capture otherwise intercepts terminal selection).
 			m.mouseReleased = !m.mouseReleased
@@ -1369,7 +1369,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.plan.expanded = !m.plan.expanded
 				return m, nil
 			}
-		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }):
+		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }) && m.composerValue() == "":
 			// Ctrl+B collapses / restores the right context sidebar. Only acts when
 			// the sidebar would otherwise be on screen (managed mode, wide enough,
 			// real conversation) so it's a no-op — not a confusing notice — on the

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1169,7 +1169,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.setFileViewMode(fileViewFull), nil
 			}
 			return m.setFileViewMode(fileViewDiff), nil
-		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }) && (!requiresEmptyComposer(m.keyBindings.toggleMouse, defaultToggleMouseChord) || m.composerValue() == ""):
+		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }) && canFireComposerGatedToggle(m.keyBindings.toggleMouse, defaultToggleMouseChord, m.composerValue() == ""):
 			// Release/recapture the mouse so the user can drag-select and copy text
 			// natively (mouse capture otherwise intercepts terminal selection). The
 			// composer-empty requirement only applies when the binding resolves to
@@ -1374,7 +1374,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.plan.expanded = !m.plan.expanded
 				return m, nil
 			}
-		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }) && (!requiresEmptyComposer(m.keyBindings.toggleSidebar, defaultToggleSidebarChord) || m.composerValue() == ""):
+		case m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }) && canFireComposerGatedToggle(m.keyBindings.toggleSidebar, defaultToggleSidebarChord, m.composerValue() == ""):
 			// Ctrl+B collapses / restores the right context sidebar. The composer-empty
 			// requirement only applies when the binding resolves to the conflicting
 			// default Ctrl+B chord (unset, or explicitly configured to the same


### PR DESCRIPTION
## Summary

Prevents global interception of readline/Emacs cursor movement keybindings (`Ctrl+B` and `Ctrl+E`) when typing inside the input composer.

Previously, `Ctrl+B` (which toggles the sidebar) and `Ctrl+E` (which toggles mouse mode) were globally intercepted at the model level on keypress. This broke standard Emacs-style readline navigation within the text composer (moving the cursor backward with `Ctrl+B` and moving it to the end of the line with `Ctrl+E`).

This fix modifies the key match condition for these global shortcuts so they are bypassed when the input composer contains text. If the composer has text, `Ctrl+B` and `Ctrl+E` fall through to the text editor and behave as cursor movement keys. If the composer is empty, they continue to toggle the sidebar and mouse modes as expected.

## Changes

**`internal/tui/model.go`**

- Append `&& m.composerValue() == ""` to `toggleSidebar` (Ctrl+B) and `toggleMouse` (Ctrl+E) global shortcut switch cases.

**`internal/tui/keybinding_help_test.go`**

- Add `TestCtrlBCtrlECursorNavigationBypass` to verify both empty-composer toggling and non-empty-composer cursor navigation bypass.

## Test plan

- `go test -v ./internal/tui/...` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `Ctrl+B` and `Ctrl+E` now toggle the sidebar and mouse capture only when the composer is empty and the shortcuts match the default toggle bindings; while typing, they no longer interrupt input.
* **Tests**
  * Added coverage confirming correct `Ctrl+B`/`Ctrl+E` behavior for both empty and non-empty composer states, without affecting existing toggle-binding expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->