### PR TITLE
fix(plugins): resolve relative executable paths against plugin root

### DIFF
--- a/internal/plugins/activate.go
+++ b/internal/plugins/activate.go
@@ -620,14 +620,12 @@ func (tool pluginTool) meta() map[string]string {
 // (parsePermission clamps allow→prompt otherwise), so honoring it does not
 // silently auto-approve a mutating plugin tool.
 func toolSafety(plugin LoadedPlugin, ext ToolExtension) tools.Safety {
-	permission := tools.PermissionPrompt
+	var permission tools.Permission
 	switch ext.Permission {
 	case PermissionAllow:
 		permission = tools.PermissionAllow
 	case PermissionDeny:
 		permission = tools.PermissionDeny
-	case PermissionPrompt:
-		permission = tools.PermissionPrompt
 	default:
 		permission = tools.PermissionPrompt
 	}

--- a/internal/plugins/activate.go
+++ b/internal/plugins/activate.go
@@ -460,6 +460,9 @@ func expandPluginRoot(value string, pluginDir string) string {
 // e.g. URLs or flag values).
 func expandPluginRootPath(value string, pluginDir string) string {
 	if !strings.Contains(value, pluginRootPlaceholder) {
+		if !filepath.IsAbs(value) && !isWindowsAbs(value) && !isRootedPath(value) && (strings.Contains(value, "/") || strings.Contains(value, "\\")) {
+			return filepath.Join(pluginDir, value)
+		}
 		return value
 	}
 	return filepath.FromSlash(strings.ReplaceAll(value, pluginRootPlaceholder, pluginDir))

--- a/internal/plugins/activate_test.go
+++ b/internal/plugins/activate_test.go
@@ -536,3 +536,24 @@ func containsSubstring(values []string, want string) bool {
 	}
 	return false
 }
+
+func TestExpandPluginRootPathRelative(t *testing.T) {
+	pluginDir := "/etc/zero/plugin"
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"./bin/tool.sh", filepath.Join(pluginDir, "./bin/tool.sh")},
+		{"../outside/tool", filepath.Join(pluginDir, "../outside/tool")},
+		{"tool.sh", "tool.sh"},             // bare binary name
+		{"/usr/bin/tool", "/usr/bin/tool"}, // absolute Unix
+		{`C:\bin\tool`, `C:\bin\tool`},     // absolute Windows
+		{"${AGENT_PLUGIN_ROOT}/bin/tool.sh", filepath.FromSlash(pluginDir + "/bin/tool.sh")},
+	}
+	for _, tc := range cases {
+		got := expandPluginRootPath(tc.input, pluginDir)
+		if got != tc.want {
+			t.Errorf("expandPluginRootPath(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a High-severity issue where relative command paths defined by plugins (e.g. `"command": "./tools/helper.sh"`) can be hijacked by malicious files placed at that same path inside an untrusted workspace.

When a plugin tool runs, `RunWithOptions` executes the plugin command within the caller's workspace CWD. If the command is a relative path (e.g. starting with `./` or containing separators), Go's `os/exec` resolves it relative to the workspace directory.

This PR resolves relative executable paths containing separators to absolute paths inside the plugin's install directory during activation.

## Changes

**`internal/plugins/activate.go`**
- In `expandPluginRootPath`, check if the command path is not absolute (`!filepath.IsAbs` and `!isWindowsAbs`) and contains path separators. If so, resolve it to an absolute path under the plugin directory using `filepath.Join`.

**`internal/plugins/activate_test.go`**
- Add `TestExpandPluginRootPathRelative` to assert that relative executable paths are resolved, absolute paths are kept verbatim, and placeholders are correctly expanded.

## Test plan

- `go test ./internal/plugins/...` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin executable path resolution for relative values that include directory separators (including `/` and `\`).
  * Relative paths now resolve correctly against the plugin directory, while bare executable names and absolute Unix/Windows paths remain unchanged.
  * Enhanced handling for parent-directory traversal and Windows absolute-path detection.
* **Tests**
  * Added coverage for relative and placeholder-expanded plugin root path cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->