### PR TITLE
fix(exec): stop false INCOMPLETE downgrades on conversational final messages

### DIFF
--- a/internal/agent/acceptance_gate_test.go
+++ b/internal/agent/acceptance_gate_test.go
@@ -72,6 +72,21 @@ func TestSelfReportedIncompletionMatching(t *testing.T) {
 		{"I replaced the placeholder value with the computed key.", false},
 		{"The retry uses exponential backoff as a fallback.", false},
 		{"Without proper error handling the function would crash, so I added it.", false},
+		// real false positive (conversational recap): retelling a PAST exchange is
+		// not an admission about the current objective — the sentence carries its
+		// own narrative context ("You asked …", "at the time"):
+		{"You asked if I could work autonomously on zero if you gave me a GitHub account — I was honest that my sandbox had no repo, no build system, and no network/integration wired up yet, so I couldn't actually do it at the time.", false},
+		{"When we last spoke, I couldn't reach the GitHub API from the sandbox.", false},
+		{"Last session I was unable to build the project; that is what we should retry now.", false},
+		// quoted admissions (the model citing its own earlier message or a log
+		// line) must NOT be flagged:
+		{`My earlier reply said "I couldn't do it" but the tooling is now installed.`, false},
+		{"The run log contains `I cannot access the network`, which is expected inside the sandbox.", false},
+		// current-objective admissions must STILL be flagged, including past tense
+		// and multi-sentence finals whose other sentences are narrative:
+		{"I couldn't complete the refactor.", true},
+		{"I hit an error I could not resolve, so the migration is unfinished.", true},
+		{"You asked me to port the parser. I couldn't finish the second half.", true},
 	}
 	for _, c := range cases {
 		got := selfReportedIncompletion(c.text) != ""

--- a/internal/agent/acceptance_gate_test.go
+++ b/internal/agent/acceptance_gate_test.go
@@ -87,6 +87,11 @@ func TestSelfReportedIncompletionMatching(t *testing.T) {
 		{"I couldn't complete the refactor.", true},
 		{"I hit an error I could not resolve, so the migration is unfinished.", true},
 		{"You asked me to port the parser. I couldn't finish the second half.", true},
+		// unbalanced delimiters must not swallow the tail (only BALANCED quoted
+		// spans are stripped), so an admission after a stray quote still fires:
+		{"The log ends with a stray \" and I couldn't finish the migration.", true},
+		{"There is an unterminated `code span and I cannot proceed with the fix.", true},
+		{"The doc opens with “a curly quote and I was unable to complete the task.", true},
 	}
 	for _, c := range cases {
 		got := selfReportedIncompletion(c.text) != ""

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -183,33 +183,101 @@ var successNegationTails = []string{
 	"reproduce", "spot any", "locate any",
 }
 
-// selfReportedIncompletion returns a short reason when the model's final text
-// admits it guessed or could not meet the objective, else "". Case-insensitive.
-func selfReportedIncompletion(text string) string {
-	lower := strings.ToLower(text)
-	for _, phrase := range selfReportPhrases {
-		if strings.Contains(lower, phrase) {
-			return selfReportReason(phrase)
+// narrativeMarkers flag a sentence as RETELLING a past exchange rather than
+// reporting the outcome of the current objective, so an inability admission in
+// that sentence is about THEN, not NOW. Grounded in a real false positive: a
+// conversational recap ("You asked if I could work autonomously … I was honest
+// that my sandbox had no repo … so I couldn't actually do it at the time") was
+// downgraded to INCOMPLETE on the quoted "i couldn't " stem even though the
+// current turn's objective (summarize where we left off) was fully met. Every
+// marker is second-person or explicitly past-referential, so a first-person
+// admission about the current task ("I couldn't complete the refactor") is
+// never masked.
+var narrativeMarkers = []string{
+	"you asked", "you said", "you wanted", "you mentioned",
+	"we discussed", "we talked", "we covered",
+	"when we last", "last time", "last session", "previous session",
+	"previous conversation", "earlier session", "earlier conversation",
+	"at the time", "back then",
+}
+
+// stripQuoted removes spans enclosed in double quotes (straight or curly) or
+// backticks, so an admission the model merely QUOTES — its own earlier message,
+// a log line, an error string — cannot fire the detector. Single quotes are
+// left alone: they are overwhelmingly apostrophes ("couldn't"), and treating
+// them as quote delimiters would swallow the text between two contractions.
+func stripQuoted(s string) string {
+	var b strings.Builder
+	open := rune(0)
+	for _, r := range s {
+		switch {
+		case open != 0:
+			if (open == '"' && r == '"') || (open == '“' && r == '”') || (open == '`' && r == '`') {
+				open = 0
+			}
+		case r == '"' || r == '“' || r == '`':
+			open = r
+		default:
+			b.WriteRune(r)
 		}
 	}
-	for _, stem := range inabilityStems {
-		// Scan EVERY occurrence of the stem, not just the first: an earlier
-		// success-negation use ("I could not find any examples, so I could not
-		// implement it") must not mask a later genuine admission with the same stem.
-		for start := 0; ; {
-			rel := strings.Index(lower[start:], stem)
-			if rel < 0 {
-				break
+	return b.String()
+}
+
+// admissionSentences splits lowered text into sentence-ish fragments so the
+// detector judges each claim in its own context. Newlines split too (markdown
+// bullets are separate claims); the exact boundaries only need to keep an
+// admission next to its own narrative/negation context, not be grammatical.
+func admissionSentences(lower string) []string {
+	return strings.FieldsFunc(lower, func(r rune) bool {
+		return r == '.' || r == '!' || r == '?' || r == '\n'
+	})
+}
+
+// selfReportedIncompletion returns a short reason when the model's final text
+// admits it guessed or could not meet the objective, else "". Case-insensitive.
+// Matching is per sentence, after dropping quoted spans, and a sentence that
+// retells a past exchange (narrativeMarkers) is skipped entirely — an admission
+// must be the model's own report about the CURRENT objective, not general
+// language that merely resembles one.
+func selfReportedIncompletion(text string) string {
+	for _, sentence := range admissionSentences(strings.ToLower(stripQuoted(text))) {
+		if containsAny(sentence, narrativeMarkers) {
+			continue
+		}
+		for _, phrase := range selfReportPhrases {
+			if strings.Contains(sentence, phrase) {
+				return selfReportReason(phrase)
 			}
-			abs := start + rel
-			tail := strings.TrimSpace(lower[abs+len(stem):])
-			if !hasAnyPrefix(tail, successNegationTails) {
-				return selfReportReason(strings.TrimSpace(stem) + " …")
+		}
+		for _, stem := range inabilityStems {
+			// Scan EVERY occurrence of the stem, not just the first: an earlier
+			// success-negation use ("I could not find any examples, so I could not
+			// implement it") must not mask a later genuine admission with the same stem.
+			for start := 0; ; {
+				rel := strings.Index(sentence[start:], stem)
+				if rel < 0 {
+					break
+				}
+				abs := start + rel
+				tail := strings.TrimSpace(sentence[abs+len(stem):])
+				if !hasAnyPrefix(tail, successNegationTails) {
+					return selfReportReason(strings.TrimSpace(stem) + " …")
+				}
+				start = abs + len(stem)
 			}
-			start = abs + len(stem)
 		}
 	}
 	return ""
+}
+
+func containsAny(s string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 func selfReportReason(marker string) string {

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -203,24 +203,33 @@ var narrativeMarkers = []string{
 
 // stripQuoted removes spans enclosed in double quotes (straight or curly) or
 // backticks, so an admission the model merely QUOTES — its own earlier message,
-// a log line, an error string — cannot fire the detector. Single quotes are
-// left alone: they are overwhelmingly apostrophes ("couldn't"), and treating
-// them as quote delimiters would swallow the text between two contractions.
+// a log line, an error string — cannot fire the detector. Only BALANCED spans
+// are removed: an opening delimiter that never closes is kept as literal text,
+// so a stray quote cannot swallow the rest of the message (and with it a
+// genuine admission the detector must see). Single quotes are left alone: they
+// are overwhelmingly apostrophes ("couldn't"), and treating them as quote
+// delimiters would swallow the text between two contractions.
 func stripQuoted(s string) string {
 	var b strings.Builder
+	var span strings.Builder // pending text since the open delimiter, kept if it never closes
 	open := rune(0)
 	for _, r := range s {
 		switch {
 		case open != 0:
 			if (open == '"' && r == '"') || (open == '“' && r == '”') || (open == '`' && r == '`') {
 				open = 0
+				span.Reset()
+				continue
 			}
+			span.WriteRune(r)
 		case r == '"' || r == '“' || r == '`':
 			open = r
+			span.WriteRune(r)
 		default:
 			b.WriteRune(r)
 		}
 	}
+	b.WriteString(span.String()) // dangling delimiter: restore the span verbatim
 	return b.String()
 }
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1326,6 +1326,8 @@ Flags:
       --notify <off|bell|notify|both>
                                     Override notification mode for this run
       --no-notify                   Disable notifications for this run
+      --no-completion-gate          Accept a no-tool-call reply as final without the INCOMPLETE
+                                    downgrade (for conversational callers with an operator present)
 `)
 	return err
 }

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -110,6 +110,16 @@ type execOptions struct {
 	notifyMode string
 	// noNotify forces ModeOff for this run. Mutually exclusive with notifyMode.
 	noNotify bool
+	// noCompletionGate turns off the headless completion gate
+	// (agent.Options.RequireCompletionSignal) for this run. It exists for
+	// CONVERSATIONAL exec callers — a chat frontend driving exec with an operator
+	// present to reply (e.g. zeroclaw chat). There, a final message that hands
+	// the turn back ("the sandbox blocks network egress, approve it and I'll
+	// continue") is a COMPLETE answer, not an unfinished task, so the gate's
+	// self-report admission check and INCOMPLETE downgrade (exit 4) would only
+	// mislabel honest blocker reports. Default off: plain `zero exec` keeps the
+	// gate, preserving CI/cron semantics.
+	noCompletionGate bool
 	// addDirs holds directories passed via --add-dir that should be allowed as
 	// additional write roots for this run. Unioned with
 	// config.SandboxConfig.AdditionalWriteRoots at scope construction time.
@@ -545,8 +555,10 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		// Headless exec: don't accept a no-tool-call turn as "done" while work
 		// clearly remains (pending plan items / a mid-step continuation cue) —
 		// nudge to continue, and finalize as INCOMPLETE rather than false success
-		// if the model keeps stalling. The interactive TUI leaves this off.
-		RequireCompletionSignal: true,
+		// if the model keeps stalling. The interactive TUI leaves this off, and
+		// --no-completion-gate lets conversational exec callers (a chat frontend
+		// with an operator present) opt out the same way.
+		RequireCompletionSignal: !options.noCompletionGate,
 		Sandbox:                 sandboxEngine,
 		FileTracker:             fileTracker,
 		Hooks:                   newHookDispatcherWithExtra(workspaceRoot, pluginActivation.hooks),

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -404,6 +404,11 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 		// rather than pretend it took effect.
 		return options, false, execUsageError{"--self-correct cannot be combined with --use-spec."}
 	}
+	if options.useSpec && options.noCompletionGate {
+		// Same reasoning as --self-correct above: the spec-draft path never consults
+		// the completion gate, so the flag would be silently ignored.
+		return options, false, execUsageError{"--no-completion-gate cannot be combined with --use-spec."}
+	}
 	if !options.useSpec && options.specModel != "" {
 		return options, false, execUsageError{"--spec-model requires --use-spec."}
 	}

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -30,6 +30,8 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			options.selfCorrect = true
 		case arg == "--no-notify":
 			options.noNotify = true
+		case arg == "--no-completion-gate":
+			options.noCompletionGate = true
 		case arg == "--notify":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {

--- a/internal/cli/exec_parse_completion_gate_test.go
+++ b/internal/cli/exec_parse_completion_gate_test.go
@@ -23,3 +23,12 @@ func TestParseExecArgsNoCompletionGate(t *testing.T) {
 		t.Fatal("noCompletionGate must default to false (gate on)")
 	}
 }
+
+// The spec-draft path never consults the completion gate, so the combination
+// must be rejected up front instead of silently ignoring the flag (mirrors the
+// existing --self-correct + --use-spec check).
+func TestParseExecArgsNoCompletionGateRejectsUseSpec(t *testing.T) {
+	if _, _, err := parseExecArgs([]string{"--prompt", "hi", "--use-spec", "--no-completion-gate"}); err == nil {
+		t.Fatal("--no-completion-gate with --use-spec must error")
+	}
+}

--- a/internal/cli/exec_parse_completion_gate_test.go
+++ b/internal/cli/exec_parse_completion_gate_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import "testing"
+
+// --no-completion-gate exists for conversational exec callers (a chat frontend
+// with an operator present): an honest blocker report that hands the turn back
+// must not be downgraded to INCOMPLETE there. The flag maps to
+// agent.Options.RequireCompletionSignal = false; default keeps the gate on.
+func TestParseExecArgsNoCompletionGate(t *testing.T) {
+	options, _, err := parseExecArgs([]string{"--prompt", "hi", "--no-completion-gate"})
+	if err != nil {
+		t.Fatalf("parseExecArgs: %v", err)
+	}
+	if !options.noCompletionGate {
+		t.Fatal("--no-completion-gate must set noCompletionGate")
+	}
+
+	options, _, err = parseExecArgs([]string{"--prompt", "hi"})
+	if err != nil {
+		t.Fatalf("parseExecArgs: %v", err)
+	}
+	if options.noCompletionGate {
+		t.Fatal("noCompletionGate must default to false (gate on)")
+	}
+}


### PR DESCRIPTION
## Summary

Headless `zero exec` runs driven by a chat frontend get wrongly downgraded to INCOMPLETE (exit 4) by the completion gate's self-report check. Two distinct causes, fixed by the two commits:

1. `selfReportedIncompletion` matched inability stems anywhere in the final message, so a recap of a past exchange tripped it. Real transcript: "You asked if I could work autonomously on zero if you gave me a GitHub account. I was honest that my sandbox had no repo, no build system, and no network wired up yet, so I couldn't actually do it at the time." The turn's objective (summarize where we left off) was fully met, but the run ended `incomplete: the final message admits the objective was not met ("i couldn't ...")`. The detector is now sentence-scoped: quoted spans are dropped and sentences that retell a past exchange ("you asked", "at the time", "when we last") are skipped. That transcript is a regression test. Present-tense admissions and genuine past-tense failure reports about the current task still fire, and the existing chess-incident regression tests still pass.

2. Some admissions are true and still should not fail the run. With an operator present, "the sandbox blocks network egress, so I can't run `gh auth status`; approve network and I'll continue" is a complete answer that hands the turn back. No phrase heuristic can distinguish that, so this adds `zero exec --no-completion-gate`, mapping to `RequireCompletionSignal=false`, for conversational callers. Plain `zero exec` is unchanged and keeps full gate semantics for CI and cron use.

## Linked issue

None. Opening directly under my contributor exception to the community PR policy.

## Checklist

- [x] The linked issue already has the `issue-approved` label. (Not applicable, see above.)
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally. (`internal/agent` and `internal/cli` pass. Three failures elsewhere are local-environment issues untouched by this diff: two `provideroauth` ChatGPT loopback-callback tests that cannot bind port 1455 on this machine, and `internal/sandbox` TestWindowsUnelevatedSetupMarkerEvictsOldestPastCap.)
- [x] `gofmt` clean.
- [x] Tests added/updated for the change (and run under `-race` where relevant).
- [ ] UI changes include screenshots or a short recording where possible. (No UI changes; the only visible change is the new line in `zero exec --help`.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--no-completion-gate` option for `zero exec`, allowing a final no-tool-call reply to be accepted without requiring a completion signal.
* **Bug Fixes**
  * Improved “incomplete response” detection to reduce false triggers from quoted text, recap-style narration, and earlier-message references.
  * Expanded coverage for genuine incomplete final answers, including delimiter/quote edge cases.
* **Documentation**
  * Updated `zero exec` help text for the new `--no-completion-gate` flag, and added validation that it can’t be combined with `--use-spec`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->