### PR TITLE
fix(tools): preserve SysProcAttr during PTY fallback

### DIFF
--- a/internal/tools/exec_command_test.go
+++ b/internal/tools/exec_command_test.go
@@ -422,6 +422,34 @@ func TestStartExecProcessFallsBackAfterPTYStartMutation(t *testing.T) {
 	}
 }
 
+func TestStartExecProcessPTYFallbackPreservesSysProcAttr(t *testing.T) {
+	original := startPTYProcessFunc
+	t.Cleanup(func() { startPTYProcessFunc = original })
+	startPTYProcessFunc = func(command *exec.Cmd, _ *execOutputBuffer) (io.WriteCloser, func(), error) {
+		return nil, nil, errors.New("pty start failed")
+	}
+
+	command := exec.CommandContext(context.Background(), os.Args[0], "--zero-bash-helper", "success")
+	customAttr := &syscall.SysProcAttr{}
+	command.SysProcAttr = customAttr
+
+	output := newExecOutputBuffer()
+	stdin, tty, cleanup, err := startExecProcess(command, output, true)
+	if err != nil {
+		t.Fatalf("startExecProcess fallback failed: %v", err)
+	}
+	if tty {
+		t.Fatal("fallback process must report tty=false")
+	}
+	_ = stdin.Close()
+	_ = command.Wait()
+	cleanup()
+
+	if command.SysProcAttr != customAttr {
+		t.Fatalf("SysProcAttr was not preserved: got %+v, want %+v", command.SysProcAttr, customAttr)
+	}
+}
+
 // TestExecOutputBufferCapsUndrainedData: a session nobody polls must not grow
 // its undrained buffer without bound — a long-lived background process that
 // keeps writing while unpolled previously ran a session's memory into the

--- a/internal/tools/exec_transport.go
+++ b/internal/tools/exec_transport.go
@@ -3,25 +3,27 @@ package tools
 import (
 	"io"
 	"os/exec"
+	"syscall"
 )
 
 func startExecProcess(command *exec.Cmd, output *execOutputBuffer, ttyRequested bool) (io.WriteCloser, bool, func(), error) {
 	if ttyRequested {
+		origSysProcAttr := command.SysProcAttr
 		if stdin, cleanup, err := startPTYProcessFunc(command, output); err == nil {
 			return stdin, true, cleanup, nil
 		}
-		resetExecCommandForPipeFallback(command)
+		resetExecCommandForPipeFallback(command, origSysProcAttr)
 	}
 	return startPipeProcess(command, output)
 }
 
 var startPTYProcessFunc = startPTYProcess
 
-func resetExecCommandForPipeFallback(command *exec.Cmd) {
+func resetExecCommandForPipeFallback(command *exec.Cmd, origSysProcAttr *syscall.SysProcAttr) {
 	command.Stdin = nil
 	command.Stdout = nil
 	command.Stderr = nil
-	command.SysProcAttr = nil
+	command.SysProcAttr = origSysProcAttr
 	command.Cancel = nil
 	command.WaitDelay = 0
 }


### PR DESCRIPTION
## Summary

Fixes a medium-severity issue where the PTY fallback path resets and wipes out custom `SysProcAttr` configurations.

On Windows, `applyWindowsShellCommandLine` sets `SysProcAttr` with a custom `CmdLine` for unescaped quoting. However, when falling back from a failed PTY setup (`startPTYProcessFunc`) to a standard pipe execution (`startPipeProcess`), `resetExecCommandForPipeFallback` would set `command.SysProcAttr = nil`. This stripped the unescaped command-line formatting and corrupted command arguments under the fallback tier.

This PR updates the fallback path to save and restore the original `SysProcAttr` configuration.

## Changes

**`internal/tools/exec_transport.go`**
- Import `syscall`.
- Capture `command.SysProcAttr` in `startExecProcess` before attempting PTY startup.
- Restore the original `SysProcAttr` in `resetExecCommandForPipeFallback` instead of resetting it to `nil`.

**`internal/tools/exec_command_test.go`**
- Add `TestStartExecProcessPTYFallbackPreservesSysProcAttr` to assert that fallback restores the original `SysProcAttr`.

## Test plan

- `go test ./internal/tools/...` — ok