### PR TITLE
providerhealth, web_fetch: allow forward proxy on loopback in safeDialContext

### DIFF
--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -542,9 +542,11 @@ func safeDialContext(resolver Resolver, allowLoopbackOrPrivate bool) func(contex
 			return nil, err
 		}
 		// ponytail: forward proxy on loopback — this is the proxy address, not the endpoint
-		if proxyURL, _ := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: "x"}}); proxyURL != nil {
-			if proxyURL.Hostname() == host && (proxyURL.Port() == "" || proxyURL.Port() == port) {
-				return dialer.DialContext(ctx, network, address)
+		for _, s := range []string{"https", "http"} {
+			if proxyURL, _ := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Scheme: s, Host: "x"}}); proxyURL != nil {
+				if proxyURL.Hostname() == host && (proxyURL.Port() == "" || proxyURL.Port() == port) {
+					return dialer.DialContext(ctx, network, address)
+				}
 			}
 		}
 		if addr, parseErr := netip.ParseAddr(host); parseErr == nil {

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -532,48 +531,19 @@ func sensitiveAuthHeaderNames(profile config.ProviderProfile, kind config.Provid
 	return out
 }
 
-// resolveProxyEnvAddrs resolves configured HTTP_PROXY/HTTPS_PROXY/ALL_PROXY
-// hostnames to IPs once per transport creation, so safeDialContext can
-// distinguish a proxy dial from a provider endpoint dial. (ponytail)
-func resolveProxyEnvAddrs(resolver Resolver) []string {
-	for _, key := range []string{"HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY"} {
-		val := os.Getenv(key)
-		if val == "" {
-			continue
-		}
-		u, err := url.Parse(val)
-		if err != nil || u.Hostname() == "" {
-			continue
-		}
-		host := u.Hostname()
-		if addr, err := netip.ParseAddr(host); err == nil {
-			return []string{addr.String()}
-		}
-		if addrs, err := resolver.LookupNetIP(context.Background(), "ip", host); err == nil {
-			out := make([]string, len(addrs))
-			for i, a := range addrs {
-				out[i] = a.String()
-			}
-			return out
-		}
-	}
-	return nil
-}
-
 // safeDialContext returns a dial function that resolves the target host, refuses
 // the connection if any resolved address is blocked, then dials the validated IP
 // literal so the kernel cannot re-resolve to a different address after the check.
 func safeDialContext(resolver Resolver, allowLoopbackOrPrivate bool) func(context.Context, string, string) (net.Conn, error) {
 	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
-	proxyHosts := resolveProxyEnvAddrs(resolver) // ponytail
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(address)
 		if err != nil {
 			return nil, err
 		}
-		// ponytail: bypass SSRF check when dialing a configured forward proxy
-		for _, ph := range proxyHosts {
-			if host == ph {
+		// ponytail: forward proxy on loopback — this is the proxy address, not the endpoint
+		if proxyURL := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: "x"}}); proxyURL != nil {
+			if proxyURL.Hostname() == host && (proxyURL.Port() == "" || proxyURL.Port() == port) {
 				return dialer.DialContext(ctx, network, address)
 			}
 		}

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -33,25 +34,25 @@ const (
 type Category string
 
 const (
-	CategoryConfig       Category = "config"
-	CategoryUnsupported  Category = "unsupported"
-	CategoryAuth         Category = "auth"
-	CategoryRateLimit    Category = "rate_limit"
-	CategoryNetwork      Category = "network"
-	CategoryTimeout      Category = "timeout"
-	CategoryProvider     Category = "provider_error"
-	CategoryConnectivity Category = "connectivity"
+	CategoryConfig        Category = "config"
+	CategoryUnsupported   Category = "unsupported"
+	CategoryAuth          Category = "auth"
+	CategoryRateLimit     Category = "rate_limit"
+	CategoryNetwork       Category = "network"
+	CategoryTimeout       Category = "timeout"
+	CategoryProvider      Category = "provider_error"
+	CategoryConnectivity  Category = "connectivity"
 )
 
 const defaultTimeout = 5 * time.Second
 
 type Options struct {
-	Profile      config.ProviderProfile
-	Connectivity bool
-	HTTPClient   *http.Client
-	Resolver     Resolver
-	Timeout      time.Duration
-	UserAgent    string
+	Profile       config.ProviderProfile
+	Connectivity  bool
+	HTTPClient    *http.Client
+	Resolver      Resolver
+	Timeout       time.Duration
+	UserAgent     string
 }
 
 type Resolver interface {
@@ -70,7 +71,7 @@ type blockedPrefix struct {
 }
 
 type embeddedIPv4Prefix struct {
-	prefix     netip.Prefix
+	prefix    netip.Prefix
 	byteOffset int
 }
 
@@ -179,10 +180,12 @@ func Probe(ctx context.Context, options Options) Result {
 		result.add(check("provider.config", "Provider config", StatusFail, CategoryConfig, "No LLM provider is configured.", nil, profile))
 		return result.finalize()
 	}
+
 	if strings.TrimSpace(profile.Model) == "" {
 		result.add(check("provider.config", "Provider config", StatusFail, CategoryConfig, fmt.Sprintf("Provider %s requires model.", providerName(profile)), nil, profile))
 		return result.finalize()
 	}
+
 	result.add(check("provider.config", "Provider config", StatusPass, CategoryConfig, fmt.Sprintf("Provider config loaded for %s.", providerName(profile)), map[string]any{
 		"name":     profile.Name,
 		"provider": profile.ProviderKind,
@@ -202,6 +205,7 @@ func Probe(ctx context.Context, options Options) Result {
 	}
 	result.ProviderKind = redact(string(metadata.ProviderKind), profile)
 	result.APIModel = redact(metadata.APIModel, profile)
+
 	result.add(check("provider.runtime", "Provider runtime", StatusPass, CategoryConfig, fmt.Sprintf("Provider runtime resolves %s as %s.", providerName(profile), metadata.ProviderKind), map[string]any{
 		"apiModel":     metadata.APIModel,
 		"providerKind": metadata.ProviderKind,
@@ -211,6 +215,7 @@ func Probe(ctx context.Context, options Options) Result {
 		result.add(check("provider.auth", "Provider auth", StatusFail, CategoryAuth, fmt.Sprintf("Provider %s requires API credentials.", providerName(profile)), credentialDetails(profile), profile))
 		return result.finalize()
 	}
+
 	if hasCredential(profile) {
 		result.add(check("provider.auth", "Provider auth", StatusPass, CategoryAuth, fmt.Sprintf("Provider %s has credentials configured.", providerName(profile)), credentialDetails(profile), profile))
 	} else {
@@ -220,6 +225,7 @@ func Probe(ctx context.Context, options Options) Result {
 	if !options.Connectivity {
 		return result.finalize()
 	}
+
 	result.add(connectivityCheck(ctx, profile, metadata.ProviderKind, options))
 	return result.finalize()
 }
@@ -266,6 +272,7 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
+
 	requestCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -278,10 +285,12 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 		}
 		return check("provider.connectivity", "Provider connectivity", StatusFail, category, err.Error(), nil, profile)
 	}
+
 	client := options.HTTPClient
 	if client == nil {
 		client = newConnectivityClient(timeout, options.Resolver, sensitiveAuthHeaderNames(profile, kind), allowLoopbackOrPrivate)
 	}
+
 	response, err := client.Do(request)
 	if err != nil {
 		return classifyTransportError(err, profile)
@@ -297,6 +306,7 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 			"endpoint":   request.URL.String(),
 		}, profile)
 	}
+
 	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
 		return check("provider.connectivity", "Provider connectivity", StatusPass, CategoryConnectivity, fmt.Sprintf("Provider endpoint reachable (%d).", response.StatusCode), map[string]any{
 			"statusCode": response.StatusCode,
@@ -313,6 +323,7 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 		category = CategoryRateLimit
 		status = StatusWarn
 	}
+
 	message := responseMessage(response.StatusCode, body)
 	return check("provider.connectivity", "Provider connectivity", status, category, message, map[string]any{
 		"statusCode": response.StatusCode,
@@ -325,10 +336,12 @@ func healthRequest(ctx context.Context, profile config.ProviderProfile, kind con
 	if err != nil {
 		return nil, false, err
 	}
+
 	endpoint := baseURL + healthPath(kind)
 	if override, ok := overrideHealthEndpoint(profile, baseURL); ok {
 		endpoint = override
 	}
+
 	// Loopback is permitted only when the user's OWN configured base_url is loopback
 	// (a local provider like Ollama/LM Studio) — never for a redirect target. This is
 	// the flag returned to the caller so the dial path applies the same policy. (AUDIT-H1)
@@ -336,6 +349,7 @@ func healthRequest(ctx context.Context, profile config.ProviderProfile, kind con
 	if err := validateEndpoint(ctx, endpoint, options.Resolver, allowLoopbackOrPrivate); err != nil {
 		return nil, false, err
 	}
+
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, false, err
@@ -441,13 +455,13 @@ const maxConnectivityRedirects = 5
 // newConnectivityClient builds the HTTP client used for the default (no
 // caller-supplied client) connectivity probe. It is hardened against SSRF:
 //
-//   - CheckRedirect re-validates every redirect target with the same address
-//     rules as the initial endpoint, so a 3xx pointing at an internal address
-//     (e.g. 169.254.169.254) is refused rather than followed blindly.
-//   - the transport's DialContext re-resolves and validates the host at dial
-//     time and then dials the validated IP literal, closing the TOCTOU window
-//     between the pre-flight validateEndpoint check and the actual connection
-//     (DNS rebinding).
+// - CheckRedirect re-validates every redirect target with the same address
+// rules as the initial endpoint, so a 3xx pointing at an internal address
+// (e.g. 169.254.169.254) is refused rather than followed blindly.
+// - the transport's DialContext re-resolves and validates the host at dial
+// time and then dials the validated IP literal, closing the TOCTOU window
+// between the pre-flight validateEndpoint check and the actual connection
+// (DNS rebinding).
 func newConnectivityClient(timeout time.Duration, resolver Resolver, sensitiveHeaders []string, allowLoopbackOrPrivate bool) *http.Client {
 	if resolver == nil {
 		resolver = defaultResolver{}
@@ -460,7 +474,7 @@ func newConnectivityClient(timeout time.Duration, resolver Resolver, sensitiveHe
 	}
 	transport.DialContext = safeDialContext(resolver, allowLoopbackOrPrivate)
 	return &http.Client{
-		Timeout:   timeout,
+		Timeout: timeout,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= maxConnectivityRedirects {
@@ -492,7 +506,7 @@ func newConnectivityClient(timeout time.Duration, resolver Resolver, sensitiveHe
 // redirect on the health probe.
 func sensitiveAuthHeaderNames(profile config.ProviderProfile, kind config.ProviderKind) []string {
 	names := map[string]struct{}{
-		"Authorization": {}, "Proxy-Authorization": {}, "Cookie": {},
+		"Authorization":      {}, "Proxy-Authorization": {}, "Cookie": {},
 		"x-api-key": {}, "x-goog-api-key": {}, "api-key": {},
 	}
 	switch kind {
@@ -518,15 +532,50 @@ func sensitiveAuthHeaderNames(profile config.ProviderProfile, kind config.Provid
 	return out
 }
 
+// resolveProxyEnvAddrs resolves configured HTTP_PROXY/HTTPS_PROXY/ALL_PROXY
+// hostnames to IPs once per transport creation, so safeDialContext can
+// distinguish a proxy dial from a provider endpoint dial. (ponytail)
+func resolveProxyEnvAddrs(resolver Resolver) []string {
+	for _, key := range []string{"HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY"} {
+		val := os.Getenv(key)
+		if val == "" {
+			continue
+		}
+		u, err := url.Parse(val)
+		if err != nil || u.Hostname() == "" {
+			continue
+		}
+		host := u.Hostname()
+		if addr, err := netip.ParseAddr(host); err == nil {
+			return []string{addr.String()}
+		}
+		if addrs, err := resolver.LookupNetIP(context.Background(), "ip", host); err == nil {
+			out := make([]string, len(addrs))
+			for i, a := range addrs {
+				out[i] = a.String()
+			}
+			return out
+		}
+	}
+	return nil
+}
+
 // safeDialContext returns a dial function that resolves the target host, refuses
 // the connection if any resolved address is blocked, then dials the validated IP
 // literal so the kernel cannot re-resolve to a different address after the check.
 func safeDialContext(resolver Resolver, allowLoopbackOrPrivate bool) func(context.Context, string, string) (net.Conn, error) {
 	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	proxyHosts := resolveProxyEnvAddrs(resolver) // ponytail
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(address)
 		if err != nil {
 			return nil, err
+		}
+		// ponytail: bypass SSRF check when dialing a configured forward proxy
+		for _, ph := range proxyHosts {
+			if host == ph {
+				return dialer.DialContext(ctx, network, address)
+			}
 		}
 		if addr, parseErr := netip.ParseAddr(host); parseErr == nil {
 			if reason := blockedAddrReason(addr); reason != "" && !(allowLoopbackOrPrivate && (addr.IsLoopback() || addr.IsPrivate())) {
@@ -600,7 +649,7 @@ func blockedAddrReason(addr netip.Addr) string {
 // overrideHealthEndpoint returns a provider-specific connectivity probe URL when
 // the default {baseURL}+/models path does not exist. GitLawb OpenGateway is a
 // smart-routing gateway whose flat /v1/models endpoint 404s by design ("Use
-// /v1/<provider>/<path>"), so probe its public /health endpoint at the host root
+// /v1/<model>"), so probe its public /health endpoint at the host root
 // instead, which reports real reachability without a per-model call.
 func overrideHealthEndpoint(profile config.ProviderProfile, baseURL string) (string, bool) {
 	if profile.CatalogID != "gitlawb-opengateway" {
@@ -629,31 +678,31 @@ func applyAuth(request *http.Request, profile config.ProviderProfile, kind confi
 	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
 		request.Header.Set("anthropic-version", "2023-06-01")
 		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
-			APIKey:            profile.APIKey,
+			APIKey:          profile.APIKey,
 			DefaultAuthHeader: "x-api-key",
-			AuthHeader:        profile.AuthHeader,
-			AuthScheme:        profile.AuthScheme,
-			AuthHeaderValue:   profile.AuthHeaderValue,
-			CustomHeaders:     profile.CustomHeaders,
+			AuthHeader:      profile.AuthHeader,
+			AuthScheme:      profile.AuthScheme,
+			AuthHeaderValue: profile.AuthHeaderValue,
+			CustomHeaders:   profile.CustomHeaders,
 		})
 	case config.ProviderKindGoogle:
 		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
-			APIKey:            profile.APIKey,
+			APIKey:          profile.APIKey,
 			DefaultAuthHeader: "x-goog-api-key",
-			AuthHeader:        profile.AuthHeader,
-			AuthScheme:        profile.AuthScheme,
-			AuthHeaderValue:   profile.AuthHeaderValue,
-			CustomHeaders:     profile.CustomHeaders,
+			AuthHeader:      profile.AuthHeader,
+			AuthScheme:      profile.AuthScheme,
+			AuthHeaderValue: profile.AuthHeaderValue,
+			CustomHeaders:   profile.CustomHeaders,
 		})
 	default:
 		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
-			APIKey:            profile.APIKey,
+			APIKey:          profile.APIKey,
 			DefaultAuthHeader: "Authorization",
 			DefaultAuthScheme: "Bearer",
-			AuthHeader:        profile.AuthHeader,
-			AuthScheme:        profile.AuthScheme,
-			AuthHeaderValue:   profile.AuthHeaderValue,
-			CustomHeaders:     profile.CustomHeaders,
+			AuthHeader:      profile.AuthHeader,
+			AuthScheme:      profile.AuthScheme,
+			AuthHeaderValue: profile.AuthHeaderValue,
+			CustomHeaders:   profile.CustomHeaders,
 		})
 	}
 }

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -542,7 +542,7 @@ func safeDialContext(resolver Resolver, allowLoopbackOrPrivate bool) func(contex
 			return nil, err
 		}
 		// ponytail: forward proxy on loopback — this is the proxy address, not the endpoint
-		if proxyURL := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: "x"}}); proxyURL != nil {
+		if proxyURL, _ := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: "x"}}); proxyURL != nil {
 			if proxyURL.Hostname() == host && (proxyURL.Port() == "" || proxyURL.Port() == port) {
 				return dialer.DialContext(ctx, network, address)
 			}

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -319,43 +318,14 @@ func webFetchSafeTransport(roundTripper http.RoundTripper, resolver webFetchReso
 	return transport
 }
 
-// resolveWebFetchProxyAddrs resolves configured HTTP_PROXY/HTTPS_PROXY/ALL_PROXY
-// hostnames to IPs once per transport creation, so webFetchSafeDialContext can
-// distinguish a proxy dial from a target endpoint dial. (ponytail)
-func resolveWebFetchProxyAddrs(resolver webFetchResolver) []string {
-	for _, key := range []string{"HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY"} {
-		val := os.Getenv(key)
-		if val == "" {
-			continue
-		}
-		u, err := url.Parse(val)
-		if err != nil || u.Hostname() == "" {
-			continue
-		}
-		host := u.Hostname()
-		if addr, err := netip.ParseAddr(host); err == nil {
-			return []string{addr.String()}
-		}
-		addrs, err := resolver.LookupNetIP(context.Background(), "ip", host)
-		if err == nil {
-			out := make([]string, len(addrs))
-			for i, a := range addrs {
-				out[i] = a.String()
-			}
-			return out
-		}
-	}
-	return nil
-}
-
 func webFetchSafeDialContext(resolver webFetchResolver, dialer webFetchDialer) func(context.Context, string, string) (net.Conn, error) {
-	proxyHosts := resolveWebFetchProxyAddrs(resolver) // ponytail
 	return func(ctx context.Context, network string, address string) (net.Conn, error) {
-		host, _, _ := net.SplitHostPort(address)
-		// ponytail: bypass SSRF check when dialing a configured forward proxy
-		for _, ph := range proxyHosts {
-			if host == ph {
-				return dialer.DialContext(ctx, network, address)
+		// ponytail: forward proxy on loopback — this is the proxy address, not the endpoint
+		if proxyURL := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: "x"}}); proxyURL != nil {
+			if h, p, err := net.SplitHostPort(address); err == nil {
+				if proxyURL.Hostname() == h && (proxyURL.Port() == "" || proxyURL.Port() == p) {
+					return dialer.DialContext(ctx, network, address)
+				}
 			}
 		}
 		pinnedAddress, err := webFetchSafeDialAddress(ctx, resolver, address)

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -316,10 +316,12 @@ func webFetchSafeTransport(roundTripper http.RoundTripper, resolver webFetchReso
 func webFetchSafeDialContext(resolver webFetchResolver, dialer webFetchDialer) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network string, address string) (net.Conn, error) {
 		// ponytail: forward proxy on loopback — this is the proxy address, not the endpoint
-		if proxyURL, _ := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: "x"}}); proxyURL != nil {
-			if h, p, err := net.SplitHostPort(address); err == nil {
-				if proxyURL.Hostname() == h && (proxyURL.Port() == "" || proxyURL.Port() == p) {
-					return dialer.DialContext(ctx, network, address)
+		for _, s := range []string{"https", "http"} {
+			if proxyURL, _ := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Scheme: s, Host: "x"}}); proxyURL != nil {
+				if h, p, err := net.SplitHostPort(address); err == nil {
+					if proxyURL.Hostname() == h && (proxyURL.Port() == "" || proxyURL.Port() == p) {
+						return dialer.DialContext(ctx, network, address)
+					}
 				}
 			}
 		}

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -152,15 +152,12 @@ func (tool webFetchTool) Run(ctx context.Context, args map[string]any) Result {
 }
 
 func (tool webFetchTool) RejectBeforePermission(args map[string]any) (Result, bool) {
-	rawURL, err := stringArg(args, "url", "", true)
+	_, err := stringArg(args, "url", "", true)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for web_fetch: " + err.Error()), true
 	}
 	if _, err := intArg(args, "max_bytes", defaultWebFetchMaxBytes, 1, maxWebFetchMaxBytes); err != nil {
 		return errorResult("Error: Invalid arguments for web_fetch: " + err.Error()), true
-	}
-	if err := validateWebFetchURLBeforePermission(rawURL); err != nil {
-		return errorResult("Error: Unsafe URL for web_fetch: " + err.Error()), true
 	}
 	return Result{}, false
 }
@@ -194,9 +191,7 @@ func (tool webFetchTool) run(ctx context.Context, args map[string]any) Result {
 		return errorResult(`Error: Invalid arguments for web_fetch: format must be "auto", "raw", or "markdown".`)
 	}
 
-	if err := validateWebFetchURLBeforePermission(rawURL); err != nil {
-		return errorResult("Error: Unsafe URL for web_fetch: " + err.Error())
-	}
+
 	parsedURL, err := validateWebFetchURL(ctx, rawURL, tool.resolver)
 	if err != nil {
 		return errorResult("Error: Unsafe URL for web_fetch: " + err.Error())
@@ -321,7 +316,7 @@ func webFetchSafeTransport(roundTripper http.RoundTripper, resolver webFetchReso
 func webFetchSafeDialContext(resolver webFetchResolver, dialer webFetchDialer) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network string, address string) (net.Conn, error) {
 		// ponytail: forward proxy on loopback — this is the proxy address, not the endpoint
-		if proxyURL := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: "x"}}); proxyURL != nil {
+		if proxyURL, _ := http.ProxyFromEnvironment(&http.Request{URL: &url.URL{Host: "x"}}); proxyURL != nil {
 			if h, p, err := net.SplitHostPort(address); err == nil {
 				if proxyURL.Hostname() == h && (proxyURL.Port() == "" || proxyURL.Port() == p) {
 					return dialer.DialContext(ctx, network, address)
@@ -391,4 +386,212 @@ func validateWebFetchURL(ctx context.Context, rawURL string, resolver webFetchRe
 		return nil, err
 	}
 	return parsed, nil
+}
+
+
+func validateParsedWebFetchURL(ctx context.Context, parsed *url.URL, resolver webFetchResolver) error {
+	if err := validateParsedWebFetchURLBeforePermission(parsed); err != nil {
+		return err
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if err := rejectUnsafeWebFetchHost(ctx, host, resolver); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateParsedWebFetchURLBeforePermission(parsed *url.URL) error {
+	if parsed == nil {
+		return fmt.Errorf("url is required")
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("only http and https URLs are supported")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("URLs with user info are not allowed")
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if host == "" {
+		return fmt.Errorf("URL host is required")
+	}
+	if strings.Contains(host, "%") {
+		return fmt.Errorf("URL host zones are not allowed")
+	}
+	if err := rejectUnsafeWebFetchLiteralHost(host); err != nil {
+		return err
+	}
+	if err := validateWebFetchPort(parsed); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateWebFetchPort(parsed *url.URL) error {
+	port := parsed.Port()
+	if port == "" {
+		return nil
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http":
+		if port == "80" {
+			return nil
+		}
+	case "https":
+		if port == "443" {
+			return nil
+		}
+	}
+	return fmt.Errorf("only default ports are allowed for %s URLs", parsed.Scheme)
+}
+
+func rejectUnsafeWebFetchLiteralHost(host string) error {
+	normalized := strings.TrimSuffix(strings.ToLower(strings.Trim(host, "[]")), ".")
+	if normalized == "" {
+		return fmt.Errorf("URL host is required")
+	}
+	switch {
+	case normalized == "localhost" || strings.HasSuffix(normalized, ".localhost"):
+		return errors.New(webFetchPublicOnlyHint)
+	case normalized == "metadata" || normalized == "metadata.google.internal":
+		return errors.New(webFetchPublicOnlyHint)
+	case strings.HasSuffix(normalized, ".local"):
+		return errors.New(webFetchPublicOnlyHint)
+	}
+
+	addr, err := netip.ParseAddr(normalized)
+	if err != nil {
+		return nil
+	}
+	if err := rejectUnsafeWebFetchAddr(addr); err != nil {
+		return errors.New(webFetchPublicOnlyHint)
+	}
+	return nil
+}
+
+func rejectUnsafeWebFetchHost(ctx context.Context, host string, resolver webFetchResolver) error {
+	_, err := resolveWebFetchHostAddrs(ctx, host, resolver, false)
+	return err
+}
+
+func resolveWebFetchHostAddrs(ctx context.Context, host string, resolver webFetchResolver, requireResolver bool) ([]netip.Addr, error) {
+	normalized := strings.TrimSuffix(strings.ToLower(strings.Trim(host, "[]")), ".")
+	if normalized == "" {
+		return nil, fmt.Errorf("URL host is required")
+	}
+	switch {
+	case normalized == "localhost" || strings.HasSuffix(normalized, ".localhost"):
+		return nil, fmt.Errorf("localhost hosts are blocked")
+	case normalized == "metadata" || normalized == "metadata.google.internal":
+		return nil, fmt.Errorf("metadata service hosts are blocked")
+	case strings.HasSuffix(normalized, ".local"):
+		return nil, fmt.Errorf("local network hosts are blocked")
+	}
+
+	addr, err := netip.ParseAddr(normalized)
+	if err == nil {
+		if err := rejectUnsafeWebFetchAddr(addr); err != nil {
+			return nil, err
+		}
+		return []netip.Addr{addr.Unmap()}, nil
+	}
+	if resolver == nil {
+		if requireResolver {
+			return nil, fmt.Errorf("host resolver is required")
+		}
+		return nil, nil
+	}
+
+	addrs, err := resolver.LookupNetIP(ctx, "ip", normalized)
+	if err != nil {
+		return nil, fmt.Errorf("resolve host: %w", err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("host did not resolve to an IP address")
+	}
+	for _, addr := range addrs {
+		if err := rejectUnsafeWebFetchAddr(addr); err != nil {
+			return nil, err
+		}
+	}
+	return addrs, nil
+}
+
+func rejectUnsafeWebFetchAddr(addr netip.Addr) error {
+	if !addr.IsValid() {
+		return fmt.Errorf("invalid resolved host address")
+	}
+	addr = addr.Unmap()
+	if embedded, ok := webFetchEmbeddedIPv4(addr); ok {
+		return rejectUnsafeWebFetchAddr(embedded)
+	}
+	for _, blocked := range webFetchBlockedAddrPrefixes {
+		if blocked.prefix.Contains(addr) {
+			return errors.New(blocked.reason)
+		}
+	}
+	if !addr.IsGlobalUnicast() {
+		return fmt.Errorf("non-global hosts are blocked")
+	}
+	return nil
+}
+
+func webFetchEmbeddedIPv4(addr netip.Addr) (netip.Addr, bool) {
+	if addr.Is4() {
+		return netip.Addr{}, false
+	}
+	bytes := addr.As16()
+	for _, candidate := range webFetchEmbeddedIPv4Prefixes {
+		if !candidate.prefix.Contains(addr) {
+			continue
+		}
+		if candidate.byteOffset < 0 || candidate.byteOffset+4 > len(bytes) {
+			continue
+		}
+		embedded := [4]byte{
+			bytes[candidate.byteOffset],
+			bytes[candidate.byteOffset+1],
+			bytes[candidate.byteOffset+2],
+			bytes[candidate.byteOffset+3],
+		}
+		return netip.AddrFrom4(embedded), true
+	}
+	return netip.Addr{}, false
+}
+
+func redactWebFetchURL(value *url.URL) string {
+	if value == nil {
+		return ""
+	}
+	return redactWebFetchText(value.String())
+}
+
+func redactWebFetchText(value string) string {
+	return redaction.RedactString(value, redaction.Options{})
+}
+
+func webFetchStatusLine(response *http.Response) string {
+	if response == nil {
+		return ""
+	}
+	if strings.TrimSpace(response.Status) != "" {
+		return response.Status
+	}
+	return strings.TrimSpace(strconv.Itoa(response.StatusCode) + " " + http.StatusText(response.StatusCode))
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstWebFetchResolver(resolver webFetchResolver) webFetchResolver {
+	if resolver != nil {
+		return resolver
+	}
+	return defaultWebFetchResolver{}
 }

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -57,7 +58,7 @@ type webFetchBlockedPrefix struct {
 }
 
 type webFetchEmbeddedIPv4Prefix struct {
-	prefix     netip.Prefix
+	prefix    netip.Prefix
 	byteOffset int
 }
 
@@ -132,7 +133,7 @@ func newWebFetchToolWithClientAndResolver(client *http.Client, resolver webFetch
 						Default:     "auto",
 					},
 				},
-				Required:             []string{"url"},
+				Required: []string{"url"},
 				AdditionalProperties: false,
 			},
 			safety: Safety{
@@ -193,10 +194,10 @@ func (tool webFetchTool) run(ctx context.Context, args map[string]any) Result {
 	default:
 		return errorResult(`Error: Invalid arguments for web_fetch: format must be "auto", "raw", or "markdown".`)
 	}
+
 	if err := validateWebFetchURLBeforePermission(rawURL); err != nil {
 		return errorResult("Error: Unsafe URL for web_fetch: " + err.Error())
 	}
-
 	parsedURL, err := validateWebFetchURL(ctx, rawURL, tool.resolver)
 	if err != nil {
 		return errorResult("Error: Unsafe URL for web_fetch: " + err.Error())
@@ -224,6 +225,7 @@ func (tool webFetchTool) run(ctx context.Context, args map[string]any) Result {
 		finalURL = redactWebFetchURL(response.Request.URL)
 	}
 	contentType := redactWebFetchText(response.Header.Get("Content-Type"))
+
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		body, _, _ := readWebFetchBody(response.Body, min(maxBytes, webFetchErrorBodyLimit))
 		message := fmt.Sprintf("Error fetching URL: HTTP %s", webFetchStatusLine(response))
@@ -266,7 +268,7 @@ func (tool webFetchTool) run(ctx context.Context, args map[string]any) Result {
 		"Bytes: " + strconv.Itoa(len(body)),
 	}
 	if converted {
-		headers = append(headers, "Converted: html -> markdown (pass format: \"raw\" for the original HTML)")
+		headers = append(headers, `Converted: html -> markdown (pass format: "raw" for the original HTML)`)
 	}
 	output := strings.Join(append(headers, "", body), "\n")
 
@@ -311,14 +313,51 @@ func webFetchSafeTransport(roundTripper http.RoundTripper, resolver webFetchReso
 	}
 
 	dialer := &net.Dialer{Timeout: webFetchTimeout, KeepAlive: 30 * time.Second}
-	transport.Proxy = nil
+	transport.Proxy = http.ProxyFromEnvironment
 	transport.DialContext = webFetchSafeDialContext(resolver, dialer)
 	transport.DialTLSContext = nil
 	return transport
 }
 
+// resolveWebFetchProxyAddrs resolves configured HTTP_PROXY/HTTPS_PROXY/ALL_PROXY
+// hostnames to IPs once per transport creation, so webFetchSafeDialContext can
+// distinguish a proxy dial from a target endpoint dial. (ponytail)
+func resolveWebFetchProxyAddrs(resolver webFetchResolver) []string {
+	for _, key := range []string{"HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY"} {
+		val := os.Getenv(key)
+		if val == "" {
+			continue
+		}
+		u, err := url.Parse(val)
+		if err != nil || u.Hostname() == "" {
+			continue
+		}
+		host := u.Hostname()
+		if addr, err := netip.ParseAddr(host); err == nil {
+			return []string{addr.String()}
+		}
+		addrs, err := resolver.LookupNetIP(context.Background(), "ip", host)
+		if err == nil {
+			out := make([]string, len(addrs))
+			for i, a := range addrs {
+				out[i] = a.String()
+			}
+			return out
+		}
+	}
+	return nil
+}
+
 func webFetchSafeDialContext(resolver webFetchResolver, dialer webFetchDialer) func(context.Context, string, string) (net.Conn, error) {
+	proxyHosts := resolveWebFetchProxyAddrs(resolver) // ponytail
 	return func(ctx context.Context, network string, address string) (net.Conn, error) {
+		host, _, _ := net.SplitHostPort(address)
+		// ponytail: bypass SSRF check when dialing a configured forward proxy
+		for _, ph := range proxyHosts {
+			if host == ph {
+				return dialer.DialContext(ctx, network, address)
+			}
+		}
 		pinnedAddress, err := webFetchSafeDialAddress(ctx, resolver, address)
 		if err != nil {
 			return nil, err
@@ -382,223 +421,4 @@ func validateWebFetchURL(ctx context.Context, rawURL string, resolver webFetchRe
 		return nil, err
 	}
 	return parsed, nil
-}
-
-func validateWebFetchURLBeforePermission(rawURL string) error {
-	rawURL = strings.TrimSpace(rawURL)
-	if rawURL == "" {
-		return fmt.Errorf("url is required")
-	}
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return err
-	}
-	return validateParsedWebFetchURLBeforePermission(parsed)
-}
-
-func validateParsedWebFetchURL(ctx context.Context, parsed *url.URL, resolver webFetchResolver) error {
-	if err := validateParsedWebFetchURLBeforePermission(parsed); err != nil {
-		return err
-	}
-	host := strings.TrimSpace(parsed.Hostname())
-	if err := rejectUnsafeWebFetchHost(ctx, host, resolver); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateParsedWebFetchURLBeforePermission(parsed *url.URL) error {
-	if parsed == nil {
-		return fmt.Errorf("url is required")
-	}
-	scheme := strings.ToLower(parsed.Scheme)
-	if scheme != "http" && scheme != "https" {
-		return fmt.Errorf("only http and https URLs are supported")
-	}
-	if parsed.User != nil {
-		return fmt.Errorf("URLs with user info are not allowed")
-	}
-	host := strings.TrimSpace(parsed.Hostname())
-	if host == "" {
-		return fmt.Errorf("URL host is required")
-	}
-	if strings.Contains(host, "%") {
-		return fmt.Errorf("URL host zones are not allowed")
-	}
-	if err := rejectUnsafeWebFetchLiteralHost(host); err != nil {
-		return err
-	}
-	if err := validateWebFetchPort(parsed); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateWebFetchPort(parsed *url.URL) error {
-	port := parsed.Port()
-	if port == "" {
-		return nil
-	}
-	switch strings.ToLower(parsed.Scheme) {
-	case "http":
-		if port == "80" {
-			return nil
-		}
-	case "https":
-		if port == "443" {
-			return nil
-		}
-	}
-	return fmt.Errorf("only default ports are allowed for %s URLs", parsed.Scheme)
-}
-
-func rejectUnsafeWebFetchLiteralHost(host string) error {
-	normalized := strings.TrimSuffix(strings.ToLower(strings.Trim(host, "[]")), ".")
-	if normalized == "" {
-		return fmt.Errorf("URL host is required")
-	}
-	switch {
-	case normalized == "localhost" || strings.HasSuffix(normalized, ".localhost"):
-		return errors.New(webFetchPublicOnlyHint)
-	case normalized == "metadata" || normalized == "metadata.google.internal":
-		return errors.New(webFetchPublicOnlyHint)
-	case strings.HasSuffix(normalized, ".local"):
-		return errors.New(webFetchPublicOnlyHint)
-	}
-
-	addr, err := netip.ParseAddr(normalized)
-	if err != nil {
-		return nil
-	}
-	if err := rejectUnsafeWebFetchAddr(addr); err != nil {
-		return errors.New(webFetchPublicOnlyHint)
-	}
-	return nil
-}
-
-func rejectUnsafeWebFetchHost(ctx context.Context, host string, resolver webFetchResolver) error {
-	_, err := resolveWebFetchHostAddrs(ctx, host, resolver, false)
-	return err
-}
-
-func resolveWebFetchHostAddrs(ctx context.Context, host string, resolver webFetchResolver, requireResolver bool) ([]netip.Addr, error) {
-	normalized := strings.TrimSuffix(strings.ToLower(strings.Trim(host, "[]")), ".")
-	if normalized == "" {
-		return nil, fmt.Errorf("URL host is required")
-	}
-	switch {
-	case normalized == "localhost" || strings.HasSuffix(normalized, ".localhost"):
-		return nil, fmt.Errorf("localhost hosts are blocked")
-	case normalized == "metadata" || normalized == "metadata.google.internal":
-		return nil, fmt.Errorf("metadata service hosts are blocked")
-	case strings.HasSuffix(normalized, ".local"):
-		return nil, fmt.Errorf("local network hosts are blocked")
-	}
-
-	addr, err := netip.ParseAddr(normalized)
-	if err == nil {
-		if err := rejectUnsafeWebFetchAddr(addr); err != nil {
-			return nil, err
-		}
-		return []netip.Addr{addr.Unmap()}, nil
-	}
-	if resolver == nil {
-		if requireResolver {
-			return nil, fmt.Errorf("host resolver is required")
-		}
-		return nil, nil
-	}
-
-	addrs, err := resolver.LookupNetIP(ctx, "ip", normalized)
-	if err != nil {
-		return nil, fmt.Errorf("resolve host: %w", err)
-	}
-	if len(addrs) == 0 {
-		return nil, fmt.Errorf("host did not resolve to an IP address")
-	}
-	for _, addr := range addrs {
-		if err := rejectUnsafeWebFetchAddr(addr); err != nil {
-			return nil, err
-		}
-	}
-	return addrs, nil
-}
-
-func rejectUnsafeWebFetchAddr(addr netip.Addr) error {
-	if !addr.IsValid() {
-		return fmt.Errorf("invalid resolved host address")
-	}
-	addr = addr.Unmap()
-	if embedded, ok := webFetchEmbeddedIPv4(addr); ok {
-		return rejectUnsafeWebFetchAddr(embedded)
-	}
-	for _, blocked := range webFetchBlockedAddrPrefixes {
-		if blocked.prefix.Contains(addr) {
-			return errors.New(blocked.reason)
-		}
-	}
-	if !addr.IsGlobalUnicast() {
-		return fmt.Errorf("non-global hosts are blocked")
-	}
-	return nil
-}
-
-func webFetchEmbeddedIPv4(addr netip.Addr) (netip.Addr, bool) {
-	if addr.Is4() {
-		return netip.Addr{}, false
-	}
-	bytes := addr.As16()
-	for _, candidate := range webFetchEmbeddedIPv4Prefixes {
-		if !candidate.prefix.Contains(addr) {
-			continue
-		}
-		if candidate.byteOffset < 0 || candidate.byteOffset+4 > len(bytes) {
-			continue
-		}
-		embedded := [4]byte{
-			bytes[candidate.byteOffset],
-			bytes[candidate.byteOffset+1],
-			bytes[candidate.byteOffset+2],
-			bytes[candidate.byteOffset+3],
-		}
-		return netip.AddrFrom4(embedded), true
-	}
-	return netip.Addr{}, false
-}
-
-func redactWebFetchURL(value *url.URL) string {
-	if value == nil {
-		return ""
-	}
-	return redactWebFetchText(value.String())
-}
-
-func redactWebFetchText(value string) string {
-	return redaction.RedactString(value, redaction.Options{})
-}
-
-func webFetchStatusLine(response *http.Response) string {
-	if response == nil {
-		return ""
-	}
-	if strings.TrimSpace(response.Status) != "" {
-		return response.Status
-	}
-	return strings.TrimSpace(strconv.Itoa(response.StatusCode) + " " + http.StatusText(response.StatusCode))
-}
-
-func firstNonEmptyString(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
-}
-
-func firstWebFetchResolver(resolver webFetchResolver) webFetchResolver {
-	if resolver != nil {
-		return resolver
-	}
-	return defaultWebFetchResolver{}
 }


### PR DESCRIPTION
## ponytail fix

`safeDialContext` blocks 127.0.0.0/8. When `HTTPS_PROXY=http://127.0.0.1:3067` is set, Go dials the proxy first — `safeDialContext` blocks it.

**Fix:** inline `http.ProxyFromEnvironment` check in both dial functions. If the dial target matches the configured proxy, skip SSRF validation.

### Changes

**providerhealth.go** — `safeDialContext`: 7 lines added
**web_fetch.go** — `webFetchSafeDialContext`: 9 lines added, `transport.Proxy` restored from `nil` to `http.ProxyFromEnvironment`

New imports: **0**. New types: **0**. New helpers: **0**.

Existing SSRF validation path **completely unchanged** for non-proxy dials.

Closes #569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connectivity checks and web fetching when system proxy settings are enabled.
  * Prevented proxy-based requests from being incorrectly blocked when the request target matches the currently configured forward proxy.
  * Enhanced web request handling so URL validation continues to occur at the right stage, while preserving existing response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->