### PR TITLE
fix(hooks): fail closed on launch failures for beforeTool hooks

### DIFF
--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -176,8 +176,7 @@ func (dispatcher *Dispatcher) runWithTimeout(ctx context.Context, hook Definitio
 func classifyResult(event Event, result commandResult) (AuditStatus, bool) {
 	// A hook that started but was killed by its deadline (or a cancellation) never
 	// returned a verdict. For a blocking event we must fail CLOSED and veto: a
-	// hung beforeTool policy hook cannot be treated as approval. (A launch failure
-	// below still fails OPEN, so a misconfigured hook doesn't wedge every tool.)
+	// hung beforeTool policy hook cannot be treated as approval.
 	if result.TimedOut {
 		if blocksOn(event) {
 			return AuditBlocked, true
@@ -185,6 +184,9 @@ func classifyResult(event Event, result commandResult) (AuditStatus, bool) {
 		return AuditError, false
 	}
 	if result.Err != nil {
+		if blocksOn(event) {
+			return AuditBlocked, true
+		}
 		return AuditError, false
 	}
 	if result.ExitCode != 0 {

--- a/internal/hooks/dispatch_test.go
+++ b/internal/hooks/dispatch_test.go
@@ -186,14 +186,18 @@ func TestExecCommandRunnerCapturesExitAndStdin(t *testing.T) {
 	}
 }
 
-func TestExecCommandRunnerReportsLaunchFailureWithoutBlocking(t *testing.T) {
+func TestExecCommandRunnerReportsLaunchFailureFailsClosedForBeforeTool(t *testing.T) {
 	result := execCommandRunner(context.Background(), "definitely-not-a-real-binary-zzz", nil, nil, t.TempDir(), nil)
 	if result.Err == nil {
 		t.Fatal("expected launch error for a missing binary")
 	}
-	// A launch failure is an error, never a block, even for beforeTool.
-	if status, blocked := classifyResult(EventBeforeTool, result); blocked || status != AuditError {
-		t.Fatalf("classify = (%q, %v), want (error, false) for a launch failure", status, blocked)
+	// A launch failure for beforeTool fails closed (vetoes/blocks).
+	if status, blocked := classifyResult(EventBeforeTool, result); !blocked || status != AuditBlocked {
+		t.Fatalf("beforeTool classify = (%q, %v), want (blocked, true) for a launch failure", status, blocked)
+	}
+	// An observational afterTool hook still fails open (does not block).
+	if status, blocked := classifyResult(EventAfterTool, result); blocked || status != AuditError {
+		t.Fatalf("afterTool classify = (%q, %v), want (error, false) for a launch failure", status, blocked)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a High-severity security issue where launch-level errors of beforeTool hooks fail open.

If a security-critical beforeTool hook fails to launch (e.g., binary not found, executable permission denied, or system resource exhaustion), it previously returned `blocked = false` (fails open). This silently bypassed the security gate.

This PR updates `classifyResult` to return `AuditBlocked, true` on launch errors if the event is a beforeTool hook (fails closed). Observational afterTool hooks still fail open.

## Changes

- Modified `classifyResult` in `internal/hooks/dispatch.go` to fail closed for beforeTool hooks when `result.Err != nil`.
- Updated unit tests in `internal/hooks/dispatch_test.go` to assert fail-closed behavior on launch failure.

## Test plan
- `go test ./internal/hooks/...` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Before-tool policy hook launch failures now block the operation, preventing execution when approval cannot be verified.
  - After-tool hook launch failures continue to be reported as errors without blocking completed operations.
  - Timeout and cancellation handling remains consistent with existing fail-closed and fail-open behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->