### PR TITLE
fix(hooks): run sessionEnd hooks after Esc/Ctrl+C interrupts

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -164,7 +164,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	result = Result{Messages: copyMessages(messages)}
 	dispatchSessionStart(ctx, options)
 	defer func() {
-		dispatchSessionEnd(ctx, options, result, err)
+		// Use a context detached from ctx's cancellation: on Esc/Ctrl+C the run
+		// context is already canceled by the time this defer runs, and a canceled
+		// parent would make Hooks.Dispatch's context.WithTimeout derive an
+		// already-expired context, so the sessionEnd hook would never actually run.
+		dispatchSessionEnd(context.WithoutCancel(ctx), options, result, err)
 	}()
 	for turn := 0; turn < maxTurns; turn++ {
 		result.Turns = turn + 1

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -115,7 +115,13 @@ func (provider *cancelingProvider) StreamCompletion(ctx context.Context, request
 func TestRunDispatchesSessionEndHookAfterContextCancellation(t *testing.T) {
 	goBinary, err := exec.LookPath("go")
 	if err != nil {
-		t.Skip("go binary not on PATH")
+		goBinary = filepath.Join(runtime.GOROOT(), "bin", "go")
+		if runtime.GOOS == "windows" {
+			goBinary += ".exe"
+		}
+		if _, statErr := os.Stat(goBinary); statErr != nil {
+			t.Skipf("go binary unavailable on PATH or in GOROOT: %v", statErr)
+		}
 	}
 	audit, err := hooks.NewAuditStore(hooks.AuditStoreOptions{AuditPath: filepath.Join(t.TempDir(), "audit.jsonl")})
 	if err != nil {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -115,7 +115,10 @@ func (provider *cancelingProvider) StreamCompletion(ctx context.Context, request
 func TestRunDispatchesSessionEndHookAfterContextCancellation(t *testing.T) {
 	goBinary, err := exec.LookPath("go")
 	if err != nil {
-		goBinary = filepath.Join(runtime.GOROOT(), "bin", "go")
+		// The test binary runs on the build machine, so its build-time GOROOT
+		// still identifies the toolchain that produced it.
+		goRoot := runtime.GOROOT() //nolint:staticcheck // Safe for this non-portable test binary.
+		goBinary = filepath.Join(goRoot, "bin", "go")
 		if runtime.GOOS == "windows" {
 			goBinary += ".exe"
 		}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -89,6 +90,78 @@ func TestRunDispatchesSessionLifecycleHooks(t *testing.T) {
 	}
 	if started[hooks.EventSessionEnd] != 1 || completed[hooks.EventSessionEnd] != 1 {
 		t.Fatalf("sessionEnd audit counts started/completed = %d/%d, events=%#v", started[hooks.EventSessionEnd], completed[hooks.EventSessionEnd], events)
+	}
+}
+
+// cancelingProvider simulates an Esc/Ctrl+C abort: it cancels the run's own
+// context mid-stream (as the TUI's interrupt handler would) and returns no
+// events, so Run observes ctx.Err() and returns early with an already-canceled
+// context in scope for the deferred sessionEnd dispatch.
+type cancelingProvider struct {
+	cancel context.CancelFunc
+}
+
+func (provider *cancelingProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	provider.cancel()
+	ch := make(chan zeroruntime.StreamEvent)
+	close(ch)
+	return ch, nil
+}
+
+// TestRunDispatchesSessionEndHookAfterContextCancellation is a regression test
+// for a bug where an interrupted run (Esc/Ctrl+C) canceled ctx before the
+// deferred sessionEnd dispatch ran, so Hooks.Dispatch's context.WithTimeout(ctx, ...)
+// derived an already-canceled context and the hook command never actually launched.
+func TestRunDispatchesSessionEndHookAfterContextCancellation(t *testing.T) {
+	goBinary, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go binary not on PATH")
+	}
+	audit, err := hooks.NewAuditStore(hooks.AuditStoreOptions{AuditPath: filepath.Join(t.TempDir(), "audit.jsonl")})
+	if err != nil {
+		t.Fatalf("NewAuditStore: %v", err)
+	}
+	dispatcher := hooks.NewDispatcher(hooks.DispatcherOptions{
+		Config: hooks.Config{
+			Enabled: true,
+			Hooks: []hooks.Definition{
+				{ID: "zero.session-end", Event: hooks.EventSessionEnd, Command: goBinary, Args: []string{"version"}, Enabled: true},
+			},
+		},
+		Audit: audit,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &cancelingProvider{cancel: cancel}
+
+	_, err = Run(ctx, "hi", provider, Options{
+		SessionID:    "session-cancel",
+		Cwd:          t.TempDir(),
+		ProviderName: "test-provider",
+		Model:        "test-model",
+		Hooks:        dispatcher,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run err = %v, want context.Canceled", err)
+	}
+
+	events, err := audit.ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	var completedStatus hooks.AuditStatus
+	found := false
+	for _, event := range events {
+		if event.Type == "hook_execution_completed" && event.Event == hooks.EventSessionEnd {
+			completedStatus = event.Status
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no sessionEnd hook_execution_completed audit event, events=%#v", events)
+	}
+	if completedStatus != hooks.AuditCompleted {
+		t.Fatalf("sessionEnd hook status = %q, want %q (hook must actually run despite ctx cancellation)", completedStatus, hooks.AuditCompleted)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #605.

- `sessionEnd` hooks were dispatched with the run's own (already-canceled) `ctx` on interrupt (Esc/Ctrl+C), so `Hooks.Dispatch`'s `context.WithTimeout(ctx, ...)` derived an already-canceled context and the hook process never actually launched — recorded as timed-out/error in the audit log even though the run completed normally.
- Detach the `sessionEnd` dispatch from the run context's cancellation via `context.WithoutCancel(ctx)`, so the dispatcher's own per-hook timeout still applies without being short-circuited by the run's cancellation.
- `sessionStart` and other lifecycle/tool hooks are unaffected — this is specific to the deferred `sessionEnd` call, which is the one hook dispatch guaranteed to run *after* the run context may already be canceled.

## Test plan

- [x] Added `TestRunDispatchesSessionEndHookAfterContextCancellation` (`internal/agent/loop_test.go`): a `cancelingProvider` cancels the run's context mid-stream (simulating Esc/Ctrl+C), then asserts the `sessionEnd` hook's audit status is `completed`, not `error`.
- [x] Verified the new test fails on the pre-fix code (`status = "error"`) and passes after the fix.
- [x] `go test ./internal/agent/... ./internal/hooks/...` passes.
- [x] `go vet ./internal/agent/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured session-end actions/hooks are dispatched and complete reliably even if a run is canceled before cleanup begins.
  * Prevents session-end steps from being skipped due to early cancellation timing.
* **Tests**
  * Added a regression test covering mid-stream/early cancellation to verify session-end hooks still reach completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->