### PR TITLE
Dispatch session lifecycle hooks

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -109,7 +109,7 @@ const escalationFailedNoticePrefix = "Note: could not switch to the requested mo
 // The system prompt (core coding-craft instructions + workspace context + safety
 // confirmation policy) is assembled in system_prompt.go via buildSystemPrompt.
 
-func Run(ctx context.Context, prompt string, provider Provider, options Options) (Result, error) {
+func Run(ctx context.Context, prompt string, provider Provider, options Options) (result Result, err error) {
 	if provider == nil {
 		return Result{}, errors.New("agent provider is required")
 	}
@@ -161,7 +161,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	// doesn't re-run the recursive schema→map conversion for every tool every turn.
 	toolDefCache := map[string]zeroruntime.ToolDefinition{}
 
-	result := Result{Messages: copyMessages(messages)}
+	result = Result{Messages: copyMessages(messages)}
+	dispatchSessionStart(ctx, options)
+	defer func() {
+		dispatchSessionEnd(ctx, options, result, err)
+	}()
 	for turn := 0; turn < maxTurns; turn++ {
 		result.Turns = turn + 1
 
@@ -1568,6 +1572,54 @@ func dispatchAfterTool(ctx context.Context, options Options, call ToolCall, args
 		},
 	})
 	return strings.TrimSpace(strings.Join(outcome.Messages, "\n"))
+}
+
+// dispatchSessionStart runs configured sessionStart hooks once before the first
+// model turn. Lifecycle hooks are advisory: dispatcher failures are audited but
+// never block the run.
+func dispatchSessionStart(ctx context.Context, options Options) {
+	if options.Hooks == nil {
+		return
+	}
+	options.Hooks.Dispatch(ctx, hooks.DispatchInput{
+		Event: hooks.EventSessionStart,
+		Payload: map[string]any{
+			"event":        string(hooks.EventSessionStart),
+			"sessionId":    options.SessionID,
+			"cwd":          options.Cwd,
+			"provider":     options.ProviderName,
+			"model":        options.Model,
+			"depth":        options.Depth,
+			"tag":          options.Tag,
+			"sessionTitle": options.SessionTitle,
+		},
+	})
+}
+
+// dispatchSessionEnd runs configured sessionEnd hooks once when the agent run
+// exits, including early error returns. Lifecycle hooks are advisory.
+func dispatchSessionEnd(ctx context.Context, options Options, result Result, runErr error) {
+	if options.Hooks == nil {
+		return
+	}
+	payload := map[string]any{
+		"event":        string(hooks.EventSessionEnd),
+		"sessionId":    options.SessionID,
+		"cwd":          options.Cwd,
+		"provider":     options.ProviderName,
+		"model":        options.Model,
+		"turns":        result.Turns,
+		"stopReason":   string(result.StopReason),
+		"finishReason": result.FinishReason,
+		"incomplete":   result.Incomplete,
+	}
+	if runErr != nil {
+		payload["error"] = runErr.Error()
+	}
+	options.Hooks.Dispatch(ctx, hooks.DispatchInput{
+		Event:   hooks.EventSessionEnd,
+		Payload: payload,
+	})
 }
 
 // blockedByHookResult is the tool result for a call vetoed by a beforeTool hook.

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gitlawb/zero/internal/hooks"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/specmode"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -36,6 +37,59 @@ func (provider *mockProvider) StreamCompletion(ctx context.Context, request zero
 	}
 	close(ch)
 	return ch, nil
+}
+
+func TestRunDispatchesSessionLifecycleHooks(t *testing.T) {
+	audit, err := hooks.NewAuditStore(hooks.AuditStoreOptions{AuditPath: filepath.Join(t.TempDir(), "audit.jsonl")})
+	if err != nil {
+		t.Fatalf("NewAuditStore: %v", err)
+	}
+	dispatcher := hooks.NewDispatcher(hooks.DispatcherOptions{
+		Config: hooks.Config{
+			Enabled: true,
+			Hooks: []hooks.Definition{
+				{ID: "zero.session-start", Event: hooks.EventSessionStart, Command: "zero-missing-hook-command", Enabled: true},
+				{ID: "zero.session-end", Event: hooks.EventSessionEnd, Command: "zero-missing-hook-command", Enabled: true},
+			},
+		},
+		Audit: audit,
+	})
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+
+	_, err = Run(context.Background(), "hi", provider, Options{
+		SessionID:    "session-123",
+		Cwd:          t.TempDir(),
+		ProviderName: "test-provider",
+		Model:        "test-model",
+		Hooks:        dispatcher,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	events, err := audit.ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	started := map[hooks.Event]int{}
+	completed := map[hooks.Event]int{}
+	for _, event := range events {
+		switch event.Type {
+		case "hook_execution_started":
+			started[event.Event]++
+		case "hook_execution_completed":
+			completed[event.Event]++
+		}
+	}
+	if started[hooks.EventSessionStart] != 1 || completed[hooks.EventSessionStart] != 1 {
+		t.Fatalf("sessionStart audit counts started/completed = %d/%d, events=%#v", started[hooks.EventSessionStart], completed[hooks.EventSessionStart], events)
+	}
+	if started[hooks.EventSessionEnd] != 1 || completed[hooks.EventSessionEnd] != 1 {
+		t.Fatalf("sessionEnd audit counts started/completed = %d/%d, events=%#v", started[hooks.EventSessionEnd], completed[hooks.EventSessionEnd], events)
+	}
 }
 
 type recordingWebSearchTool struct {


### PR DESCRIPTION
## Summary

- dispatch sessionStart hooks before the first model turn
- dispatch sessionEnd hooks when agent runs exit, including error exits
- add regression coverage proving both lifecycle events produce audit records

## Root Cause

sessionStart and sessionEnd were accepted by hook config parsing but never emitted by the agent loop.

## Validation

- go test ./internal/agent

Fixes #567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session start and end lifecycle notifications during agent runs, improving observability of run progress and completion.
* **Bug Fixes**
  * Improved run cleanup so final results and errors are consistently available when execution ends early or normally.
  * Added coverage to verify lifecycle notifications fire exactly once at the start and end of a run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->