### PR TITLE
fix(windows): resolve absolute path for taskkill to prevent hijacking

### DIFF
--- a/internal/background/process_windows.go
+++ b/internal/background/process_windows.go
@@ -5,6 +5,7 @@ package background
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 )
 
@@ -14,7 +15,8 @@ import (
 func ConfigureChildProcessGroup(cmd *exec.Cmd) {}
 
 func terminateProcess(pid int) error {
-	if err := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run(); err == nil {
+	taskkill := taskkillPath()
+	if err := exec.Command(taskkill, "/T", "/F", "/PID", strconv.Itoa(pid)).Run(); err == nil {
 		return nil
 	}
 	process, err := os.FindProcess(pid)
@@ -22,4 +24,15 @@ func terminateProcess(pid int) error {
 		return err
 	}
 	return process.Kill()
+}
+
+func taskkillPath() string {
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("windir")
+	}
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", "taskkill.exe")
 }

--- a/internal/config/process_windows.go
+++ b/internal/config/process_windows.go
@@ -3,7 +3,9 @@
 package config
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 )
 
@@ -13,6 +15,18 @@ func terminateCommandProcess(cmd *exec.Cmd) {
 	if cmd.Process == nil {
 		return
 	}
-	_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
+	taskkill := taskkillPath()
+	_ = exec.Command(taskkill, "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
 	_ = cmd.Process.Kill()
+}
+
+func taskkillPath() string {
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("windir")
+	}
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", "taskkill.exe")
 }

--- a/internal/tools/bash_proc_windows.go
+++ b/internal/tools/bash_proc_windows.go
@@ -3,7 +3,9 @@
 package tools
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -27,9 +29,21 @@ func hardenProcessLifetime(command *exec.Cmd) {
 		if command.Process == nil {
 			return nil
 		}
-		_ = exec.Command("taskkill.exe", "/T", "/F", "/PID", strconv.Itoa(command.Process.Pid)).Run()
+		taskkill := taskkillPath()
+		_ = exec.Command(taskkill, "/T", "/F", "/PID", strconv.Itoa(command.Process.Pid)).Run()
 		return nil
 	}
+}
+
+func taskkillPath() string {
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("windir")
+	}
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", "taskkill.exe")
 }
 
 // applyWindowsShellCommandLine overrides command's raw child command line so


### PR DESCRIPTION
## Summary

Fixes a medium-severity issue where invoking `taskkill` or `taskkill.exe` without an absolute path on Windows can allow binary hijacking under certain conditions.

This PR ensures all process-termination paths on Windows resolve the absolute path to `taskkill.exe` under `System32` (referencing `SystemRoot` / `windir`, with a fallback to `C:\Windows`).

## Changes

**`internal/background/process_windows.go`**
- Add `taskkillPath()` helper and use it to resolve absolute path of `taskkill` in `terminateProcess`.

**`internal/config/process_windows.go`**
- Add `taskkillPath()` helper and use it to resolve absolute path of `taskkill` in `terminateCommandProcess`.

**`internal/tools/bash_proc_windows.go`**
- Add `taskkillPath()` helper and use it to resolve absolute path of `taskkill` in `hardenProcessLifetime` Cancel callback.

## Test plan

- `go test ./internal/background/... ./internal/config/... ./internal/tools/...` — ok