### PR TITLE
fix(tui): unblock main — picker_test for switchProviderModel 4-value return

### DIFF
--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -768,7 +768,7 @@ func TestSwitchProviderModelRecordsRecentHistory(t *testing.T) {
 		},
 	})
 
-	next, status, _ := m.switchProviderModel("ollama", "kimi-k2.7-code:cloud")
+	next, status, _, _ := m.switchProviderModel("ollama", "kimi-k2.7-code:cloud")
 	wantStatus := "Model\nSwitched to ollama · kimi-k2.7-code:cloud"
 	if status != wantStatus {
 		t.Fatalf("switchProviderModel() status = %q, want %q (a mismatch here means the switch itself failed, not the recentModels assertion below)", status, wantStatus)


### PR DESCRIPTION
main's Smoke is red. #568 added a fourth return value (`bool`) to `switchProviderModel` in `internal/tui/command_center.go` and updated every call site except one — `internal/tui/picker_test.go:771` still assigns three values:

```
assignment mismatch: 3 variables but m.switchProviderModel returns 4 values
```

That fails the `internal/tui` test build on all three Smoke jobs, so every open PR is blocked behind branch protection.

One-line fix: add the missing receiver so the test matches the signature the other five call sites already use. No runtime change.

Merge unblocks CI on the rest of the queue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated coverage to match a recent change in the app’s provider/model switching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->