### PR TITLE
fix(securefile,credstore): call Sync on temp file before close and rename

### DIFF
--- a/internal/credstore/credstore.go
+++ b/internal/credstore/credstore.go
@@ -251,6 +251,10 @@ func (s *Store) write(data map[string]string) error {
 		_ = tmp.Close()
 		return fmt.Errorf("credstore: write: %w", err)
 	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("credstore: sync: %w", err)
+	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("credstore: write: %w", err)
 	}

--- a/internal/securefile/securefile.go
+++ b/internal/securefile/securefile.go
@@ -161,6 +161,10 @@ func writeNewSecretFile(path string) ([]byte, error) {
 		_ = tmp.Close()
 		return nil, fmt.Errorf("securefile: write secret: %w", werr)
 	}
+	if serr := tmp.Sync(); serr != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("securefile: sync secret: %w", serr)
+	}
 	if cerr := tmp.Close(); cerr != nil {
 		return nil, fmt.Errorf("securefile: write secret: %w", cerr)
 	}


### PR DESCRIPTION
## Summary

Fixes a High-severity durability issue where credential and secret files could be corrupted or lost (0-byte file) if a system crash or power failure occurs shortly after a write.

Although a write-to-temp-then-rename pattern is used, neither `securefile` nor `credstore` called `tmp.Sync()` (fsync) to flush the page cache and directory metadata to physical disk before renaming.

This PR adds `Sync()` calls (and checks their errors) before closing and renaming.

## Changes

- In `internal/securefile/securefile.go`: Call `tmp.Sync()` in `writeNewSecretFile`.
- In `internal/credstore/credstore.go`: Call `tmp.Sync()` in `Store.write`.

## Test plan
- `go test -race ./internal/securefile/... ./internal/credstore/...` — ok