### PR TITLE
test(config): make Resolve local-control tests env-independent

### DIFF
--- a/internal/config/local_control_test.go
+++ b/internal/config/local_control_test.go
@@ -21,7 +21,7 @@ func TestResolveLocalControlFromUserConfig(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	resolved, err := Resolve(ResolveOptions{UserConfigPath: path})
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestResolveLocalControlIgnoresProjectOptIn(t *testing.T) {
 		t.Fatalf("write project config: %v", err)
 	}
 
-	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: projectPath})
+	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: projectPath, Env: map[string]string{}})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestResolveLocalControlIgnoresProjectOptIn(t *testing.T) {
 }
 
 func TestLocalControlDefaultsBrowserAndTerminalOn(t *testing.T) {
-	resolved, err := Resolve(ResolveOptions{})
+	resolved, err := Resolve(ResolveOptions{Env: map[string]string{}})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestLocalControlExplicitGlobalDisable(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`{"localControl":{"enabled":false}}`), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	resolved, err := Resolve(ResolveOptions{UserConfigPath: path})
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -768,7 +768,7 @@ func TestSwitchProviderModelRecordsRecentHistory(t *testing.T) {
 		},
 	})
 
-	next, status, _ := m.switchProviderModel("ollama", "kimi-k2.7-code:cloud")
+	next, status, _, _ := m.switchProviderModel("ollama", "kimi-k2.7-code:cloud")
 	wantStatus := "Model\nSwitched to ollama · kimi-k2.7-code:cloud"
 	if status != wantStatus {
 		t.Fatalf("switchProviderModel() status = %q, want %q (a mismatch here means the switch itself failed, not the recentModels assertion below)", status, wantStatus)


### PR DESCRIPTION
## Summary

`Resolve` reads `ZERO_PROVIDER` from the environment via `applyEnv`, then fails with `no active provider configured` when that provider is not present in the config. This made `TestResolveLocalControlFromUserConfig`, `TestResolveLocalControlIgnoresProjectOptIn`, `TestLocalControlDefaultsBrowserAndTerminalOn`, and `TestLocalControlExplicitGlobalDisable` fail whenever the process environment happened to export `ZERO_PROVIDER` (e.g. an agent session), even though the tests never intended to exercise provider resolution.

## Fix

Pass `Env: map[string]string{}` to the affected `Resolve` calls so the tests assert only local-control resolution and are unaffected by ambient environment variables.

## Verification

The four tests pass even with `ZERO_PROVIDER=gitlawb-opengateway` set. This branch contains only the test change on top of current `upstream/main` — no unrelated commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated local-control resolution tests to pass an explicit empty environment map to ensure consistent behavior across configuration scenarios.
  * Adjusted TUI picker tests to match a changed return signature when recording recent switch-provider model history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->