### PR TITLE
Update plugin skill discovery docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ description: Run the project's benchmark suite and summarize the deltas.
 3. Report any regression > 5% with the function name and the previous value.
 ```
 
-Only `name` and `description` are recognized in the frontmatter today. The `name` defaults to the directory name. If two skills declare the same name, the one in the lexicographically-first directory wins — duplicates are dropped silently. Plugin-declared skills (section 6) are not yet merged into the loader, so a `skills:` entry inside a plugin's `plugin.json` is not visible to the `skill` tool today.
+Only `name` and `description` are recognized in the frontmatter today. The `name` defaults to the directory name. If two skills declare the same name, the one in the lexicographically-first directory wins — duplicates are dropped silently. Plugin-declared skills (section 6) are merged into the active agent run at plugin activation time, so bundled skills appear in the available skills list and can be loaded with the `skill` tool.
 
 The `skill` core tool lets the agent load any discovered skill by name.
 
@@ -282,7 +282,7 @@ A plugin is enabled by being present in the plugins directory and disabled by re
 
 Plugin commands run with the plugin directory as their working directory. Use relative paths; the loader resolves them at activation time.
 
-> **Roadmap.** An in-UI plugins manager (browse, install, enable / disable) is on the backlog. Today you use the `zero plugins` CLI subcommands above. Skills declared inside a plugin's `plugin.json` are not yet merged into the `skill` tool's discovery (see section 3).
+> **Roadmap.** An in-UI plugins manager (browse, install, enable / disable) is on the backlog. Today you use the `zero plugins` CLI subcommands above.
 
 ## 7. Configuration locations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ description: Run the project's benchmark suite and summarize the deltas.
 3. Report any regression > 5% with the function name and the previous value.
 ```
 
-Only `name` and `description` are recognized in the frontmatter today. The `name` defaults to the directory name. If two skills declare the same name, the one in the lexicographically-first directory wins — duplicates are dropped silently. Plugin-declared skills (section 6) are merged into the active agent run at plugin activation time, so bundled skills appear in the available skills list and can be loaded with the `skill` tool.
+Only `name` and `description` are recognized in the frontmatter today. The `name` defaults to the directory name. Within a single skills root, duplicate names are resolved by lexicographic directory order. During an agent run, Zero loads the default skills directory before plugin skill roots; earlier roots win name collisions silently. Plugin-declared skills (section 6) are merged into the active agent run at plugin activation time, so bundled skills appear in the available skills list and can be loaded with the `skill` tool.
 
 The `skill` core tool lets the agent load any discovered skill by name.
 

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -77,9 +77,9 @@ type DuplicateName struct {
 // winner regardless of sort stability. Use Duplicates to surface a warning about
 // any such collisions.
 //
-// NOTE: Load currently scans a single root (ZERO_SKILLS_DIR / the data dir).
-// Plugin-declared skill paths (the plugins manifest "skills" array) are NOT yet
-// merged into this lookup; multi-root loading is tracked as a separate feature.
+// NOTE: Load scans one root. Agent startup merges plugin-declared skill roots
+// separately during plugin activation, so the runtime skill surface can include
+// both the default directory and skills bundled by active plugins.
 func Load(dir string) ([]Skill, error) {
 	skills, _, err := load(dir)
 	return skills, err


### PR DESCRIPTION
## Summary

- update AGENTS.md to describe current plugin skill discovery behavior
- clarify the single-root skills loader comment now that plugin roots are merged during activation

## Context

Current main already wires plugin-declared skill roots into the active agent run through plugin activation. The remaining stale docs/comments still said plugin skills were not discoverable, which made issue #566 appear unresolved from the documentation.

## Validation

- focused internal/plugins and internal/cli plugin skill discovery tests passed

Refs #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skills provided by installed plugins are now merged into the active skill set, so they appear in the available skills list and can be loaded with the skill tool.
* **Bug Fixes**
  * Duplicate skill names are now resolved consistently by selecting one version and silently ignoring the rest.
* **Documentation**
  * Updated guidance to clarify which skill frontmatter fields are recognized and how plugin-provided skills are discovered/merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->