### PR TITLE
fix(sandbox): make Windows token fully restricted to enforce DenyRead policies

### DIFF
--- a/internal/sandbox/runner_windows_integration_test.go
+++ b/internal/sandbox/runner_windows_integration_test.go
@@ -145,12 +145,22 @@ func TestWindowsUnelevatedRealSandboxSmoke(t *testing.T) {
 
 	root := t.TempDir()
 	outside := t.TempDir()
+	privateDir := filepath.Join(root, "private")
+	if err := os.MkdirAll(privateDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll private: %v", err)
+	}
+	secretFile := filepath.Join(privateDir, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("super-secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile secret: %v", err)
+	}
+
 	sandboxHome := filepath.Join(root, ".zero-sandbox")
 	profile := PermissionProfile{
 		FileSystem: FileSystemPolicy{
 			Kind:                 FileSystemRestricted,
 			ReadRoots:            []string{root},
 			WriteRoots:           []WritableRoot{{Root: root, ProtectedMetadataNames: []string{".git", ".zero", ".agents"}}},
+			DenyRead:             []string{privateDir},
 			IncludePlatformRoots: true,
 			AllowTemp:            true,
 		},
@@ -178,6 +188,11 @@ func TestWindowsUnelevatedRealSandboxSmoke(t *testing.T) {
 	if _, err := os.Stat(WindowsUnelevatedSetupMarkerPath(sandboxHome)); err != nil {
 		t.Fatalf("expected the unelevated setup marker to be recorded: %v", err)
 	}
+
+	// DenyRead check: reading from the privateDir must be blocked (exit code 1)
+	runWindowsRealSmokeCommand(t, runnerExe, config, []string{
+		"cmd.exe", "/d", "/s", "/c", "type " + secretFile,
+	}, 1)
 
 	outsideMarker := filepath.Join(outside, "unelevated-write-denied.txt")
 	runWindowsRealSmokeCommand(t, runnerExe, config, []string{

--- a/internal/sandbox/windows_token_windows.go
+++ b/internal/sandbox/windows_token_windows.go
@@ -105,7 +105,7 @@ func createWindowsRestrictedTokenFromBase(base windows.Token, capabilitySIDs []w
 	var restricted windows.Token
 	result, _, callErr := procCreateRestrictedToken.Call(
 		uintptr(base),
-		uintptr(windowsDisableMaxPrivilege|windowsLUAToken|windowsWriteRestricted),
+		uintptr(windowsDisableMaxPrivilege|windowsLUAToken),
 		0,
 		0,
 		0,


### PR DESCRIPTION
## Summary

Fixes a security vulnerability on Windows where sandboxed processes could completely bypass `DenyRead` sandbox file policies.

When creating the restricted token, we previously passed the `windowsWriteRestricted` flag (`0x08`). Under this mode, the Windows kernel only checks the restricted SID list during write operations, skipping it entirely for read operations. Consequently, NTFS deny-read ACEs associated with the capability SIDs were ignored, allowing the sandboxed process to read files located in `DenyRead` directories.

This PR removes the `windowsWriteRestricted` flag so that the token is fully restricted, enforcing SID constraints for both read and write operations.

## Changes

**`internal/sandbox/windows_token_windows.go`**
- Remove `windowsWriteRestricted` from the flags passed to `procCreateRestrictedToken.Call`.

**`internal/sandbox/runner_windows_integration_test.go`**
- Update `TestWindowsUnelevatedRealSandboxSmoke` to write a secret file to a `DenyRead` subdirectory, and assert that attempting to type/read it from the sandboxed process fails with an access-denied exit code.

## Test plan

- `go test ./internal/sandbox/...` — ok
- Verified that compiling sandbox code succeeds on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows sandbox behavior so restricted processes are less likely to retain unintended write limitations.
  * Added stronger verification that sandboxed apps cannot read files from blocked locations, with the expected failure behavior now covered by tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->