### PR TITLE
fix(agent,tui): resolve git branch detection when starting Zero in subdirectories

### DIFF
--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -2947,6 +2947,24 @@ func TestGitBranchForPromptResolvesRelativeWorktreeGitdir(t *testing.T) {
 	}
 }
 
+func TestGitBranchForPromptInSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	gitdir := filepath.Join(root, ".git")
+	if err := os.MkdirAll(gitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitdir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(root, "sub", "dir")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := gitBranchForPrompt(subdir); got != "main" {
+		t.Fatalf("gitBranchForPrompt in subdirectory = %q, want main", got)
+	}
+}
+
 func TestBuildSystemPromptInjectsWorkspaceContext(t *testing.T) {
 	cwd := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("Always run `make lint` before committing."), 0o644); err != nil {

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -295,7 +295,7 @@ func workspaceContext(cwd string) string {
 	}
 	b.WriteString("</environment>")
 
-	b.WriteString(projectGuidelines(cwd, findProjectGitRoot(cwd)))
+	b.WriteString(projectGuidelines(cwd, FindProjectGitRoot(cwd)))
 	if repoMap := repoMapContext(cwd); repoMap != "" {
 		b.WriteString("\n\n## Repo map\n\n" + repoMap)
 	}
@@ -542,17 +542,17 @@ func resolveDirCaseInsensitive(target, anchor string) (string, bool) {
 	return cur, true
 }
 
-// findProjectGitRoot returns the nearest ancestor of cwd that contains a
+// FindProjectGitRoot returns the nearest ancestor of cwd that contains a
 // .git entry (file or directory). Returns "" when no git root is found, so
 // the caller can fall back to cwd-only lookup.
-func findProjectGitRoot(cwd string) string {
+func FindProjectGitRoot(cwd string) string {
 	cwd = strings.TrimSpace(cwd)
 	if cwd == "" {
 		return ""
 	}
 	cur := cwd
 	for {
-		if hasGitMetadata(cur) {
+		if HasGitMetadata(cur) {
 			return cur
 		}
 		parent := filepath.Dir(cur)
@@ -563,7 +563,7 @@ func findProjectGitRoot(cwd string) string {
 	}
 }
 
-func hasGitMetadata(dir string) bool {
+func HasGitMetadata(dir string) bool {
 	gitPath := filepath.Join(dir, ".git")
 	info, err := os.Stat(gitPath)
 	if err != nil {
@@ -619,7 +619,11 @@ func repoMapContext(cwd string) string {
 // cwd, handling both a regular checkout (.git dir) and a worktree (.git file).
 // Returns "" on any problem — the prompt simply omits the branch segment.
 func gitBranchForPrompt(cwd string) string {
-	gitPath := filepath.Join(cwd, ".git")
+	gitRoot := FindProjectGitRoot(cwd)
+	if gitRoot == "" {
+		return ""
+	}
+	gitPath := filepath.Join(gitRoot, ".git")
 	info, err := os.Stat(gitPath)
 	if err != nil {
 		return ""
@@ -635,10 +639,10 @@ func gitBranchForPrompt(cwd string) string {
 			return ""
 		}
 		// In worktree mode the gitdir is often RELATIVE (e.g.
-		// "gitdir: ../.git/worktrees/<name>") — resolve it against cwd, not the
+		// "gitdir: ../.git/worktrees/<name>") — resolve it against the worktree root (gitRoot), not the
 		// process working directory, or HEAD lookup fails and we drop the branch.
 		if !filepath.IsAbs(dir) {
-			dir = filepath.Join(cwd, dir)
+			dir = filepath.Join(gitRoot, dir)
 		}
 		headPath = filepath.Join(dir, "HEAD")
 	}

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -424,7 +424,7 @@ func TestFindProjectGitRootIgnoresEmptyGitDirectory(t *testing.T) {
 	if err := os.MkdirAll(leaf, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got := findProjectGitRoot(leaf); got != "" {
-		t.Fatalf("findProjectGitRoot = %q, want empty for invalid .git directory", got)
+	if got := FindProjectGitRoot(leaf); got != "" {
+		t.Fatalf("FindProjectGitRoot = %q, want empty for invalid .git directory", got)
 	}
 }

--- a/internal/tui/tui_fixes_test.go
+++ b/internal/tui/tui_fixes_test.go
@@ -160,3 +160,21 @@ func suggestionNames2(s []commandSuggestion) []string {
 	}
 	return out
 }
+
+func TestGitBranchInSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	gitdir := filepath.Join(root, ".git")
+	if err := os.MkdirAll(gitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitdir, "HEAD"), []byte("ref: refs/heads/feature-tui-branch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(root, "nested", "sub", "dir")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := gitBranch(subdir); got != "feature-tui-branch" {
+		t.Fatalf("gitBranch in subdirectory = %q, want feature-tui-branch", got)
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -462,10 +462,15 @@ func shortenPath(path string) string {
 // both regular checkouts (.git dir) and worktrees (.git file). Returns "" on any
 // problem — the header simply omits the segment.
 func gitBranch(cwd string) string {
-	if strings.TrimSpace(cwd) == "" {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
 		return ""
 	}
-	gitPath := filepath.Join(cwd, ".git")
+	gitRoot := agent.FindProjectGitRoot(cwd)
+	if gitRoot == "" {
+		return ""
+	}
+	gitPath := filepath.Join(gitRoot, ".git")
 	info, err := os.Stat(gitPath)
 	if err != nil {
 		return ""
@@ -480,6 +485,12 @@ func gitBranch(cwd string) string {
 		dir := strings.TrimPrefix(strings.TrimSpace(string(data)), "gitdir: ")
 		if dir == "" {
 			return ""
+		}
+		// In worktree mode the gitdir is often RELATIVE (e.g.
+		// "gitdir: ../.git/worktrees/<name>") — resolve it against the worktree root (gitRoot), not the
+		// process working directory, or HEAD lookup fails and we drop the branch.
+		if !filepath.IsAbs(dir) {
+			dir = filepath.Join(gitRoot, dir)
 		}
 		headPath = filepath.Join(dir, "HEAD")
 	}


### PR DESCRIPTION
## Summary

Fixes a medium-severity issue where starting Zero from a nested subdirectory of a Git repository fails to detect the current branch name (e.g. for prompt assembly or in TUI header/welcome screens).

Previously, both `gitBranchForPrompt` (in prompt assembly) and `gitBranch` (in TUI view) checked for `.git` metadata directly in the current working directory (`cwd`). In subdirectories, this check fails, causing the branch name to be omitted.

This fix exports the existing unexported `findProjectGitRoot` helper from `internal/agent` as `FindProjectGitRoot`. Both branch resolution paths are updated to first find the nearest Git repository root via this helper and resolve the branch relative to it.

## Changes

**`internal/agent/system_prompt.go`**
- Export `findProjectGitRoot` as `FindProjectGitRoot` and `hasGitMetadata` as `HasGitMetadata`.
- Update `projectGuidelines` to call the exported helper.
- Update `gitBranchForPrompt` to use `FindProjectGitRoot(cwd)` to resolve repository root, and resolve relative worktree gitdirs relative to `gitRoot`.

**`internal/agent/system_prompt_test.go`**
- Update references of `findProjectGitRoot` to `FindProjectGitRoot`.

**`internal/agent/loop_test.go`**
- Add unit test `TestGitBranchForPromptInSubdirectory`.

**`internal/tui/view.go`**
- Update `gitBranch` to use `agent.FindProjectGitRoot(cwd)` to resolve the Git repository root.

**`internal/tui/tui_fixes_test.go`**
- Add unit test `TestGitBranchInSubdirectory`.

## Test plan

- `go test ./internal/agent/...` — ok
- `go test ./internal/tui/...` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git branch detection when working from nested subdirectories, including worktree setups with relative metadata paths.
  * Branch information now resolves more reliably and returns no value when a git root cannot be found.
  * Fixed prompt context detection so project settings are loaded from the correct repository root.
  * Added tests covering branch lookup from subdirectories and git-root discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->