### PR TITLE
fix(auth): persist OpenRouter API key after login

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Gitlawb/zero/internal/plugins"
 	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
+	"github.com/Gitlawb/zero/internal/provideroauth"
 	"github.com/Gitlawb/zero/internal/provideronboarding"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/redaction"
@@ -60,6 +61,7 @@ type appDeps struct {
 	probeProviderHealth    func(context.Context, providerhealth.Options) providerhealth.Result
 	discoverProviderModels func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	detectLocalRuntimes    func(context.Context, provideronboarding.LocalDetectOptions) []provideronboarding.DetectedLocalRuntime
+	openRouterLogin        func(context.Context, provideroauth.OpenRouterOptions) (string, error)
 	newSessionStore        func() *sessions.Store
 	loadPlugins            func(plugins.LoadOptions) (plugins.LoadResult, error)
 	loadHooks              func(hooks.LoadOptions) (hooks.LoadResult, error)
@@ -144,6 +146,7 @@ func defaultAppDeps() appDeps {
 		probeProviderHealth:    providerhealth.Probe,
 		discoverProviderModels: defaultDiscoverProviderModels,
 		detectLocalRuntimes:    provideronboarding.DetectLocalRuntimes,
+		openRouterLogin:        provideroauth.OpenRouterLogin,
 		newSessionStore: func() *sessions.Store {
 			return sessions.NewStore(sessions.StoreOptions{})
 		},
@@ -464,6 +467,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.detectLocalRuntimes == nil {
 		deps.detectLocalRuntimes = defaults.detectLocalRuntimes
+	}
+	if deps.openRouterLogin == nil {
+		deps.openRouterLogin = defaults.openRouterLogin
 	}
 	if deps.newSessionStore == nil {
 		deps.newSessionStore = defaults.newSessionStore

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -82,11 +83,11 @@ func runAuth(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 }
 
-// runAuthOpenRouter runs OpenRouter's browser PKCE login and prints the freshly
-// minted API key. Unlike `auth login` (which stores an OAuth bearer token),
-// OpenRouter's flow mints a normal API key; the setup wizard saves it to a
-// provider profile, while this command prints it for manual configuration.
-func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, _ appDeps) int {
+// runAuthOpenRouter runs OpenRouter's browser PKCE login and saves the freshly
+// minted API key into the user's provider credential store. Unlike `auth login`
+// (which stores an OAuth bearer token), OpenRouter's flow mints a normal API key;
+// persist it immediately so the provider is usable after the command completes.
+func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
 	for _, a := range args {
 		if a == "-h" || a == "--help" || a == "help" {
 			_ = writeAuthHelp(stdout)
@@ -98,7 +99,7 @@ func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, _ appD
 	if len(args) > 0 {
 		return writeExecUsageError(stderr, fmt.Sprintf("zero auth openrouter takes no arguments (got %q)", args[0]))
 	}
-	key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
+	key, err := deps.openRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
 		Out:        stdout,
 		HTTPClient: &http.Client{Timeout: 30 * time.Second},
 		// ZERO_OPENROUTER_BASE_URL overrides the endpoint (self-hosted gateway or tests).
@@ -107,10 +108,53 @@ func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, _ appD
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
-	if _, err := fmt.Fprintf(stdout, "\nOpenRouter login complete — new API key minted.\nUse it with zero, e.g.:\n  export OPENROUTER_API_KEY=%s\n(or add it to a provider profile with catalogID \"openrouter\").\n", key); err != nil {
+	line, err := saveOpenRouterProviderKey(deps, key)
+	if err != nil {
+		if _, writeErr := fmt.Fprintf(stdout, "\nOpenRouter login complete — new API key minted, but Zero could not save it: %s\nUse it manually, e.g.:\n  export OPENROUTER_API_KEY=%s\n", err, key); writeErr != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintf(stdout, "\nOpenRouter login complete — new API key saved.\n%s\n", line); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
+}
+
+func saveOpenRouterProviderKey(deps appDeps, key string) (string, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", fmt.Errorf("OpenRouter returned an empty API key")
+	}
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return "", err
+	}
+	ensured, err := config.EnsureCatalogProvider(configPath, "openrouter")
+	if err != nil {
+		return "", err
+	}
+	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		return "", err
+	}
+	if err := store.Set(ensured.Name, key); err != nil {
+		return "", err
+	}
+	if err := config.MarkProviderAPIKeyStored(configPath, ensured.Name); err != nil {
+		return "", err
+	}
+	active := strings.EqualFold(strings.TrimSpace(ensured.Active), strings.TrimSpace(ensured.Name))
+	switch {
+	case ensured.Created && active:
+		return fmt.Sprintf("Added provider %q to your config and set it active.", ensured.Name), nil
+	case ensured.Created:
+		return fmt.Sprintf("Added provider %q to your config; the active provider is still %q.\nSwitch with: zero providers use %s", ensured.Name, ensured.Active, ensured.Name), nil
+	case active:
+		return fmt.Sprintf("Provider %q is configured, active, and ready to use.", ensured.Name), nil
+	default:
+		return fmt.Sprintf("Provider %q is configured with the new key.\nSwitch with: zero providers use %s", ensured.Name, ensured.Name), nil
+	}
 }
 
 // runAuthChatGPT runs the ChatGPT (Codex) browser PKCE login, persists the

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -108,6 +108,7 @@ func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, deps a
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
+	key = strings.TrimSpace(key)
 	line, err := saveOpenRouterProviderKey(deps, key)
 	if err != nil {
 		if _, writeErr := fmt.Fprintf(stdout, "\nOpenRouter login complete — new API key minted, but Zero could not save it: %s\nUse it manually, e.g.:\n  export OPENROUTER_API_KEY=%s\n", err, key); writeErr != nil {
@@ -142,6 +143,9 @@ func saveOpenRouterProviderKey(deps appDeps, key string) (string, error) {
 		return "", err
 	}
 	if err := config.MarkProviderAPIKeyStored(configPath, ensured.Name); err != nil {
+		// Best-effort rollback: don't leave the key orphaned in the credential
+		// store while config.json still says it isn't there.
+		_, _ = store.Delete(ensured.Name)
 		return "", err
 	}
 	active := strings.EqualFold(strings.TrimSpace(ensured.Active), strings.TrimSpace(ensured.Name))

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
+	"github.com/Gitlawb/zero/internal/provideroauth"
 )
 
 // withAuthStore points the provider OAuth store at a temp file for the test,
@@ -148,6 +150,44 @@ func TestRunAuthOpenRouterRejectsArgs(t *testing.T) {
 	stderr.Reset()
 	if code := runWithDeps([]string{"auth", "openrouter", "--help"}, &stdout, &stderr, appDeps{}); code != exitSuccess {
 		t.Fatalf("openrouter --help should succeed, stderr=%q", stderr.String())
+	}
+}
+
+func TestRunAuthOpenRouterSavesMintedKey(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	var stdout, stderr bytes.Buffer
+
+	code := runWithDeps([]string{"auth", "openrouter"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+		openRouterLogin: func(context.Context, provideroauth.OpenRouterOptions) (string, error) {
+			return "sk-openrouter-test", nil
+		},
+	})
+
+	if code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "new API key saved") {
+		t.Fatalf("expected saved-key confirmation, got %q", stdout.String())
+	}
+	cfg := readCLIConfigFixture(t, configPath)
+	if cfg.ActiveProvider != "openrouter" || len(cfg.Providers) != 1 {
+		t.Fatalf("config = %#v", cfg)
+	}
+	profile := cfg.Providers[0]
+	if profile.Name != "openrouter" || profile.CatalogID != "openrouter" || !profile.APIKeyStored || profile.APIKey != "" || profile.APIKeyEnv != "" {
+		t.Fatalf("provider not stored-key sanitized: %#v", profile)
+	}
+	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, ok, err := store.Get("openrouter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || key != "sk-openrouter-test" {
+		t.Fatalf("stored key = %q, %v", key, ok)
 	}
 }
 

--- a/internal/cli/exec_provider_hint_test.go
+++ b/internal/cli/exec_provider_hint_test.go
@@ -20,8 +20,8 @@ func TestWriteExecProviderErrorAppendsHint(t *testing.T) {
 		if !strings.Contains(out, "auth error:") {
 			t.Fatalf("expected raw message, got %q", out)
 		}
-		if !strings.Contains(out, "zero auth") {
-			t.Fatalf("expected an actionable hint referencing `zero auth`, got %q", out)
+		if !strings.Contains(out, "zero setup") || !strings.Contains(out, "zero auth openrouter") {
+			t.Fatalf("expected an actionable setup/auth hint, got %q", out)
 		}
 	})
 
@@ -43,7 +43,7 @@ func TestWriteExecProviderErrorAppendsHint(t *testing.T) {
 		if stderr.Len() != 0 {
 			t.Fatalf("json mode must not write to stderr, got %q", stderr.String())
 		}
-		if strings.Contains(stdout.String(), "zero auth") {
+		if strings.Contains(stdout.String(), "zero setup") {
 			t.Fatalf("json mode must not inject a hint into the structured payload, got %q", stdout.String())
 		}
 	})

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -111,6 +111,39 @@ func EnsureCatalogProvider(path string, catalogID string) (EnsuredProvider, erro
 	return EnsuredProvider{Name: profile.Name, Created: true, Active: written.ActiveProvider}, nil
 }
 
+// MarkProviderAPIKeyStored records that provider's API key now lives in the
+// credential store. It also clears inline/env key fields so the stored key is the
+// runtime credential; an old apiKeyEnv value must not keep overriding a freshly
+// captured key from `zero auth openrouter` or provider setup.
+func MarkProviderAPIKeyStored(path string, provider string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("config path is required")
+	}
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return fmt.Errorf("provider name is required")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	for index := range cfg.Providers {
+		if strings.EqualFold(strings.TrimSpace(cfg.Providers[index].Name), provider) {
+			cfg.Providers[index].APIKey = ""
+			cfg.Providers[index].APIKeyEnv = ""
+			cfg.Providers[index].APIKeyStored = true
+			return writeConfigFile(path, cfg)
+		}
+	}
+	return fmt.Errorf("provider %q not found", provider)
+}
+
 func SetActiveProvider(path string, name string) (FileConfig, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -554,6 +554,36 @@ func TestEnsureCatalogProviderRejectsUnknownCatalogID(t *testing.T) {
 	}
 }
 
+func TestMarkProviderAPIKeyStoredClearsInlineAndEnvKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "openrouter",
+		Providers: []ProviderProfile{{
+			Name:      "openrouter",
+			CatalogID: "openrouter",
+			APIKey:    "sk-inline",
+			APIKeyEnv: "OPENROUTER_API_KEY",
+			Model:     "openai/gpt-4.1",
+		}},
+	}, 0o600)
+
+	if err := MarkProviderAPIKeyStored(path, "openrouter"); err != nil {
+		t.Fatalf("MarkProviderAPIKeyStored: %v", err)
+	}
+
+	cfg := readConfigFixture(t, path)
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("providers = %#v", cfg.Providers)
+	}
+	profile := cfg.Providers[0]
+	if !profile.APIKeyStored || profile.APIKey != "" || profile.APIKeyEnv != "" {
+		t.Fatalf("provider credential fields = %#v", profile)
+	}
+	if profile.Model != "openai/gpt-4.1" || cfg.ActiveProvider != "openrouter" {
+		t.Fatalf("unrelated config changed: %#v", cfg)
+	}
+}
+
 func TestRemoveProviderDeletesAndHandsOffActive(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "zero.json")
 	writeConfigFixture(t, path, FileConfig{

--- a/internal/errhint/errhint.go
+++ b/internal/errhint/errhint.go
@@ -106,7 +106,7 @@ func TUIHint(err error) string {
 func CLIHint(err error) string {
 	switch Classify(err) {
 	case Auth:
-		return "API key rejected — run `zero auth` or set the provider's API key, then retry"
+		return "API key rejected — run `zero setup`, `zero auth openrouter` for OpenRouter, or set the provider's API key"
 	case RateLimit:
 		return "Rate limited — wait a moment, or switch model with --model"
 	case Connectivity:

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -385,7 +385,7 @@ func ClassifiedError(statusCode int, message string, secrets ...string) string {
 		// Lead with an actionable instruction rather than the raw upstream auth blurb
 		// (which often points the user at the wrong provider's dashboard URL). Keep a
 		// redacted, one-line upstream detail for context — never the raw body. (AUDIT-H7)
-		curated := "auth error: your API key is missing or invalid — run `zero auth`, or set the provider's API key, then retry."
+		curated := "auth error: your API key is missing or invalid — run `zero setup`, `zero auth openrouter` for OpenRouter, or set the provider's API key, then retry."
 		if detail := strings.TrimSpace(Redact(message, secrets...)); detail != "" {
 			return curated + " (provider said: " + detail + ")"
 		}

--- a/internal/providers/providerio/redact_classify_test.go
+++ b/internal/providers/providerio/redact_classify_test.go
@@ -32,11 +32,11 @@ func TestRedactDoesNotMangleHelpText(t *testing.T) {
 }
 
 func TestClassifiedErrorCuratesAuthFailure(t *testing.T) {
-	// AUDIT-H7: 401/403 must lead with an actionable instruction (run `zero auth`),
+	// AUDIT-H7: 401/403 must lead with an actionable instruction,
 	// not the raw upstream dashboard blurb.
 	msg := ClassifiedError(http.StatusUnauthorized, "Incorrect API key provided: sk-bad. Visit https://platform.openai.com/account/api-keys", "sk-bad")
-	if !strings.Contains(msg, "zero auth") {
-		t.Errorf("401 message should point at `zero auth`, got %q", msg)
+	if !strings.Contains(msg, "zero setup") || !strings.Contains(msg, "zero auth openrouter") {
+		t.Errorf("401 message should point at setup/provider-specific auth, got %q", msg)
 	}
 	if !strings.HasPrefix(msg, "auth error:") {
 		t.Errorf("401 message should lead with 'auth error:', got %q", msg)
@@ -45,7 +45,7 @@ func TestClassifiedErrorCuratesAuthFailure(t *testing.T) {
 		t.Errorf("401 message leaked the key: %q", msg)
 	}
 	// 403 also curated.
-	if got := ClassifiedError(http.StatusForbidden, "forbidden"); !strings.Contains(got, "zero auth") {
+	if got := ClassifiedError(http.StatusForbidden, "forbidden"); !strings.Contains(got, "zero setup") {
 		t.Errorf("403 should also be curated, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- `zero auth openrouter` minted an API key but only printed it to the terminal, leaving the provider unusable unless the user manually exported an env var or hand-edited config — this is the root cause of #588 ("not able to use any api keys when i add them")
- The minted key is now saved into the credential store, the provider profile is created/activated automatically, and stale inline/env key fields that could shadow the new key are cleared
- Generic auth-failure hints now point at `zero setup` and `zero auth openrouter` instead of the vaguer `zero auth`

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/cli/... ./internal/config/... ./internal/errhint/... ./internal/providers/providerio/...` (all pass)
- [x] New tests cover the save path end-to-end: `TestRunAuthOpenRouterSavesMintedKey`, `TestMarkProviderAPIKeyStoredClearsInlineAndEnvKey`

Fixes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `zero auth openrouter` now automatically saves the minted OpenRouter API key to the provider’s credentials and confirms when successful.
* **Bug Fixes**
  * When saving, inline API key values and API key environment fields are cleared and marked as stored for the OpenRouter provider.
  * Provider authentication guidance is more actionable: suggests `zero setup` and `zero auth openrouter` (or setting the provider API key) after auth failures.
* **Documentation**
  * Updated CLI hint and error-message text for OpenRouter auth next steps.
* **Tests**
  * Added/updated OpenRouter auth and hint-related test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->