### PR TITLE
fix(tui): resolve pending askUser callbacks to prevent runner hangs

### DIFF
--- a/internal/tui/ask_user_test.go
+++ b/internal/tui/ask_user_test.go
@@ -417,3 +417,55 @@ func TestAskUserEmptyRequestResolvesImmediately(t *testing.T) {
 		t.Fatalf("an empty request should resolve immediately, got %#v", answers)
 	}
 }
+
+func TestAskUserStaleRequestResolvesEmpty(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7 // current run
+
+	// Message for stale runID = 5
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   5,
+		request: agent.AskUserRequest{ToolCallID: "c", Questions: []agent.AskUserQuestion{{Question: "Proceed?"}}},
+		answer:  func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+	if next.pendingAskUser != nil {
+		t.Fatal("a stale request must not create a pending prompt")
+	}
+	if len(answers) != 1 || answers[0] != nil {
+		t.Fatalf("expected stale request callback to resolve immediately with nil, got: %v", answers)
+	}
+}
+
+func TestAskUserCompleteClearsAndResolves(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+
+	// Start a prompt
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: agent.AskUserRequest{ToolCallID: "c", Questions: []agent.AskUserQuestion{{Question: "Proceed?"}}},
+		answer:  func(values []string) { answers = append(answers, values) },
+	})
+	next := updated.(model)
+	if next.pendingAskUser == nil {
+		t.Fatal("expected pendingAskUser to be populated")
+	}
+
+	// Receive run completion event before prompt is manually answered
+	finalized, _ := next.Update(agentResponseMsg{
+		runID: 7,
+		err:   context.Canceled,
+	})
+	finalModel := finalized.(model)
+	if finalModel.pendingAskUser != nil {
+		t.Fatal("pendingAskUser must be cleared on response/cancel")
+	}
+	if len(answers) != 1 || answers[0] != nil {
+		t.Fatalf("expected pendingAskUser answer callback to be resolved with nil, got: %v", answers)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2050,6 +2050,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case askUserRequestMsg:
 		if msg.runID != m.activeRunID {
+			if msg.answer != nil {
+				msg.answer(nil)
+			}
 			return m, nil
 		}
 		// A request with no questions has nothing to answer — resolve it
@@ -2163,6 +2166,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.plan.completeRemaining(m.now())
 		}
 		m.pendingPermission = nil
+		if m.pendingAskUser != nil && m.pendingAskUser.answer != nil {
+			m.pendingAskUser.answer(nil)
+		}
 		m.pendingAskUser = nil
 		liveUsageCount := m.liveUsageCounts[msg.runID]
 		for index, event := range msg.usageEvents {


### PR DESCRIPTION
## Summary

Fixes a medium-severity issue where the TUI does not invoke the answer callback of a discarded `askUserRequestMsg` during cancellation or stale runs, causing goroutine leaks or runner hangs.

This PR ensures:
- If a stale/superseded `askUserRequestMsg` (where `msg.runID != m.activeRunID`) is handled, the callback is invoked with `nil` immediately.
- If a run is completed or canceled (`agentResponseMsg`) while an `ask_user` prompt is pending (`m.pendingAskUser != nil`), the callback is invoked with `nil` before clearing the state.

This matches the robust, fail-safe callback resolution mechanism used for `permissionRequestMsg`.

## Changes

**`internal/tui/model.go`**
- Invoke `msg.answer(nil)` for stale `askUserRequestMsg` events.
- Invoke `m.pendingAskUser.answer(nil)` when discarding pending askUser states inside the `agentResponseMsg` handler.

**`internal/tui/ask_user_test.go`**
- Add `TestAskUserStaleRequestResolvesEmpty` to assert that stale prompts resolve immediately.
- Add `TestAskUserCompleteClearsAndResolves` to assert that pending prompts resolve when the run completes/cancels.

## Test plan

- `go test ./internal/tui/...` — ok