### PR TITLE
fix: gitignore Windows sandbox helpers and npm version marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ docs/superpowers/
 # Termux/Android build artifacts
 zero-termux-arm64
 zero-linux-sandbox
+zero-seccomp

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,10 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 /zero
 /zero.exe
+/zero-windows-command-runner.exe
+/zero-windows-sandbox-setup.exe
 /zero-skills
+/.zero-binary-version
 /snake-game.html
 
 # Superpowers skill artifacts (brainstorm mockups, specs, plans) — local only


### PR DESCRIPTION
Add three missing build artifacts to .gitignore:

- /zero-windows-command-runner.exe — helper built by cmd/zero-windows-command-runner
- /zero-windows-sandbox-setup.exe — helper built by cmd/zero-windows-sandbox-setup
- /.zero-binary-version — marker file written by scripts/postinstall.mjs during npm install

These are generated files analogous to the already-ignored /zero, /zero.exe, zero-termux-arm64, and zero-linux-sandbox entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded the ignore list for additional `zero*` artifacts, including Windows `.exe` files and a binary version file.
  * Added `zero-seccomp` to the build artifact ignores.
  * Kept the related ignore entries grouped for clearer repository maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->