### PR TITLE
fix(mcp): add HTTP client timeout and harden workflow limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   smoke:
     name: Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +58,7 @@ jobs:
   performance:
     name: Performance Smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -87,6 +89,7 @@ jobs:
   security:
     name: Security & code health
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish Artifacts
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  compute-target:
+    name: Compute publish target key
+    runs-on: ubuntu-latest
+    outputs:
+      key: ${{ steps.k.outputs.key }}
+    steps:
+      - id: k
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "key=prod-${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            echo "key=canary-main" >> "$GITHUB_OUTPUT"
+          else
+            echo "key=pre-${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: compute-target
+    concurrency:
+      group: ${{ github.workflow }}-${{ needs.compute-target.outputs.key }}
+      cancel-in-progress: true
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -11,10 +11,15 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   package:
     name: Package (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     permissions:
       contents: write # create/upload the GitHub Release on a tag push
     strategy:
@@ -112,6 +117,7 @@ jobs:
     needs: package
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Manual approval gate: this environment carries a required-reviewer rule
     # (Settings -> Environments -> npm-publish), so the job pauses until a
     # maintainer approves it in the Actions UI before anything reaches npm.

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -12,7 +12,7 @@ on:
       - 'v*'
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  compute-target:
+    name: Compute release target key
+    runs-on: ubuntu-latest
+    outputs:
+      key: ${{ steps.k.outputs.key }}
+    steps:
+      - id: k
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "key=prod-${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            echo "key=canary-main" >> "$GITHUB_OUTPUT"
+          else
+            echo "key=pre-${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    needs: compute-target
+    concurrency:
+      group: ${{ github.workflow }}-${{ needs.compute-target.outputs.key }}
+      cancel-in-progress: true
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4

--- a/internal/mcp/http_clients.go
+++ b/internal/mcp/http_clients.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/http2"
 )
 
 // ToolCallType classifies HTTP calls for timeout semantics.
@@ -56,8 +54,16 @@ func NewHTTPClients(cfg HTTPClientConfig) *HTTPClients {
 		DisableCompression:    false,
 		ResponseHeaderTimeout: 0,
 		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+		// ForceAttemptHTTP2 restores HTTP/2 support using net/http's own
+		// vendored implementation. A custom DialContext/TLSClientConfig
+		// conservatively disables automatic HTTP/2 negotiation unless this
+		// is set (see http.Transport's doc comment); it requires no
+		// external module, unlike golang.org/x/net/http2.ConfigureTransport
+		// (which this package previously depended on without ever adding
+		// golang.org/x/net to go.mod/go.sum -- a guaranteed
+		// "no required module provides package" build failure).
+		ForceAttemptHTTP2: true,
 	}
-	_ = http2.ConfigureTransport(streamingTransport)
 
 	// Bounded requests rely on per-request context deadlines.
 	boundedTransport := &http.Transport{
@@ -71,14 +77,27 @@ func NewHTTPClients(cfg HTTPClientConfig) *HTTPClients {
 		DisableCompression:    false,
 		ResponseHeaderTimeout: 0,
 		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+		ForceAttemptHTTP2:     true,
 	}
-	_ = http2.ConfigureTransport(boundedTransport)
 
 	return &HTTPClients{
 		Streaming: &http.Client{Transport: streamingTransport},
 		Bounded:   &http.Client{Transport: boundedTransport},
 		cfg:       cfg,
 	}
+}
+
+// NewHTTPClientsFromClients wraps already-configured streaming and bounded
+// http.Clients so ToolHTTP's classify/timeout/idle-watchdog behavior can be
+// reused by callers that need to preserve additional per-server transport
+// semantics beyond NewHTTPClients' bare defaults -- e.g. the MCP
+// networkClient's OAuth bearer-token round tripper and cross-origin redirect
+// guard (see mcpHTTPClient/oauthHTTPClient in network_client.go and
+// network_redirect.go). Only cfg.StreamIdleTimeout and cfg.DefaultExecTimeout
+// are consulted for clients built this way; DialTimeout/TLSHandshakeTimeout
+// are ignored since the given clients' transports are already fully formed.
+func NewHTTPClientsFromClients(streaming, bounded *http.Client, cfg HTTPClientConfig) *HTTPClients {
+	return &HTTPClients{Streaming: streaming, Bounded: bounded, cfg: cfg}
 }
 
 // ToolHTTP routes requests to the appropriate client and enforces deadlines.
@@ -101,9 +120,21 @@ func (c *ToolHTTP) Do(ctx context.Context, req *http.Request, kind ToolCallType,
 			t = *execTimeout
 		}
 		ctx2, cancel := context.WithTimeout(ctx, t)
-		defer cancel()
 		req = req.WithContext(ctx2)
-		return c.clients.Bounded.Do(req)
+		resp, err := c.clients.Bounded.Do(req)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		// Release ctx2 when the caller closes the body, not as soon as Do()
+		// returns. A bare `defer cancel()` at this call's own scope would
+		// fire the instant Do() returns -- i.e. right after headers arrive,
+		// before the caller has read the body -- cancelling ctx2 and
+		// aborting any real (non-empty) response body with
+		// context.Canceled. The context.WithTimeout deadline still fires on
+		// its own if reading the body takes longer than t.
+		resp.Body = &cancelOnCloseReadCloser{ReadCloser: resp.Body, cancel: cancel}
+		return resp, nil
 	case ToolCallStreaming:
 		// Unbounded execution; apply optional idle watchdog.
 		if c.clients.cfg.StreamIdleTimeout > 0 {
@@ -122,6 +153,20 @@ func (c *ToolHTTP) Do(ctx context.Context, req *http.Request, kind ToolCallType,
 	default:
 		return nil, fmt.Errorf("unknown ToolCallType: %d", kind)
 	}
+}
+
+// cancelOnCloseReadCloser defers releasing a ToolCallFinite request's
+// context.WithTimeout cancel func until the response body is closed. See the
+// comment at its construction site in ToolHTTP.Do for why this must not
+// happen any earlier.
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelOnCloseReadCloser) Close() error {
+	defer c.cancel()
+	return c.ReadCloser.Close()
 }
 
 // idleWatchdogReader cancels context if no bytes are read for timeout.
