### PR TITLE
fix(cron): prevent cron job Mutate from clobbering concurrent updates

### DIFF
--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -211,11 +211,12 @@ func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Wr
 			fmt.Fprintf(stderr, "warning: could not re-read job %s before persist: %v\n", job.ID, readErr)
 			return job, nil
 		}
-		if current.Status == cron.StatusPaused {
-			// Honor an external pause that landed while the job ran.
-			job.Status = cron.StatusPaused
+		current.FireCount = job.FireCount
+		current.NextRunAt = job.NextRunAt
+		if current.Status != cron.StatusPaused {
+			current.Status = job.Status
 		}
-		return job, nil
+		return current, nil
 	})
 	if errors.Is(err, cron.ErrJobNotFound) {
 		// Genuinely removed mid-run: don't recreate it (no run record, no persist).


### PR DESCRIPTION
## Summary

Fixes a High-severity issue where updates to cron jobs (e.g. `zero cron edit`, pausing) made by the user while a job is running are silently overwritten and clobbered.

In `fireJob`, the scheduler advances the job schedule and updates its state using `store.Mutate`. The transaction callback previously returned the stale `job` copy (which was read at the beginning of the scheduler tick, potentially minutes earlier). This clobbered any changes written to disk in the meantime.

This PR updates the Mutate callback to apply only the execution updates (`FireCount`, `NextRunAt`, `Status`) to the fresh `current` job loaded from disk, and returns that fresh object.

## Changes

- Modified `fireJob` inside `internal/cli/cron_run.go` to update the fresh `current` job inside the Mutate callback rather than returning the stale `job` instance.

## Test plan
- `go test ./internal/cli/...` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled job state handling when jobs are triggered.
  * Preserved paused jobs while still updating their execution count and next scheduled run time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->