### PR TITLE
feat(modelregistry): allow /effort on Hunyuan and vendor-prefixed gateway models

### DIFF
--- a/internal/modelregistry/catalog.go
+++ b/internal/modelregistry/catalog.go
@@ -214,11 +214,22 @@ func reasoningEffortsForModelName(name string) []ReasoningEffort {
 	if i := strings.IndexByte(n, ':'); i >= 0 { // drop a "provider:" qualifier
 		n = n[i+1:]
 	}
+	// Gateway ids also carry a slash-form "vendor/" qualifier (e.g. the
+	// OpenGateway's tencent/hy3, github's openai/o3-mini) — match on the bare name.
+	if i := strings.LastIndexByte(n, '/'); i >= 0 {
+		n = n[i+1:]
+	}
 	switch {
 	case strings.HasPrefix(n, "gpt-5") || strings.HasPrefix(n, "gpt5"):
 		// GPT-5 / Codex (gpt-5.x) add a "minimal" tier below low.
 		return []ReasoningEffort{ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}
 	case strings.Contains(n, "codex") || isOSeriesModelName(n):
+		return []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}
+	case strings.HasPrefix(n, "hy3") || strings.Contains(n, "hunyuan"):
+		// Tencent Hunyuan reasoning models (served via OpenAI-compatible gateways).
+		// The client forwards reasoning_effort; whether the upstream honors it is
+		// the gateway's translation concern — unknown fields are ignored, so the
+		// worst case is a silent no-op rather than a 400.
 		return []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}
 	default:
 		return nil

--- a/internal/modelregistry/effort_fallback_test.go
+++ b/internal/modelregistry/effort_fallback_test.go
@@ -16,9 +16,14 @@ func TestReasoningEffortsFallbackForGPT5AndOSeries(t *testing.T) {
 		{"gpt-5.4-mini", []ReasoningEffort{ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
 		{"o3-mini", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
 		{"gpt-5.3-codex-spark", []ReasoningEffort{ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"tencent/hy3", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"hy3", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"hunyuan-t1", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
+		{"openai/o3-mini", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}}, // github-style vendor/ id
 		{"gpt-4.1", nil}, // non-reasoning, registered: stays empty
 		{"gpt-4o-mini", nil},
 		{"ollama/llama3.1", nil},
+		{"nvidia/llama-3.1-nemotron-70b-instruct", nil}, // vendor/ id, non-reasoning: stays empty
 	}
 	for _, c := range cases {
 		got := reg.ReasoningEfforts(c.name)


### PR DESCRIPTION
## Summary
`/effort` refused to set a level on OpenGateway models like `tencent/hy3` because the name-based fallback in `reasoningEffortsForModelName` only recognized GPT-5, Codex, and o-series names.

- Strip a slash-form `vendor/` qualifier (`tencent/hy3`, `openai/o3-mini`) before matching, mirroring the existing `provider:` strip. This also lights up `/effort` for o-series models served under GitHub-style ids.
- Add hy3/hunyuan as a known reasoning family with low/medium/high.

Once the fallback returns a non-empty list, the existing plumbing handles the rest: the `/effort` picker, `/effort <value>`, and the Ctrl+T cycle, with the value forwarded as `reasoning_effort` in the OpenAI-compatible payload.

## Limitations
I'm well aware of the limitations here: the client only sends `reasoning_effort` on the wire. Whether OpenGateway translates it for the Tencent upstream is the gateway's concern, and compatible servers ignore unknown fields, so the worst case is a silent no-op rather than an error.

## Testing
- `go test ./internal/modelregistry/...` (includes new fallback cases for `tencent/hy3`, `hy3`, `hunyuan-t1`, `openai/o3-mini`, and a non-reasoning `nvidia/...` id)
- `go build ./...` and `go test ./internal/tui/... ./internal/providers/...` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model-name handling so vendor-style prefixes are recognized more reliably.
  * Added support for additional model families, including Tencent Hunyuan-style names, so reasoning effort levels are assigned more accurately.
  * Expanded coverage for several model identifiers to ensure consistent behavior across supported model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->