### PR TITLE
fix: bump Go to 1.26.5 for crypto/tls fix (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Gitlawb/zero
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.26.4 to 1.26.5 to fix GO-2026-5856, an Encrypted
Client Hello privacy leak in the standard library's `crypto/tls` that was
failing CI's govulncheck job. Our code reaches the vulnerable paths through
normal TLS usage — the MCP OAuth callback server, dictation downloads, and the
daemon protocol/remote client — so any TLS use tripped it.

Since every workflow resolves the toolchain via `go-version-file: go.mod`,
bumping the `go` directive is the complete fix; no code changes needed.
Verified: `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...` now reports
**No vulnerabilities found** (this also clears the second, uncalled dependency
finding from the failing run).

## Checklist

- [ ] The linked issue already has the `issue-approved` label. (No linked issue — direct fix for the currently failing govulncheck CI job.)
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] `gofmt` clean.
- [x] Tests added/updated for the change (and run under `-race` where relevant). (N/A — toolchain version bump only, no code changed; full existing suite passes on 1.26.5.)
- [x] UI changes include screenshots or a short recording where possible. (N/A — no UI changes.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go runtime version to 1.26.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->