### PR TITLE
Harden project-scoped MCP credential boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,13 @@ Servers are merged from user and project configs (project wins on conflicts). To
 - A `--header` value produced by command substitution (`"Authorization=Bearer $(print-token)"`) in a private shell config that you keep out of git.
 - A secret manager that injects the env var your MCP server reads on its own (the `command` and `args` then run inside that environment).
 
+Project MCP config remains supported for shared team servers, but a project layer
+that changes an existing server's target (`url`, `command`, or `args`) does not
+inherit user credentials. Clear or replace `headers`, `env`, or `oauth` explicitly,
+or use a new server name. OAuth tokens are bound to the resolved server identity,
+so changing a server target can require `zero mcp oauth login <server>` again.
+OAuth server names ending in `.<32 hex chars>` are reserved for token storage.
+
 ### As a server — expose Zero's tools to another agent
 
 ```bash

--- a/internal/cli/mcp_oauth.go
+++ b/internal/cli/mcp_oauth.go
@@ -86,7 +86,7 @@ func runMCPOAuthLogin(args []string, stdout io.Writer, stderr io.Writer, deps ap
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
-	if err := store.Save(serverName, token); err != nil {
+	if err := store.SaveForServer(server, token); err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
 
@@ -116,7 +116,7 @@ func runMCPOAuthLogout(args []string, stdout io.Writer, stderr io.Writer, deps a
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
-	removed, err := store.Delete(serverName)
+	removed, err := store.DeleteForServerName(serverName)
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}

--- a/internal/cli/mcp_oauth_test.go
+++ b/internal/cli/mcp_oauth_test.go
@@ -88,6 +88,9 @@ func TestRunMCPOAuthLogout(t *testing.T) {
 	if err := store.Save("remote", mcp.StoredToken{AccessToken: "a", RefreshToken: "r"}); err != nil {
 		t.Fatalf("Save() error = %v", err)
 	}
+	if err := store.SaveForServer(mcp.Server{Name: "remote", Identity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, mcp.StoredToken{AccessToken: "identity", RefreshToken: "ir"}); err != nil {
+		t.Fatalf("SaveForServer() error = %v", err)
+	}
 	deps := appDeps{newMCPTokenStore: func() (*mcp.TokenStore, error) { return store, nil }}
 
 	var stdout, stderr bytes.Buffer
@@ -100,6 +103,9 @@ func TestRunMCPOAuthLogout(t *testing.T) {
 	}
 	if _, ok, _ := store.Load("remote"); ok {
 		t.Fatal("token still present after logout")
+	}
+	if statuses, err := store.Status(); err != nil || len(statuses) != 0 {
+		t.Fatalf("status after logout = %#v err=%v, want no tokens", statuses, err)
 	}
 }
 
@@ -122,23 +128,24 @@ func TestRunMCPOAuthLoginStoresTokens(t *testing.T) {
 	}
 
 	cwd := t.TempDir()
+	mcpConfig := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"remote": {
+			Type: "http",
+			URL:  "https://remote.invalid/mcp",
+			Auth: "oauth",
+			OAuth: &config.MCPOAuthConfig{
+				ClientID:              "client-123",
+				AuthorizationEndpoint: "https://remote.invalid/authorize",
+				TokenEndpoint:         tokenServer.URL,
+				Scopes:                []string{"read"},
+			},
+		},
+	}}
 	deps := appDeps{
 		getwd:            func() (string, error) { return cwd, nil },
 		newMCPTokenStore: func() (*mcp.TokenStore, error) { return store, nil },
-		resolveMCPConfig: func(workspaceRoot string, _ bool) (config.MCPConfig, error) {
-			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
-				"remote": {
-					Type: "http",
-					URL:  "https://remote.invalid/mcp",
-					Auth: "oauth",
-					OAuth: &config.MCPOAuthConfig{
-						ClientID:              "client-123",
-						AuthorizationEndpoint: "https://remote.invalid/authorize",
-						TokenEndpoint:         tokenServer.URL,
-						Scopes:                []string{"read"},
-					},
-				},
-			}}, nil
+		resolveMCPConfig: func(_ string, _ bool) (config.MCPConfig, error) {
+			return mcpConfig, nil
 		},
 		now: time.Now,
 	}
@@ -173,9 +180,13 @@ func TestRunMCPOAuthLoginStoresTokens(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("exitCode = %d stderr=%s stdout=%s", exitCode, stderr.String(), stdout.String())
 	}
-	token, ok, err := store.Load("remote")
+	servers, err := mcp.NormalizeConfig(mcpConfig)
+	if err != nil || len(servers) != 1 {
+		t.Fatalf("NormalizeConfig() servers=%#v err=%v", servers, err)
+	}
+	token, ok, err := store.LoadForServer(servers[0])
 	if err != nil || !ok {
-		t.Fatalf("Load() ok=%v err=%v", ok, err)
+		t.Fatalf("LoadForServer() ok=%v err=%v", ok, err)
 	}
 	if token.AccessToken != "access-final" || token.RefreshToken != "refresh-final" {
 		t.Fatalf("stored token = %#v", token)
@@ -483,7 +494,13 @@ func TestRunMCPOAuthLoginTrustedProjectServerStoresToken(t *testing.T) {
 	if gotExclude {
 		t.Fatal("trusted workspace must resolve MCP config with excludeProject=false")
 	}
-	token, ok, err := store.Load("remote")
+	servers, err := mcp.NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"remote": projectServer,
+	}})
+	if err != nil || len(servers) != 1 {
+		t.Fatalf("NormalizeConfig() servers=%#v err=%v", servers, err)
+	}
+	token, ok, err := store.LoadForServer(servers[0])
 	if err != nil || !ok {
 		t.Fatalf("token must be stored on trusted login; ok=%v err=%v", ok, err)
 	}

--- a/internal/config/mcp_merge.go
+++ b/internal/config/mcp_merge.go
@@ -1,0 +1,168 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+func mergeMCPConfig(dst *MCPConfig, src MCPConfig) {
+	if len(src.Servers) == 0 {
+		return
+	}
+	if dst.Servers == nil {
+		dst.Servers = map[string]MCPServerConfig{}
+	}
+	for name, server := range src.Servers {
+		dst.Servers[name] = mergeMCPServer(dst.Servers[name], server)
+	}
+}
+
+func mergeProjectMCPConfig(dst *MCPConfig, src MCPConfig) error {
+	if len(src.Servers) == 0 {
+		return nil
+	}
+	if dst.Servers == nil {
+		dst.Servers = map[string]MCPServerConfig{}
+	}
+	for name, server := range src.Servers {
+		base := dst.Servers[name]
+		candidate := mergeMCPServer(base, server)
+		if projectMCPServerTargetChanges(base, server) && hasInheritedMCPCredentialMaterial(server, candidate) {
+			return fmt.Errorf("project MCP server %q cannot override target while inheriting user credentials; set headers/env/oauth explicitly or use a new server name", name)
+		}
+		candidate.ProjectConfigured = true
+		dst.Servers[name] = candidate
+	}
+	return nil
+}
+
+func mergeMCPServer(base MCPServerConfig, next MCPServerConfig) MCPServerConfig {
+	if strings.TrimSpace(next.Type) != "" {
+		base.Type = next.Type
+	}
+	if strings.TrimSpace(next.Command) != "" {
+		base.Command = next.Command
+	}
+	if next.Args != nil {
+		base.Args = append([]string{}, next.Args...)
+	}
+	if next.Env != nil {
+		base.Env = copyMCPStringMap(next.Env)
+	}
+	if strings.TrimSpace(next.URL) != "" {
+		base.URL = next.URL
+	}
+	if next.Headers != nil {
+		base.Headers = copyMCPStringMap(next.Headers)
+	}
+	if strings.TrimSpace(next.Auth) != "" {
+		base.Auth = next.Auth
+	}
+	if next.OAuth != nil {
+		base.OAuth = next.OAuth
+	}
+	if next.disabledSet || next.Disabled {
+		base.Disabled = next.Disabled
+	}
+	if next.configured {
+		base.configured = true
+	}
+	if next.ProjectConfigured {
+		base.ProjectConfigured = true
+	}
+	return base
+}
+
+func projectMCPServerTargetChanges(base MCPServerConfig, next MCPServerConfig) bool {
+	if strings.TrimSpace(next.Type) != "" && mcpServerTransportKind(base) != mcpServerTransportKind(mergeMCPServer(base, next)) {
+		return true
+	}
+	if strings.TrimSpace(next.URL) != "" && strings.TrimSpace(next.URL) != strings.TrimSpace(base.URL) {
+		return true
+	}
+	if strings.TrimSpace(next.Command) != "" && strings.TrimSpace(next.Command) != strings.TrimSpace(base.Command) {
+		return true
+	}
+	if next.Args != nil && !slices.Equal(trimMCPArgs(next.Args), trimMCPArgs(base.Args)) {
+		return true
+	}
+	return false
+}
+
+func mcpServerTransportKind(server MCPServerConfig) string {
+	if typ := strings.TrimSpace(strings.ToLower(server.Type)); typ != "" {
+		return typ
+	}
+	if strings.TrimSpace(server.URL) != "" {
+		return "http"
+	}
+	return "stdio"
+}
+
+func hasInheritedMCPCredentialMaterial(project MCPServerConfig, candidate MCPServerConfig) bool {
+	if project.Headers == nil && hasMCPStringMapMaterial(candidate.Headers) {
+		return true
+	}
+	if project.Env == nil && hasMCPStringMapMaterial(candidate.Env) {
+		return true
+	}
+	if project.OAuth == nil && hasMCPOAuthMaterial(candidate.OAuth) {
+		return true
+	}
+	return false
+}
+
+func hasMCPStringMapMaterial(values map[string]string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMCPOAuthMaterial(oauth *MCPOAuthConfig) bool {
+	if oauth == nil {
+		return false
+	}
+	if strings.TrimSpace(oauth.ClientID) != "" ||
+		strings.TrimSpace(oauth.ClientSecret) != "" ||
+		strings.TrimSpace(oauth.AuthorizationEndpoint) != "" ||
+		strings.TrimSpace(oauth.TokenEndpoint) != "" ||
+		strings.TrimSpace(oauth.RegistrationEndpoint) != "" ||
+		strings.TrimSpace(oauth.IssuerURL) != "" {
+		return true
+	}
+	for _, scope := range oauth.Scopes {
+		if strings.TrimSpace(scope) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func trimMCPArgs(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			trimmed = append(trimmed, value)
+		}
+	}
+	return trimmed
+}
+
+func copyMCPStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
+}

--- a/internal/config/mcp_merge_test.go
+++ b/internal/config/mcp_merge_test.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveRejectsProjectMCPURLOverrideWithInheritedHeaders(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {
+					"type": "http",
+					"url": "https://trusted.example/mcp",
+					"headers": {"Authorization": "Bearer user-secret"}
+				}
+			}
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {"url": "https://attacker.example/mcp"}
+			}
+		}
+	}`)
+
+	_, err := Resolve(ResolveOptions{UserConfigPath: userPath, ProjectConfigPath: projectPath, Env: map[string]string{}})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want inherited MCP credential rejection")
+	}
+	if strings.Contains(err.Error(), "user-secret") {
+		t.Fatalf("error leaked header secret: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), `project MCP server "docs" cannot override target`) {
+		t.Fatalf("error = %q, want project MCP target rejection", err.Error())
+	}
+}
+
+func TestResolveMCPRejectsProjectURLOverrideWithInheritedHeaders(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {
+					"type": "http",
+					"url": "https://trusted.example/mcp",
+					"headers": {"Authorization": "Bearer user-secret"}
+				}
+			}
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"mcpServers": {
+			"docs": {"url": "https://attacker.example/mcp"}
+		}
+	}`)
+
+	_, err := ResolveMCP(ResolveOptions{UserConfigPath: userPath, ProjectConfigPath: projectPath})
+	if err == nil {
+		t.Fatal("ResolveMCP() error = nil, want inherited MCP credential rejection")
+	}
+	if strings.Contains(err.Error(), "user-secret") {
+		t.Fatalf("error leaked header secret: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), `project MCP server "docs" cannot override target`) {
+		t.Fatalf("error = %q, want project MCP target rejection", err.Error())
+	}
+}
+
+func TestResolveRejectsProjectMCPStdioOverrideWithInheritedEnv(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {
+					"type": "stdio",
+					"command": "docs-mcp",
+					"args": ["--user"],
+					"env": {"ZERO_DOCS_TOKEN": "user-secret"}
+				}
+			}
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {"args": ["--project"]}
+			}
+		}
+	}`)
+
+	_, err := Resolve(ResolveOptions{UserConfigPath: userPath, ProjectConfigPath: projectPath, Env: map[string]string{}})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want inherited MCP env rejection")
+	}
+	if strings.Contains(err.Error(), "user-secret") {
+		t.Fatalf("error leaked env secret: %q", err.Error())
+	}
+}
+
+func TestResolveAllowsProjectMCPTargetOverrideWhenCredentialsCleared(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"web": {
+					"type": "http",
+					"url": "https://trusted.example/mcp",
+					"headers": {"Authorization": "Bearer user-secret"}
+				},
+				"docs": {
+					"type": "stdio",
+					"command": "docs-mcp",
+					"args": ["--user"],
+					"env": {"ZERO_DOCS_TOKEN": "user-secret"}
+				}
+			}
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"web": {"url": "https://project.example/mcp", "headers": {}},
+				"docs": {"args": ["--project"], "env": {}}
+			}
+		}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: userPath, ProjectConfigPath: projectPath, Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	web := resolved.MCP.Servers["web"]
+	if web.URL != "https://project.example/mcp" || len(web.Headers) != 0 || !web.ProjectConfigured {
+		t.Fatalf("web = %#v, want project URL, cleared headers, project marker", web)
+	}
+	docs := resolved.MCP.Servers["docs"]
+	if got := strings.Join(docs.Args, " "); got != "--project" {
+		t.Fatalf("docs.Args = %q, want --project", got)
+	}
+	if len(docs.Env) != 0 || !docs.ProjectConfigured {
+		t.Fatalf("docs = %#v, want cleared env and project marker", docs)
+	}
+}
+
+func TestResolveAllowsTrustedMCPOverridesToInheritCredentials(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {
+					"type": "http",
+					"url": "https://trusted.example/mcp",
+					"headers": {"Authorization": "Bearer user-secret"}
+				}
+			}
+		}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath: userPath,
+		Env:            map[string]string{},
+		Overrides: Overrides{MCP: MCPConfig{Servers: map[string]MCPServerConfig{
+			"docs": {URL: "https://cli.example/mcp"},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	docs := resolved.MCP.Servers["docs"]
+	if docs.URL != "https://cli.example/mcp" || docs.Headers["Authorization"] != "Bearer user-secret" || docs.ProjectConfigured {
+		t.Fatalf("docs = %#v, want trusted override to inherit headers without project marker", docs)
+	}
+}
+
+func TestResolveMCPProjectArgsTargetCompareUsesNormalizedArgs(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {
+					"type": "stdio",
+					"command": "docs-mcp",
+					"args": ["--port", "7777"],
+					"env": {"ZERO_DOCS_TOKEN": "user-secret"}
+				}
+			}
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {"args": [" --port ", "7777", ""]}
+			}
+		}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: userPath, ProjectConfigPath: projectPath, Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !resolved.MCP.Servers["docs"].ProjectConfigured {
+		t.Fatalf("docs = %#v, want project marker", resolved.MCP.Servers["docs"])
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -163,21 +163,24 @@ func ResolveMCP(options ResolveOptions) (MCPConfig, error) {
 	// can override any field or disable a default by writing over it.
 	cfg := FileConfig{MCP: MCPConfig{Servers: DefaultMCPServers()}}
 
-	for _, path := range []string{options.UserConfigPath, options.ProjectConfigPath} {
-		if path == "" {
-			continue
-		}
-		// Drop the project layer when the workspace is untrusted, so a cloned repo's
-		// ./.zero/config.json cannot register (and spawn) stdio MCP servers. Fail-closed:
-		// only a trusted workspace clears ExcludeProject. Defaults and user config still load.
-		if options.ExcludeProject && path == options.ProjectConfigPath {
-			continue
-		}
-		fileConfig, err := loadConfigFile(path)
+	if options.UserConfigPath != "" {
+		fileConfig, err := loadConfigFile(options.UserConfigPath)
 		if err != nil {
 			return MCPConfig{}, err
 		}
 		mergeMCPConfig(&cfg.MCP, fileConfig.MCP)
+	}
+	// Drop the project layer when the workspace is untrusted, so a cloned repo's
+	// ./.zero/config.json cannot register (and spawn) MCP servers. Fail-closed:
+	// only a trusted workspace clears ExcludeProject. Defaults and user config still load.
+	if options.ProjectConfigPath != "" && !options.ExcludeProject {
+		fileConfig, err := loadConfigFile(options.ProjectConfigPath)
+		if err != nil {
+			return MCPConfig{}, err
+		}
+		if err := mergeProjectMCPConfig(&cfg.MCP, fileConfig.MCP); err != nil {
+			return MCPConfig{}, err
+		}
 	}
 	mergeMCPConfig(&cfg.MCP, options.Overrides.MCP)
 	return cfg.MCP, nil
@@ -261,7 +264,9 @@ func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
 		}
 		mergeProvider(dst, provider)
 	}
-	mergeMCPConfig(&dst.MCP, src.MCP)
+	if err := mergeProjectMCPConfig(&dst.MCP, src.MCP); err != nil {
+		return err
+	}
 	// Sandbox.AdditionalWriteRoots is intentionally NOT merged from project
 	// config: a cloned repo's .zero/config.json must not be able to grant
 	// itself write access outside the workspace. Global config and CLI flags
@@ -832,63 +837,6 @@ func validateSTTConfig(cfg STTConfig) error {
 		return fmt.Errorf("invalid stt.localServerPort %d: must be between 1 and 65535 (0 uses the default)", cfg.LocalServerPort)
 	}
 	return nil
-}
-
-func mergeMCPConfig(dst *MCPConfig, src MCPConfig) {
-	if len(src.Servers) == 0 {
-		return
-	}
-	if dst.Servers == nil {
-		dst.Servers = map[string]MCPServerConfig{}
-	}
-	for name, server := range src.Servers {
-		dst.Servers[name] = mergeMCPServer(dst.Servers[name], server)
-	}
-}
-
-func mergeMCPServer(base MCPServerConfig, next MCPServerConfig) MCPServerConfig {
-	if strings.TrimSpace(next.Type) != "" {
-		base.Type = next.Type
-	}
-	if strings.TrimSpace(next.Command) != "" {
-		base.Command = next.Command
-	}
-	if next.Args != nil {
-		base.Args = append([]string{}, next.Args...)
-	}
-	if next.Env != nil {
-		base.Env = copyMCPStringMap(next.Env)
-	}
-	if strings.TrimSpace(next.URL) != "" {
-		base.URL = next.URL
-	}
-	if next.Headers != nil {
-		base.Headers = copyMCPStringMap(next.Headers)
-	}
-	if strings.TrimSpace(next.Auth) != "" {
-		base.Auth = next.Auth
-	}
-	if next.OAuth != nil {
-		base.OAuth = next.OAuth
-	}
-	if next.disabledSet || next.Disabled {
-		base.Disabled = next.Disabled
-	}
-	if next.configured {
-		base.configured = true
-	}
-	return base
-}
-
-func copyMCPStringMap(values map[string]string) map[string]string {
-	if values == nil {
-		return nil
-	}
-	copied := make(map[string]string, len(values))
-	for key, value := range values {
-		copied[key] = value
-	}
-	return copied
 }
 
 func hasProviderFields(profile ProviderProfile) bool {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -440,16 +440,19 @@ type MCPConfig struct {
 }
 
 type MCPServerConfig struct {
-	Type        string            `json:"type,omitempty"`
-	Command     string            `json:"command,omitempty"`
-	Args        []string          `json:"args,omitempty"`
-	Env         map[string]string `json:"env,omitempty"`
-	URL         string            `json:"url,omitempty"`
-	Headers     map[string]string `json:"headers,omitempty"`
-	Auth        string            `json:"auth,omitempty"`
-	OAuth       *MCPOAuthConfig   `json:"oauth,omitempty"`
-	Disabled    bool              `json:"disabled,omitempty"`
-	disabledSet bool
+	Type     string            `json:"type,omitempty"`
+	Command  string            `json:"command,omitempty"`
+	Args     []string          `json:"args,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	URL      string            `json:"url,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
+	Auth     string            `json:"auth,omitempty"`
+	OAuth    *MCPOAuthConfig   `json:"oauth,omitempty"`
+	Disabled bool              `json:"disabled,omitempty"`
+	// ProjectConfigured marks servers touched by project config. It is runtime
+	// metadata, not persisted config.
+	ProjectConfigured bool `json:"-"`
+	disabledSet       bool
 	// configured is true when the user's config JSON declared an object for
 	// this server at all (i.e. UnmarshalJSON ran for it), regardless of which
 	// fields it set or what values they hold. A built-in default seeded by

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -31,6 +31,9 @@ type Server struct {
 	Auth     string
 	OAuth    *OAuthConfig
 	Identity string
+	// ProjectConfigured is true when project config touched this server. Runtime
+	// credential lookup uses it to avoid reusing legacy user tokens by name.
+	ProjectConfigured bool
 	// UnconfiguredDefault is true when this server is one of Zero's built-in
 	// defaults (e.g. keyless Firecrawl) that the user never touched in their
 	// config — no credentials, no overrides. Callers use it to avoid warning
@@ -88,6 +91,7 @@ func normalizeServer(name string, raw config.MCPServerConfig) (Server, error) {
 		Headers:             copyStringMap(raw.Headers),
 		Auth:                auth,
 		OAuth:               normalizeOAuthConfig(raw.OAuth),
+		ProjectConfigured:   raw.ProjectConfigured,
 		UnconfiguredDefault: config.IsUnconfiguredDefault(name, raw),
 	}
 

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -847,7 +847,7 @@ func (source *storeTokenSource) config() OAuthConfig {
 }
 
 func (source *storeTokenSource) AccessToken(ctx context.Context) (string, error) {
-	token, ok, err := source.store.Load(source.server.Name)
+	token, ok, err := source.store.LoadForServer(source.server)
 	if err != nil {
 		return "", err
 	}
@@ -858,7 +858,7 @@ func (source *storeTokenSource) AccessToken(ctx context.Context) (string, error)
 }
 
 func (source *storeTokenSource) Refresh(ctx context.Context) (string, error) {
-	token, ok, err := source.store.Load(source.server.Name)
+	token, ok, err := source.store.LoadForServer(source.server)
 	if err != nil {
 		return "", err
 	}
@@ -869,7 +869,7 @@ func (source *storeTokenSource) Refresh(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := source.store.Save(source.server.Name, refreshed); err != nil {
+	if err := source.store.SaveForServer(source.server, refreshed); err != nil {
 		return "", err
 	}
 	return refreshed.AccessToken, nil

--- a/internal/mcp/oauth_store.go
+++ b/internal/mcp/oauth_store.go
@@ -15,6 +15,9 @@ import (
 // tokenStoreSchemaVersion is the schema of the legacy mcp-oauth-tokens.json file,
 // retained so migration can recognize a file it understands.
 const tokenStoreSchemaVersion = 1
+const mcpServerIdentityLength = 32
+const maxOAuthTokenKeySegmentLength = 128
+const maxMCPServerNameForIdentityToken = maxOAuthTokenKeySegmentLength - 1 - mcpServerIdentityLength
 
 // StoredToken holds the credentials issued by an OAuth 2.0 authorization server
 // for a single MCP server. The token fields are sensitive: they are tagged so
@@ -32,6 +35,7 @@ type StoredToken struct {
 // omits the access and refresh token material so it can be printed by the CLI.
 type TokenStatus struct {
 	ServerName      string    `json:"serverName"`
+	ServerIdentity  string    `json:"serverIdentity,omitempty"`
 	HasToken        bool      `json:"hasToken"`
 	HasRefreshToken bool      `json:"hasRefreshToken"`
 	TokenType       string    `json:"tokenType,omitempty"`
@@ -148,6 +152,17 @@ func (store *TokenStore) Save(serverName string, token StoredToken) error {
 	return store.store.Save(key, storedToOAuth(token))
 }
 
+// SaveForServer persists a token under the server's target identity. Identity
+// binding prevents a project config with the same server name from reusing a
+// token issued for a different MCP endpoint.
+func (store *TokenStore) SaveForServer(server Server, token StoredToken) error {
+	key, err := mcpIdentityKey(server)
+	if err != nil {
+		return err
+	}
+	return store.store.Save(key, storedToOAuth(token))
+}
+
 // Load returns the stored token for a server. The second return value is false
 // when no token has been stored for the server.
 func (store *TokenStore) Load(serverName string) (StoredToken, bool, error) {
@@ -162,6 +177,30 @@ func (store *TokenStore) Load(serverName string) (StoredToken, bool, error) {
 	return tokenToStored(token), true, nil
 }
 
+// LoadForServer returns the token matching the server's target identity. Legacy
+// name-only tokens are migrated only for servers untouched by project config.
+func (store *TokenStore) LoadForServer(server Server) (StoredToken, bool, error) {
+	key, err := mcpIdentityKey(server)
+	if err != nil {
+		return StoredToken{}, false, err
+	}
+	token, ok, err := store.store.Load(key)
+	if err != nil || ok {
+		return tokenToStored(token), ok, err
+	}
+	if server.ProjectConfigured {
+		return StoredToken{}, false, nil
+	}
+	legacy, ok, err := store.Load(server.Name)
+	if err != nil || !ok {
+		return StoredToken{}, ok, err
+	}
+	if err := store.store.Save(key, storedToOAuth(legacy)); err != nil {
+		return StoredToken{}, false, err
+	}
+	return legacy, true, nil
+}
+
 // Delete removes the stored token for a server. It reports whether an entry was
 // present before deletion.
 func (store *TokenStore) Delete(serverName string) (bool, error) {
@@ -170,6 +209,36 @@ func (store *TokenStore) Delete(serverName string) (bool, error) {
 		return false, err
 	}
 	return store.store.Delete(key)
+}
+
+// DeleteForServerName removes both legacy name-only and identity-bound tokens
+// for a server name.
+func (store *TokenStore) DeleteForServerName(serverName string) (bool, error) {
+	name := strings.TrimSpace(serverName)
+	if err := ValidateServerName(name); err != nil {
+		return false, err
+	}
+	removed, err := store.Delete(name)
+	if err != nil {
+		return false, err
+	}
+	statuses, err := store.store.Status(oauth.KeyPrefixMCP)
+	if err != nil {
+		return removed, err
+	}
+	for _, status := range statuses {
+		segment := strings.TrimPrefix(status.Key, oauth.KeyPrefixMCP)
+		parsedName, _, ok := splitMCPIdentityKeySegment(segment)
+		if !ok || parsedName != name {
+			continue
+		}
+		deleted, err := store.store.Delete(status.Key)
+		if err != nil {
+			return removed, err
+		}
+		removed = removed || deleted
+	}
+	return removed, nil
 }
 
 // Status returns a redaction-safe summary of every stored MCP token, sorted by
@@ -181,8 +250,10 @@ func (store *TokenStore) Status() ([]TokenStatus, error) {
 	}
 	out := make([]TokenStatus, 0, len(statuses))
 	for _, s := range statuses {
+		serverName, serverIdentity, _ := splitMCPIdentityKeySegment(strings.TrimPrefix(s.Key, oauth.KeyPrefixMCP))
 		out = append(out, TokenStatus{
-			ServerName:      strings.TrimPrefix(s.Key, oauth.KeyPrefixMCP),
+			ServerName:      serverName,
+			ServerIdentity:  serverIdentity,
 			HasToken:        s.HasToken,
 			HasRefreshToken: s.HasRefreshToken,
 			TokenType:       s.TokenType,
@@ -250,14 +321,67 @@ func (store *TokenStore) migrateLegacy(legacyPath string) error {
 
 // mcpKey builds and validates the unified store key for an MCP server token.
 func mcpKey(serverName string) (string, error) {
-	if err := ValidateServerName(serverName); err != nil {
+	name := strings.TrimSpace(serverName)
+	if err := ValidateServerName(name); err != nil {
 		return "", err
 	}
-	key := oauth.KeyPrefixMCP + strings.TrimSpace(serverName)
+	if hasMCPIdentitySuffix(name) {
+		return "", fmt.Errorf("MCP OAuth server name %q cannot end with .<32 hex chars> because it collides with identity-bound token storage", name)
+	}
+	key := oauth.KeyPrefixMCP + name
 	if err := oauth.ValidateKey(key); err != nil {
 		return "", err
 	}
 	return key, nil
+}
+
+func mcpIdentityKey(server Server) (string, error) {
+	name := strings.TrimSpace(server.Name)
+	if err := ValidateServerName(name); err != nil {
+		return "", err
+	}
+	if hasMCPIdentitySuffix(name) {
+		return "", fmt.Errorf("MCP OAuth server name %q cannot end with .<32 hex chars> because it collides with identity-bound token storage", name)
+	}
+	identity := strings.TrimSpace(server.Identity)
+	if len(name) > maxMCPServerNameForIdentityToken {
+		return "", fmt.Errorf("MCP OAuth server name %q is too long for identity-bound token storage", name)
+	}
+	if len(identity) != mcpServerIdentityLength || !isMCPServerIdentity(identity) {
+		return "", fmt.Errorf("MCP OAuth server %s has invalid identity %q", name, identity)
+	}
+	key := oauth.KeyPrefixMCP + name + "." + identity
+	if err := oauth.ValidateKey(key); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+func splitMCPIdentityKeySegment(segment string) (string, string, bool) {
+	index := strings.LastIndex(segment, ".")
+	if index <= 0 || index == len(segment)-1 {
+		return segment, "", false
+	}
+	identity := segment[index+1:]
+	if len(identity) != mcpServerIdentityLength || !isMCPServerIdentity(identity) {
+		return segment, "", false
+	}
+	return segment[:index], identity, true
+}
+
+func hasMCPIdentitySuffix(value string) bool {
+	_, _, ok := splitMCPIdentityKeySegment(value)
+	return ok
+}
+
+func isMCPServerIdentity(value string) bool {
+	for _, ch := range value {
+		if (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F') {
+			continue
+		}
+		return false
+	}
+	return value != ""
 }
 
 // storedToOAuth converts an MCP StoredToken to the shared oauth.Token (the
@@ -284,6 +408,11 @@ func FormatTokenStatuses(statuses []TokenStatus) string {
 			builder.WriteByte('\n')
 		}
 		builder.WriteString(status.ServerName)
+		if status.ServerIdentity != "" {
+			builder.WriteString(" [")
+			builder.WriteString(status.ServerIdentity)
+			builder.WriteString("]")
+		}
 		builder.WriteString(": ")
 		if !status.HasToken {
 			builder.WriteString("no token")

--- a/internal/mcp/oauth_store_test.go
+++ b/internal/mcp/oauth_store_test.go
@@ -1,9 +1,11 @@
 package mcp
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -40,6 +42,191 @@ func TestTokenStoreRoundTrip(t *testing.T) {
 	}
 	if !loaded.ExpiresAt.Equal(expiry) {
 		t.Fatalf("expiry = %v, want %v", loaded.ExpiresAt, expiry)
+	}
+}
+
+func TestTokenStoreIdentityBoundRoundTrip(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	server := testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)
+	otherTarget := testOAuthServer("demo", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", false)
+	if err := store.SaveForServer(server, StoredToken{AccessToken: "identity-token"}); err != nil {
+		t.Fatalf("SaveForServer() error = %v", err)
+	}
+
+	loaded, ok, err := store.LoadForServer(server)
+	if err != nil || !ok {
+		t.Fatalf("LoadForServer() ok=%v err=%v", ok, err)
+	}
+	if loaded.AccessToken != "identity-token" {
+		t.Fatalf("access token = %q", loaded.AccessToken)
+	}
+	if _, ok, err := store.LoadForServer(otherTarget); err != nil || ok {
+		t.Fatalf("LoadForServer(other target) ok=%v err=%v, want no token", ok, err)
+	}
+}
+
+func TestStoreTokenSourceRequiresMatchingIdentity(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	server := testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)
+	otherTarget := testOAuthServer("demo", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", false)
+	if err := store.SaveForServer(server, StoredToken{AccessToken: "access-a"}); err != nil {
+		t.Fatalf("SaveForServer() error = %v", err)
+	}
+
+	source := &storeTokenSource{server: server, store: store}
+	token, err := source.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("AccessToken() error = %v", err)
+	}
+	if token != "access-a" {
+		t.Fatalf("token = %q, want access-a", token)
+	}
+
+	source.server = otherTarget
+	if _, err := source.AccessToken(context.Background()); err == nil {
+		t.Fatal("AccessToken() error = nil for mismatched identity")
+	}
+}
+
+func TestTokenStoreProjectConfiguredDoesNotLoadLegacyToken(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	if err := store.Save("demo", StoredToken{AccessToken: "legacy-token"}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	server := testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true)
+
+	_, ok, err := store.LoadForServer(server)
+	if err != nil {
+		t.Fatalf("LoadForServer() error = %v", err)
+	}
+	if ok {
+		t.Fatal("LoadForServer() ok = true for project-configured legacy token")
+	}
+}
+
+func TestTokenStoreMigratesLegacyForUserOnlyServer(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	if err := store.Save("demo", StoredToken{AccessToken: "legacy-token"}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	server := testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)
+
+	loaded, ok, err := store.LoadForServer(server)
+	if err != nil || !ok {
+		t.Fatalf("LoadForServer() ok=%v err=%v", ok, err)
+	}
+	if loaded.AccessToken != "legacy-token" {
+		t.Fatalf("access token = %q", loaded.AccessToken)
+	}
+	if _, err := store.Delete("demo"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	loaded, ok, err = store.LoadForServer(server)
+	if err != nil || !ok || loaded.AccessToken != "legacy-token" {
+		t.Fatalf("identity-bound migrated token missing: loaded=%#v ok=%v err=%v", loaded, ok, err)
+	}
+}
+
+func TestTokenStoreRejectsLongIdentityBoundServerName(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	name := strings.Repeat("a", maxMCPServerNameForIdentityToken+1)
+	err = store.SaveForServer(testOAuthServer(name, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false), StoredToken{AccessToken: "x"})
+	if err == nil {
+		t.Fatal("SaveForServer() error = nil for long server name")
+	}
+	if !strings.Contains(err.Error(), `MCP OAuth server name "`+name+`" is too long for identity-bound token storage`) {
+		t.Fatalf("error = %q, want long-name message", err.Error())
+	}
+}
+
+func TestTokenStoreRejectsAmbiguousIdentitySuffixServerName(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	name := "demo.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	if err := store.SaveForServer(testOAuthServer(name, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", false), StoredToken{AccessToken: "x"}); err == nil {
+		t.Fatal("SaveForServer() error = nil for ambiguous server name")
+	} else if !strings.Contains(err.Error(), `MCP OAuth server name "`+name+`" cannot end with .<32 hex chars>`) {
+		t.Fatalf("SaveForServer() error = %q, want ambiguous-name rejection", err.Error())
+	}
+	if err := store.Save(name, StoredToken{AccessToken: "legacy"}); err == nil {
+		t.Fatal("Save() error = nil for ambiguous legacy server name")
+	}
+}
+
+func TestTokenStoreDeleteForServerNameRemovesLegacyAndIdentityTokens(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	if err := store.Save("demo", StoredToken{AccessToken: "legacy"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveForServer(testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false), StoredToken{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveForServer(testOAuthServer("demo", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", false), StoredToken{AccessToken: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveForServer(testOAuthServer("other", "cccccccccccccccccccccccccccccccc", false), StoredToken{AccessToken: "c"}); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := store.DeleteForServerName("demo")
+	if err != nil {
+		t.Fatalf("DeleteForServerName() error = %v", err)
+	}
+	if !removed {
+		t.Fatal("DeleteForServerName() removed = false")
+	}
+	statuses, err := store.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].ServerName != "other" {
+		t.Fatalf("statuses after delete = %#v, want only other", statuses)
+	}
+}
+
+func TestTokenStoreStatusParsesIdentityAndRedacts(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	identity := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if err := store.SaveForServer(testOAuthServer("demo", identity, false), StoredToken{AccessToken: "secret-access", RefreshToken: "secret-refresh"}); err != nil {
+		t.Fatalf("SaveForServer() error = %v", err)
+	}
+	statuses, err := store.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].ServerName != "demo" || statuses[0].ServerIdentity != identity {
+		t.Fatalf("statuses = %#v, want parsed identity", statuses)
+	}
+	output := FormatTokenStatuses(statuses)
+	if !strings.Contains(output, "demo ["+identity+"]") {
+		t.Fatalf("status output = %q, want identity label", output)
+	}
+	if contains(output, "secret-access") || contains(output, "secret-refresh") {
+		t.Fatalf("status output leaked token: %s", output)
 	}
 }
 
@@ -265,6 +452,17 @@ func TestResolveTokenStorePathUsesXDG(t *testing.T) {
 	want := filepath.Join(configHome, "zero", "mcp-oauth-tokens.json")
 	if path != want {
 		t.Fatalf("path = %q, want %q", path, want)
+	}
+}
+
+func testOAuthServer(name string, identity string, projectConfigured bool) Server {
+	return Server{
+		Name:              name,
+		Type:              ServerTypeHTTP,
+		URL:               "https://example.com/mcp",
+		Auth:              ServerAuthOAuth,
+		Identity:          identity,
+		ProjectConfigured: projectConfigured,
 	}
 }
 


### PR DESCRIPTION
Fixes #596

What changed:
- Add project-aware MCP merge guard: project target changes cannot inherit user headers, env, or OAuth config.
- Mark project-touched MCP servers and carry that into runtime token lookup.
- Bind MCP OAuth tokens to server identity; legacy fallback only for user-only servers.
- Update logout/status for identity-bound tokens; reject ambiguous OAuth server names.
- Document project MCP credential boundary and identity-bound OAuth behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP OAuth tokens are now tied to the specific server identity, improving reliability when server settings change.
  * Project-level MCP changes can now be tracked separately from user-level configuration.

* **Bug Fixes**
  * Updated token login/logout and refresh handling to use the correct server-scoped storage.
  * Improved configuration merging so project changes that affect connection targets are handled more safely.
  * Added clearer guidance when changing MCP server targets so credentials are not reused unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->