@@ -181,6 +226,16 @@ func NewDefaultToolHTTP() *ToolHTTP {
 
 // ClassifyToolCall determines whether a request should be treated as streaming.
 // Heuristics: SSE (Accept: text/event-stream), WebSocket upgrade, or explicit stream query.
+//
+// Note: this header-based heuristic cannot distinguish an MCP tools/call
+// request from initialize/tools/list/notifications, because the MCP
+// Streamable HTTP spec has the client send the same
+// `Accept: application/json, text/event-stream` header on every POST
+// regardless of JSON-RPC method. MCP's networkClient therefore classifies by
+// method name instead (see toolCallTypeFor in network_client.go) and calls
+// ToolHTTP.Do directly rather than routing through this function. It remains
+// the right classifier for generic (non-MCP-method-aware) callers -- see
+// routeAndDo in network_redirect.go.
 func ClassifyToolCall(req *http.Request) ToolCallType {
 	accept := req.Header.Get("Accept")
 	if strings.Contains(strings.ToLower(accept), "text/event-stream") {

--- a/internal/mcp/http_clients.go
+++ b/internal/mcp/http_clients.go
@@ -1,0 +1,206 @@
+package mcp
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+// ToolCallType classifies HTTP calls for timeout semantics.
+type ToolCallType int
+
+const (
+	ToolCallStreaming ToolCallType = iota
+	ToolCallFinite
+)
+
+// HTTPClientConfig centralizes transport-related timeouts.
+type HTTPClientConfig struct {
+	DialTimeout         time.Duration
+	TLSHandshakeTimeout time.Duration
+	StreamIdleTimeout   time.Duration
+	DefaultExecTimeout  time.Duration
+}
+
+// HTTPClients holds separate clients for streaming vs bounded calls.
+type HTTPClients struct {
+	Streaming *http.Client
+	Bounded   *http.Client
+	cfg       HTTPClientConfig
+}
+
+// NewHTTPClients builds Streaming and Bounded http.Clients with shared dialer and HTTP/2.
+func NewHTTPClients(cfg HTTPClientConfig) *HTTPClients {
+	baseDialer := &net.Dialer{
+		Timeout:   cfg.DialTimeout,
+		KeepAlive: 30 * time.Second,
+	}
+
+	// Unbounded response header timeout for streaming; rely on idle watchdog.
+	streamingTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           baseDialer.DialContext,
+		TLSHandshakeTimeout:   cfg.TLSHandshakeTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		DisableCompression:    false,
+		ResponseHeaderTimeout: 0,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+	_ = http2.ConfigureTransport(streamingTransport)
+
+	// Bounded requests rely on per-request context deadlines.
+	boundedTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           baseDialer.DialContext,
+		TLSHandshakeTimeout:   cfg.TLSHandshakeTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		DisableCompression:    false,
+		ResponseHeaderTimeout: 0,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+	_ = http2.ConfigureTransport(boundedTransport)
+
+	return &HTTPClients{
+		Streaming: &http.Client{Transport: streamingTransport},
+		Bounded:   &http.Client{Transport: boundedTransport},
+		cfg:       cfg,
+	}
+}
+
+// ToolHTTP routes requests to the appropriate client and enforces deadlines.
+type ToolHTTP struct {
+	clients *HTTPClients
+}
+
+// NewToolHTTP creates a ToolHTTP from clients.
+func NewToolHTTP(clients *HTTPClients) *ToolHTTP {
+	return &ToolHTTP{clients: clients}
+}
+
+// Do executes the request according to call type. For ToolCallFinite, an execTimeout
+// overrides the default if non-nil and >0. Streaming calls may use an idle watchdog.
+func (c *ToolHTTP) Do(ctx context.Context, req *http.Request, kind ToolCallType, execTimeout *time.Duration) (*http.Response, error) {
+	switch kind {
+	case ToolCallFinite:
+		t := c.clients.cfg.DefaultExecTimeout
+		if execTimeout != nil && *execTimeout > 0 {
+			t = *execTimeout
+		}
+		ctx2, cancel := context.WithTimeout(ctx, t)
+		defer cancel()
+		req = req.WithContext(ctx2)
+		return c.clients.Bounded.Do(req)
+	case ToolCallStreaming:
+		// Unbounded execution; apply optional idle watchdog.
+		if c.clients.cfg.StreamIdleTimeout > 0 {
+			ctx2, cancel := context.WithCancel(ctx)
+			req = req.WithContext(ctx2)
+			resp, err := c.clients.Streaming.Do(req)
+			if err != nil {
+				cancel()
+				return nil, err
+			}
+			resp.Body = newIdleWatchdogReadCloser(resp.Body, c.clients.cfg.StreamIdleTimeout, cancel)
+			return resp, nil
+		}
+		req = req.WithContext(ctx)
+		return c.clients.Streaming.Do(req)
+	default:
+		return nil, fmt.Errorf("unknown ToolCallType: %d", kind)
+	}
+}
+
+// idleWatchdogReader cancels context if no bytes are read for timeout.
+type idleWatchdogReader struct {
+	r       io.ReadCloser
+	timer   *time.Timer
+	timeout time.Duration
+	cancel  context.CancelFunc
+	mu      sync.Mutex
+}
+
+func newIdleWatchdogReadCloser(r io.ReadCloser, timeout time.Duration, cancel context.CancelFunc) io.ReadCloser {
+	iw := &idleWatchdogReader{
+		r:       r,
+		timeout: timeout,
+		cancel:  cancel,
+	}
+	iw.timer = time.AfterFunc(timeout, iw.fire)
+	return iw
+}
+
+func (iw *idleWatchdogReader) fire() {
+	// Cancel the request context on idle timeout.
+	iw.cancel()
+}
+
+func (iw *idleWatchdogReader) Read(p []byte) (int, error) {
+	n, err := iw.r.Read(p)
+	iw.mu.Lock()
+	if iw.timer != nil && n > 0 {
+		iw.timer.Reset(iw.timeout)
+	}
+	iw.mu.Unlock()
+	return n, err
+}
+
+func (iw *idleWatchdogReader) Close() error {
+	iw.mu.Lock()
+	if iw.timer != nil {
+		iw.timer.Stop()
+		iw.timer = nil
+	}
+	iw.mu.Unlock()
+	return iw.r.Close()
+}
+
+// NewDefaultToolHTTP builds ToolHTTP with confirmed defaults.
+func NewDefaultToolHTTP() *ToolHTTP {
+	cfg := HTTPClientConfig{
+		DialTimeout:         5 * time.Second,
+		TLSHandshakeTimeout: 5 * time.Second,
+		StreamIdleTimeout:   10 * time.Minute,
+		DefaultExecTimeout:  30 * time.Second,
+	}
+	return NewToolHTTP(NewHTTPClients(cfg))
+}
+
+// ClassifyToolCall determines whether a request should be treated as streaming.
+// Heuristics: SSE (Accept: text/event-stream), WebSocket upgrade, or explicit stream query.
+func ClassifyToolCall(req *http.Request) ToolCallType {
+	accept := req.Header.Get("Accept")
+	if strings.Contains(strings.ToLower(accept), "text/event-stream") {
+		return ToolCallStreaming
+	}
+	if strings.EqualFold(req.Header.Get("Upgrade"), "websocket") {
+		return ToolCallStreaming
+	}
+	if strings.Contains(strings.ToLower(req.Header.Get("Connection")), "upgrade") {
+		return ToolCallStreaming
+	}
+	if req.URL != nil && strings.EqualFold(req.URL.Query().Get("stream"), "1") {
+		return ToolCallStreaming
+	}
+	// Default: finite (e.g., JSON POST)
+	return ToolCallFinite
+}
+
+// DoToolHTTPRequest is a convenience wrapper using NewDefaultToolHTTP.
+// execTimeout applies only to finite calls; pass nil to use default.
+func DoToolHTTPRequest(ctx context.Context, req *http.Request, execTimeout *time.Duration) (*http.Response, error) {
+	return NewDefaultToolHTTP().Do(ctx, req, ClassifyToolCall(req), execTimeout)
+}

--- a/internal/mcp/http_clients_timeout_test.go
+++ b/internal/mcp/http_clients_timeout_test.go
@@ -1,0 +1,122 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newTestClients() *ToolHTTP {
+	cfg := HTTPClientConfig{
+		DialTimeout:         200 * time.Millisecond,
+		TLSHandshakeTimeout: 200 * time.Millisecond,
+		StreamIdleTimeout:   100 * time.Millisecond,
+		DefaultExecTimeout:  100 * time.Millisecond,
+	}
+	return NewToolHTTP(NewHTTPClients(cfg))
+}
+
+func TestStreamingHeaderDelayUnbounded(t *testing.T) {
+	// Server delays headers then streams data.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond) // header delay > default exec timeout
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl, _ := w.(http.Flusher)
+		fmt.Fprintf(w, "data: 1\n\n")
+		if fl != nil {
+			fl.Flush()
+		}
+		time.Sleep(50 * time.Millisecond)
+		fmt.Fprintf(w, "data: 2\n\n")
+		if fl != nil {
+			fl.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	tool := newTestClients()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Accept", "text/event-stream")
+	ctx := context.Background()
+	resp, err := tool.Do(ctx, req, ToolCallStreaming, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read first event to confirm stream success after delayed headers.
+	reader := bufio.NewReader(resp.Body)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read first line: %v", err)
+	}
+	if line == "" {
+		t.Fatalf("empty first line")
+	}
+}
+
+func TestFiniteRespectsContextTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(150 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tool := newTestClients()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	ctx := context.Background()
+	custom := 50 * time.Millisecond
+	_, err := tool.Do(ctx, req, ToolCallFinite, &custom)
+	if err == nil {
+		t.Fatalf("expected deadline exceeded, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got: %v", err)
+	}
+}
+
+func TestStreamingIdleWatchdogCancels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl, _ := w.(http.Flusher)
+		fmt.Fprintf(w, "data: hello\n\n")
+		if fl != nil {
+			fl.Flush()
+		}
+		// Stall longer than idle timeout to trigger watchdog.
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	tool := newTestClients()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Accept", "text/event-stream")
+	ctx := context.Background()
+	resp, err := tool.Do(ctx, req, ToolCallStreaming, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	// Read first event
+	if _, err := reader.ReadString('\n'); err != nil {
+		t.Fatalf("failed reading first line: %v", err)
+	}
+	start := time.Now()
+	// Next read should error due to idle watchdog cancel.
+	_, err = reader.ReadString('\n')
+	if err == nil {
+		t.Fatalf("expected read error after idle timeout")
+	}
+	if time.Since(start) > 300*time.Millisecond {
+		t.Fatalf("idle watchdog did not cancel in time")
+	}
+}

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -369,7 +369,12 @@ type idleWatchdogReadCloser struct {
 	stopped bool
 }
 
-func newIdleWatchdogReadCloser(body io.ReadCloser, idle time.Duration, cancel context.CancelFunc) *idleWatchdogReadCloser {
+// newToolCallIdleWatchdog wraps body in an idleWatchdogReadCloser for
+// networkClient's tools/call responses. Named distinctly from
+// http_clients.go's newIdleWatchdogReadCloser (a separate, not-yet-wired
+// mechanism added concurrently in this package) to avoid a duplicate
+// declaration build failure.
+func newToolCallIdleWatchdog(body io.ReadCloser, idle time.Duration, cancel context.CancelFunc) *idleWatchdogReadCloser {
 	watchdog := &idleWatchdogReadCloser{body: body, idle: idle, cancel: cancel}
 	watchdog.timer = time.AfterFunc(idle, watchdog.onIdle)
 	return watchdog
@@ -448,7 +453,7 @@ func (client *networkClient) post(ctx context.Context, message rpcMessage, expec
 	}
 
 	if toolCall {
-		response.Body = newIdleWatchdogReadCloser(response.Body, toolCallIdleTimeout, cancel)
+		response.Body = newToolCallIdleWatchdog(response.Body, toolCallIdleTimeout, cancel)
 	}
 	defer closeResponseBody(&err, client.server, response.Body)
 

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -392,6 +392,14 @@ func (client *remoteSSEClient) openStream(ctx context.Context) error {
 	}
 }
 
+// sseFinitePostTimeout bounds a single finite POST to the SSE endpoint. The
+// remoteSSEClient's underlying *http.Client carries no timeout of its own
+// because it is shared with openStream's long-lived GET request, which must
+// stay open for the life of the connection. Deriving a bounded context here
+// ensures a stalled POST fails the individual tool call instead of hanging
+// indefinitely on the connection reserved for the open-ended stream.
+const sseFinitePostTimeout = 30 * time.Second
+
 func (client *remoteSSEClient) post(ctx context.Context, message rpcMessage) (err error) {
 	endpointURL, err := client.currentEndpoint()
 	if err != nil {
@@ -401,7 +409,11 @@ func (client *remoteSSEClient) post(ctx context.Context, message rpcMessage) (er
 	if err != nil {
 		return err
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
+
+	postCtx, cancel := context.WithTimeout(ctx, sseFinitePostTimeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(postCtx, http.MethodPost, endpointURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create MCP SSE post for %s: %w", client.server.Name, err)
 	}
@@ -896,5 +908,5 @@ func oauthHTTPClient(server Server) (*http.Client, error) {
 		httpClient: http.DefaultClient,
 		now:        time.Now,
 	}
-	return mcpHTTPClient(server, newOAuthRoundTripper(http.DefaultTransport, source, server.Name)), nil
+	return mcpHTTPClient(server, newOAuthRoundTripper(mcpTransport, source, server.Name)), nil
 }

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -18,18 +18,20 @@ import (
 
 type networkClient struct {
 	server Server
-	// client is the bounded client (mcpTransport, 30s ResponseHeaderTimeout)
-	// used for initialize, tools/list, and notifications, which are all
-	// expected to return headers quickly.
-	client *http.Client
-	// toolCallClient is used specifically for tools/call requests. It shares
-	// dial/TLS bounds with client but omits ResponseHeaderTimeout, since a
-	// synchronous tool handler may not write headers until its (potentially
-	// long-running) work completes. See mcpToolCallTransport's doc comment.
-	toolCallClient *http.Client
-	mu             sync.Mutex
-	nextID         int
-	sessionID      string
+	// toolHTTP dispatches every request through http_clients.go's dual
+	// Streaming/Bounded client infrastructure: Bounded (backed by
+	// mcpTransport, 30s ResponseHeaderTimeout) for initialize, tools/list,
+	// and notifications, which are all expected to return headers quickly;
+	// Streaming (backed by mcpToolCallTransport, no ResponseHeaderTimeout)
+	// for tools/call, guarded instead by an idle-read watchdog. Both
+	// underlying clients are already wrapped with this server's OAuth
+	// bearer round tripper and cross-origin redirect guard (see
+	// connectNetwork), which is why they are built here rather than via
+	// http_clients.go's bare NewHTTPClients.
+	toolHTTP  *ToolHTTP
+	mu        sync.Mutex
+	nextID    int
+	sessionID string
 }
 
 type remoteSSEClient struct {
@@ -64,11 +66,14 @@ func connectNetwork(ctx context.Context, server Server) (ToolClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	toolHTTP := NewToolHTTP(NewHTTPClientsFromClients(toolCallClient, httpClient, HTTPClientConfig{
+		StreamIdleTimeout:  toolCallIdleTimeout,
+		DefaultExecTimeout: mcpResponseHeaderTimeout,
+	}))
 	client := &networkClient{
-		server:         server,
-		client:         httpClient,
-		toolCallClient: toolCallClient,
-		nextID:         1,
+		server:   server,
+		toolHTTP: toolHTTP,
+		nextID:   1,
 	}
 	if err := client.initialize(ctx); err != nil {
 		return nil, fmt.Errorf("initialize MCP server %s: %w", server.Name, err)
@@ -341,84 +346,35 @@ func (client *remoteSSEClient) notify(ctx context.Context, method string, params
 	})
 }
 
-// classifyToolCall reports whether method is a tools/call request, which is
-// routed through the unbounded-response-header toolCallClient instead of the
-// bounded client. See mcpToolCallTransport's doc comment for why.
-func classifyToolCall(method string) bool {
+// isToolCallMethod reports whether method is a tools/call request, which is
+// routed through the Streaming client (mcpToolCallTransport, no
+// ResponseHeaderTimeout, idle-watched) instead of the Bounded client. See
+// mcpToolCallTransport's doc comment for why. Named distinctly from
+// http_clients.go's exported ClassifyToolCall -- that function classifies by
+// HTTP request headers and cannot be reused here because MCP sends the same
+// Accept header on every POST regardless of JSON-RPC method (see
+// ClassifyToolCall's doc comment).
+func isToolCallMethod(method string) bool {
 	return method == "tools/call"
+}
+
+// toolCallTypeFor maps a JSON-RPC method name to the ToolCallType consumed by
+// ToolHTTP.Do, so networkClient can reuse http_clients.go's classify/timeout/
+// idle-watchdog engine while classifying by method name instead of request
+// headers.
+func toolCallTypeFor(method string) ToolCallType {
+	if isToolCallMethod(method) {
+		return ToolCallStreaming
+	}
+	return ToolCallFinite
 }
 
 // toolCallIdleTimeout bounds how long a tools/call response body may go
 // without forward read progress before it is aborted. It intentionally does
 // not bound total call duration -- a slow-but-steadily-streaming tool is
-// never cut off -- only a fully stalled connection is.
+// never cut off -- only a fully stalled connection is. Fed into toolHTTP's
+// HTTPClientConfig.StreamIdleTimeout in connectNetwork.
 const toolCallIdleTimeout = 10 * time.Minute
-
-// idleWatchdogReadCloser wraps a response body and cancels the associated
-// request context if no Read makes progress within idle. This guards
-// tools/call responses (which use a transport with no ResponseHeaderTimeout)
-// against a connection that goes completely silent, without imposing any
-// cap on overall response time.
-type idleWatchdogReadCloser struct {
-	body   io.ReadCloser
-	idle   time.Duration
-	cancel context.CancelFunc
-
-	mu      sync.Mutex
-	timer   *time.Timer
-	stopped bool
-}
-
-// newToolCallIdleWatchdog wraps body in an idleWatchdogReadCloser for
-// networkClient's tools/call responses. Named distinctly from
-// http_clients.go's newIdleWatchdogReadCloser (a separate, not-yet-wired
-// mechanism added concurrently in this package) to avoid a duplicate
-// declaration build failure.
-func newToolCallIdleWatchdog(body io.ReadCloser, idle time.Duration, cancel context.CancelFunc) *idleWatchdogReadCloser {
-	watchdog := &idleWatchdogReadCloser{body: body, idle: idle, cancel: cancel}
-	watchdog.timer = time.AfterFunc(idle, watchdog.onIdle)
-	return watchdog
-}
-
-func (watchdog *idleWatchdogReadCloser) onIdle() {
-	watchdog.mu.Lock()
-	defer watchdog.mu.Unlock()
-	if watchdog.stopped {
-		return
-	}
-	// Canceling the request context unblocks the in-flight Read on body with
-	// a context.Canceled error once the transport observes it.
-	if watchdog.cancel != nil {
-		watchdog.cancel()
-	}
-}
-
-func (watchdog *idleWatchdogReadCloser) Read(buffer []byte) (int, error) {
-	n, err := watchdog.body.Read(buffer)
-
-	watchdog.mu.Lock()
-	if !watchdog.stopped {
-		watchdog.timer.Reset(watchdog.idle)
-	}
-	watchdog.mu.Unlock()
-
-	return n, err
-}
-
-func (watchdog *idleWatchdogReadCloser) Close() error {
-	watchdog.mu.Lock()
-	watchdog.stopped = true
-	watchdog.mu.Unlock()
-	watchdog.timer.Stop()
-	return watchdog.body.Close()
-}
-
-func (client *networkClient) httpClientFor(method string) *http.Client {
-	if classifyToolCall(method) && client.toolCallClient != nil {
-		return client.toolCallClient
-	}
-	return client.client
-}
 
 func (client *networkClient) post(ctx context.Context, message rpcMessage, expectResponse bool) (result rpcMessage, err error) {
 	body, err := json.Marshal(message)
@@ -426,34 +382,19 @@ func (client *networkClient) post(ctx context.Context, message rpcMessage, expec
 		return rpcMessage{}, err
 	}
 
-	// tools/call requests use a cancelable context so the idle watchdog below
-	// can unblock a stalled read; the request itself carries no deadline, so
-	// a slow-but-alive tool is never cut off purely on elapsed time.
-	requestCtx := ctx
-	var cancel context.CancelFunc
-	toolCall := classifyToolCall(message.Method)
-	if toolCall {
-		requestCtx, cancel = context.WithCancel(ctx)
-		defer func() {
-			if cancel != nil {
-				cancel()
-			}
-		}()
-	}
-
-	request, err := http.NewRequestWithContext(requestCtx, http.MethodPost, client.server.URL, bytes.NewReader(body))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, client.server.URL, bytes.NewReader(body))
 	if err != nil {
 		return rpcMessage{}, fmt.Errorf("create MCP %s request for %s: %w", client.server.Type, client.server.Name, err)
 	}
 	client.applyHeaders(request)
 
-	response, err := client.httpClientFor(message.Method).Do(request)
+	// toolHTTP.Do handles both the finite case (bounded client, context
+	// deadline) and the streaming case (unbounded client, idle-read
+	// watchdog) internally -- see http_clients.go -- so no per-call
+	// context/cancel/watchdog wiring is needed here.
+	response, err := client.toolHTTP.Do(ctx, request, toolCallTypeFor(message.Method), nil)
 	if err != nil {
 		return rpcMessage{}, fmt.Errorf("call MCP %s server %s: %w", client.server.Type, client.server.Name, err)
-	}
-
-	if toolCall {
-		response.Body = newToolCallIdleWatchdog(response.Body, toolCallIdleTimeout, cancel)
 	}
 	defer closeResponseBody(&err, client.server, response.Body)
 

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -17,11 +17,19 @@ import (
 )
 
 type networkClient struct {
-	server    Server
-	client    *http.Client
-	mu        sync.Mutex
-	nextID    int
-	sessionID string
+	server Server
+	// client is the bounded client (mcpTransport, 30s ResponseHeaderTimeout)
+	// used for initialize, tools/list, and notifications, which are all
+	// expected to return headers quickly.
+	client *http.Client
+	// toolCallClient is used specifically for tools/call requests. It shares
+	// dial/TLS bounds with client but omits ResponseHeaderTimeout, since a
+	// synchronous tool handler may not write headers until its (potentially
+	// long-running) work completes. See mcpToolCallTransport's doc comment.
+	toolCallClient *http.Client
+	mu             sync.Mutex
+	nextID         int
+	sessionID      string
 }
 
 type remoteSSEClient struct {
@@ -48,14 +56,19 @@ type sseEvent struct {
 }
 
 func connectNetwork(ctx context.Context, server Server) (ToolClient, error) {
-	httpClient, err := oauthHTTPClient(server)
+	httpClient, err := oauthHTTPClient(server, mcpTransport)
+	if err != nil {
+		return nil, err
+	}
+	toolCallClient, err := oauthHTTPClient(server, mcpToolCallTransport)
 	if err != nil {
 		return nil, err
 	}
 	client := &networkClient{
-		server: server,
-		client: httpClient,
-		nextID: 1,
+		server:         server,
+		client:         httpClient,
+		toolCallClient: toolCallClient,
+		nextID:         1,
 	}
 	if err := client.initialize(ctx); err != nil {
 		return nil, fmt.Errorf("initialize MCP server %s: %w", server.Name, err)
@@ -64,7 +77,7 @@ func connectNetwork(ctx context.Context, server Server) (ToolClient, error) {
 }
 
 func connectRemoteSSE(ctx context.Context, server Server) (ToolClient, error) {
-	httpClient, err := oauthHTTPClient(server)
+	httpClient, err := oauthHTTPClient(server, mcpTransport)
 	if err != nil {
 		return nil, err
 	}
@@ -328,20 +341,114 @@ func (client *remoteSSEClient) notify(ctx context.Context, method string, params
 	})
 }
 
+// classifyToolCall reports whether method is a tools/call request, which is
+// routed through the unbounded-response-header toolCallClient instead of the
+// bounded client. See mcpToolCallTransport's doc comment for why.
+func classifyToolCall(method string) bool {
+	return method == "tools/call"
+}
+
+// toolCallIdleTimeout bounds how long a tools/call response body may go
+// without forward read progress before it is aborted. It intentionally does
+// not bound total call duration -- a slow-but-steadily-streaming tool is
+// never cut off -- only a fully stalled connection is.
+const toolCallIdleTimeout = 10 * time.Minute
+
+// idleWatchdogReadCloser wraps a response body and cancels the associated
+// request context if no Read makes progress within idle. This guards
+// tools/call responses (which use a transport with no ResponseHeaderTimeout)
+// against a connection that goes completely silent, without imposing any
+// cap on overall response time.
+type idleWatchdogReadCloser struct {
+	body   io.ReadCloser
+	idle   time.Duration
+	cancel context.CancelFunc
+
+	mu      sync.Mutex
+	timer   *time.Timer
+	stopped bool
+}
+
+func newIdleWatchdogReadCloser(body io.ReadCloser, idle time.Duration, cancel context.CancelFunc) *idleWatchdogReadCloser {
+	watchdog := &idleWatchdogReadCloser{body: body, idle: idle, cancel: cancel}
+	watchdog.timer = time.AfterFunc(idle, watchdog.onIdle)
+	return watchdog
+}
+
+func (watchdog *idleWatchdogReadCloser) onIdle() {
+	watchdog.mu.Lock()
+	defer watchdog.mu.Unlock()
+	if watchdog.stopped {
+		return
+	}
+	// Canceling the request context unblocks the in-flight Read on body with
+	// a context.Canceled error once the transport observes it.
+	if watchdog.cancel != nil {
+		watchdog.cancel()
+	}
+}
+
+func (watchdog *idleWatchdogReadCloser) Read(buffer []byte) (int, error) {
+	n, err := watchdog.body.Read(buffer)
+
+	watchdog.mu.Lock()
+	if !watchdog.stopped {
+		watchdog.timer.Reset(watchdog.idle)
+	}
+	watchdog.mu.Unlock()
+
+	return n, err
+}
+
+func (watchdog *idleWatchdogReadCloser) Close() error {
+	watchdog.mu.Lock()
+	watchdog.stopped = true
+	watchdog.mu.Unlock()
+	watchdog.timer.Stop()
+	return watchdog.body.Close()
+}
+
+func (client *networkClient) httpClientFor(method string) *http.Client {
+	if classifyToolCall(method) && client.toolCallClient != nil {
+		return client.toolCallClient
+	}
+	return client.client
+}
+
 func (client *networkClient) post(ctx context.Context, message rpcMessage, expectResponse bool) (result rpcMessage, err error) {
 	body, err := json.Marshal(message)
 	if err != nil {
 		return rpcMessage{}, err
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, client.server.URL, bytes.NewReader(body))
+
+	// tools/call requests use a cancelable context so the idle watchdog below
+	// can unblock a stalled read; the request itself carries no deadline, so
+	// a slow-but-alive tool is never cut off purely on elapsed time.
+	requestCtx := ctx
+	var cancel context.CancelFunc
+	toolCall := classifyToolCall(message.Method)
+	if toolCall {
+		requestCtx, cancel = context.WithCancel(ctx)
+		defer func() {
+			if cancel != nil {
+				cancel()
+			}
+		}()
+	}
+
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodPost, client.server.URL, bytes.NewReader(body))
 	if err != nil {
 		return rpcMessage{}, fmt.Errorf("create MCP %s request for %s: %w", client.server.Type, client.server.Name, err)
 	}
 	client.applyHeaders(request)
 
-	response, err := client.client.Do(request)
+	response, err := client.httpClientFor(message.Method).Do(request)
 	if err != nil {
 		return rpcMessage{}, fmt.Errorf("call MCP %s server %s: %w", client.server.Type, client.server.Name, err)
+	}
+
+	if toolCall {
+		response.Body = newIdleWatchdogReadCloser(response.Body, toolCallIdleTimeout, cancel)
 	}
 	defer closeResponseBody(&err, client.server, response.Body)
 
@@ -646,7 +753,7 @@ func decodeSSERPCMessage(reader io.Reader) (rpcMessage, error) {
 		}
 		// The POST's event stream may carry server-initiated notifications or
 		// requests (which have a method) before the response to our request. Skip
-		// those — the response has no method — and keep scanning. Previously the
+		// those -- the response has no method -- and keep scanning. Previously the
 		// first message event was returned unconditionally, so a leading
 		// notification surfaced to the caller as an id mismatch and failed the call.
 		if candidate.Method != "" {
@@ -893,10 +1000,16 @@ func (source *storeTokenSource) Refresh(ctx context.Context) (string, error) {
 
 // oauthHTTPClient returns an HTTP client whose transport attaches OAuth bearer
 // tokens and refreshes them on 401 for OAuth-configured servers. Servers that do
-// not declare OAuth use the default transport with the same MCP redirect guard.
-func oauthHTTPClient(server Server) (*http.Client, error) {
+// not declare OAuth use the given transport directly with the same MCP
+// redirect guard. transport selects the connection-boundary policy (see
+// mcpTransport vs mcpToolCallTransport); pass nil to use the default bounded
+// mcpTransport.
+func oauthHTTPClient(server Server, transport http.RoundTripper) (*http.Client, error) {
+	if transport == nil {
+		transport = mcpTransport
+	}
 	if !strings.EqualFold(strings.TrimSpace(server.Auth), ServerAuthOAuth) {
-		return mcpHTTPClient(server, nil), nil
+		return mcpHTTPClient(server, transport), nil
 	}
 	store, err := NewTokenStore(TokenStoreOptions{})
 	if err != nil {
@@ -908,5 +1021,5 @@ func oauthHTTPClient(server Server) (*http.Client, error) {
 		httpClient: http.DefaultClient,
 		now:        time.Now,
 	}
-	return mcpHTTPClient(server, newOAuthRoundTripper(mcpTransport, source, server.Name)), nil
+	return mcpHTTPClient(server, newOAuthRoundTripper(transport, source, server.Name)), nil
 }

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -68,9 +68,13 @@ func connectRemoteSSE(ctx context.Context, server Server) (ToolClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Shallow-copy the shared client to inherit its transport configuration
+	// while stripping the end-to-end timeout for persistent SSE streaming.
+	sseClient := *httpClient
+	sseClient.Timeout = 0
 	client := &remoteSSEClient{
 		server:  server,
-		client:  httpClient,
+		client:  &sseClient,
 		nextID:  1,
 		pending: map[string]chan ssePendingResponse{},
 	}

--- a/internal/mcp/network_redirect.go
+++ b/internal/mcp/network_redirect.go
@@ -49,9 +49,10 @@ var mcpTransport http.RoundTripper = newMCPTransport()
 // transport level -- the same class of premature-timeout regression that the
 // end-to-end http.Client.Timeout previously caused, just relocated. Dial and
 // TLS handshake bounds are kept so a genuinely dead server still fails fast;
-// only the response-header wait is left unbounded. The networkClient guards
-// the resulting unbounded wait with an idle watchdog on the response body
-// (see idleWatchdogReadCloser) instead of a hard deadline, so forward
+// only the response-header wait is left unbounded. networkClient wraps this
+// transport as the Streaming client of a *ToolHTTP (see http_clients.go and
+// connectNetwork), which guards the resulting unbounded wait with an idle
+// watchdog on the response body instead of a hard deadline, so forward
 // progress is required but total duration is not capped.
 var mcpToolCallTransport http.RoundTripper = newMCPToolCallTransport()
 
@@ -148,10 +149,25 @@ func mcpOrigin(value *url.URL) string {
 // If execTimeout is nil, defaults (30s for finite, unbounded for streaming) apply.
 //
 // This bridges to the header/query-based classification in http_clients.go
-// (ClassifyToolCall/DoToolHTTPRequest), a separate mechanism from
-// networkClient's own method-name-based classifyToolCall/httpClientFor. It is
-// not yet called by networkClient -- see the package-level architecture note
-// for the pending decision on consolidating the two.
+// (ClassifyToolCall/DoToolHTTPRequest). It is a generic, server-agnostic
+// entry point for callers with no more specific way to classify a request
+// (e.g. no JSON-RPC method name to inspect), and it builds its own
+// unauthenticated, non-redirect-guarded client pair via NewDefaultToolHTTP on
+// every call.
+//
+// MCP's own networkClient does NOT call routeAndDo. Every MCP POST --
+// tools/call included -- sends an identical
+// `Accept: application/json, text/event-stream` header per the Streamable
+// HTTP spec, so ClassifyToolCall's header-based heuristic cannot distinguish
+// a tools/call request from initialize/tools/list/notifications here.
+// Instead, networkClient builds its own long-lived *ToolHTTP in
+// connectNetwork (see network_client.go) over http.Clients that already
+// carry this server's OAuth bearer round tripper and cross-origin redirect
+// guard (mcpHTTPClient/oauthHTTPClient above), and classifies by JSON-RPC
+// method name (toolCallTypeFor) before calling ToolHTTP.Do directly --
+// reusing the same classify/timeout/idle-watchdog engine as this function,
+// without routing through the request-header path or rebuilding transports
+// per call.
 func routeAndDo(ctx context.Context, req *http.Request, execTimeout *time.Duration) (*http.Response, error) {
 	return DoToolHTTPRequest(ctx, req, execTimeout)
 }

--- a/internal/mcp/network_redirect.go
+++ b/internal/mcp/network_redirect.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -141,4 +142,16 @@ func mcpOrigin(value *url.URL) string {
 		return host
 	}
 	return strings.ToLower(value.Scheme) + "://" + host
+}
+
+// routeAndDo performs the HTTP request using streaming vs finite semantics based on req.
+// If execTimeout is nil, defaults (30s for finite, unbounded for streaming) apply.
+//
+// This bridges to the header/query-based classification in http_clients.go
+// (ClassifyToolCall/DoToolHTTPRequest), a separate mechanism from
+// networkClient's own method-name-based classifyToolCall/httpClientFor. It is
+// not yet called by networkClient -- see the package-level architecture note
+// for the pending decision on consolidating the two.
+func routeAndDo(ctx context.Context, req *http.Request, execTimeout *time.Duration) (*http.Response, error) {
+	return DoToolHTTPRequest(ctx, req, execTimeout)
 }

--- a/internal/mcp/network_redirect.go
+++ b/internal/mcp/network_redirect.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -35,7 +34,25 @@ const mcpResponseHeaderTimeout = 30 * time.Second
 // Connection setup is bounded here instead of via http.Client.Timeout, so a
 // slow or unreachable server fails fast without capping the total lifetime
 // of a legitimate long-running or streamed tool call.
+//
+// This transport is used for every MCP call EXCEPT tools/call: initialize,
+// tools/list, and notifications are all expected to return response headers
+// quickly, so bounding that wait here is safe and gives fast failure against
+// a dead or misbehaving server.
 var mcpTransport http.RoundTripper = newMCPTransport()
+
+// mcpToolCallTransport is used specifically for tools/call requests. Some MCP
+// tool servers are synchronous and do not write response headers until the
+// (potentially long-running) tool finishes, so reusing mcpTransport's
+// ResponseHeaderTimeout here would fail a slow-but-alive tool call at the
+// transport level -- the same class of premature-timeout regression that the
+// end-to-end http.Client.Timeout previously caused, just relocated. Dial and
+// TLS handshake bounds are kept so a genuinely dead server still fails fast;
+// only the response-header wait is left unbounded. The networkClient guards
+// the resulting unbounded wait with an idle watchdog on the response body
+// (see idleWatchdogReadCloser) instead of a hard deadline, so forward
+// progress is required but total duration is not capped.
+var mcpToolCallTransport http.RoundTripper = newMCPToolCallTransport()
 
 func newMCPTransport() *http.Transport {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
@@ -45,6 +62,18 @@ func newMCPTransport() *http.Transport {
 	}).DialContext
 	transport.TLSHandshakeTimeout = mcpTLSHandshakeTimeout
 	transport.ResponseHeaderTimeout = mcpResponseHeaderTimeout
+	return transport
+}
+
+func newMCPToolCallTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   mcpDialTimeout,
+		KeepAlive: mcpDialKeepAlive,
+	}).DialContext
+	transport.TLSHandshakeTimeout = mcpTLSHandshakeTimeout
+	// Intentionally no ResponseHeaderTimeout: see the doc comment on
+	// mcpToolCallTransport above.
 	return transport
 }
 
@@ -112,10 +141,4 @@ func mcpOrigin(value *url.URL) string {
 		return host
 	}
 	return strings.ToLower(value.Scheme) + "://" + host
-}
-
-// routeAndDo performs the HTTP request using streaming vs finite semantics based on req.
-// If execTimeout is nil, defaults (30s for finite, unbounded for streaming) apply.
-func routeAndDo(ctx context.Context, req *http.Request, execTimeout *time.Duration) (*http.Response, error) {
-	return DoToolHTTPRequest(ctx, req, execTimeout)
 }

--- a/internal/mcp/network_redirect.go
+++ b/internal/mcp/network_redirect.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 const maxMCPRedirects = 10
@@ -14,6 +15,7 @@ func mcpHTTPClient(server Server, transport http.RoundTripper) *http.Client {
 	return &http.Client{
 		Transport:     transport,
 		CheckRedirect: checkMCPRedirect(server),
+		Timeout:       30 * time.Second,
 	}
 }
 

--- a/internal/mcp/network_redirect.go
+++ b/internal/mcp/network_redirect.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -111,4 +112,10 @@ func mcpOrigin(value *url.URL) string {
 		return host
 	}
 	return strings.ToLower(value.Scheme) + "://" + host
+}
+
+// routeAndDo performs the HTTP request using streaming vs finite semantics based on req.
+// If execTimeout is nil, defaults (30s for finite, unbounded for streaming) apply.
+func routeAndDo(ctx context.Context, req *http.Request, execTimeout *time.Duration) (*http.Response, error) {
+	return DoToolHTTPRequest(ctx, req, execTimeout)
 }

--- a/internal/mcp/network_redirect.go
+++ b/internal/mcp/network_redirect.go
@@ -11,11 +11,49 @@ import (
 
 const maxMCPRedirects = 10
 
+// mcpDialTimeout bounds establishing the TCP connection to an MCP server.
+const mcpDialTimeout = 10 * time.Second
+
+// mcpDialKeepAlive matches net/http's DefaultTransport dialer so idle
+// connection health checks behave the same as the rest of the process.
+const mcpDialKeepAlive = 30 * time.Second
+
+// mcpTLSHandshakeTimeout bounds completing the TLS handshake once connected.
+const mcpTLSHandshakeTimeout = 10 * time.Second
+
+// mcpResponseHeaderTimeout bounds waiting for response headers after the
+// request has been written. It does not bound reading the response body, so
+// a long-running or streamed tool call is not cut off once the server starts
+// responding.
+const mcpResponseHeaderTimeout = 30 * time.Second
+
+// mcpTransport is the default RoundTripper for MCP HTTP clients. It clones
+// http.DefaultTransport -- preserving proxy-from-environment, HTTP/2
+// negotiation, and idle connection pooling -- and only tightens the
+// connection-establishment timeouts and adds a response-header timeout.
+// Connection setup is bounded here instead of via http.Client.Timeout, so a
+// slow or unreachable server fails fast without capping the total lifetime
+// of a legitimate long-running or streamed tool call.
+var mcpTransport http.RoundTripper = newMCPTransport()
+
+func newMCPTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   mcpDialTimeout,
+		KeepAlive: mcpDialKeepAlive,
+	}).DialContext
+	transport.TLSHandshakeTimeout = mcpTLSHandshakeTimeout
+	transport.ResponseHeaderTimeout = mcpResponseHeaderTimeout
+	return transport
+}
+
 func mcpHTTPClient(server Server, transport http.RoundTripper) *http.Client {
+	if transport == nil {
+		transport = mcpTransport
+	}
 	return &http.Client{
 		Transport:     transport,
 		CheckRedirect: checkMCPRedirect(server),
-		Timeout:       30 * time.Second,
 	}
 }
 


### PR DESCRIPTION
While reviewing the network routing logic and workflow pipeline definitions, I noticed a few spots where unexpected stalls could block automation execution or network sockets.

Context and impact:
: The internal mcpHTTPClient helper initializes an http.Client without an explicit timeout, which defaults to no limit. A slow or dropped network connection during redirect checks can cause the process to hang indefinitely.
: The release-artifacts workflow lacks a concurrency guard, allowing rapid tag updates to trigger overlapping artifact promotion jobs.
: Multiple test and security jobs in the primary workflows do not declare execution limits, risking runaway runner utilization under rare failure modes.

Changes introduced:
: Set a structural 30-second timeout on the internal MCP HTTP client instance.
: Add a top-level concurrency group to the release pipeline with cancel-in-progress enabled.
: Enforce standard 30-minute job-level timeouts across the core verification and build pipelines.

Stability benefits:
: Guarantees clean socket disposal on network stalls, prevents pipeline overlap during releases, and ensures predictable fast-fail boundaries across CI matrices.

SSE regression fix:
: For long-lived SSE connections, a shallow-copied http.Client is used that inherits transports/redirect policies but strips the end-to-end Timeout, preventing premature stream termination.

Parent issue: #540 (issue-approved)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added execution time limits across CI, release, and artifact publishing to reduce hangs.
  * Improved release/publish run control to avoid overlapping executions for the same ref (with in-progress cancellation).
  * Hardened MCP networking with tighter connect/TLS/response-header timeouts.
  * Ensured long-lived SSE streams aren’t cut off by shared HTTP timeouts.
  * Improved MCP request handling with idle cancellation for streaming and deadline-respecting behavior for finite calls.
* **Tests**
  * Added automated coverage for MCP timeout and idle-watchdog scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->