### PR TITLE
fix(daemon): handle os.ErrPermission as collision during Windows lock creation

### DIFF
--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -52,7 +52,7 @@ func acquireLock(path string, isAlive func(pid int) bool) (*fileLock, error) {
 			}
 			return &fileLock{path: path}, nil
 		}
-		if !errors.Is(err, fs.ErrExist) {
+		if !errors.Is(err, fs.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, err
 		}
 		pid, perr := readPidFile(path)


### PR DESCRIPTION
## Summary

Fixes a medium-severity issue where single-instance daemon lock creation on Windows is fragile under concurrency. 

On Windows, when a process releases the lock via `os.Remove`, the file is placed in a "delete pending" state. During this time, any racing `O_EXCL` file creation attempts fail with `ERROR_ACCESS_DENIED` (mapped to `os.ErrPermission`) rather than `ERROR_FILE_EXISTS` (mapped to `fs.ErrExist`). 

Previously, `internal/daemon/lock.go` only checked for `fs.ErrExist`, causing the acquire operation to fail immediately with a permission error instead of waiting/retrying.

This PR updates the lock checks to treat `os.ErrPermission` as a collision/contention indicator, allowing the daemon to wait/retry or correctly detect the stale status.

## Changes

**`internal/daemon/lock.go`**
- Treat `os.ErrPermission` as a collision/contention indicator during O_EXCL file creation.

## Test plan

- `go test ./internal/daemon/...` — ok