### PR TITLE
fix(modelregistry): reject oversized models.dev cache responses

### DIFF
--- a/internal/modelregistry/modelsdev.go
+++ b/internal/modelregistry/modelsdev.go
@@ -246,7 +246,7 @@ func RefreshModelsDevCache(ctx context.Context) error {
 		return err
 	}
 	if len(data) > modelsDevFetchLimit {
-		return fmt.Errorf("modelregistry: models.dev response exceeds %d byte limit", modelsDevFetchLimit)
+		return fmt.Errorf("modelregistry: models.dev response is %d bytes, exceeds %d byte limit", len(data), modelsDevFetchLimit)
 	}
 	// Validate before persisting: a bad body must never clobber a good cache.
 	if _, err := parseModelsDev(data); err != nil {

--- a/internal/modelregistry/modelsdev.go
+++ b/internal/modelregistry/modelsdev.go
@@ -241,9 +241,12 @@ func RefreshModelsDevCache(ctx context.Context) error {
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("modelregistry: models.dev fetch: HTTP %d", response.StatusCode)
 	}
-	data, err := io.ReadAll(io.LimitReader(response.Body, modelsDevFetchLimit))
+	data, err := io.ReadAll(io.LimitReader(response.Body, modelsDevFetchLimit+1))
 	if err != nil {
 		return err
+	}
+	if len(data) > modelsDevFetchLimit {
+		return fmt.Errorf("modelregistry: models.dev response exceeds %d byte limit", modelsDevFetchLimit)
 	}
 	// Validate before persisting: a bad body must never clobber a good cache.
 	if _, err := parseModelsDev(data); err != nil {

--- a/internal/modelregistry/modelsdev_test.go
+++ b/internal/modelregistry/modelsdev_test.go
@@ -160,7 +160,8 @@ func TestRefreshModelsDevCacheRejectsBadBodyWithoutClobbering(t *testing.T) {
 }
 
 func TestRefreshModelsDevCacheRejectsOversizedResponse(t *testing.T) {
-	oversized := sampleModelsDev + strings.Repeat(" ", modelsDevFetchLimit)
+	// Repro: valid JSON + padding up to the limit + one extra byte.
+	oversized := sampleModelsDev + strings.Repeat(" ", modelsDevFetchLimit-len(sampleModelsDev)+1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(oversized))
 	}))
@@ -176,6 +177,7 @@ func TestRefreshModelsDevCacheRejectsOversizedResponse(t *testing.T) {
 	}
 	t.Setenv("ZERO_MODELS_CACHE_PATH", cachePath)
 	t.Setenv("ZERO_MODELS_URL", server.URL)
+	t.Setenv("ZERO_DISABLE_MODELS_FETCH", "")
 
 	if err := RefreshModelsDevCache(t.Context()); err == nil {
 		t.Fatal("oversized response must return an error")

--- a/internal/modelregistry/modelsdev_test.go
+++ b/internal/modelregistry/modelsdev_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -155,6 +156,33 @@ func TestRefreshModelsDevCacheRejectsBadBodyWithoutClobbering(t *testing.T) {
 	content, err := os.ReadFile(cachePath)
 	if err != nil || string(content) != sampleModelsDev {
 		t.Fatal("bad fetch must not clobber the existing cache")
+	}
+}
+
+func TestRefreshModelsDevCacheRejectsOversizedResponse(t *testing.T) {
+	oversized := sampleModelsDev + strings.Repeat(" ", modelsDevFetchLimit)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(oversized))
+	}))
+	defer server.Close()
+
+	cachePath := filepath.Join(t.TempDir(), "modelsdev.json")
+	if err := os.WriteFile(cachePath, []byte(sampleModelsDev), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(cachePath, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ZERO_MODELS_CACHE_PATH", cachePath)
+	t.Setenv("ZERO_MODELS_URL", server.URL)
+
+	if err := RefreshModelsDevCache(t.Context()); err == nil {
+		t.Fatal("oversized response must return an error")
+	}
+	content, err := os.ReadFile(cachePath)
+	if err != nil || string(content) != sampleModelsDev {
+		t.Fatal("oversized fetch must not clobber the existing cache")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Read `modelsDevFetchLimit+1` bytes instead of `modelsDevFetchLimit` when fetching models.dev
- Return an error if the response exceeds the 32 MiB guard, leaving existing cache untouched

## Problem
`RefreshModelsDevCache` uses `io.LimitReader(response.Body, modelsDevFetchLimit)` which silently truncates oversized responses. If the truncated prefix is valid JSON, it gets cached — a malicious or buggy server could serve a response that passes validation after truncation.

## Fix
- `internal/modelregistry/modelsdev.go:244`: Read `modelsDevFetchLimit+1` bytes, reject if `len(data) > modelsDevFetchLimit`
- `internal/modelregistry/modelsdev_test.go`: Added `TestRefreshModelsDevCacheRejectsOversizedResponse` — serves a valid JSON payload padded beyond the limit, verifies the error is returned and existing cache is preserved

## Testing
- `go build ./...` passes
- `go test ./internal/modelregistry/...` passes
- `go vet ./internal/modelregistry/...` passes

Fixes #510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit handling to reject models payloads that exceed the configured maximum size, with a clearer error.
  * Prevented oversized/invalid responses from overwriting the existing cached model file when refresh fails.
  * Improved safety around model cache refresh by ensuring truncated payloads don’t pass unnoticed.

* **Tests**
  * Added a test that simulates an oversized response to confirm refresh is rejected and the stale cache remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->