### PR TITLE
fix(securefile): reclaim stale lock files to prevent permanent DOS

### DIFF
--- a/internal/securefile/securefile.go
+++ b/internal/securefile/securefile.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 )
 
@@ -24,9 +25,13 @@ const (
 
 	secretRetryAttempts = 500
 	secretRetryDelay    = 2 * time.Millisecond
+	secureLockStaleAfter = 10 * time.Second
 )
 
-var openSecretLockFile = os.OpenFile
+var (
+	openSecretLockFile = os.OpenFile
+	secureLockSeq      atomic.Uint64
+)
 
 // Crypter encrypts a blob at rest with AES-256-GCM under a per-user random secret
 // persisted (0600) at secretPath.
@@ -107,12 +112,25 @@ func loadOrCreateSecret(path string, create bool) ([]byte, error) {
 
 func createSecretFile(path string) ([]byte, error) {
 	lockPath := path + ".lock"
+	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), time.Now().UnixNano(), secureLockSeq.Add(1))
 	var lastErr error
 	for attempt := 0; attempt < secretRetryAttempts; attempt++ {
 		lock, err := openSecretLockFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
-			_ = lock.Close()
-			defer os.Remove(lockPath)
+			if _, werr := lock.WriteString(token); werr != nil {
+				_ = lock.Close()
+				_ = os.Remove(lockPath)
+				return nil, fmt.Errorf("securefile: write secret lock: %w", werr)
+			}
+			if cerr := lock.Close(); cerr != nil {
+				_ = os.Remove(lockPath)
+				return nil, fmt.Errorf("securefile: close secret lock: %w", cerr)
+			}
+			defer func() {
+				if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == token {
+					_ = os.Remove(lockPath)
+				}
+			}()
 			if data, rerr := readSecretFileRetry(path); rerr == nil {
 				return data, nil
 			} else if !errors.Is(rerr, os.ErrNotExist) {
@@ -133,12 +151,33 @@ func createSecretFile(path string) ([]byte, error) {
 		// contention/ACL problem is masked by the expected-while-waiting
 		// ErrNotExist once the retries are exhausted.
 		lastErr = err
+
+		// Reclaim a stale lock left by a crashed holder
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > secureLockStaleAfter {
+			if reclaimStaleLock(lockPath, token, secureLockStaleAfter) {
+				continue
+			}
+		}
+
 		if data, rerr := readSecretFileRetry(path); rerr == nil {
 			return data, nil
 		}
 		time.Sleep(secretRetryDelay)
 	}
 	return nil, fmt.Errorf("securefile: timed out waiting for secret %s: %w", path, lastErr)
+}
+
+func reclaimStaleLock(lockPath, token string, staleAfter time.Duration) bool {
+	reclaimed := fmt.Sprintf("%s.stale.%s", lockPath, token)
+	if err := os.Rename(lockPath, reclaimed); err != nil {
+		return false
+	}
+	if info, err := os.Stat(reclaimed); err == nil && time.Since(info.ModTime()) <= staleAfter {
+		_ = os.Rename(reclaimed, lockPath)
+		return false
+	}
+	_ = os.Remove(reclaimed)
+	return true
 }
 
 func writeNewSecretFile(path string) ([]byte, error) {

--- a/internal/securefile/securefile.go
+++ b/internal/securefile/securefile.go
@@ -23,8 +23,8 @@ const (
 	// secretBytes is the AES-256 key length kept in the per-user secret file.
 	secretBytes = 32
 
-	secretRetryAttempts = 500
-	secretRetryDelay    = 2 * time.Millisecond
+	secretRetryAttempts  = 500
+	secretRetryDelay     = 2 * time.Millisecond
 	secureLockStaleAfter = 10 * time.Second
 )
 

--- a/internal/securefile/securefile_test.go
+++ b/internal/securefile/securefile_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestCreateSecretFileRetriesOnPermissionContention(t *testing.T) {
@@ -105,5 +106,35 @@ func TestWrongSecretCannotDecrypt(t *testing.T) {
 	b := NewCrypter(filepath.Join(dir, "b.secret")) // different secret
 	if _, err := b.Open(blob); err == nil {
 		t.Fatal("expected decryption under a different secret to fail")
+	}
+}
+
+func TestCreateSecretFileReclaimsStaleLock(t *testing.T) {
+	secretPath := filepath.Join(t.TempDir(), "k.secret")
+	lockPath := secretPath + ".lock"
+
+	// Create a stale lock file manually
+	if err := os.WriteFile(lockPath, []byte("99999-12345-1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate the lock file's modification time so it is considered stale
+	staleTime := time.Now().Add(-2 * secureLockStaleAfter)
+	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
+		t.Fatal(err)
+	}
+
+	// Attempt to create the secret file; it should detect the stale lock, reclaim it, and succeed
+	secret, err := createSecretFile(secretPath)
+	if err != nil {
+		t.Fatalf("createSecretFile failed to reclaim stale lock: %v", err)
+	}
+	if len(secret) != secretBytes {
+		t.Fatalf("secret length = %d, want %d", len(secret), secretBytes)
+	}
+
+	// The lock file should be removed after completion
+	if _, err := os.Stat(lockPath); err == nil {
+		t.Fatal("expected lock file to be cleaned up after successful acquisition")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a medium-severity issue where stale `.lock` files left behind after abrupt process crashes (e.g. SIGKILL or system panic) cause all future attempts to create/acquire secrets to fail with a permanent timeout, resulting in a denial of service (DOS).

This PR brings the stale lock reclamation logic from `internal/cron/lock.go` and `internal/oauth/lock.go` over to `internal/securefile/securefile.go`:
- Write process-specific owner tokens to the `.lock` file.
- Inspect the lock file modification time if O_EXCL acquisition fails.
- Reclaim lock files older than 10 seconds (`secureLockStaleAfter`) using the same atomic rename-aside routine (`reclaimStaleLock`).

## Changes

**`internal/securefile/securefile.go`**
- Define `secureLockStaleAfter` and atomic counter `secureLockSeq`.
- Update `createSecretFile` to write owner tokens, release only owned lock files, and detect and reclaim stale locks.
- Add `reclaimStaleLock` helper.

**`internal/securefile/securefile_test.go`**
- Add `TestCreateSecretFileReclaimsStaleLock` to verify that stale locks are correctly reclaimed.

## Test plan

- `go test ./internal/securefile/...` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret file creation to safely detect and reclaim stale lock files.
  * Updated lock handling so cleanup only occurs when the lock content still matches the current operation.
  * Strengthened error handling around lock-file writing and lifecycle to reduce leftover locks.
* **Tests**
  * Added a new test to verify stale lock reclamation during secret creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->