### PR TITLE
fix(acp): make truncateHint rune-safe

### DIFF
--- a/internal/acp/translate.go
+++ b/internal/acp/translate.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"encoding/json"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -70,8 +71,8 @@ func primaryArgHint(rawArgs string) string {
 func truncateHint(s string) string {
 	s = strings.TrimSpace(s)
 	const max = 60
-	if len(s) > max {
-		return s[:max] + "…"
+	if utf8.RuneCountInString(s) > max {
+		return string([]rune(s)[:max]) + "…"
 	}
 	return s
 }

--- a/internal/acp/translate_test.go
+++ b/internal/acp/translate_test.go
@@ -1,7 +1,9 @@
 package acp
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -124,5 +126,37 @@ func TestPromptText(t *testing.T) {
 	})
 	if got != "hello world" {
 		t.Fatalf("promptText = %q", got)
+	}
+}
+
+func TestToolTitleTruncateHintRuneSafe(t *testing.T) {
+	// A 61-character string containing multi-byte UTF-8 runes (emojis / CJK characters).
+	// We want to verify that it is truncated without cutting any runes or producing invalid UTF-8.
+	longPath := "📁/项目/非常长的路径名称/测试/🚀/emoji-and-cjk-characters-which-are-very-long-and-exceed-sixty-characters"
+
+	// Create JSON args for read_file
+	rawArgs := `{"path":"` + longPath + `"}`
+	got := toolTitle("read_file", rawArgs)
+
+	expectedPrefix := "read_file "
+	if !strings.HasPrefix(got, expectedPrefix) {
+		t.Fatalf("expected title to start with %q, got %q", expectedPrefix, got)
+	}
+
+	hint := strings.TrimPrefix(got, expectedPrefix)
+	// Hint should end with the ellipsis character
+	if !strings.HasSuffix(hint, "…") {
+		t.Fatalf("expected truncated hint to end with ellipsis, got %q", hint)
+	}
+
+	// Check that we don't have invalid UTF-8 runes
+	if !utf8.ValidString(hint) {
+		t.Fatalf("truncated hint is not a valid UTF-8 string: %q", hint)
+	}
+
+	// The rune count of the hint (excluding ellipsis) should be exactly 60
+	runes := []rune(strings.TrimSuffix(hint, "…"))
+	if len(runes) != 60 {
+		t.Fatalf("expected exactly 60 runes before ellipsis, got %d (hint: %q)", len(runes), hint)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a medium-severity issue where `truncateHint` slices strings by raw byte offset (`s[:max]`), which can split a multi-byte UTF-8 character (like Chinese/Japanese/Korean text, emojis, or accents) in half and produce invalid UTF-8.

This PR updates `truncateHint` to slice string values using a rune slice conversion to guarantee valid UTF-8 sequences.

## Changes

**`internal/acp/translate.go`**
- Import `unicode/utf8`.
- Change `truncateHint` to count and slice by runes rather than raw bytes.

**`internal/acp/translate_test.go`**
- Import `strings` and `unicode/utf8`.
- Add `TestToolTitleTruncateHintRuneSafe` to verify truncation does not split multi-byte characters and produces exactly 60 runes before the ellipsis.

## Test plan

- `go test ./internal/acp/...` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation so multi-byte characters are handled safely and display correctly.
  * Truncated hints now preserve valid Unicode and add an ellipsis consistently.

* **Tests**
  * Added coverage to verify truncation remains UTF-8 safe.
  * Confirmed the visible hint length is limited as expected before the ellipsis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->