### PR TITLE
fix(secrets,worktrees): fix secret redaction leakage and prune stale worktrees

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -81,6 +81,7 @@ type appDeps struct {
 	runSandboxSetupHelper  func(path string, args []string, stdout io.Writer, stderr io.Writer) error
 	registerMCPTools       func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error)
 	prepareWorktree        func(context.Context, worktrees.Options) (worktrees.Result, error)
+	releaseWorktree        func(context.Context, worktrees.Options, string) error
 	detectVerifyPlan       func(string) (verify.Plan, error)
 	runVerify              func(context.Context, verify.Plan, verify.RunOptions) verify.Report
 	runSelfVerify          func(context.Context, verify.Plan, selfverify.Options) selfverify.Report
@@ -187,6 +188,7 @@ func defaultAppDeps() appDeps {
 			return mcp.RegisterTools(ctx, registry, cfg, options)
 		},
 		prepareWorktree:  worktrees.Prepare,
+		releaseWorktree:  worktrees.Release,
 		detectVerifyPlan: verify.DetectPlan,
 		runVerify:        verify.Run,
 		runSelfVerify:    selfverify.Run,
@@ -531,6 +533,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.prepareWorktree == nil {
 		deps.prepareWorktree = defaults.prepareWorktree
+	}
+	if deps.releaseWorktree == nil {
+		deps.releaseWorktree = defaults.releaseWorktree
 	}
 	if deps.detectVerifyPlan == nil {
 		deps.detectVerifyPlan = defaults.detectVerifyPlan

--- a/internal/cli/completions.go
+++ b/internal/cli/completions.go
@@ -84,7 +84,7 @@ var completionRoot = completionNode{
 		}},
 		{names: []string{"update"}},
 		{names: []string{"upgrade"}},
-		{names: []string{"worktrees", "worktree"}, children: leafNodes("prepare")},
+		{names: []string{"worktrees", "worktree"}, children: leafNodes("prepare", "release")},
 		{names: []string{"verify"}},
 		{names: []string{"trust"}, children: leafNodes("list", "remove")},
 		{names: []string{"eval"}, children: leafNodes("validate", "run", "bench")},

--- a/internal/cli/completions_test.go
+++ b/internal/cli/completions_test.go
@@ -155,6 +155,8 @@ func TestCompletionTreeCoversAliasesNestingAndCommonFlags(t *testing.T) {
 
 	assertCandidates(t, byPath[""], "sessions", "session", "plugins", "plugin", "worktrees", "worktree", "--add-dir", "--theme", "-p", "--prompt")
 	assertCandidates(t, byPath["exec"], "--model", "--cwd", "--worktree", "--output-format", "--resume", "--skip-permissions-unsafe")
+	assertCandidates(t, byPath["worktrees"], "prepare", "release")
+	assertCandidates(t, byPath["worktree"], "prepare", "release")
 	assertCandidates(t, byPath["daemon"], "start", "stop", "status", "run", "attach")
 	assertCandidates(t, byPath["mcp oauth"], "login", "logout", "status")
 	assertCandidates(t, byPath["sandbox grants"], "list", "allow", "deny", "revoke", "clear")

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -222,7 +222,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		if preparedWorktree.LockAcquired {
 			defer func() {
 				if releaseErr := deps.releaseWorktree(context.Background(), worktrees.Options{Cwd: trustRoot}, preparedWorktree.Path); releaseErr != nil {
-					fmt.Fprintf(stderr, "zero: failed to release worktree lock on %s: %v\n", redactCLIString(preparedWorktree.Path), releaseErr)
+					fmt.Fprintf(stderr, "zero: failed to release worktree lock on %s: %s\n", redactCLIString(preparedWorktree.Path), redactCLIString(releaseErr.Error()))
 				}
 			}()
 		}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -204,15 +204,23 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 		}
 		workspaceRoot = preparedWorktree.Path
-		// This run's own process is the only user of the worktree it just
-		// created or reused, so its lifetime is bound to this function: release
-		// the Prepare lock once it returns so Clean can reclaim the worktree
-		// later if it goes stale. (zero worktrees prepare hands the path to an
-		// external, longer-lived caller instead, so it can't release this way —
-		// that caller must run `zero worktrees release` itself when done.)
-		defer func() {
-			_ = deps.releaseWorktree(context.Background(), worktrees.Options{}, preparedWorktree.Path)
-		}()
+		// When this run's own Prepare call took the worktree lock, its
+		// lifetime is bound to this function: release the lock once it returns
+		// so Clean can reclaim the worktree later if it goes stale. A reused
+		// worktree whose lock an external `zero worktrees prepare` caller
+		// still holds reports LockAcquired=false; releasing it here would
+		// clear that caller's lease and expose its workspace to Clean, so the
+		// matching release stays that caller's responsibility. A failed unlock
+		// leaves a lock Clean will permanently skip, so it must not pass
+		// silently; the run's primary result has already been emitted by the
+		// time the defer runs, so surface it as a diagnostic.
+		if preparedWorktree.LockAcquired {
+			defer func() {
+				if releaseErr := deps.releaseWorktree(context.Background(), worktrees.Options{Cwd: trustRoot}, preparedWorktree.Path); releaseErr != nil {
+					fmt.Fprintf(stderr, "zero: failed to release worktree lock on %s: %v\n", preparedWorktree.Path, releaseErr)
+				}
+			}()
+		}
 	}
 
 	registry := newCoreRegistry(workspaceRoot)

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -199,6 +199,11 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			Name:    options.worktreeName,
 			BaseDir: options.worktreeDir,
 			Now:     deps.now,
+			// The worktree's lifetime is bound to this process (the deferred
+			// release below), so record the PID: if this process dies without
+			// releasing, Clean can expire the lease instead of skipping the
+			// locked worktree forever.
+			LeasePID: os.Getpid(),
 		})
 		if err != nil {
 			return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -217,7 +217,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		if preparedWorktree.LockAcquired {
 			defer func() {
 				if releaseErr := deps.releaseWorktree(context.Background(), worktrees.Options{Cwd: trustRoot}, preparedWorktree.Path); releaseErr != nil {
-					fmt.Fprintf(stderr, "zero: failed to release worktree lock on %s: %v\n", preparedWorktree.Path, releaseErr)
+					fmt.Fprintf(stderr, "zero: failed to release worktree lock on %s: %v\n", redactCLIString(preparedWorktree.Path), releaseErr)
 				}
 			}()
 		}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -204,6 +204,15 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 		}
 		workspaceRoot = preparedWorktree.Path
+		// This run's own process is the only user of the worktree it just
+		// created or reused, so its lifetime is bound to this function: release
+		// the Prepare lock once it returns so Clean can reclaim the worktree
+		// later if it goes stale. (zero worktrees prepare hands the path to an
+		// external, longer-lived caller instead, so it can't release this way —
+		// that caller must run `zero worktrees release` itself when done.)
+		defer func() {
+			_ = deps.releaseWorktree(context.Background(), worktrees.Options{}, preparedWorktree.Path)
+		}()
 	}
 
 	registry := newCoreRegistry(workspaceRoot)

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -272,6 +272,32 @@ func TestRunWorktreesReleaseWiresWorkspaceCwd(t *testing.T) {
 	}
 }
 
+func TestRunWorktreesReleaseHonorsExplicitCwd(t *testing.T) {
+	// The deleted-path recovery cannot derive the source repository from the
+	// worktree path (the directory is gone and its name is a one-way hash),
+	// so -C names it explicitly; the resolved root must reach Release as
+	// Options.Cwd regardless of where the command was launched.
+	launchDir := t.TempDir()
+	repoDir := t.TempDir()
+	var gotCwd string
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "release", "-C", repoDir, filepath.Join(repoDir, "already-deleted")}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return launchDir, nil },
+		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
+			gotCwd = options.Cwd
+			return nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if gotCwd != repoDir {
+		t.Fatalf("release Options.Cwd = %q, want explicit -C root %q", gotCwd, repoDir)
+	}
+}
+
 func TestRunWorktreesReleaseReportsErrors(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -800,11 +826,11 @@ func TestRunExecWorktreeReleasesLockAfterRun(t *testing.T) {
 }
 
 func TestRunExecWorktreeKeepsLockItDidNotAcquire(t *testing.T) {
-	// Prepare reports LockAcquired=false when it reused a worktree whose lock
-	// an external `zero worktrees prepare` caller still holds. Releasing that
-	// lock here would clear the external caller's lease and let a later Clean
-	// force-delete a workspace that caller is still using, so exec must only
-	// release the ownership its own invocation established.
+	// Defense in depth: Prepare now rejects an in-use lease outright, so a
+	// successful result always reports LockAcquired=true. Should that ever
+	// change, exec must still only release the ownership its own invocation
+	// established; releasing a lock it did not acquire would clear another
+	// caller's lease and let a later Clean force-delete a live workspace.
 	root := t.TempDir()
 	worktreeDir := t.TempDir()
 	releaseCalls := 0

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -312,6 +313,32 @@ func TestRunWorktreesReleaseReportsErrors(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "not a valid worktree") {
 		t.Fatalf("expected underlying error, got %q", stderr.String())
+	}
+}
+
+func TestRunWorktreesReleaseRedactsErrorText(t *testing.T) {
+	// Release errors interpolate the caller-supplied path (see
+	// verifyZeroOwnedWorktree's "refusing to release %s" messages); unlike the
+	// success path, which redacts before printing, the error was previously
+	// forwarded to stderr verbatim, so a rejected path containing a key-shaped
+	// segment would reach terminal/model-visible output unredacted.
+	secret := "sk-proj-abcDEF123_ghiJKL456-mnoPQR789stu"
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "release", "/tmp/" + secret + "/task"}, &stdout, &stderr, appDeps{
+		releaseWorktree: func(context.Context, worktrees.Options, string) error {
+			return fmt.Errorf("refusing to release /tmp/%s/task: not a registered worktree of this repository", secret)
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if strings.Contains(stderr.String(), secret) {
+		t.Fatalf("release error leaked unredacted key-shaped path: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "[REDACTED]") {
+		t.Fatalf("expected redaction placeholder in error output, got %q", stderr.String())
 	}
 }
 
@@ -892,6 +919,45 @@ func TestRunExecWorktreeSurfacesReleaseFailure(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), worktreeDir) || !strings.Contains(stderr.String(), "boom") {
 		t.Fatalf("expected release failure with path on stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunExecWorktreeRedactsReleaseFailureText(t *testing.T) {
+	// The release path argument was already redacted before this diagnostic
+	// was added, but the error's own text was forwarded verbatim; Release's
+	// ownership errors interpolate the caller-supplied path (see
+	// verifyZeroOwnedWorktree), so a key-shaped path reaching this message
+	// leaked unredacted onto stderr.
+	root := t.TempDir()
+	worktreeDir := t.TempDir()
+	secret := "sk-proj-abcDEF123_ghiJKL456-mnoPQR789stu"
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--worktree", "task-a", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return root, nil },
+		prepareWorktree: func(ctx context.Context, options worktrees.Options) (worktrees.Result, error) {
+			return worktrees.Result{Name: "task-a", Path: worktreeDir, RepoRoot: root, SourceBranch: "main", SourceCommit: "abc1234", LockAcquired: true}, nil
+		},
+		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
+			return fmt.Errorf("refusing to release /tmp/%s/task: not a registered worktree of this repository", secret)
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if strings.Contains(stderr.String(), secret) {
+		t.Fatalf("deferred release diagnostic leaked unredacted key-shaped path: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "[REDACTED]") {
+		t.Fatalf("expected redaction placeholder in deferred release diagnostic, got %q", stderr.String())
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -201,6 +201,15 @@ func TestRunWorktreesReleaseNormalizesRelativePath(t *testing.T) {
 		}
 	}()
 
+	// filepath.Abs resolves against os.Getwd, whose spelling of the temp dir
+	// can differ from t.TempDir()'s (macOS reports /private/var for /var), so
+	// derive the expected value through the same resolution instead of
+	// joining onto the lexical parent path.
+	expectedPath, err := filepath.Abs("task-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var releasedPath string
 	var stdout, stderr bytes.Buffer
 	exitCode := runWithDeps([]string{"worktrees", "release", "task-a"}, &stdout, &stderr, appDeps{
@@ -213,8 +222,8 @@ func TestRunWorktreesReleaseNormalizesRelativePath(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
-	if releasedPath != worktreeDir {
-		t.Fatalf("released path = %q, want absolute %q", releasedPath, worktreeDir)
+	if releasedPath != expectedPath {
+		t.Fatalf("released path = %q, want absolute %q", releasedPath, expectedPath)
 	}
 }
 
@@ -233,6 +242,33 @@ func TestRunWorktreesReleaseRequiresPath(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "requires a worktree path") {
 		t.Fatalf("expected missing-path error, got %q", stderr.String())
+	}
+}
+
+func TestRunWorktreesReleaseWiresWorkspaceCwd(t *testing.T) {
+	// Release only consults Options.Cwd when the worktree directory itself is
+	// already gone (deleted by hand instead of released); git then has to run
+	// from the source repository to clear the orphaned lock. The CLI must
+	// wire the resolved workspace root through, or that advertised recovery
+	// path runs git from a possibly non-repository directory and the lock is
+	// never cleared (Clean skips locked entries).
+	root := t.TempDir()
+	var gotCwd string
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "release", filepath.Join(root, "already-deleted")}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return root, nil },
+		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
+			gotCwd = options.Cwd
+			return nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if gotCwd != root {
+		t.Fatalf("release Options.Cwd = %q, want workspace root %q", gotCwd, root)
 	}
 }
 
@@ -732,7 +768,7 @@ func TestRunExecWorktreeReleasesLockAfterRun(t *testing.T) {
 	exitCode := runWithDeps([]string{"exec", "--worktree", "task-a", "hello"}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) { return root, nil },
 		prepareWorktree: func(ctx context.Context, options worktrees.Options) (worktrees.Result, error) {
-			return worktrees.Result{Name: "task-a", Path: worktreeDir, RepoRoot: root, SourceBranch: "main", SourceCommit: "abc1234"}, nil
+			return worktrees.Result{Name: "task-a", Path: worktreeDir, RepoRoot: root, SourceBranch: "main", SourceCommit: "abc1234", LockAcquired: true}, nil
 		},
 		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
 			releaseCalls++
@@ -760,6 +796,76 @@ func TestRunExecWorktreeReleasesLockAfterRun(t *testing.T) {
 	}
 	if releasedPath != worktreeDir {
 		t.Fatalf("released path = %q, want %q", releasedPath, worktreeDir)
+	}
+}
+
+func TestRunExecWorktreeKeepsLockItDidNotAcquire(t *testing.T) {
+	// Prepare reports LockAcquired=false when it reused a worktree whose lock
+	// an external `zero worktrees prepare` caller still holds. Releasing that
+	// lock here would clear the external caller's lease and let a later Clean
+	// force-delete a workspace that caller is still using, so exec must only
+	// release the ownership its own invocation established.
+	root := t.TempDir()
+	worktreeDir := t.TempDir()
+	releaseCalls := 0
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--worktree", "task-a", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return root, nil },
+		prepareWorktree: func(ctx context.Context, options worktrees.Options) (worktrees.Result, error) {
+			return worktrees.Result{Name: "task-a", Path: worktreeDir, RepoRoot: root, SourceBranch: "main", SourceCommit: "abc1234", Reused: true, LockAcquired: false}, nil
+		},
+		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
+			releaseCalls++
+			return nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if releaseCalls != 0 {
+		t.Fatalf("releaseWorktree call count = %d, want 0 for a lock this run did not acquire", releaseCalls)
+	}
+}
+
+func TestRunExecWorktreeSurfacesReleaseFailure(t *testing.T) {
+	// A failed unlock leaves a lock Clean permanently skips, recreating the
+	// disk leak silently; the failure must reach the user with the affected
+	// path so the leaked lock can be cleared by hand.
+	root := t.TempDir()
+	worktreeDir := t.TempDir()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--worktree", "task-a", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return root, nil },
+		prepareWorktree: func(ctx context.Context, options worktrees.Options) (worktrees.Result, error) {
+			return worktrees.Result{Name: "task-a", Path: worktreeDir, RepoRoot: root, SourceBranch: "main", SourceCommit: "abc1234", LockAcquired: true}, nil
+		},
+		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
+			return errors.New("unlock git worktree: boom")
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), worktreeDir) || !strings.Contains(stderr.String(), "boom") {
+		t.Fatalf("expected release failure with path on stderr, got %q", stderr.String())
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -153,6 +153,65 @@ func TestRunWorktreesPrepareRejectsDuplicateNames(t *testing.T) {
 	}
 }
 
+func TestRunWorktreesRelease(t *testing.T) {
+	worktreeDir := t.TempDir()
+	var releasedPath string
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "release", worktreeDir}, &stdout, &stderr, appDeps{
+		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
+			releasedPath = path
+			return nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if releasedPath != worktreeDir {
+		t.Fatalf("released path = %q, want %q", releasedPath, worktreeDir)
+	}
+	if !strings.Contains(stdout.String(), worktreeDir) {
+		t.Fatalf("expected confirmation output to mention path, got %q", stdout.String())
+	}
+}
+
+func TestRunWorktreesReleaseRequiresPath(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "release"}, &stdout, &stderr, appDeps{
+		releaseWorktree: func(context.Context, worktrees.Options, string) error {
+			t.Fatal("releaseWorktree should not be called without a path")
+			return nil
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if !strings.Contains(stderr.String(), "requires a worktree path") {
+		t.Fatalf("expected missing-path error, got %q", stderr.String())
+	}
+}
+
+func TestRunWorktreesReleaseReportsErrors(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "release", "/no/such/worktree"}, &stdout, &stderr, appDeps{
+		releaseWorktree: func(context.Context, worktrees.Options, string) error {
+			return errors.New("unlock git worktree: not a valid worktree")
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if !strings.Contains(stderr.String(), "not a valid worktree") {
+		t.Fatalf("expected underlying error, got %q", stderr.String())
+	}
+}
+
 func TestRunVerifyTextAndJSON(t *testing.T) {
 	cwd := t.TempDir()
 	plan := verify.Plan{Root: cwd, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
@@ -618,6 +677,48 @@ func TestRunExecWorktreeUsesPreparedWorkspace(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "hello") {
 		t.Fatalf("expected provider output, got %q", stdout.String())
+	}
+}
+
+func TestRunExecWorktreeReleasesLockAfterRun(t *testing.T) {
+	root := t.TempDir()
+	worktreeDir := t.TempDir()
+	var releasedPath string
+	releaseCalls := 0
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--worktree", "task-a", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return root, nil },
+		prepareWorktree: func(ctx context.Context, options worktrees.Options) (worktrees.Result, error) {
+			return worktrees.Result{Name: "task-a", Path: worktreeDir, RepoRoot: root, SourceBranch: "main", SourceCommit: "abc1234"}, nil
+		},
+		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
+			releaseCalls++
+			releasedPath = path
+			return nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	// A `zero exec --worktree` run is the only user of the worktree it prepares:
+	// its own process created it and is now exiting, so it must release the
+	// Prepare lock itself rather than leaving it locked forever (unlike `zero
+	// worktrees prepare`, which hands the path to a longer-lived external
+	// caller and has no such end-of-life signal to act on).
+	if releaseCalls != 1 {
+		t.Fatalf("releaseWorktree call count = %d, want 1", releaseCalls)
+	}
+	if releasedPath != worktreeDir {
+		t.Fatalf("released path = %q, want %q", releasedPath, worktreeDir)
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -177,6 +177,47 @@ func TestRunWorktreesRelease(t *testing.T) {
 	}
 }
 
+func TestRunWorktreesReleaseNormalizesRelativePath(t *testing.T) {
+	// git worktree unlock matches against the path git recorded when the
+	// worktree was created, so a relative argument (resolved against
+	// whatever directory the caller happens to be running `zero` from) can
+	// fail to match. Chdir into a known directory and pass a relative
+	// argument to confirm it reaches releaseWorktree as an absolute path.
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := t.TempDir()
+	worktreeDir := filepath.Join(parent, "task-a")
+	if err := os.Mkdir(worktreeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(parent); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(origWd); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	var releasedPath string
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "release", "task-a"}, &stdout, &stderr, appDeps{
+		releaseWorktree: func(ctx context.Context, options worktrees.Options, path string) error {
+			releasedPath = path
+			return nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if releasedPath != worktreeDir {
+		t.Fatalf("released path = %q, want absolute %q", releasedPath, worktreeDir)
+	}
+}
+
 func TestRunWorktreesReleaseRequiresPath(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -114,13 +114,24 @@ func runWorktrees(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 // caller is responsible for running this once it is done.
 func runWorktreesRelease(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
 	var path string
-	for _, arg := range args {
+	var cwdFlag string
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
 		switch {
 		case arg == "-h" || arg == "--help" || arg == "help":
 			if err := writeWorktreesHelp(stdout); err != nil {
 				return exitCrash
 			}
 			return exitSuccess
+		case arg == "-C" || arg == "--cwd":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return writeExecUsageError(stderr, err.Error())
+			}
+			cwdFlag = value
+			index = next
+		case strings.HasPrefix(arg, "--cwd="):
+			cwdFlag = strings.TrimPrefix(arg, "--cwd=")
 		case strings.HasPrefix(arg, "-"):
 			return writeExecUsageError(stderr, fmt.Sprintf("unknown worktrees release flag %q", arg))
 		default:
@@ -148,10 +159,19 @@ func runWorktreesRelease(args []string, stdout io.Writer, stderr io.Writer, deps
 	// no Cwd wired in, that recovery path runs `git worktree unlock` from
 	// wherever the caller happens to be, which outside the source repository
 	// leaves the orphaned lock behind forever (Clean skips locked entries).
-	// Resolve the workspace root best-effort: the ordinary existing-path case
-	// does not need it, so a resolution failure is not an error here.
+	// -C/--cwd names the source repository explicitly for exactly that case,
+	// since the deleted worktree path itself carries no way back to the repo;
+	// without the flag, resolve the launch directory best-effort (the
+	// ordinary existing-path case does not need it, so a resolution failure
+	// is not an error here).
 	releaseOptions := worktrees.Options{}
-	if workspaceRoot, rootErr := resolveWorkspaceRoot("", deps); rootErr == nil {
+	if cwdFlag != "" {
+		workspaceRoot, err := resolveWorkspaceRoot(cwdFlag, deps)
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		releaseOptions.Cwd = workspaceRoot
+	} else if workspaceRoot, rootErr := resolveWorkspaceRoot("", deps); rootErr == nil {
 		releaseOptions.Cwd = workspaceRoot
 	}
 	if err := deps.releaseWorktree(context.Background(), releaseOptions, absPath); err != nil {
@@ -847,13 +867,15 @@ func formatCommitResult(result zerogit.CommitResult) string {
 func writeWorktreesHelp(w io.Writer) error {
 	_, err := fmt.Fprint(w, `Usage:
   zero worktrees prepare [flags] [name]
-  zero worktrees release <path>
+  zero worktrees release [flags] <path>
 
 Prepares an isolated git worktree for a Zero task.
 
 prepare locks the worktree it creates so Zero's automatic cleanup never
 removes it out from under you. release unlocks a worktree prepare created,
 once you are done with it, so cleanup can reclaim it later if it goes stale.
+If the worktree directory was deleted by hand, run release with -C pointing
+at the source repository so the orphaned lock can still be cleared.
 
 Flags:
       --name <name>       Worktree name; defaults to a timestamped task name

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -143,7 +143,18 @@ func runWorktreesRelease(args []string, stdout io.Writer, stderr io.Writer, deps
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
-	if err := deps.releaseWorktree(context.Background(), worktrees.Options{}, absPath); err != nil {
+	// Release falls back to Options.Cwd as git's working directory when the
+	// worktree directory itself was deleted by hand instead of released; with
+	// no Cwd wired in, that recovery path runs `git worktree unlock` from
+	// wherever the caller happens to be, which outside the source repository
+	// leaves the orphaned lock behind forever (Clean skips locked entries).
+	// Resolve the workspace root best-effort: the ordinary existing-path case
+	// does not need it, so a resolution failure is not an error here.
+	releaseOptions := worktrees.Options{}
+	if workspaceRoot, rootErr := resolveWorkspaceRoot("", deps); rootErr == nil {
+		releaseOptions.Cwd = workspaceRoot
+	}
+	if err := deps.releaseWorktree(context.Background(), releaseOptions, absPath); err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
 	if _, err := fmt.Fprintf(stdout, "released %s\n", path); err != nil {

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -175,7 +175,7 @@ func runWorktreesRelease(args []string, stdout io.Writer, stderr io.Writer, deps
 		releaseOptions.Cwd = workspaceRoot
 	}
 	if err := deps.releaseWorktree(context.Background(), releaseOptions, absPath); err != nil {
-		return writeExecUsageError(stderr, err.Error())
+		return writeExecUsageError(stderr, redactCLIString(err.Error()))
 	}
 	if _, err := fmt.Fprintf(stdout, "released %s\n", redactCLIString(path)); err != nil {
 		return exitCrash

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -177,7 +177,7 @@ func runWorktreesRelease(args []string, stdout io.Writer, stderr io.Writer, deps
 	if err := deps.releaseWorktree(context.Background(), releaseOptions, absPath); err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
-	if _, err := fmt.Fprintf(stdout, "released %s\n", path); err != nil {
+	if _, err := fmt.Fprintf(stdout, "released %s\n", redactCLIString(path)); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
@@ -877,11 +877,15 @@ once you are done with it, so cleanup can reclaim it later if it goes stale.
 If the worktree directory was deleted by hand, run release with -C pointing
 at the source repository so the orphaned lock can still be cleared.
 
-Flags:
+prepare flags:
       --name <name>       Worktree name; defaults to a timestamped task name
       --dir <path>        Base directory for Zero worktrees
   -C, --cwd <path>        Source repository directory
       --json              Print JSON output
+
+release flags:
+  -C, --cwd <path>        Source repository directory (required if the
+                           worktree directory was already deleted)
   -h, --help              Show this help
 `)
 	return err

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -63,6 +63,9 @@ func runWorktrees(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 		}
 		return exitSuccess
 	}
+	if command == "release" {
+		return runWorktreesRelease(args, stdout, stderr, deps)
+	}
 	if command != "prepare" {
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown worktrees command %q", command))
 	}
@@ -97,6 +100,43 @@ func runWorktrees(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 		return exitSuccess
 	}
 	if _, err := fmt.Fprintln(stdout, formatWorktreeResult(safeResult)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+// runWorktreesRelease unlocks a worktree `zero worktrees prepare` created, so
+// Zero's automatic Clean pass can reclaim it once it goes stale. Prepare locks
+// every worktree it creates and nothing else in that command's own lifetime
+// unlocks it (its process exits right after printing the path, long before
+// whatever external caller actually finishes using the worktree), so that
+// caller is responsible for running this once it is done.
+func runWorktreesRelease(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	var path string
+	for _, arg := range args {
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			if err := writeWorktreesHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		case strings.HasPrefix(arg, "-"):
+			return writeExecUsageError(stderr, fmt.Sprintf("unknown worktrees release flag %q", arg))
+		default:
+			if path != "" {
+				return writeExecUsageError(stderr, "worktree path was provided more than once")
+			}
+			path = arg
+		}
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return writeExecUsageError(stderr, "worktrees release requires a worktree path")
+	}
+	if err := deps.releaseWorktree(context.Background(), worktrees.Options{}, path); err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if _, err := fmt.Fprintf(stdout, "released %s\n", path); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
@@ -786,8 +826,13 @@ func formatCommitResult(result zerogit.CommitResult) string {
 func writeWorktreesHelp(w io.Writer) error {
 	_, err := fmt.Fprint(w, `Usage:
   zero worktrees prepare [flags] [name]
+  zero worktrees release <path>
 
 Prepares an isolated git worktree for a Zero task.
+
+prepare locks the worktree it creates so Zero's automatic cleanup never
+removes it out from under you. release unlocks a worktree prepare created,
+once you are done with it, so cleanup can reclaim it later if it goes stale.
 
 Flags:
       --name <name>       Worktree name; defaults to a timestamped task name

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -133,7 +134,16 @@ func runWorktreesRelease(args []string, stdout io.Writer, stderr io.Writer, deps
 	if path == "" {
 		return writeExecUsageError(stderr, "worktrees release requires a worktree path")
 	}
-	if err := deps.releaseWorktree(context.Background(), worktrees.Options{}, path); err != nil {
+	// git worktree unlock matches against the path git recorded when the
+	// worktree was created, so a relative argument here (resolved against
+	// whatever directory the caller happens to be running in, not
+	// necessarily the worktree's own) can fail to match. Resolve to absolute
+	// up front so the unlock target is unambiguous regardless of cwd.
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if err := deps.releaseWorktree(context.Background(), worktrees.Options{}, absPath); err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
 	if _, err := fmt.Fprintf(stdout, "released %s\n", path); err != nil {

--- a/internal/redaction/audit_fixes_test.go
+++ b/internal/redaction/audit_fixes_test.go
@@ -61,6 +61,19 @@ func TestRedactString_CompoundKeyForms(t *testing.T) {
 	}
 }
 
+func TestRedactString_OverlappingExtraSecrets(t *testing.T) {
+	opts := Options{
+		ExtraSecretValues: []string{"secret", "secret_token"},
+	}
+	out := RedactString("my secret_token value", opts)
+	if strings.Contains(out, "_token") {
+		t.Fatalf("RedactString left partial fragment '_token': got %q", out)
+	}
+	if !strings.Contains(out, RedactedSecret) {
+		t.Fatalf("expected RedactedSecret in output: got %q", out)
+	}
+}
+
 func TestRedactString_AuthHeaderSchemes(t *testing.T) {
 	o := Options{}
 	// Opaque values (no token-format prefix) so only the header/colon logic can

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"unicode"
 )
@@ -156,9 +157,15 @@ func keyLooksSensitive(normalized string) bool {
 func RedactString(value string, options Options) string {
 	replacement := replacement(options)
 	redacted := value
-	for _, secret := range options.ExtraSecretValues {
-		if strings.TrimSpace(secret) != "" {
-			redacted = strings.ReplaceAll(redacted, secret, replacement)
+	if len(options.ExtraSecretValues) > 0 {
+		secrets := append([]string{}, options.ExtraSecretValues...)
+		sort.SliceStable(secrets, func(i, j int) bool {
+			return len(secrets[i]) > len(secrets[j])
+		})
+		for _, secret := range secrets {
+			if strings.TrimSpace(secret) != "" {
+				redacted = strings.ReplaceAll(redacted, secret, replacement)
+			}
 		}
 	}
 

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -45,10 +45,11 @@ var patterns = []pattern{
 	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`)},
 	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`)},
 	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`)},
-	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct- / sk-admin-) and
-	// hyphenated OpenAI-compatible provider keys (sk-or-v1- for OpenRouter) from
-	// normal kebab-case phrases, and match legacy sk-<alnum> keys by length (>= 20).
-	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-|admin-|or-v1-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}`)},
+	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct- / sk-admin-),
+	// Anthropic keys (sk-ant-apiNN- / sk-ant-), and hyphenated OpenAI-compatible
+	// provider keys (sk-or-v1- for OpenRouter) from normal kebab-case phrases, and
+	// match legacy sk-<alnum> keys by length (>= 20).
+	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-|admin-|or-v1-|ant-api\d{2}-|ant-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}`)},
 	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
 	// included) so redaction removes the key material, not just the header.
 	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -45,9 +45,10 @@ var patterns = []pattern{
 	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`)},
 	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`)},
 	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`)},
-	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct- / sk-admin-) from
+	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct- / sk-admin-) and
+	// hyphenated OpenAI-compatible provider keys (sk-or-v1- for OpenRouter) from
 	// normal kebab-case phrases, and match legacy sk-<alnum> keys by length (>= 20).
-	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-|admin-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}`)},
+	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-|admin-|or-v1-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}`)},
 	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
 	// included) so redaction removes the key material, not just the header.
 	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -31,22 +31,23 @@ type pattern struct {
 // as an openai_key. Real secrets are preceded by a delimiter (space, quote, =, :,
 // start-of-string), all of which satisfy \b.
 //
-// A trailing \b is omitted on patterns whose body class allows "-": \b only
-// matches at a word/non-word transition, so a secret that ends in "-" right
-// before a non-word delimiter (space, end of string) has no such transition,
-// and the engine backtracks the greedy quantifier to drop that last
-// character rather than fail the match, leaving the trailing "-" un-redacted.
-// The body character class is itself the real stopping boundary once the
-// input runs out of allowed characters, so the anchor is unnecessary there.
+// A trailing \b is omitted on every pattern: \b only matches at a word/non-word
+// transition, so a secret immediately followed by more word characters that
+// fall outside its body class (an appended suffix like "...EXAMPLEEXTRA" or
+// "..._suffix") has no such transition there, and a fixed or greedy quantifier
+// cannot backtrack its way to one — the whole match fails and the credential
+// leaks un-redacted. The body character class is itself the real stopping
+// boundary once the input runs out of allowed characters, so the anchor is
+// unnecessary; the leading \b already keeps these from firing mid-word.
 var patterns = []pattern{
-	{"aws_access_key_id", regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)},
-	{"github_token", regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}\b`)},
-	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}\b`)},
+	{"aws_access_key_id", regexp.MustCompile(`\bAKIA[0-9A-Z]{16}`)},
+	{"github_token", regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}`)},
+	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`)},
 	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`)},
 	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`)},
-	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct-) from normal kebab-case phrases,
-	// and match legacy sk-<alnum> keys by length (>= 20).
-	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}\b`)},
+	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct- / sk-admin-) from
+	// normal kebab-case phrases, and match legacy sk-<alnum> keys by length (>= 20).
+	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-|admin-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}`)},
 	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
 	// included) so redaction removes the key material, not just the header.
 	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -31,18 +31,18 @@ type pattern struct {
 // as an openai_key. Real secrets are preceded by a delimiter (space, quote, =, :,
 // start-of-string), all of which satisfy \b.
 var patterns = []pattern{
-	{"aws_access_key_id", regexp.MustCompile(`\bAKIA[0-9A-Z]{16}`)},
-	{"github_token", regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36}`)},
-	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`)},
-	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`)},
-	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35}`)},
-	// Body allows - and _ so modern prefixed keys (sk-proj-…, sk-svcacct-…) match,
-	// not just the legacy sk-<alnum> shape.
-	{"openai_key", regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}`)},
+	{"aws_access_key_id", regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)},
+	{"github_token", regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}\b`)},
+	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}\b`)},
+	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`)},
+	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}\b`)},
+	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct-) from normal kebab-case phrases,
+	// and match legacy sk-<alnum> keys by length (>= 20).
+	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-)[A-Za-z0-9_-]{20,}\b|\bsk-[A-Za-z0-9]{20,}\b`)},
 	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
 	// included) so redaction removes the key material, not just the header.
 	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},
-	{"jwt", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)},
+	{"jwt", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`)},
 }
 
 // Scan returns the distinct secrets found in text (deduplicated by match,

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -30,19 +30,27 @@ type pattern struct {
 // mid-word — e.g. "sk-" inside "task-management-and-coordination" must NOT match
 // as an openai_key. Real secrets are preceded by a delimiter (space, quote, =, :,
 // start-of-string), all of which satisfy \b.
+//
+// A trailing \b is omitted on patterns whose body class allows "-": \b only
+// matches at a word/non-word transition, so a secret that ends in "-" right
+// before a non-word delimiter (space, end of string) has no such transition,
+// and the engine backtracks the greedy quantifier to drop that last
+// character rather than fail the match, leaving the trailing "-" un-redacted.
+// The body character class is itself the real stopping boundary once the
+// input runs out of allowed characters, so the anchor is unnecessary there.
 var patterns = []pattern{
 	{"aws_access_key_id", regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)},
 	{"github_token", regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}\b`)},
 	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}\b`)},
-	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`)},
-	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}\b`)},
+	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`)},
+	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`)},
 	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct-) from normal kebab-case phrases,
 	// and match legacy sk-<alnum> keys by length (>= 20).
-	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-)[A-Za-z0-9_-]{20,}\b|\bsk-[A-Za-z0-9]{20,}\b`)},
+	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}\b`)},
 	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
 	// included) so redaction removes the key material, not just the header.
 	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},
-	{"jwt", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`)},
+	{"jwt", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)},
 }
 
 // Scan returns the distinct secrets found in text (deduplicated by match,

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -45,11 +45,8 @@ var patterns = []pattern{
 	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`)},
 	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`)},
 	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`)},
-	// Distinguish modern prefixed keys (sk-proj- / sk-svcacct- / sk-admin-),
-	// Anthropic keys (sk-ant-apiNN- / sk-ant-), and hyphenated OpenAI-compatible
-	// provider keys (sk-or-v1- for OpenRouter) from normal kebab-case phrases, and
-	// match legacy sk-<alnum> keys by length (>= 20).
-	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-|admin-|or-v1-|ant-api\d{2}-|ant-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}`)},
+	{"anthropic_key", regexp.MustCompile(`\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{20,}`)},
+	{"openai_key", regexp.MustCompile(`\bsk-(?:proj-|svcacct-|admin-|or-v1-)[A-Za-z0-9_-]{20,}|\bsk-[A-Za-z0-9]{20,}`)},
 	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
 	// included) so redaction removes the key material, not just the header.
 	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -102,11 +102,12 @@ func TestRedactNoMatchReturnsInputUnchanged(t *testing.T) {
 }
 
 func TestScanDetectsModernPrefixedOpenAIKeys(t *testing.T) {
-	// Modern keys carry sk-proj-/sk-svcacct- prefixes and use - and _ in the body;
-	// the legacy sk-<alnum> pattern would have missed them.
+	// Modern keys carry sk-proj-/sk-svcacct-/sk-admin- prefixes and use - and _ in
+	// the body; the legacy sk-<alnum> pattern would have missed them.
 	for _, key := range []string{
 		"sk-proj-abcDEF123_ghiJKL456-mnoPQR789stu",
 		"sk-svcacct-abcDEF123_ghiJKL456-mnoPQR789",
+		"sk-admin-abcDEF123_ghiJKL456-mnoPQR789stu",
 	} {
 		redacted, findings := Redact("token=" + key)
 		if len(findings) != 1 || findings[0].Type != "openai_key" {
@@ -171,6 +172,41 @@ func TestScanRedactsTrailingHyphenWithoutTailLeak(t *testing.T) {
 		wantRedacted := "secret is [REDACTED:" + tc.wantType + "] end"
 		if redacted != wantRedacted {
 			t.Errorf("%s: redacted = %q, want %q", tc.wantType, redacted, wantRedacted)
+		}
+	}
+}
+
+// A credential with more word characters appended right after its body (a
+// copy-paste artifact, an env-var-style suffix) must still have its real
+// secret material redacted, even though the appended run itself is outside
+// the body class and so is left un-redacted. A trailing \b anchor would find
+// no word/non-word transition there and, for a fixed or unbounded-greedy
+// quantifier, fail the whole match instead of backtracking, leaking the
+// credential entirely.
+func TestScanRedactsCredentialWithAppendedSuffix(t *testing.T) {
+	cases := []struct {
+		wantType string
+		secret   string
+		suffix   string
+	}{
+		{"aws_access_key_id", "AKIAIOSFODNN7EXAMPLE", "EXTRA"},
+		{"github_token", "ghp_1234567890abcdefghijklmnopqrstuvwxyz", "_suffix"},
+	}
+	for _, tc := range cases {
+		text := "token=" + tc.secret + tc.suffix + " end"
+		redacted, findings := Redact(text)
+		if len(findings) != 1 || findings[0].Type != tc.wantType {
+			t.Fatalf("%s: expected one finding for %q, got %#v", tc.wantType, tc.secret+tc.suffix, findings)
+		}
+		if findings[0].Match != tc.secret {
+			t.Fatalf("%s: matched %q, want the credential prefix %q", tc.wantType, findings[0].Match, tc.secret)
+		}
+		if strings.Contains(redacted, tc.secret) {
+			t.Fatalf("%s: credential leaked after redaction: %q", tc.wantType, redacted)
+		}
+		wantRedacted := "token=[REDACTED:" + tc.wantType + "]" + tc.suffix + " end"
+		if redacted != wantRedacted {
+			t.Fatalf("%s: redacted = %q, want %q", tc.wantType, redacted, wantRedacted)
 		}
 	}
 }

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -143,6 +143,38 @@ func TestScanRedactsLongerKeysWithoutTailLeak(t *testing.T) {
 	}
 }
 
+// Patterns whose body class allows "-" (slack_token, google_api_key, the
+// modern openai_key branch, jwt) must redact a secret that ends in "-" right
+// before a delimiter: a trailing \b anchor would have no word/non-word
+// transition to match there, forcing the engine to drop that last character
+// from the match and leaking it.
+func TestScanRedactsTrailingHyphenWithoutTailLeak(t *testing.T) {
+	cases := []struct {
+		wantType string
+		secret   string
+	}{
+		{"slack_token", "xoxb-1234567890-abcdefghi-"},
+		{"google_api_key", "AIzaSyA1234567890abcdefghijklmnopqrstu-"},
+		{"openai_key", "sk-proj-abcDEF123_ghiJKL456-mnoPQR789st-"},
+		{"jwt", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fw-"},
+	}
+	for _, tc := range cases {
+		text := "secret is " + tc.secret + " end"
+		redacted, findings := Redact(text)
+		if len(findings) != 1 || findings[0].Type != tc.wantType {
+			t.Errorf("%s: expected one finding for %q, got %#v", tc.wantType, tc.secret, findings)
+			continue
+		}
+		if strings.Contains(redacted, "-  end") || strings.Contains(redacted, "-] end") {
+			t.Errorf("%s: trailing hyphen leaked: %q", tc.wantType, redacted)
+		}
+		wantRedacted := "secret is [REDACTED:" + tc.wantType + "] end"
+		if redacted != wantRedacted {
+			t.Errorf("%s: redacted = %q, want %q", tc.wantType, redacted, wantRedacted)
+		}
+	}
+}
+
 func TestScanIgnoresKebabCaseStartingWithSk(t *testing.T) {
 	phrase := "sk-learn-machine-learning-model"
 	findings := Scan("testing " + phrase + " in text")

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -139,6 +139,24 @@ func TestScanDetectsHyphenatedOpenAICompatibleKeys(t *testing.T) {
 	}
 }
 
+func TestScanDetectsAnthropicKeys(t *testing.T) {
+	for _, key := range []string{
+		"sk-ant-api03-1234567890abcdefghijklmnopqrstuvwxyz-12345",
+		"sk-ant-1234567890abcdefghijklmnopqrstuvwxyz-12345",
+	} {
+		redacted, findings := Redact("token=" + key)
+		if len(findings) != 1 || findings[0].Type != "openai_key" {
+			t.Fatalf("expected one openai_key finding for %q, got %#v", key, findings)
+		}
+		if strings.Contains(redacted, key) {
+			t.Fatalf("key leaked after redaction: %q", redacted)
+		}
+		if !strings.Contains(redacted, "[REDACTED:openai_key]") {
+			t.Fatalf("missing typed placeholder for %q: %q", key, redacted)
+		}
+	}
+}
+
 func TestScanRedactsLongerKeysWithoutTailLeak(t *testing.T) {
 	cases := []struct {
 		wantType string

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -122,6 +122,23 @@ func TestScanDetectsModernPrefixedOpenAIKeys(t *testing.T) {
 	}
 }
 
+func TestScanDetectsHyphenatedOpenAICompatibleKeys(t *testing.T) {
+	// OpenRouter's sk-or-v1- keys are hyphenated like the modern sk-proj-
+	// family; the legacy sk-<alnum-only> branch does not match a "-" right
+	// after "sk-", so this format needs its own explicit prefix branch.
+	key := "sk-or-v1-1234567890abcdef1234567890abcdef1234567890abcdef1234"
+	redacted, findings := Redact("token=" + key)
+	if len(findings) != 1 || findings[0].Type != "openai_key" {
+		t.Fatalf("expected one openai_key finding for %q, got %#v", key, findings)
+	}
+	if strings.Contains(redacted, key) {
+		t.Fatalf("key leaked after redaction: %q", redacted)
+	}
+	if !strings.Contains(redacted, "[REDACTED:openai_key]") {
+		t.Fatalf("missing typed placeholder for %q: %q", key, redacted)
+	}
+}
+
 func TestScanRedactsLongerKeysWithoutTailLeak(t *testing.T) {
 	cases := []struct {
 		wantType string

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -50,11 +50,11 @@ func TestRedactNestedSecretStillRemovesWholeBlock(t *testing.T) {
 	// AWS key shape, which sorts before private_key_block). Redaction must remove
 	// the WHOLE block: if the inner match were replaced first it would corrupt the
 	// block's exact string and leave the BEGIN/END header in the output.
-	key := "-----BEGIN PRIVATE KEY-----\nAKIAABCDEFGHIJKLMNOP\nMIIEowIBAAKCAQEAbody\n-----END PRIVATE KEY-----"
+	key := "-----BEGIN PRIVATE KEY-----\nAKIAIOSFODNN7EXAMPLE\nMIIEowIBAAKCAQEAbody\n-----END PRIVATE KEY-----"
 	text := "leaked:\n" + key + "\ndone"
 
 	redacted, _ := Redact(text)
-	for _, leaked := range []string{"PRIVATE KEY", "AKIAABCDEFGHIJKLMNOP", "MIIEowIBAAKCAQEAbody"} {
+	for _, leaked := range []string{"PRIVATE KEY", "AKIAIOSFODNN7EXAMPLE", "MIIEowIBAAKCAQEAbody"} {
 		if strings.Contains(redacted, leaked) {
 			t.Fatalf("redaction leaked %q from a nested-secret block: %q", leaked, redacted)
 		}
@@ -118,5 +118,35 @@ func TestScanDetectsModernPrefixedOpenAIKeys(t *testing.T) {
 		if !strings.Contains(redacted, "[REDACTED:openai_key]") {
 			t.Fatalf("missing typed placeholder for %q: %q", key, redacted)
 		}
+	}
+}
+
+func TestScanRedactsLongerKeysWithoutTailLeak(t *testing.T) {
+	cases := []struct {
+		wantType string
+		secret   string
+	}{
+		{"github_token", "ghp_1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdef"}, // 50 chars instead of 40
+		{"google_api_key", "AIzaSyA1234567890abcdefghijklmnopqrstuv12345678"},        // 50 chars instead of 39
+	}
+	for _, tc := range cases {
+		text := "longer key is " + tc.secret + " in text"
+		redacted, findings := Redact(text)
+		if len(findings) != 1 || findings[0].Type != tc.wantType {
+			t.Errorf("expected one %s finding, got %#v", tc.wantType, findings)
+			continue
+		}
+		wantRedacted := "longer key is [REDACTED:" + tc.wantType + "] in text"
+		if redacted != wantRedacted {
+			t.Errorf("redacted = %q, want %q", redacted, wantRedacted)
+		}
+	}
+}
+
+func TestScanIgnoresKebabCaseStartingWithSk(t *testing.T) {
+	phrase := "sk-learn-machine-learning-model"
+	findings := Scan("testing " + phrase + " in text")
+	if len(findings) != 0 {
+		t.Errorf("expected no match for non-secret kebab-case phrase %q, got: %#v", phrase, findings)
 	}
 }

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -145,13 +145,13 @@ func TestScanDetectsAnthropicKeys(t *testing.T) {
 		"sk-ant-1234567890abcdefghijklmnopqrstuvwxyz-12345",
 	} {
 		redacted, findings := Redact("token=" + key)
-		if len(findings) != 1 || findings[0].Type != "openai_key" {
-			t.Fatalf("expected one openai_key finding for %q, got %#v", key, findings)
+		if len(findings) != 1 || findings[0].Type != "anthropic_key" {
+			t.Fatalf("expected one anthropic_key finding for %q, got %#v", key, findings)
 		}
 		if strings.Contains(redacted, key) {
 			t.Fatalf("key leaked after redaction: %q", redacted)
 		}
-		if !strings.Contains(redacted, "[REDACTED:openai_key]") {
+		if !strings.Contains(redacted, "[REDACTED:anthropic_key]") {
 			t.Fatalf("missing typed placeholder for %q: %q", key, redacted)
 		}
 	}

--- a/internal/tools/bash_secrets_test.go
+++ b/internal/tools/bash_secrets_test.go
@@ -24,3 +24,13 @@ func TestFormatBashOutputLeavesCleanOutputAlone(t *testing.T) {
 		t.Fatalf("clean output should not be altered, got %q", out)
 	}
 }
+
+func TestFormatBashOutputRedactsAnthropicKey(t *testing.T) {
+	out := formatBashOutput("anthropic key: sk-ant-api03-1234567890abcdefghijklmnopqrstuvwxyz-12345\n", "", 0)
+	if strings.Contains(out, "sk-ant-api03") {
+		t.Fatalf("bash output leaked an Anthropic key: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED:openai_key]") {
+		t.Fatalf("expected typed redaction placeholder, got %q", out)
+	}
+}

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -50,11 +50,6 @@ type Result struct {
 var worktreeNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$`)
 
 func Prepare(ctx context.Context, options Options) (Result, error) {
-	// Clean up stale worktrees (older than 24 hours) automatically to prevent disk space leaks.
-	if options.RunGit == nil {
-		_ = Clean(ctx, options, 24*time.Hour)
-	}
-
 	cwd, err := resolveCwd(options.Cwd)
 	if err != nil {
 		return Result{}, err
@@ -73,6 +68,14 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	}
 	if err := validateName(name); err != nil {
 		return Result{}, err
+	}
+
+	// Clean up stale worktrees (older than 24 hours) automatically to prevent
+	// disk space leaks. Only after the request itself validated: a rejected
+	// command (for example an invalid --name) must not have destructive
+	// cleanup side effects before reporting its error.
+	if options.RunGit == nil {
+		_ = Clean(ctx, options, 24*time.Hour)
 	}
 
 	repoRoot, err := gitOutput(ctx, runGit, cwd, "rev-parse", "--show-toplevel")
@@ -120,14 +123,19 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		// A reused worktree may have been released by a prior run's exit, and
 		// an unlocked target is exposed to Clean's staleness heuristic while
 		// this caller is still using it, so re-establish the lease here. A
-		// lock already held (an external prepare caller is still using the
-		// path) stays in place and is reported via LockAcquired=false so this
-		// caller knows the release duty is not its own.
+		// lock already held means another run is still using the path: two
+		// live runs must not share one supposedly isolated checkout (they
+		// would edit the same tree, and whichever exits first would release
+		// the single Git lock out from under the other), so reject it rather
+		// than hand the second caller an unprotected shared workspace.
 		acquired, err := lockWorktree(ctx, runGit, repoRoot, target)
 		if err != nil {
 			return Result{}, err
 		}
-		result.LockAcquired = acquired
+		if !acquired {
+			return Result{}, fmt.Errorf("worktree %s is locked by another active run; release it with `zero worktrees release %s` if that run is finished, or use a different --name", target, target)
+		}
+		result.LockAcquired = true
 		return result, nil
 	}
 	if err := os.MkdirAll(repoDir, 0o700); err != nil {
@@ -149,12 +157,17 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	// network, or user for a long time") never force-removes a worktree zero
 	// itself is still using. entry.locked already makes Clean skip a worktree
 	// a human locked by hand; locking here extends that same protection to
-	// the worktrees zero creates.
-	if _, err := lockWorktree(ctx, runGit, repoRoot, target); err != nil {
+	// the worktrees zero creates. An "already locked" answer on a worktree
+	// this call just created means another process raced us to it: treat that
+	// exactly like the reuse collision above rather than claiming a lease
+	// this call never acquired.
+	acquired, err := lockWorktree(ctx, runGit, repoRoot, target)
+	if err != nil {
 		return Result{}, err
 	}
-	// This call created the worktree, so it owns the lease regardless of what
-	// git reported for the lock itself.
+	if !acquired {
+		return Result{}, fmt.Errorf("worktree %s is locked by another active run; release it with `zero worktrees release %s` if that run is finished, or use a different --name", target, target)
+	}
 	result.LockAcquired = true
 	return result, nil
 }

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -217,28 +216,16 @@ func leasePID(reason string) (int, bool) {
 
 // processAlive reports whether pid is a live process. It fails closed: any
 // ambiguity (permission denied, platform limits) counts as alive, so an
-// uncertain answer can only keep a lease, never expire one.
+// uncertain answer can only keep a lease, never expire one. Detection is
+// platform-specific (see osProcessAlive in worktrees_posix.go /
+// worktrees_windows.go): os.FindProcess alone cannot tell a dead PID from a
+// live one on Windows, since OpenProcess can still succeed for a process that
+// has already exited but whose handle has not been fully released.
 func processAlive(pid int) bool {
 	if pid <= 0 {
 		return true
 	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		// Windows: FindProcess opens the process and fails when it is gone.
-		return false
-	}
-	if runtime.GOOS == "windows" {
-		return true
-	}
-	err = proc.Signal(syscall.Signal(0))
-	if err == nil {
-		return true
-	}
-	if errors.Is(err, os.ErrProcessDone) {
-		return false
-	}
-	// EPERM: the process exists but belongs to another user.
-	return errors.Is(err, syscall.EPERM)
+	return osProcessAlive(pid)
 }
 
 // lockWorktree takes the Clean-protection lease on target via `git worktree
@@ -297,26 +284,32 @@ func Release(ctx context.Context, options Options, path string) error {
 }
 
 // verifyZeroOwnedWorktree confirms path has a zero-worktree-<repoKey> ancestor
-// directory component, so Release cannot be used to clear the lock on a
-// worktree a user (or another tool) manages by hand: the command is
+// directory component, and that if git currently has it locked, the lock
+// reason is one Zero itself set, so Release cannot be used to clear the lock
+// on a worktree a user (or another tool) manages by hand: the command is
 // documented as releasing a worktree `prepare` created, not an arbitrary git
-// worktree lock. This checks for the ancestor component itself rather than
-// reconstructing and comparing a full repoDir, because Release has no
-// reliable way to know which --dir a long-gone Prepare call used (the CLI
-// never threads BaseDir through to Release, and a custom --dir is not
-// recorded anywhere the lock/unlock path can read back); the repoKey
-// component is Prepare's actual ownership signature regardless of which
-// directory it was created under. gitCommonDir resolves the shared .git
-// directory whether dir is the worktree itself or the main repository, so
-// this needs no branching on which of Release's two cwd cases is in play;
-// its parent is the same repoRoot Prepare/Clean use to compute repoKey.
+// worktree lock. The ancestor-component check stands in for reconstructing
+// and comparing a full repoDir, because Release has no reliable way to know
+// which --dir a long-gone Prepare call used (the CLI never threads BaseDir
+// through to Release, and a custom --dir is not recorded anywhere the
+// lock/unlock path can read back); the repoKey component is Prepare's actual
+// ownership signature regardless of which directory it was created under.
+// The repository root for that key, and the lock reason for the ownership
+// check, both come from the same `git worktree list --porcelain` call, which
+// works whether dir is the worktree itself or the main repository (its first
+// entry is always the main working tree, from any worktree, regardless of
+// git-dir layout), so this needs no branching on which of Release's two cwd
+// cases is in play.
 func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, path string) error {
-	commonDir, err := gitCommonDir(ctx, runGit, dir)
+	output, err := gitOutput(ctx, runGit, dir, "worktree", "list", "--porcelain")
 	if err != nil {
 		return fmt.Errorf("resolve repository for %s: %w", path, err)
 	}
-	repoRoot := filepath.Dir(commonDir)
-	want := "zero-worktree-" + repoKey(repoRoot)
+	entries := parseWorktreeList(output)
+	if len(entries) == 0 {
+		return fmt.Errorf("resolve repository for %s: git worktree list returned no entries", path)
+	}
+	want := "zero-worktree-" + repoKey(entries[0].path)
 
 	target := path
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
@@ -324,12 +317,29 @@ func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, 
 	} else if abs, err := filepath.Abs(path); err == nil {
 		target = abs
 	}
-	for _, component := range strings.Split(filepath.Clean(target), string(filepath.Separator)) {
+	target = filepath.Clean(target)
+
+	hasZeroComponent := false
+	for _, component := range strings.Split(target, string(filepath.Separator)) {
 		if component == want {
-			return nil
+			hasZeroComponent = true
+			break
 		}
 	}
-	return fmt.Errorf("refusing to release %s: not a zero-managed worktree (expected an ancestor directory named %q)", path, want)
+	if !hasZeroComponent {
+		return fmt.Errorf("refusing to release %s: not a zero-managed worktree (expected an ancestor directory named %q)", path, want)
+	}
+
+	for _, entry := range entries {
+		if entry.path != target {
+			continue
+		}
+		if entry.locked && !strings.HasPrefix(entry.lockReason, leaseReasonPrefix) {
+			return fmt.Errorf("refusing to release %s: locked with reason %q, not a zero lease", path, entry.lockReason)
+		}
+		break
+	}
+	return nil
 }
 
 func DefaultBaseDir(env map[string]string) (string, error) {

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -366,8 +366,12 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 		}
 
 		if worktreeIsStale(entry.path, cutoff) {
-			_, err = runGit(ctx, repoRoot, "worktree", "remove", "--force", entry.path)
-			if err != nil {
+			// gitOutput (not a raw runGit call) so a nonzero exit code is
+			// reported as a failure: defaultRunGit deliberately returns a nil
+			// error alongside a nonzero CommandResult.ExitCode for a failed git
+			// invocation, so checking only the returned error would silently
+			// treat a failed removal (busy, permission denied) as success.
+			if _, err := gitOutput(ctx, runGit, repoRoot, "worktree", "remove", "--force", entry.path); err != nil {
 				lastErr = fmt.Errorf("remove worktree %s: %w", entry.path, err)
 			}
 		}
@@ -428,15 +432,21 @@ func isUnderDir(path, dir string) bool {
 // task edits files deeper in the tree, so checking root's mtime alone can
 // mistake an actively-used worktree for stale. Walking the tree and bailing
 // out on the first recent entry avoids that false positive.
+//
+// Any inspection failure (a WalkDir error, or a DirEntry that can't report its
+// own info) fails closed: it's treated the same as "not stale," never as
+// "stale," so an incomplete inspection can't authorize a forced removal.
 func worktreeIsStale(root string, cutoff time.Time) bool {
 	stale := true
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return nil
+			stale = false
+			return filepath.SkipAll
 		}
 		info, err := d.Info()
 		if err != nil {
-			return nil
+			stale = false
+			return filepath.SkipAll
 		}
 		if info.ModTime().After(cutoff) {
 			stale = false
@@ -444,5 +454,5 @@ func worktreeIsStale(root string, cutoff time.Time) bool {
 		}
 		return nil
 	})
-	return stale
+	return stale && walkErr == nil
 }

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -337,36 +338,111 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 		return fmt.Errorf("list git worktrees: %w", err)
 	}
 
-	lines := strings.Split(output, "\n")
+	cutoff := time.Now().Add(-maxAge)
 	var lastErr error
-	for _, line := range lines {
-		if !strings.HasPrefix(line, "worktree ") {
-			continue
-		}
-		path := strings.TrimPrefix(line, "worktree ")
-		path = filepath.Clean(path)
-
-		// Only prune worktrees that belong to zero (i.e. inside baseDir)
-		if !strings.HasPrefix(path, baseDir) {
+	for _, entry := range parseWorktreeList(output) {
+		// A worktree a caller has explicitly locked (git worktree lock) is
+		// never a prune candidate, regardless of its mtime.
+		if entry.locked {
 			continue
 		}
 
-		info, err := os.Stat(path)
+		// Only prune worktrees that belong to zero (i.e. inside baseDir), using
+		// a path-boundary-safe comparison so a sibling directory that merely
+		// shares baseDir as a string prefix (e.g. "<baseDir>-other") can't match.
+		if !isUnderDir(entry.path, baseDir) {
+			continue
+		}
+
+		info, err := os.Stat(entry.path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				_, _ = runGit(ctx, repoRoot, "worktree", "prune")
 			}
 			continue
 		}
+		if !info.IsDir() {
+			continue
+		}
 
-		if time.Since(info.ModTime()) > maxAge {
-			_, err = runGit(ctx, repoRoot, "worktree", "remove", "--force", path)
+		if worktreeIsStale(entry.path, cutoff) {
+			_, err = runGit(ctx, repoRoot, "worktree", "remove", "--force", entry.path)
 			if err != nil {
-				lastErr = fmt.Errorf("remove worktree %s: %w", path, err)
+				lastErr = fmt.Errorf("remove worktree %s: %w", entry.path, err)
 			}
 		}
 	}
 
 	_, _ = runGit(ctx, repoRoot, "worktree", "prune")
 	return lastErr
+}
+
+type worktreeEntry struct {
+	path   string
+	locked bool
+}
+
+// parseWorktreeList reads `git worktree list --porcelain` output into one
+// entry per worktree. Entries are delimited by their own "worktree <path>"
+// line rather than by blank-line blocks, so this tolerates both real git
+// output (attribute lines plus a blank-line separator) and a minimal listing
+// with no separators.
+func parseWorktreeList(output string) []worktreeEntry {
+	var entries []worktreeEntry
+	var current *worktreeEntry
+	for _, line := range strings.Split(output, "\n") {
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			if current != nil {
+				entries = append(entries, *current)
+			}
+			current = &worktreeEntry{path: filepath.Clean(strings.TrimPrefix(line, "worktree "))}
+		case current != nil && (line == "locked" || strings.HasPrefix(line, "locked ")):
+			current.locked = true
+		}
+	}
+	if current != nil {
+		entries = append(entries, *current)
+	}
+	return entries
+}
+
+// isUnderDir reports whether path is dir itself or a descendant of it. Unlike
+// a bare strings.HasPrefix(path, dir), this rejects a sibling that merely
+// shares dir as a string prefix (e.g. dir "/a/base" must not match
+// "/a/base-other"), and filepath.Rel makes the comparison Windows-correct.
+func isUnderDir(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// worktreeIsStale reports whether every file under root was last modified
+// before cutoff. A directory's own mtime only changes when an entry is
+// added, removed, or renamed directly inside it, not when a long-running
+// task edits files deeper in the tree, so checking root's mtime alone can
+// mistake an actively-used worktree for stale. Walking the tree and bailing
+// out on the first recent entry avoids that false positive.
+func worktreeIsStale(root string, cutoff time.Time) bool {
+	stale := true
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if info.ModTime().After(cutoff) {
+			stale = false
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return stale
 }

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -92,6 +92,19 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		return Result{}, fmt.Errorf("not a git repository: %w", err)
 	}
 	repoRoot = filepath.Clean(repoRoot)
+	// Key the per-repository worktree bucket off the MAIN worktree's root, not
+	// repoRoot (which is whichever worktree - main or a linked one - this call
+	// happened to run from): git worktree list --porcelain always reports the
+	// main worktree first, regardless of invocation location, so this keeps
+	// Prepare and Release's ownership key derivation in agreement (see
+	// verifyZeroOwnedWorktree) even when Prepare runs from a linked worktree.
+	// Without it, a worktree prepared from a linked checkout hashes a
+	// different repoKey than Release computes, and its lease can never be
+	// cleared.
+	primaryRoot, err := primaryWorktreeRoot(ctx, runGit, repoRoot)
+	if err != nil {
+		return Result{}, err
+	}
 	branch, _ := gitOutput(ctx, runGit, repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
 	commit, _ := gitOutput(ctx, runGit, repoRoot, "rev-parse", "--short", "HEAD")
 
@@ -107,7 +120,7 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		return Result{}, fmt.Errorf("resolve worktree dir: %w", err)
 	}
 
-	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(primaryRoot))
 	target := filepath.Join(repoDir, name)
 	result := Result{
 		Name:         name,
@@ -172,6 +185,20 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	// this call never acquired.
 	acquired, err := lockWorktree(ctx, runGit, repoRoot, target, options.LeasePID)
 	if err != nil {
+		// This call created target and nothing else can own it yet (a
+		// concurrent racer would have made lockWorktree return acquired=false,
+		// not an error), so a failure here (not "already locked", an actual
+		// git failure) must not leave an unleased, newly created worktree
+		// behind: Clean cannot distinguish it from live-but-not-yet-touched
+		// work, so it would sit as a disk leak until the staleness window
+		// passes. Best-effort: report a removal failure alongside the
+		// original lock error rather than letting it mask the leak.
+		// gitOutput (not a raw runGit call) so a nonzero exit code is treated
+		// as a failure: defaultRunGit returns a nil error alongside a nonzero
+		// CommandResult.ExitCode for a failed git invocation.
+		if _, removeErr := gitOutput(ctx, runGit, repoRoot, "worktree", "remove", "--force", target); removeErr != nil {
+			return Result{}, errors.Join(err, fmt.Errorf("clean up worktree after failed lock: %w", removeErr))
+		}
 		return Result{}, err
 	}
 	if !acquired {
@@ -312,6 +339,9 @@ func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, 
 	if len(entries) == 0 {
 		return fmt.Errorf("resolve repository for %s: git worktree list returned no entries", path)
 	}
+	// entries[0].path is always the main worktree (see primaryWorktreeRoot),
+	// which is what Prepare now also keys its repoKey off, so this and Prepare
+	// agree regardless of which worktree either call ran from.
 	want := "zero-worktree-" + repoKey(entries[0].path)
 
 	target := canonicalizePath(path)
@@ -367,10 +397,45 @@ func canonicalizePath(path string) string {
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		return filepath.Clean(resolved)
 	}
-	if abs, err := filepath.Abs(path); err == nil {
-		return filepath.Clean(abs)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
 	}
-	return filepath.Clean(path)
+	abs = filepath.Clean(abs)
+	// path itself does not exist (the documented release -C recovery: the
+	// worktree directory was deleted by hand before releasing it), so
+	// EvalSymlinks above had nothing to resolve. If an ANCESTOR of path is
+	// itself a symlink (a symlinked --worktree-dir), the plain Abs+Clean
+	// fallback keeps that ancestor's logical spelling, which never matches
+	// git's physical-path porcelain entry, and the lock can never be
+	// released. Resolve symlinks through the nearest existing ancestor
+	// instead and reattach the missing tail.
+	return resolveThroughNearestExistingAncestor(abs)
+}
+
+// resolveThroughNearestExistingAncestor walks up from path until it finds an
+// existing ancestor directory, resolves that ancestor's symlinks, and
+// reattaches path's missing remainder onto the resolved ancestor.
+func resolveThroughNearestExistingAncestor(path string) string {
+	var missing []string
+	current := path
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			result := filepath.Clean(resolved)
+			for i := len(missing) - 1; i >= 0; i-- {
+				result = filepath.Join(result, missing[i])
+			}
+			return result
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached the filesystem root without finding an existing
+			// ancestor; nothing left to resolve symlinks through.
+			return path
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
 }
 
 func DefaultBaseDir(env map[string]string) (string, error) {
@@ -460,6 +525,24 @@ func gitOutput(ctx context.Context, runGit GitRunner, dir string, args ...string
 		return "", fmt.Errorf("%s", message)
 	}
 	return strings.TrimSpace(result.Stdout), nil
+}
+
+// primaryWorktreeRoot returns the repository's main worktree path. `git
+// worktree list --porcelain` always reports the main worktree first (its
+// first entry), regardless of which linked worktree the command runs from -
+// which is what lets Prepare and verifyZeroOwnedWorktree agree on one
+// repoKey for the same repository even when invoked from different
+// worktrees of it.
+func primaryWorktreeRoot(ctx context.Context, runGit GitRunner, dir string) (string, error) {
+	output, err := gitOutput(ctx, runGit, dir, "worktree", "list", "--porcelain")
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root: %w", err)
+	}
+	entries := parseWorktreeList(output)
+	if len(entries) == 0 {
+		return "", fmt.Errorf("resolve repository root: git worktree list returned no entries")
+	}
+	return entries[0].path, nil
 }
 
 func sameGitCommonDir(ctx context.Context, runGit GitRunner, sourceDir string, targetDir string) (bool, error) {

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -332,6 +332,11 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 	if err != nil {
 		return err
 	}
+	// Prepare only ever creates worktrees under this per-repository subtree
+	// (mirroring the repoDir it computes). Scoping pruning to baseDir itself
+	// would authorize deleting a worktree a user manages by hand in the same
+	// directory, which Zero never created and has no business force-removing.
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
 
 	output, err := gitOutput(ctx, runGit, repoRoot, "worktree", "list", "--porcelain")
 	if err != nil {
@@ -347,10 +352,11 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 			continue
 		}
 
-		// Only prune worktrees that belong to zero (i.e. inside baseDir), using
-		// a path-boundary-safe comparison so a sibling directory that merely
-		// shares baseDir as a string prefix (e.g. "<baseDir>-other") can't match.
-		if !isUnderDir(entry.path, baseDir) {
+		// Only prune worktrees zero created for this repository (i.e. inside
+		// repoDir), using a path-boundary-safe comparison so a sibling
+		// directory that merely shares repoDir as a string prefix (e.g.
+		// "<repoDir>-other") can't match.
+		if !isUnderDir(entry.path, repoDir) {
 			continue
 		}
 
@@ -366,6 +372,15 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 		}
 
 		if worktreeIsStale(entry.path, cutoff) {
+			if worktreeIsDirty(ctx, runGit, entry.path) {
+				// A stale mtime only means nothing changed at the worktree's
+				// top level or below recently; it does not mean the task
+				// holding it is done. Uncommitted or untracked changes are
+				// still live work waiting on a model, network, or user, so
+				// force-removing here would discard it. Skip until it either
+				// gets committed/cleaned (no longer dirty) or unlocked.
+				continue
+			}
 			// gitOutput (not a raw runGit call) so a nonzero exit code is
 			// reported as a failure: defaultRunGit deliberately returns a nil
 			// error alongside a nonzero CommandResult.ExitCode for a failed git
@@ -455,4 +470,21 @@ func worktreeIsStale(root string, cutoff time.Time) bool {
 		return nil
 	})
 	return stale && walkErr == nil
+}
+
+// worktreeIsDirty reports whether a worktree has uncommitted or untracked
+// changes, via `git status --porcelain` run inside it. A task can hold a
+// worktree with live, unpushed work while it waits on a model, network, or
+// user for far longer than the staleness window, without writing to the tree
+// again in that time; mtime alone can't distinguish that from an abandoned
+// one, but a dirty working tree still can.
+//
+// An inspection failure fails closed, treating it as dirty rather than clean:
+// an incomplete check must not authorize a forced removal.
+func worktreeIsDirty(ctx context.Context, runGit GitRunner, path string) bool {
+	output, err := gitOutput(ctx, runGit, path, "status", "--porcelain")
+	if err != nil {
+		return true
+	}
+	return output != ""
 }

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -41,6 +41,10 @@ type Result struct {
 	SourceBranch string `json:"sourceBranch,omitempty"`
 	SourceCommit string `json:"sourceCommit,omitempty"`
 	Reused       bool   `json:"reused"`
+	// LockAcquired reports whether this Prepare call took the worktree lock.
+	// It is false when a reused worktree was already locked by another live
+	// caller; releasing that lease is that caller's responsibility, not ours.
+	LockAcquired bool `json:"lockAcquired"`
 }
 
 var worktreeNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$`)
@@ -113,6 +117,17 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 			return Result{}, fmt.Errorf("worktree path already exists for a different git repository: %s", target)
 		}
 		result.Reused = true
+		// A reused worktree may have been released by a prior run's exit, and
+		// an unlocked target is exposed to Clean's staleness heuristic while
+		// this caller is still using it, so re-establish the lease here. A
+		// lock already held (an external prepare caller is still using the
+		// path) stays in place and is reported via LockAcquired=false so this
+		// caller knows the release duty is not its own.
+		acquired, err := lockWorktree(ctx, runGit, repoRoot, target)
+		if err != nil {
+			return Result{}, err
+		}
+		result.LockAcquired = acquired
 		return result, nil
 	}
 	if err := os.MkdirAll(repoDir, 0o700); err != nil {
@@ -135,18 +150,35 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	// itself is still using. entry.locked already makes Clean skip a worktree
 	// a human locked by hand; locking here extends that same protection to
 	// the worktrees zero creates.
+	if _, err := lockWorktree(ctx, runGit, repoRoot, target); err != nil {
+		return Result{}, err
+	}
+	// This call created the worktree, so it owns the lease regardless of what
+	// git reported for the lock itself.
+	result.LockAcquired = true
+	return result, nil
+}
+
+// lockWorktree takes the Clean-protection lease on target via `git worktree
+// lock`. It reports whether this call acquired the lease: a lock already held
+// by someone else is left in place and reported as not acquired, so the
+// caller knows the matching Release belongs to the lease's original owner.
+func lockWorktree(ctx context.Context, runGit GitRunner, repoRoot string, target string) (bool, error) {
 	lockResult, err := runGit(ctx, repoRoot, "worktree", "lock", "--reason", "zero: active task worktree", target)
 	if err != nil {
-		return Result{}, fmt.Errorf("lock git worktree: %w", err)
+		return false, fmt.Errorf("lock git worktree: %w", err)
 	}
-	if lockResult.ExitCode != 0 {
-		message := strings.TrimSpace(firstNonEmpty(lockResult.Stderr, lockResult.Stdout))
-		if message == "" {
-			message = fmt.Sprintf("git worktree lock exited with code %d", lockResult.ExitCode)
-		}
-		return Result{}, fmt.Errorf("lock git worktree: %s", message)
+	if lockResult.ExitCode == 0 {
+		return true, nil
 	}
-	return result, nil
+	message := strings.TrimSpace(firstNonEmpty(lockResult.Stderr, lockResult.Stdout))
+	if strings.Contains(message, "already locked") {
+		return false, nil
+	}
+	if message == "" {
+		message = fmt.Sprintf("git worktree lock exited with code %d", lockResult.ExitCode)
+	}
+	return false, fmt.Errorf("lock git worktree: %s", message)
 }
 
 // Release unlocks a worktree that Prepare locked, via `git worktree unlock`,

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -904,7 +904,7 @@ func parseWorktreeList(output string) []worktreeEntry {
 			if current != nil {
 				entries = append(entries, *current)
 			}
-			current = &worktreeEntry{path: filepath.Clean(strings.TrimPrefix(line, "worktree "))}
+			current = &worktreeEntry{path: canonicalizePath(strings.TrimPrefix(line, "worktree "))}
 		case current != nil && (line == "locked" || strings.HasPrefix(line, "locked ")):
 			current.locked = true
 			current.lockReason = strings.TrimSpace(strings.TrimPrefix(line, "locked"))

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -13,7 +13,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -32,6 +34,14 @@ type Options struct {
 	Env     map[string]string
 	Now     func() time.Time
 	RunGit  GitRunner
+	// LeasePID, when positive, records the owning process in the worktree
+	// lock reason. A lease carrying a PID is recoverable: if that process
+	// dies without releasing (SIGKILL, crash, power loss), Clean can expire
+	// the lease instead of skipping the locked worktree forever. Callers
+	// whose worktree outlives their process (zero worktrees prepare hands
+	// the path to an external owner) leave it zero for a persistent lock
+	// that only an explicit release clears.
+	LeasePID int
 }
 
 type Result struct {
@@ -128,7 +138,7 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		// would edit the same tree, and whichever exits first would release
 		// the single Git lock out from under the other), so reject it rather
 		// than hand the second caller an unprotected shared workspace.
-		acquired, err := lockWorktree(ctx, runGit, repoRoot, target)
+		acquired, err := lockWorktree(ctx, runGit, repoRoot, target, options.LeasePID)
 		if err != nil {
 			return Result{}, err
 		}
@@ -161,7 +171,7 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	// this call just created means another process raced us to it: treat that
 	// exactly like the reuse collision above rather than claiming a lease
 	// this call never acquired.
-	acquired, err := lockWorktree(ctx, runGit, repoRoot, target)
+	acquired, err := lockWorktree(ctx, runGit, repoRoot, target, options.LeasePID)
 	if err != nil {
 		return Result{}, err
 	}
@@ -172,12 +182,71 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	return result, nil
 }
 
+// leaseReasonPrefix marks a lock Zero itself created (vs a human `git
+// worktree lock`); a "(pid N)" suffix makes the lease recoverable by Clean
+// once the owning process is gone.
+const leaseReasonPrefix = "zero: active task worktree"
+
+// leaseReason renders the lock reason for a Zero lease, embedding the owning
+// PID when the caller's worktree lifetime is bound to its process.
+func leaseReason(pid int) string {
+	if pid > 0 {
+		return fmt.Sprintf("%s (pid %d)", leaseReasonPrefix, pid)
+	}
+	return leaseReasonPrefix
+}
+
+// leasePID extracts the owning PID from a Zero lease reason. ok=false for
+// human locks and PID-less Zero leases (external prepare callers), which
+// only an explicit release may clear.
+func leasePID(reason string) (int, bool) {
+	rest, found := strings.CutPrefix(strings.TrimSpace(reason), leaseReasonPrefix+" (pid ")
+	if !found {
+		return 0, false
+	}
+	digits, found := strings.CutSuffix(rest, ")")
+	if !found {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(digits)
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// processAlive reports whether pid is a live process. It fails closed: any
+// ambiguity (permission denied, platform limits) counts as alive, so an
+// uncertain answer can only keep a lease, never expire one.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return true
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		// Windows: FindProcess opens the process and fails when it is gone.
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrProcessDone) {
+		return false
+	}
+	// EPERM: the process exists but belongs to another user.
+	return errors.Is(err, syscall.EPERM)
+}
+
 // lockWorktree takes the Clean-protection lease on target via `git worktree
 // lock`. It reports whether this call acquired the lease: a lock already held
 // by someone else is left in place and reported as not acquired, so the
 // caller knows the matching Release belongs to the lease's original owner.
-func lockWorktree(ctx context.Context, runGit GitRunner, repoRoot string, target string) (bool, error) {
-	lockResult, err := runGit(ctx, repoRoot, "worktree", "lock", "--reason", "zero: active task worktree", target)
+func lockWorktree(ctx context.Context, runGit GitRunner, repoRoot string, target string, pid int) (bool, error) {
+	lockResult, err := runGit(ctx, repoRoot, "worktree", "lock", "--reason", leaseReason(pid), target)
 	if err != nil {
 		return false, fmt.Errorf("lock git worktree: %w", err)
 	}
@@ -489,18 +558,27 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 	cutoff := time.Now().Add(-maxAge)
 	var lastErr error
 	for _, entry := range parseWorktreeList(output) {
-		// A worktree a caller has explicitly locked (git worktree lock) is
-		// never a prune candidate, regardless of its mtime.
-		if entry.locked {
-			continue
-		}
-
 		// Only prune worktrees zero created for this repository (i.e. inside
 		// repoDir), using a path-boundary-safe comparison so a sibling
 		// directory that merely shares repoDir as a string prefix (e.g.
 		// "<repoDir>-other") can't match.
 		if !isUnderDir(entry.path, repoDir) {
 			continue
+		}
+
+		// A locked worktree is never a prune candidate — with one recovery
+		// carve-out: a Zero lease whose recorded owner process is provably
+		// dead (SIGKILL, crash, power loss skipped the deferred release).
+		// Without it, an abnormal exit leaves the lock in place forever and
+		// Clean can never reclaim the disk. Human locks and PID-less Zero
+		// leases (external prepare callers) are always honored.
+		expiredLease := false
+		if entry.locked {
+			pid, ok := leasePID(entry.lockReason)
+			if !ok || processAlive(pid) {
+				continue
+			}
+			expiredLease = true
 		}
 
 		info, err := os.Stat(entry.path)
@@ -515,7 +593,13 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 		}
 
 		if worktreeIsStale(entry.path, cutoff) {
-			if worktreeIsDirty(ctx, runGit, entry.path) {
+			// An explicit release is the owner's completion signal, so a
+			// worktree holding only gitignored residue (node_modules, build
+			// output) after release is reclaimable — otherwise every released
+			// worktree with such artifacts leaks forever. An expired lease is
+			// NOT a completion signal (the task may have died mid-work), so
+			// there ignored files still count as live data.
+			if worktreeIsDirty(ctx, runGit, entry.path, expiredLease) {
 				// A stale mtime only means nothing changed at the worktree's
 				// top level or below recently; it does not mean the task
 				// holding it is done. Uncommitted or untracked changes are
@@ -527,6 +611,15 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 			if err := preserveUnreachableWorktreeHead(ctx, runGit, repoRoot, entry.path); err != nil {
 				lastErr = errors.Join(lastErr, fmt.Errorf("preserve worktree HEAD %s: %w", entry.path, err))
 				continue
+			}
+			if expiredLease {
+				// Recover the dead owner's lease only once every removal
+				// guard has passed, so a failed unlock (or a later guard)
+				// leaves the lock in place rather than half-recovered.
+				if _, err := gitOutput(ctx, runGit, repoRoot, "worktree", "unlock", entry.path); err != nil {
+					lastErr = errors.Join(lastErr, fmt.Errorf("recover expired lease %s: %w", entry.path, err))
+					continue
+				}
 			}
 			// gitOutput (not a raw runGit call) so a nonzero exit code is
 			// reported as a failure: defaultRunGit deliberately returns a nil
@@ -547,8 +640,9 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 }
 
 type worktreeEntry struct {
-	path   string
-	locked bool
+	path       string
+	locked     bool
+	lockReason string
 }
 
 // parseWorktreeList reads `git worktree list --porcelain` output into one
@@ -568,6 +662,7 @@ func parseWorktreeList(output string) []worktreeEntry {
 			current = &worktreeEntry{path: filepath.Clean(strings.TrimPrefix(line, "worktree "))}
 		case current != nil && (line == "locked" || strings.HasPrefix(line, "locked ")):
 			current.locked = true
+			current.lockReason = strings.TrimSpace(strings.TrimPrefix(line, "locked"))
 		}
 	}
 	if current != nil {
@@ -662,21 +757,29 @@ func worktreeIsStale(root string, cutoff time.Time) bool {
 	return stale && walkErr == nil
 }
 
-// worktreeIsDirty reports whether a worktree has uncommitted, untracked, or
-// ignored changes, via `git status --porcelain --ignored` run inside it. A
-// task can hold a worktree with live, unpushed work while it waits on a
-// model, network, or user for far longer than the staleness window, without
-// writing to the tree again in that time; mtime alone can't distinguish that
-// from an abandoned one, but a dirty working tree still can. --ignored is
-// included because files matched by .gitignore (credentials, generated
-// drafts, task artifacts) are real data a task can leave behind; without it,
-// plain `git status --porcelain` reports a worktree holding only such files
-// as clean, and Clean would force-remove it and silently discard them.
+// worktreeIsDirty reports whether a worktree has changes that block a forced
+// removal, via `git status --porcelain` run inside it. A task can hold a
+// worktree with live, unpushed work while it waits on a model, network, or
+// user for far longer than the staleness window, without writing to the tree
+// again in that time; mtime alone can't distinguish that from an abandoned
+// one, but a dirty working tree still can.
+//
+// includeIgnored additionally counts files matched by .gitignore
+// (credentials, generated drafts, task artifacts) as live data. It is set
+// when the worktree's owner never signaled completion (an expired crashed
+// lease): such files may be all a dead task left behind. It is clear for an
+// explicitly released worktree, where ignored residue like node_modules or
+// build output would otherwise make the released checkout unreclaimable at
+// every age — release is the owner's statement that the task is done.
 //
 // An inspection failure fails closed, treating it as dirty rather than clean:
 // an incomplete check must not authorize a forced removal.
-func worktreeIsDirty(ctx context.Context, runGit GitRunner, path string) bool {
-	output, err := gitOutput(ctx, runGit, path, "status", "--porcelain", "--ignored")
+func worktreeIsDirty(ctx context.Context, runGit GitRunner, path string, includeIgnored bool) bool {
+	args := []string{"status", "--porcelain"}
+	if includeIgnored {
+		args = append(args, "--ignored")
+	}
+	output, err := gitOutput(ctx, runGit, path, args...)
 	if err != nil {
 		return true
 	}

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -44,6 +44,11 @@ type Result struct {
 var worktreeNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$`)
 
 func Prepare(ctx context.Context, options Options) (Result, error) {
+	// Clean up stale worktrees (older than 24 hours) automatically to prevent disk space leaks.
+	if options.RunGit == nil {
+		_ = Clean(ctx, options, 24*time.Hour)
+	}
+
 	cwd, err := resolveCwd(options.Cwd)
 	if err != nil {
 		return Result{}, err
@@ -297,4 +302,71 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// Clean prunes any zero-owned git worktrees older than maxAge to prevent disk space leaks.
+func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
+	cwd, err := resolveCwd(options.Cwd)
+	if err != nil {
+		return err
+	}
+	runGit := options.RunGit
+	if runGit == nil {
+		runGit = defaultRunGit
+	}
+	repoRoot, err := gitOutput(ctx, runGit, cwd, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return fmt.Errorf("not a git repository: %w", err)
+	}
+	repoRoot = filepath.Clean(repoRoot)
+
+	baseDir := strings.TrimSpace(options.BaseDir)
+	if baseDir == "" {
+		baseDir, err = DefaultBaseDir(options.Env)
+		if err != nil {
+			return err
+		}
+	}
+	baseDir, err = filepath.Abs(baseDir)
+	if err != nil {
+		return err
+	}
+
+	output, err := gitOutput(ctx, runGit, repoRoot, "worktree", "list", "--porcelain")
+	if err != nil {
+		return fmt.Errorf("list git worktrees: %w", err)
+	}
+
+	lines := strings.Split(output, "\n")
+	var lastErr error
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		path := strings.TrimPrefix(line, "worktree ")
+		path = filepath.Clean(path)
+
+		// Only prune worktrees that belong to zero (i.e. inside baseDir)
+		if !strings.HasPrefix(path, baseDir) {
+			continue
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				_, _ = runGit(ctx, repoRoot, "worktree", "prune")
+			}
+			continue
+		}
+
+		if time.Since(info.ModTime()) > maxAge {
+			_, err = runGit(ctx, repoRoot, "worktree", "remove", "--force", path)
+			if err != nil {
+				lastErr = fmt.Errorf("remove worktree %s: %w", path, err)
+			}
+		}
+	}
+
+	_, _ = runGit(ctx, repoRoot, "worktree", "prune")
+	return lastErr
 }

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -159,7 +159,8 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		}
 		result.LockAcquired = true
 		if err := writeOwnershipMarker(ctx, runGit, target); err != nil {
-			return Result{}, err
+			_, unlockErr := gitOutput(ctx, runGit, repoRoot, "worktree", "unlock", target)
+			return Result{}, errors.Join(err, unlockErr)
 		}
 		return result, nil
 	}
@@ -209,7 +210,9 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	}
 	result.LockAcquired = true
 	if err := writeOwnershipMarker(ctx, runGit, target); err != nil {
-		return Result{}, err
+		_, unlockErr := gitOutput(ctx, runGit, repoRoot, "worktree", "unlock", target)
+		_, removeErr := gitOutput(ctx, runGit, repoRoot, "worktree", "remove", "--force", target)
+		return Result{}, errors.Join(err, unlockErr, removeErr)
 	}
 	return result, nil
 }
@@ -373,6 +376,24 @@ func hasOwnershipMarker(ctx context.Context, runGit GitRunner, target string) (b
 		return false, fmt.Errorf("read worktree ownership marker: %w", err)
 	}
 	return string(content) == zeroOwnerMarkerContent, nil
+}
+
+// isLegacyZeroWorktree verifies whether a worktree lacking zero-owner was
+// created by a pre-upgrade version of Zero for this repository.
+func isLegacyZeroWorktree(ctx context.Context, runGit GitRunner, target string, repoDir string, entry worktreeEntry) bool {
+	if !isUnderDir(canonicalizePath(target), repoDir) {
+		return false
+	}
+	if entry.locked {
+		if !strings.HasPrefix(strings.TrimSpace(entry.lockReason), leaseReasonPrefix) {
+			return false
+		}
+	}
+	gitDir, err := gitOutput(ctx, runGit, target, "rev-parse", "--absolute-git-dir")
+	if err != nil || strings.TrimSpace(gitDir) == "" {
+		return false
+	}
+	return true
 }
 
 // verifyZeroOwnedWorktree confirms path has a zero-worktree-<repoKey> ancestor
@@ -817,6 +838,9 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 		}
 		if err != nil {
 			if os.IsNotExist(err) {
+				if expiredLease {
+					_, _ = gitOutput(ctx, runGit, repoRoot, "worktree", "unlock", entry.path)
+				}
 				_, _ = runGit(ctx, repoRoot, "worktree", "prune")
 			}
 			continue
@@ -841,16 +865,22 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 				// gets committed/cleaned (no longer dirty) or unlocked.
 				continue
 			}
-			// The zero-worktree-<repoKey> path and (for the expired-lease
-			// branch above) the leaseReasonPrefix lock reason are both public
-			// conventions a user can reproduce by hand for a worktree of the
-			// same repository; neither is proof Zero created this one.
 			// Require the ownership marker Prepare itself persists before
-			// force-touching anything below. Any failure to verify it
-			// (including the marker simply being absent) is treated the same
-			// as "not ours": skip it, the same fail-closed stance as an
-			// unreadable worktree above.
-			if owned, err := hasOwnershipMarker(ctx, runGit, statPath); err != nil || !owned {
+			// force-touching anything below. For legacy Zero worktrees created
+			// before markers existed, verify they are in repoDir with a Zero
+			// lease and migrate them by writing the marker.
+			owned, err := hasOwnershipMarker(ctx, runGit, statPath)
+			if err != nil {
+				continue
+			}
+			if !owned {
+				if isLegacyZeroWorktree(ctx, runGit, statPath, repoDir, entry) {
+					if writeErr := writeOwnershipMarker(ctx, runGit, statPath); writeErr == nil {
+						owned = true
+					}
+				}
+			}
+			if !owned {
 				continue
 			}
 			if err := preserveUnreachableWorktreeHead(ctx, runGit, repoRoot, statPath); err != nil {

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -148,6 +148,25 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	return result, nil
 }
 
+// Release unlocks a worktree that Prepare locked, via `git worktree unlock`,
+// making it eligible for Clean's staleness check again. Zero itself only
+// knows a worktree's use is over when its own process created it and is now
+// exiting (zero exec --worktree calls this via defer); zero worktrees
+// prepare hands the path to an external caller with no defined end-of-life,
+// so that caller must run `zero worktrees release <path>` itself once done.
+// Until it does, the worktree stays locked and Clean will never touch it,
+// which is the safe default over silently guessing at liveness from mtimes.
+func Release(ctx context.Context, options Options, path string) error {
+	runGit := options.RunGit
+	if runGit == nil {
+		runGit = defaultRunGit
+	}
+	if _, err := gitOutput(ctx, runGit, path, "worktree", "unlock", path); err != nil {
+		return fmt.Errorf("unlock git worktree: %w", err)
+	}
+	return nil
+}
+
 func DefaultBaseDir(env map[string]string) (string, error) {
 	if runtime.GOOS == "windows" {
 		if localAppData := strings.TrimSpace(envValue(env, "LOCALAPPDATA")); localAppData != "" {

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -161,7 +162,18 @@ func Release(ctx context.Context, options Options, path string) error {
 	if runGit == nil {
 		runGit = defaultRunGit
 	}
-	if _, err := gitOutput(ctx, runGit, path, "worktree", "unlock", path); err != nil {
+	// git needs a working directory that still exists to run in. path itself
+	// normally works (it's the worktree being unlocked), but if a caller
+	// manually deleted a locked worktree directory instead of releasing it
+	// first, path is gone; fall back to options.Cwd (the main repo) so the
+	// leaked, now-orphaned lock can still be unlocked and later pruned.
+	dir := path
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if cwd, cwdErr := resolveCwd(options.Cwd); cwdErr == nil {
+			dir = cwd
+		}
+	}
+	if _, err := gitOutput(ctx, runGit, dir, "worktree", "unlock", path); err != nil {
 		return fmt.Errorf("unlock git worktree: %w", err)
 	}
 	return nil
@@ -423,7 +435,10 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 			// invocation, so checking only the returned error would silently
 			// treat a failed removal (busy, permission denied) as success.
 			if _, err := gitOutput(ctx, runGit, repoRoot, "worktree", "remove", "--force", entry.path); err != nil {
-				lastErr = fmt.Errorf("remove worktree %s: %w", entry.path, err)
+				// errors.Join, not a plain overwrite: multiple stale worktrees can
+				// fail removal in the same Clean pass (locking, permissions), and
+				// only reporting the last one would hide the others from the caller.
+				lastErr = errors.Join(lastErr, fmt.Errorf("remove worktree %s: %w", entry.path, err))
 			}
 		}
 	}

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -218,10 +218,49 @@ func Release(ctx context.Context, options Options, path string) error {
 			dir = cwd
 		}
 	}
+	if err := verifyZeroOwnedWorktree(ctx, runGit, dir, path); err != nil {
+		return err
+	}
 	if _, err := gitOutput(ctx, runGit, dir, "worktree", "unlock", path); err != nil {
 		return fmt.Errorf("unlock git worktree: %w", err)
 	}
 	return nil
+}
+
+// verifyZeroOwnedWorktree confirms path has a zero-worktree-<repoKey> ancestor
+// directory component, so Release cannot be used to clear the lock on a
+// worktree a user (or another tool) manages by hand: the command is
+// documented as releasing a worktree `prepare` created, not an arbitrary git
+// worktree lock. This checks for the ancestor component itself rather than
+// reconstructing and comparing a full repoDir, because Release has no
+// reliable way to know which --dir a long-gone Prepare call used (the CLI
+// never threads BaseDir through to Release, and a custom --dir is not
+// recorded anywhere the lock/unlock path can read back); the repoKey
+// component is Prepare's actual ownership signature regardless of which
+// directory it was created under. gitCommonDir resolves the shared .git
+// directory whether dir is the worktree itself or the main repository, so
+// this needs no branching on which of Release's two cwd cases is in play;
+// its parent is the same repoRoot Prepare/Clean use to compute repoKey.
+func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, path string) error {
+	commonDir, err := gitCommonDir(ctx, runGit, dir)
+	if err != nil {
+		return fmt.Errorf("resolve repository for %s: %w", path, err)
+	}
+	repoRoot := filepath.Dir(commonDir)
+	want := "zero-worktree-" + repoKey(repoRoot)
+
+	target := path
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		target = resolved
+	} else if abs, err := filepath.Abs(path); err == nil {
+		target = abs
+	}
+	for _, component := range strings.Split(filepath.Clean(target), string(filepath.Separator)) {
+		if component == want {
+			return nil
+		}
+	}
+	return fmt.Errorf("refusing to release %s: not a zero-managed worktree (expected an ancestor directory named %q)", path, want)
 }
 
 func DefaultBaseDir(env map[string]string) (string, error) {
@@ -425,6 +464,17 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 	if err != nil {
 		return err
 	}
+	// git worktree list --porcelain reports each worktree's PHYSICAL location,
+	// resolving any symlink component (for example a --worktree-dir that is
+	// itself a symlink, or a symlinked ancestor). Comparing entry paths against
+	// a merely-absolute (but not symlink-resolved) baseDir would then reject
+	// every worktree Prepare actually created under a symlinked base, leaving
+	// them permanently unprunable. EvalSymlinks failing (most commonly because
+	// the directory does not exist yet) just means there is nothing under it
+	// to prune, so falling back to the plain absolute path is safe.
+	if resolved, err := filepath.EvalSymlinks(baseDir); err == nil {
+		baseDir = resolved
+	}
 	// Prepare only ever creates worktrees under this per-repository subtree
 	// (mirroring the repoDir it computes). Scoping pruning to baseDir itself
 	// would authorize deleting a worktree a user manages by hand in the same
@@ -472,6 +522,10 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 				// still live work waiting on a model, network, or user, so
 				// force-removing here would discard it. Skip until it either
 				// gets committed/cleaned (no longer dirty) or unlocked.
+				continue
+			}
+			if err := preserveUnreachableWorktreeHead(ctx, runGit, repoRoot, entry.path); err != nil {
+				lastErr = errors.Join(lastErr, fmt.Errorf("preserve worktree HEAD %s: %w", entry.path, err))
 				continue
 			}
 			// gitOutput (not a raw runGit call) so a nonzero exit code is
@@ -535,6 +589,46 @@ func isUnderDir(path, dir string) bool {
 		return true
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// preserveUnreachableWorktreeHead guards against `git worktree remove --force`
+// silently discarding a commit: Prepare creates every worktree with `worktree
+// add --detach`, so its HEAD is a plain commit, not a branch, and nothing
+// outside that worktree's own administrative files points at it. If a task
+// committed its result there and the worktree goes stale before that commit
+// is otherwise referenced (merged, pushed, cherry-picked), force-removing it
+// deletes the only ref keeping the commit reachable — it becomes immediately
+// eligible for git gc, exactly as if it had never been committed. This checks
+// whether some OTHER ref in the repository already contains worktreePath's
+// HEAD; if none does, it creates a durable ref for it in the main
+// repository's refs namespace before the caller proceeds to remove the
+// worktree, so the commit survives (visible under refs/zero/orphaned-worktree)
+// even after the worktree itself is gone.
+func preserveUnreachableWorktreeHead(ctx context.Context, runGit GitRunner, repoRoot, worktreePath string) error {
+	head, err := gitOutput(ctx, runGit, worktreePath, "rev-parse", "HEAD")
+	if err != nil {
+		// No commit to preserve (an empty/unborn worktree, or one already
+		// gone) — nothing for this guard to do; let the caller proceed.
+		return nil
+	}
+	head = strings.TrimSpace(head)
+	if head == "" {
+		return nil
+	}
+	contained, err := gitOutput(ctx, runGit, repoRoot, "for-each-ref", "--contains="+head, "--count=1", "--format=%(refname)")
+	if err != nil {
+		return fmt.Errorf("check ref reachability for %s: %w", head, err)
+	}
+	if strings.TrimSpace(contained) != "" {
+		// Already reachable from some branch/tag; the worktree's own HEAD is
+		// redundant and removal cannot orphan the commit.
+		return nil
+	}
+	refName := "refs/zero/orphaned-worktree/" + head
+	if _, err := gitOutput(ctx, runGit, repoRoot, "update-ref", refName, head); err != nil {
+		return fmt.Errorf("preserve unreachable commit %s: %w", head, err)
+	}
+	return nil
 }
 
 // worktreeIsStale reports whether every file under root was last modified

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -275,6 +275,9 @@ func Release(ctx context.Context, options Options, path string) error {
 		}
 	}
 	if err := verifyZeroOwnedWorktree(ctx, runGit, dir, path); err != nil {
+		if errors.Is(err, errAlreadyUnlocked) {
+			return nil
+		}
 		return err
 	}
 	if _, err := gitOutput(ctx, runGit, dir, "worktree", "unlock", path); err != nil {
@@ -284,22 +287,22 @@ func Release(ctx context.Context, options Options, path string) error {
 }
 
 // verifyZeroOwnedWorktree confirms path has a zero-worktree-<repoKey> ancestor
-// directory component, and that if git currently has it locked, the lock
-// reason is one Zero itself set, so Release cannot be used to clear the lock
-// on a worktree a user (or another tool) manages by hand: the command is
-// documented as releasing a worktree `prepare` created, not an arbitrary git
-// worktree lock. The ancestor-component check stands in for reconstructing
-// and comparing a full repoDir, because Release has no reliable way to know
-// which --dir a long-gone Prepare call used (the CLI never threads BaseDir
-// through to Release, and a custom --dir is not recorded anywhere the
-// lock/unlock path can read back); the repoKey component is Prepare's actual
-// ownership signature regardless of which directory it was created under.
-// The repository root for that key, and the lock reason for the ownership
-// check, both come from the same `git worktree list --porcelain` call, which
-// works whether dir is the worktree itself or the main repository (its first
-// entry is always the main working tree, from any worktree, regardless of
-// git-dir layout), so this needs no branching on which of Release's two cwd
-// cases is in play.
+// directory component, is a registered worktree of the repository, and (when
+// locked) carries a lock reason Zero itself set, so Release cannot be used to
+// clear the lock on a worktree a user (or another tool) manages by hand: the
+// command is documented as releasing a worktree `prepare` created, not an
+// arbitrary git worktree lock. The ancestor-component check stands in for
+// reconstructing and comparing a full repoDir, because Release has no
+// reliable way to know which --dir a long-gone Prepare call used (the CLI
+// never threads BaseDir through to Release, and a custom --dir is not
+// recorded anywhere the lock/unlock path can read back); the repoKey
+// component is Prepare's actual ownership signature regardless of which
+// directory it was created under. The repository root for that key, and the
+// lock reason for the ownership check, both come from the same `git worktree
+// list --porcelain` call, which works whether dir is the worktree itself or
+// the main repository (its first entry is always the main working tree, from
+// any worktree, regardless of git-dir layout), so this needs no branching on
+// which of Release's two cwd cases is in play.
 func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, path string) error {
 	output, err := gitOutput(ctx, runGit, dir, "worktree", "list", "--porcelain")
 	if err != nil {
@@ -311,13 +314,7 @@ func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, 
 	}
 	want := "zero-worktree-" + repoKey(entries[0].path)
 
-	target := path
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		target = resolved
-	} else if abs, err := filepath.Abs(path); err == nil {
-		target = abs
-	}
-	target = filepath.Clean(target)
+	target := canonicalizePath(path)
 
 	hasZeroComponent := false
 	for _, component := range strings.Split(target, string(filepath.Separator)) {
@@ -330,16 +327,50 @@ func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, 
 		return fmt.Errorf("refusing to release %s: not a zero-managed worktree (expected an ancestor directory named %q)", path, want)
 	}
 
+	// Require a registered porcelain entry before unlocking. Matching only
+	// the public zero-worktree-<repoKey> path component would let Release
+	// clear a manual lock on any same-named path under that directory.
+	// Path comparison uses canonicalizePath so a lexical user argument
+	// (macOS /var vs /private/var, symlink --worktree-dir) still matches
+	// the physical spelling git worktree list reports.
+	matched := false
 	for _, entry := range entries {
-		if entry.path != target {
+		if canonicalizePath(entry.path) != target {
 			continue
 		}
-		if entry.locked && !strings.HasPrefix(entry.lockReason, leaseReasonPrefix) {
+		matched = true
+		if !entry.locked {
+			// Already unlocked: nothing to release. Treat as success so a
+			// double release is a no-op rather than a git "not locked" error.
+			return errAlreadyUnlocked
+		}
+		if !strings.HasPrefix(entry.lockReason, leaseReasonPrefix) {
 			return fmt.Errorf("refusing to release %s: locked with reason %q, not a zero lease", path, entry.lockReason)
 		}
 		break
 	}
+	if !matched {
+		return fmt.Errorf("refusing to release %s: not a registered worktree of this repository", path)
+	}
 	return nil
+}
+
+// errAlreadyUnlocked is a sentinel for a Zero-managed path whose git lock is
+// already clear; Release returns nil without calling unlock.
+var errAlreadyUnlocked = errors.New("worktree already unlocked")
+
+// canonicalizePath returns the physical, cleaned form of path when it can be
+// resolved (EvalSymlinks), otherwise Abs+Clean. Used so comparisons against
+// `git worktree list --porcelain` (which reports physical paths) succeed for
+// lexical or symlinked user spellings of the same location.
+func canonicalizePath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(path)
 }
 
 func DefaultBaseDir(env map[string]string) (string, error) {
@@ -568,15 +599,21 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 	cutoff := time.Now().Add(-maxAge)
 	var lastErr error
 	for _, entry := range parseWorktreeList(output) {
+		// Compare against the physical spelling of the entry path. Git's
+		// porcelain listing is normally already physical, but test fixtures
+		// and some symlink layouts can leave a logical spelling that would
+		// otherwise fail the containment check against the resolved repoDir.
+		// Git commands still receive entry.path (the registered spelling).
+		entryPath := canonicalizePath(entry.path)
 		// Only prune worktrees zero created for this repository (i.e. inside
 		// repoDir), using a path-boundary-safe comparison so a sibling
 		// directory that merely shares repoDir as a string prefix (e.g.
 		// "<repoDir>-other") can't match.
-		if !isUnderDir(entry.path, repoDir) {
+		if !isUnderDir(entryPath, repoDir) {
 			continue
 		}
 
-		// A locked worktree is never a prune candidate — with one recovery
+		// A locked worktree is never a prune candidate - with one recovery
 		// carve-out: a Zero lease whose recorded owner process is provably
 		// dead (SIGKILL, crash, power loss skipped the deferred release).
 		// Without it, an abnormal exit leaves the lock in place forever and
@@ -591,7 +628,15 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 			expiredLease = true
 		}
 
-		info, err := os.Stat(entry.path)
+		// Prefer the physical path for filesystem probes when the entry
+		// resolves; fall back to the registered spelling if it does not
+		// (for example a prunable entry whose directory is already gone).
+		statPath := entryPath
+		info, err := os.Stat(statPath)
+		if err != nil && statPath != entry.path {
+			statPath = entry.path
+			info, err = os.Stat(statPath)
+		}
 		if err != nil {
 			if os.IsNotExist(err) {
 				_, _ = runGit(ctx, repoRoot, "worktree", "prune")
@@ -602,14 +647,14 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 			continue
 		}
 
-		if worktreeIsStale(entry.path, cutoff) {
+		if worktreeIsStale(statPath, cutoff) {
 			// An explicit release is the owner's completion signal, so a
 			// worktree holding only gitignored residue (node_modules, build
-			// output) after release is reclaimable — otherwise every released
+			// output) after release is reclaimable - otherwise every released
 			// worktree with such artifacts leaks forever. An expired lease is
 			// NOT a completion signal (the task may have died mid-work), so
 			// there ignored files still count as live data.
-			if worktreeIsDirty(ctx, runGit, entry.path, expiredLease) {
+			if worktreeIsDirty(ctx, runGit, statPath, expiredLease) {
 				// A stale mtime only means nothing changed at the worktree's
 				// top level or below recently; it does not mean the task
 				// holding it is done. Uncommitted or untracked changes are
@@ -618,7 +663,7 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 				// gets committed/cleaned (no longer dirty) or unlocked.
 				continue
 			}
-			if err := preserveUnreachableWorktreeHead(ctx, runGit, repoRoot, entry.path); err != nil {
+			if err := preserveUnreachableWorktreeHead(ctx, runGit, repoRoot, statPath); err != nil {
 				lastErr = errors.Join(lastErr, fmt.Errorf("preserve worktree HEAD %s: %w", entry.path, err))
 				continue
 			}
@@ -702,7 +747,7 @@ func isUnderDir(path, dir string) bool {
 // outside that worktree's own administrative files points at it. If a task
 // committed its result there and the worktree goes stale before that commit
 // is otherwise referenced (merged, pushed, cherry-picked), force-removing it
-// deletes the only ref keeping the commit reachable — it becomes immediately
+// deletes the only ref keeping the commit reachable - it becomes immediately
 // eligible for git gc, exactly as if it had never been committed. This checks
 // whether some OTHER ref in the repository already contains worktreePath's
 // HEAD; if none does, it creates a durable ref for it in the main
@@ -713,7 +758,7 @@ func preserveUnreachableWorktreeHead(ctx context.Context, runGit GitRunner, repo
 	head, err := gitOutput(ctx, runGit, worktreePath, "rev-parse", "HEAD")
 	if err != nil {
 		// No commit to preserve (an empty/unborn worktree, or one already
-		// gone) — nothing for this guard to do; let the caller proceed.
+		// gone) - nothing for this guard to do; let the caller proceed.
 		return nil
 	}
 	head = strings.TrimSpace(head)
@@ -780,7 +825,7 @@ func worktreeIsStale(root string, cutoff time.Time) bool {
 // lease): such files may be all a dead task left behind. It is clear for an
 // explicitly released worktree, where ignored residue like node_modules or
 // build output would otherwise make the released checkout unreclaimable at
-// every age — release is the owner's statement that the task is done.
+// every age - release is the owner's statement that the task is done.
 //
 // An inspection failure fails closed, treating it as dirty rather than clean:
 // an incomplete check must not authorize a forced removal.

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -158,6 +158,9 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 			return Result{}, fmt.Errorf("worktree %s is locked by another active run; release it with `zero worktrees release %s` if that run is finished, or use a different --name", target, target)
 		}
 		result.LockAcquired = true
+		if err := writeOwnershipMarker(ctx, runGit, target); err != nil {
+			return Result{}, err
+		}
 		return result, nil
 	}
 	if err := os.MkdirAll(repoDir, 0o700); err != nil {
@@ -205,6 +208,9 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		return Result{}, fmt.Errorf("worktree %s is locked by another active run; release it with `zero worktrees release %s` if that run is finished, or use a different --name", target, target)
 	}
 	result.LockAcquired = true
+	if err := writeOwnershipMarker(ctx, runGit, target); err != nil {
+		return Result{}, err
+	}
 	return result, nil
 }
 
@@ -313,6 +319,62 @@ func Release(ctx context.Context, options Options, path string) error {
 	return nil
 }
 
+// zeroOwnerMarkerFile is the name of the ownership marker Prepare writes into
+// a worktree's own private git admin directory (`git rev-parse
+// --absolute-git-dir`), never into the working tree itself: the working tree
+// is what `git status` inspects for staleness/dirtiness, and a marker living
+// there would either show up as untracked noise (defeating Clean's dirty
+// check) or need a .gitignore entry this package has no business adding to a
+// caller's repository. The admin directory survives even after the worktree
+// directory itself is deleted by hand (git only forgets it on `worktree
+// prune`), and is not something `git worktree add` populates on its own, so
+// its presence is what actually proves Zero's own Prepare created a given
+// worktree - unlike the public zero-worktree-<repoKey> path convention and
+// the leaseReasonPrefix lock-reason string, both of which a user can
+// reproduce by hand for a worktree of the same repository.
+const zeroOwnerMarkerFile = "zero-owner"
+
+// zeroOwnerMarkerContent is the marker's fixed body. Its value carries no
+// meaning beyond "Prepare wrote this"; the file's mere presence at the
+// expected location is the signal Release and Clean check.
+const zeroOwnerMarkerContent = "zero: this worktree was created by `zero worktrees prepare`\n"
+
+// writeOwnershipMarker persists the ownership marker for target, a worktree
+// path that must still exist on disk (Prepare calls this immediately after
+// creating or re-locking it). Overwriting an existing marker is harmless and
+// lets a worktree Prepare created before this marker existed self-heal the
+// next time Prepare reuses it.
+func writeOwnershipMarker(ctx context.Context, runGit GitRunner, target string) error {
+	gitDir, err := gitOutput(ctx, runGit, target, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return fmt.Errorf("resolve worktree git dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, zeroOwnerMarkerFile), []byte(zeroOwnerMarkerContent), 0o600); err != nil {
+		return fmt.Errorf("write worktree ownership marker: %w", err)
+	}
+	return nil
+}
+
+// hasOwnershipMarker reports whether target's own git admin directory carries
+// the marker writeOwnershipMarker persists. It fails closed: any error other
+// than the marker simply not existing is returned rather than treated as
+// "not owned so it's fine to skip," since callers otherwise use false to mean
+// "safe to leave alone."
+func hasOwnershipMarker(ctx context.Context, runGit GitRunner, target string) (bool, error) {
+	gitDir, err := gitOutput(ctx, runGit, target, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return false, fmt.Errorf("resolve worktree git dir: %w", err)
+	}
+	content, err := os.ReadFile(filepath.Join(gitDir, zeroOwnerMarkerFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read worktree ownership marker: %w", err)
+	}
+	return string(content) == zeroOwnerMarkerContent, nil
+}
+
 // verifyZeroOwnedWorktree confirms path has a zero-worktree-<repoKey> ancestor
 // directory component, is a registered worktree of the repository, and (when
 // locked) carries a lock reason Zero itself set, so Release cannot be used to
@@ -376,6 +438,25 @@ func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, 
 		}
 		if !strings.HasPrefix(entry.lockReason, leaseReasonPrefix) {
 			return fmt.Errorf("refusing to release %s: locked with reason %q, not a zero lease", path, entry.lockReason)
+		}
+		// The lease prefix is a public string a user can copy onto their own
+		// `git worktree lock` call for a worktree they created by hand under
+		// this same predictable directory, so it is a cheap first filter, not
+		// proof. When the worktree directory still exists, require the
+		// ownership marker Prepare actually persists before trusting it. If
+		// the directory is already gone (the documented `release -C` recovery
+		// path for a worktree deleted by hand), there is no marker left to
+		// check and nothing left for a forced removal to destroy, so the
+		// prefix match above is enough to let a genuinely orphaned zero lease
+		// still be cleared.
+		if info, statErr := os.Stat(entry.path); statErr == nil && info.IsDir() {
+			owned, err := hasOwnershipMarker(ctx, runGit, entry.path)
+			if err != nil {
+				return fmt.Errorf("verify worktree ownership for %s: %w", path, err)
+			}
+			if !owned {
+				return fmt.Errorf("refusing to release %s: missing zero ownership marker (not created by `zero worktrees prepare`)", path)
+			}
 		}
 		break
 	}
@@ -668,20 +749,34 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 	if resolved, err := filepath.EvalSymlinks(baseDir); err == nil {
 		baseDir = resolved
 	}
-	// Prepare only ever creates worktrees under this per-repository subtree
-	// (mirroring the repoDir it computes). Scoping pruning to baseDir itself
-	// would authorize deleting a worktree a user manages by hand in the same
-	// directory, which Zero never created and has no business force-removing.
-	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
 
 	output, err := gitOutput(ctx, runGit, repoRoot, "worktree", "list", "--porcelain")
 	if err != nil {
 		return fmt.Errorf("list git worktrees: %w", err)
 	}
+	entries := parseWorktreeList(output)
+	if len(entries) == 0 {
+		return fmt.Errorf("list git worktrees: git worktree list returned no entries")
+	}
+	// Prepare only ever creates worktrees under this per-repository subtree
+	// (mirroring the repoDir it computes). Scoping pruning to baseDir itself
+	// would authorize deleting a worktree a user manages by hand in the same
+	// directory, which Zero never created and has no business force-removing.
+	//
+	// The bucket must be keyed off the MAIN worktree's root
+	// (entries[0].path, per primaryWorktreeRoot), not repoRoot: repoRoot is
+	// --show-toplevel for whichever worktree Clean itself runs from, which is
+	// a linked checkout's own root when Clean (or the Prepare call that
+	// auto-invokes it) runs there. Prepare keys repoDir off the same
+	// entries[0].path, so using repoRoot here instead would compute a
+	// different repoDir than Prepare's and filter out every actual
+	// zero-owned worktree for this repository whenever either call runs from
+	// a linked worktree.
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(entries[0].path))
 
 	cutoff := time.Now().Add(-maxAge)
 	var lastErr error
-	for _, entry := range parseWorktreeList(output) {
+	for _, entry := range entries {
 		// Compare against the physical spelling of the entry path. Git's
 		// porcelain listing is normally already physical, but test fixtures
 		// and some symlink layouts can leave a logical spelling that would
@@ -744,6 +839,18 @@ func Clean(ctx context.Context, options Options, maxAge time.Duration) error {
 				// still live work waiting on a model, network, or user, so
 				// force-removing here would discard it. Skip until it either
 				// gets committed/cleaned (no longer dirty) or unlocked.
+				continue
+			}
+			// The zero-worktree-<repoKey> path and (for the expired-lease
+			// branch above) the leaseReasonPrefix lock reason are both public
+			// conventions a user can reproduce by hand for a worktree of the
+			// same repository; neither is proof Zero created this one.
+			// Require the ownership marker Prepare itself persists before
+			// force-touching anything below. Any failure to verify it
+			// (including the marker simply being absent) is treated the same
+			// as "not ours": skip it, the same fail-closed stance as an
+			// unreadable worktree above.
+			if owned, err := hasOwnershipMarker(ctx, runGit, statPath); err != nil || !owned {
 				continue
 			}
 			if err := preserveUnreachableWorktreeHead(ctx, runGit, repoRoot, statPath); err != nil {

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -128,6 +128,23 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		}
 		return Result{}, fmt.Errorf("create git worktree: %s", message)
 	}
+	// Lock the worktree so Clean's mtime+dirty staleness heuristic (which
+	// cannot tell "abandoned" apart from "clean but waiting on a model,
+	// network, or user for a long time") never force-removes a worktree zero
+	// itself is still using. entry.locked already makes Clean skip a worktree
+	// a human locked by hand; locking here extends that same protection to
+	// the worktrees zero creates.
+	lockResult, err := runGit(ctx, repoRoot, "worktree", "lock", "--reason", "zero: active task worktree", target)
+	if err != nil {
+		return Result{}, fmt.Errorf("lock git worktree: %w", err)
+	}
+	if lockResult.ExitCode != 0 {
+		message := strings.TrimSpace(firstNonEmpty(lockResult.Stderr, lockResult.Stdout))
+		if message == "" {
+			message = fmt.Sprintf("git worktree lock exited with code %d", lockResult.ExitCode)
+		}
+		return Result{}, fmt.Errorf("lock git worktree: %s", message)
+	}
 	return result, nil
 }
 
@@ -472,17 +489,21 @@ func worktreeIsStale(root string, cutoff time.Time) bool {
 	return stale && walkErr == nil
 }
 
-// worktreeIsDirty reports whether a worktree has uncommitted or untracked
-// changes, via `git status --porcelain` run inside it. A task can hold a
-// worktree with live, unpushed work while it waits on a model, network, or
-// user for far longer than the staleness window, without writing to the tree
-// again in that time; mtime alone can't distinguish that from an abandoned
-// one, but a dirty working tree still can.
+// worktreeIsDirty reports whether a worktree has uncommitted, untracked, or
+// ignored changes, via `git status --porcelain --ignored` run inside it. A
+// task can hold a worktree with live, unpushed work while it waits on a
+// model, network, or user for far longer than the staleness window, without
+// writing to the tree again in that time; mtime alone can't distinguish that
+// from an abandoned one, but a dirty working tree still can. --ignored is
+// included because files matched by .gitignore (credentials, generated
+// drafts, task artifacts) are real data a task can leave behind; without it,
+// plain `git status --porcelain` reports a worktree holding only such files
+// as clean, and Clean would force-remove it and silently discard them.
 //
 // An inspection failure fails closed, treating it as dirty rather than clean:
 // an incomplete check must not authorize a forced removal.
 func worktreeIsDirty(ctx context.Context, runGit GitRunner, path string) bool {
-	output, err := gitOutput(ctx, runGit, path, "status", "--porcelain")
+	output, err := gitOutput(ctx, runGit, path, "status", "--porcelain", "--ignored")
 	if err != nil {
 		return true
 	}

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -158,6 +158,18 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 			return Result{}, fmt.Errorf("worktree %s is locked by another active run; release it with `zero worktrees release %s` if that run is finished, or use a different --name", target, target)
 		}
 		result.LockAcquired = true
+		// Touch the worktree directory so Clean's mtime-based staleness check
+		// doesn't prune a worktree that's actively in use by the current process.
+		// Long-running tasks that don't write new files (e.g. waiting on a model)
+		// would otherwise accumulate stale mtimes and be wrongly force-removed.
+		_ = os.Chtimes(target, time.Now(), time.Now())
+		if err != nil {
+			return Result{}, err
+		}
+		if !acquired {
+			return Result{}, fmt.Errorf("worktree %s is locked by another active run; release it with `zero worktrees release %s` if that run is finished, or use a different --name", target, target)
+		}
+		result.LockAcquired = true
 		if err := writeOwnershipMarker(ctx, runGit, target); err != nil {
 			_, unlockErr := gitOutput(ctx, runGit, repoRoot, "worktree", "unlock", target)
 			return Result{}, errors.Join(err, unlockErr)

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -162,14 +162,10 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		// doesn't prune a worktree that's actively in use by the current process.
 		// Long-running tasks that don't write new files (e.g. waiting on a model)
 		// would otherwise accumulate stale mtimes and be wrongly force-removed.
-		_ = os.Chtimes(target, time.Now(), time.Now())
-		if err != nil {
-			return Result{}, err
+		if err := os.Chtimes(target, time.Now(), time.Now()); err != nil {
+			_, unlockErr := gitOutput(ctx, runGit, repoRoot, "worktree", "unlock", target)
+			return Result{}, errors.Join(err, unlockErr)
 		}
-		if !acquired {
-			return Result{}, fmt.Errorf("worktree %s is locked by another active run; release it with `zero worktrees release %s` if that run is finished, or use a different --name", target, target)
-		}
-		result.LockAcquired = true
 		if err := writeOwnershipMarker(ctx, runGit, target); err != nil {
 			_, unlockErr := gitOutput(ctx, runGit, repoRoot, "worktree", "unlock", target)
 			return Result{}, errors.Join(err, unlockErr)

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -125,7 +125,7 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 	result := Result{
 		Name:         name,
 		Path:         target,
-		RepoRoot:     repoRoot,
+		RepoRoot:     primaryRoot,
 		SourceBranch: branch,
 		SourceCommit: commit,
 	}
@@ -318,13 +318,14 @@ func Release(ctx context.Context, options Options, path string) error {
 			dir = cwd
 		}
 	}
-	if err := verifyZeroOwnedWorktree(ctx, runGit, dir, path); err != nil {
+	matchedPath, err := verifyZeroOwnedWorktree(ctx, runGit, dir, path)
+	if err != nil {
 		if errors.Is(err, errAlreadyUnlocked) {
 			return nil
 		}
 		return err
 	}
-	if _, err := gitOutput(ctx, runGit, dir, "worktree", "unlock", path); err != nil {
+	if _, err := gitOutput(ctx, runGit, dir, "worktree", "unlock", matchedPath); err != nil {
 		return fmt.Errorf("unlock git worktree: %w", err)
 	}
 	return nil
@@ -421,14 +422,14 @@ func isLegacyZeroWorktree(ctx context.Context, runGit GitRunner, target string, 
 // the main repository (its first entry is always the main working tree, from
 // any worktree, regardless of git-dir layout), so this needs no branching on
 // which of Release's two cwd cases is in play.
-func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, path string) error {
+func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, path string) (string, error) {
 	output, err := gitOutput(ctx, runGit, dir, "worktree", "list", "--porcelain")
 	if err != nil {
-		return fmt.Errorf("resolve repository for %s: %w", path, err)
+		return "", fmt.Errorf("resolve repository for %s: %w", path, err)
 	}
 	entries := parseWorktreeList(output)
 	if len(entries) == 0 {
-		return fmt.Errorf("resolve repository for %s: git worktree list returned no entries", path)
+		return "", fmt.Errorf("resolve repository for %s: git worktree list returned no entries", path)
 	}
 	// entries[0].path is always the main worktree (see primaryWorktreeRoot),
 	// which is what Prepare now also keys its repoKey off, so this and Prepare
@@ -445,7 +446,7 @@ func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, 
 		}
 	}
 	if !hasZeroComponent {
-		return fmt.Errorf("refusing to release %s: not a zero-managed worktree (expected an ancestor directory named %q)", path, want)
+		return "", fmt.Errorf("refusing to release %s: not a zero-managed worktree (expected an ancestor directory named %q)", path, want)
 	}
 
 	// Require a registered porcelain entry before unlocking. Matching only
@@ -454,45 +455,35 @@ func verifyZeroOwnedWorktree(ctx context.Context, runGit GitRunner, dir string, 
 	// Path comparison uses canonicalizePath so a lexical user argument
 	// (macOS /var vs /private/var, symlink --worktree-dir) still matches
 	// the physical spelling git worktree list reports.
-	matched := false
+	var matchedPath string
 	for _, entry := range entries {
 		if canonicalizePath(entry.path) != target {
 			continue
 		}
-		matched = true
+		matchedPath = entry.path
 		if !entry.locked {
 			// Already unlocked: nothing to release. Treat as success so a
 			// double release is a no-op rather than a git "not locked" error.
-			return errAlreadyUnlocked
+			return "", errAlreadyUnlocked
 		}
 		if !strings.HasPrefix(entry.lockReason, leaseReasonPrefix) {
-			return fmt.Errorf("refusing to release %s: locked with reason %q, not a zero lease", path, entry.lockReason)
+			return "", fmt.Errorf("refusing to release %s: locked with reason %q, not a zero lease", path, entry.lockReason)
 		}
-		// The lease prefix is a public string a user can copy onto their own
-		// `git worktree lock` call for a worktree they created by hand under
-		// this same predictable directory, so it is a cheap first filter, not
-		// proof. When the worktree directory still exists, require the
-		// ownership marker Prepare actually persists before trusting it. If
-		// the directory is already gone (the documented `release -C` recovery
-		// path for a worktree deleted by hand), there is no marker left to
-		// check and nothing left for a forced removal to destroy, so the
-		// prefix match above is enough to let a genuinely orphaned zero lease
-		// still be cleared.
 		if info, statErr := os.Stat(entry.path); statErr == nil && info.IsDir() {
 			owned, err := hasOwnershipMarker(ctx, runGit, entry.path)
 			if err != nil {
-				return fmt.Errorf("verify worktree ownership for %s: %w", path, err)
+				return "", fmt.Errorf("verify worktree ownership for %s: %w", path, err)
 			}
 			if !owned {
-				return fmt.Errorf("refusing to release %s: missing zero ownership marker (not created by `zero worktrees prepare`)", path)
+				return "", fmt.Errorf("refusing to release %s: missing zero ownership marker (not created by `zero worktrees prepare`)", path)
 			}
 		}
 		break
 	}
-	if !matched {
-		return fmt.Errorf("refusing to release %s: not a registered worktree of this repository", path)
+	if matchedPath == "" {
+		return "", fmt.Errorf("refusing to release %s: not a registered worktree of this repository", path)
 	}
-	return nil
+	return matchedPath, nil
 }
 
 // errAlreadyUnlocked is a sentinel for a Zero-managed path whose git lock is

--- a/internal/worktrees/worktrees_posix.go
+++ b/internal/worktrees/worktrees_posix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package worktrees
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// osProcessAlive reports whether pid is a live process on POSIX. Signal 0
+// does not deliver a signal; it only checks existence/permission. ESRCH means
+// no such process (dead); EPERM means it exists but we may not signal it
+// (alive).
+func osProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrProcessDone) {
+		return false
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -49,6 +49,7 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 	runner := &fakeRunner{
 		results: []CommandResult{
 			{Stdout: root + "\n"},
+			{Stdout: "worktree " + root + "\n"},
 			{Stdout: "main\n"},
 			{Stdout: "abc1234\n"},
 			{},
@@ -76,13 +77,13 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 	if !strings.HasPrefix(result.Path, filepath.Join(base, "zero-worktree-")) {
 		t.Fatalf("Path = %q, want under base %q", result.Path, base)
 	}
-	if got := runner.commandLine(3); got != "git worktree add --detach "+result.Path+" HEAD" {
+	if got := runner.commandLine(4); got != "git worktree add --detach "+result.Path+" HEAD" {
 		t.Fatalf("git worktree command = %q", got)
 	}
 	// Prepare must lock every worktree it creates: this is what makes
 	// entry.locked inside Clean protect zero's own worktrees, not just ones a
 	// human locked by hand (see TestCleanSkipsLockedZeroOwnedWorktree).
-	if got := runner.commandLine(4); got != "git worktree lock --reason zero: active task worktree "+result.Path {
+	if got := runner.commandLine(5); got != "git worktree lock --reason zero: active task worktree "+result.Path {
 		t.Fatalf("git worktree lock command = %q", got)
 	}
 	if !result.LockAcquired {
@@ -272,6 +273,7 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 	runner := &fakeRunner{
 		results: []CommandResult{
 			{Stdout: root + "\n"},
+			{Stdout: "worktree " + root + "\n"},
 			{Stdout: "main\n"},
 			{Stdout: "abc1234\n"},
 			{Stdout: sourceGit + "\n"},
@@ -296,13 +298,13 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 	if result.Path != existing {
 		t.Fatalf("Path = %q, want existing %q", result.Path, existing)
 	}
-	if len(runner.calls) != 6 {
+	if len(runner.calls) != 7 {
 		t.Fatalf("expected metadata git calls plus lock, got %#v", runner.calls)
 	}
 	// The original lock may have been released by a prior run's exit, which
 	// would leave the reused worktree exposed to Clean's staleness heuristic
 	// while this caller is still using it: reuse must re-establish the lease.
-	if got := runner.commandLine(5); got != "git worktree lock --reason zero: active task worktree "+existing {
+	if got := runner.commandLine(6); got != "git worktree lock --reason zero: active task worktree "+existing {
 		t.Fatalf("git worktree lock command = %q", got)
 	}
 	if !result.LockAcquired {
@@ -329,6 +331,7 @@ func TestPrepareRejectsWorktreeLockedByAnotherRun(t *testing.T) {
 	runner := &fakeRunner{
 		results: []CommandResult{
 			{Stdout: root + "\n"},
+			{Stdout: "worktree " + root + "\n"},
 			{Stdout: "main\n"},
 			{Stdout: "abc1234\n"},
 			{Stdout: sourceGit + "\n"},
@@ -348,6 +351,45 @@ func TestPrepareRejectsWorktreeLockedByAnotherRun(t *testing.T) {
 	}
 }
 
+// TestPrepareRollsBackWorktreeOnLockFailure pins the fix for a newly created
+// worktree being left behind, unleased, when the lock call after `git
+// worktree add` fails for a reason other than a concurrent racer (an actual
+// git failure, not "already locked"): nothing else can own a worktree this
+// call just created, so Prepare must remove it rather than leaking it until
+// Clean's staleness window eventually reclaims it.
+func TestPrepareRollsBackWorktreeOnLockFailure(t *testing.T) {
+	root := t.TempDir()
+	base := t.TempDir()
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: root + "\n"},
+			{Stdout: "worktree " + root + "\n"},
+			{Stdout: "main\n"},
+			{Stdout: "abc1234\n"},
+			{}, // worktree add
+			{ExitCode: 1, Stderr: "fatal: disk full"}, // worktree lock
+			{}, // worktree remove --force (rollback)
+		},
+	}
+
+	_, err := Prepare(context.Background(), Options{
+		Cwd:     root,
+		Name:    "review-api",
+		BaseDir: base,
+		RunGit:  runner.Run,
+	})
+	if err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("Prepare must surface the lock failure, got %v", err)
+	}
+	if len(runner.calls) != 7 {
+		t.Fatalf("expected add, lock, and a rollback removal, got %#v", runner.calls)
+	}
+	lastCall := runner.calls[len(runner.calls)-1]
+	if lastCall.args[0] != "worktree" || lastCall.args[1] != "remove" {
+		t.Fatalf("last call = %#v, want a rollback `git worktree remove`", lastCall)
+	}
+}
+
 // physicalTestPath resolves a test directory to its physical spelling
 // (symlinks and Windows 8.3 short names), matching how git records paths.
 func physicalTestPath(t *testing.T, path string) string {
@@ -357,6 +399,51 @@ func physicalTestPath(t *testing.T, path string) string {
 		t.Fatalf("resolve %s: %v", path, err)
 	}
 	return resolved
+}
+
+// TestPrepareFromLinkedWorktreeCanBeReleased pins the fix for Prepare and
+// Release deriving different repoKeys when Prepare is invoked from a linked
+// worktree instead of the main one. Before the fix, Prepare hashed
+// --show-toplevel (the linked checkout's own root when run there), while
+// Release always hashes the main worktree's root (via git worktree list
+// --porcelain, whose first entry is always the main worktree); a worktree
+// prepared from a linked checkout therefore failed its own ownership check
+// on release and its lease could never be cleared.
+func TestPrepareFromLinkedWorktreeCanBeReleased(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	mainRepo := physicalTestPath(t, t.TempDir())
+	mustGit := func(dir string, args ...string) string {
+		t.Helper()
+		out, err := gitOutput(ctx, defaultRunGit, dir, args...)
+		if err != nil {
+			t.Skipf("git unavailable or failed (%v): %v", args, err)
+		}
+		return out
+	}
+	mustGit(mainRepo, "init")
+	mustGit(mainRepo, "-c", "user.email=t@example.invalid", "-c", "user.name=t", "commit", "--allow-empty", "-m", "seed")
+
+	// A linked worktree of mainRepo, checked out elsewhere on disk. Its own
+	// --show-toplevel is this directory, not mainRepo.
+	linkedWorktree := filepath.Join(t.TempDir(), "linked")
+	mustGit(mainRepo, "worktree", "add", "--detach", linkedWorktree, "HEAD")
+
+	base := physicalTestPath(t, t.TempDir())
+	result, err := Prepare(ctx, Options{Cwd: linkedWorktree, BaseDir: base, Name: "from-linked"})
+	if err != nil {
+		t.Fatalf("Prepare from a linked worktree: %v", err)
+	}
+	wantComponent := "zero-worktree-" + repoKey(mainRepo)
+	if !strings.Contains(result.Path, wantComponent) {
+		t.Fatalf("Path = %q, want it keyed off the main worktree %q (component %q)", result.Path, mainRepo, wantComponent)
+	}
+
+	if err := Release(ctx, Options{}, result.Path); err != nil {
+		t.Fatalf("Release of a worktree Prepare created from a linked worktree: %v", err)
+	}
 }
 
 // TestCleanPrunesStaleWorktreeUnderSymlinkedBaseDir pins the fix for a
@@ -415,6 +502,42 @@ func TestCleanPrunesStaleWorktreeUnderSymlinkedBaseDir(t *testing.T) {
 	}
 	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
 		t.Fatalf("Clean should have pruned the stale worktree under the symlinked base dir, stat err: %v", err)
+	}
+}
+
+// TestReleaseRecoversDeletedWorktreeUnderSymlinkedBaseDir pins the fix for
+// the documented `release -C` recovery path failing when --worktree-dir was
+// a symlink and the worktree itself was then deleted by hand: EvalSymlinks
+// has nothing to resolve on a path that no longer exists, so the prior
+// Abs+Clean fallback kept the symlinked (logical) spelling, which never
+// matched git's physical-path porcelain entry, and the orphaned lock could
+// never be released. canonicalizePath must resolve through the nearest
+// existing ancestor (the symlink itself, since everything under it is gone)
+// and reattach the missing tail.
+func TestReleaseRecoversDeletedWorktreeUnderSymlinkedBaseDir(t *testing.T) {
+	ctx := context.Background()
+	repo := physicalTestPath(t, t.TempDir())
+	realBase := physicalTestPath(t, t.TempDir())
+	base := filepath.Join(t.TempDir(), "base-link")
+	if err := os.Symlink(realBase, base); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	// The worktree directory under the symlinked base was deleted by hand;
+	// nothing on disk exists below base itself.
+	deletedPath := filepath.Join(base, "zero-worktree-"+repoKey(repo), "already-deleted")
+	physicalPath := filepath.Join(realBase, "zero-worktree-"+repoKey(repo), "already-deleted")
+
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: "worktree " + repo + "\nworktree " + physicalPath + "\nlocked " + leaseReasonPrefix + "\n"},
+		{},
+	}}
+
+	if err := Release(ctx, Options{RunGit: runner.Run, Cwd: repo}, deletedPath); err != nil {
+		t.Fatalf("Release must recover a deleted worktree under a symlinked base dir: %v", err)
+	}
+	if got := runner.commandLine(1); got != "git worktree unlock "+deletedPath {
+		t.Fatalf("git worktree unlock command = %q", got)
 	}
 }
 
@@ -491,6 +614,7 @@ func TestPrepareRejectsExistingWorktreeFromDifferentRepo(t *testing.T) {
 	runner := &fakeRunner{
 		results: []CommandResult{
 			{Stdout: root + "\n"},
+			{Stdout: "worktree " + root + "\n"},
 			{Stdout: "main\n"},
 			{Stdout: "abc1234\n"},
 			{Stdout: sourceGit + "\n"},
@@ -515,6 +639,7 @@ func TestPrepareValidatesNameAndExistingDirectory(t *testing.T) {
 	runner := &fakeRunner{
 		results: []CommandResult{
 			{Stdout: root + "\n"},
+			{Stdout: "worktree " + root + "\n"},
 			{Stdout: "main\n"},
 			{Stdout: "abc1234\n"},
 		},

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -46,7 +46,15 @@ func TestDefaultRunGitSeparatesStdoutAndStderr(t *testing.T) {
 func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 	root := t.TempDir()
 	base := t.TempDir()
+	// autoAbsoluteGitDir answers Prepare's post-lock ownership-marker write
+	// (`git rev-parse --absolute-git-dir`) for the newly created worktree
+	// without a canned result: without it, the fake runner falls off the end
+	// of results and returns an empty CommandResult, so writeOwnershipMarker
+	// resolves gitDir to "" and os.WriteFile writes "zero-owner" as a
+	// relative path into the test process's actual working directory instead
+	// of failing loudly.
 	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
 		results: []CommandResult{
 			{Stdout: root + "\n"},
 			{Stdout: "worktree " + root + "\n"},
@@ -88,6 +96,15 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 	}
 	if !result.LockAcquired {
 		t.Fatalf("LockAcquired = false, want true for a worktree this call created")
+	}
+	// Prepare must also persist the ownership marker so Release/Clean can
+	// tell this worktree apart from one a user created and locked by hand
+	// under the same predictable zero-worktree-<repoKey> path convention.
+	if got := runner.commandLine(6); got != "git rev-parse --absolute-git-dir" {
+		t.Fatalf("marker write command = %q", got)
+	}
+	if len(runner.calls) != 7 {
+		t.Fatalf("expected metadata calls plus lock and marker write, got %#v", runner.calls)
 	}
 }
 
@@ -141,6 +158,42 @@ func TestReleaseUnlocksWorktree(t *testing.T) {
 	}
 	if got := runner.commandLine(2); got != "git worktree unlock "+path {
 		t.Fatalf("git worktree unlock command = %q", got)
+	}
+}
+
+// TestReleaseRejectsForgedZeroLeaseWithoutOwnershipMarker pins the fix for
+// ownership being inferred from the public zero-worktree-<repoKey> path
+// convention plus a lock reason that merely starts with leaseReasonPrefix: a
+// user (or another tool) can create a same-repository worktree at that
+// predictable path and lock it by hand with a reason like "zero: active task
+// worktree manually-owned", which passes both the ancestor-component and
+// HasPrefix checks. Only the ownership marker Prepare itself writes can tell
+// that apart from a genuine Zero lease, so Release must still refuse to
+// unlock it when the worktree directory exists but carries no marker.
+func TestReleaseRejectsForgedZeroLeaseWithoutOwnershipMarker(t *testing.T) {
+	repoRoot := physicalTestPath(t, t.TempDir())
+	base := physicalTestPath(t, t.TempDir())
+	path := filepath.Join(base, "zero-worktree-"+repoKey(repoRoot), "manually-owned")
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately no plantOwnershipMarker call: this worktree exists and is
+	// locked with a reason that starts with leaseReasonPrefix, exactly what a
+	// user could reproduce by hand, but Prepare never created it.
+	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
+		results: []CommandResult{
+			{Stdout: "worktree " + repoRoot + "\nworktree " + path + "\nlocked " + leaseReasonPrefix + " manually-owned\n"},
+		},
+	}
+
+	err := Release(context.Background(), Options{RunGit: runner.Run}, path)
+	if err == nil || !strings.Contains(err.Error(), "missing zero ownership marker") {
+		t.Fatalf("Release error = %v, want a missing-ownership-marker rejection", err)
+	}
+	// list + marker check, no unlock call.
+	if len(runner.calls) != 2 {
+		t.Fatalf("expected only the ownership check and marker read, no unlock call, got %#v", runner.calls)
 	}
 }
 
@@ -456,6 +509,65 @@ func TestPrepareFromLinkedWorktreeCanBeReleased(t *testing.T) {
 
 	if err := Release(ctx, Options{}, result.Path); err != nil {
 		t.Fatalf("Release of a worktree Prepare created from a linked worktree: %v", err)
+	}
+}
+
+// TestCleanFromLinkedWorktreePrunesStaleWorktree pins the fix for Clean
+// keying its owned-subtree bucket off repoRoot (--show-toplevel for whatever
+// worktree Clean itself runs from) instead of the main worktree's root:
+// Prepare and Clean must agree on repoKey regardless of which checkout
+// either call runs from, or a Clean invoked from a linked worktree computes
+// a different repoDir than Prepare used and silently skips every
+// zero-owned worktree for the repository.
+func TestCleanFromLinkedWorktreePrunesStaleWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	mainRepo := physicalTestPath(t, t.TempDir())
+	mustGit := func(dir string, args ...string) string {
+		t.Helper()
+		out, err := gitOutput(ctx, defaultRunGit, dir, args...)
+		if err != nil {
+			t.Skipf("git unavailable or failed (%v): %v", args, err)
+		}
+		return out
+	}
+	mustGit(mainRepo, "init")
+	mustGit(mainRepo, "-c", "user.email=t@example.invalid", "-c", "user.name=t", "commit", "--allow-empty", "-m", "seed")
+
+	// A linked worktree of mainRepo, checked out elsewhere on disk. Its own
+	// --show-toplevel is this directory, not mainRepo, so Clean run from here
+	// would compute repoKey(linkedWorktree) unless it instead keys off the
+	// main worktree's root the way Prepare does.
+	linkedWorktree := filepath.Join(t.TempDir(), "linked")
+	mustGit(mainRepo, "worktree", "add", "--detach", linkedWorktree, "HEAD")
+
+	base := physicalTestPath(t, t.TempDir())
+	result, err := Prepare(ctx, Options{Cwd: linkedWorktree, BaseDir: base, Name: "stale-from-linked"})
+	if err != nil {
+		t.Fatalf("Prepare from a linked worktree: %v", err)
+	}
+	if err := Release(ctx, Options{Cwd: linkedWorktree}, result.Path); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := filepath.WalkDir(result.Path, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, old, old)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean itself also runs from the linked worktree here, mirroring a
+	// Prepare/Clean invocation started from a linked checkout.
+	if err := Clean(ctx, Options{Cwd: linkedWorktree, BaseDir: base}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean: %v", err)
+	}
+	if _, err := os.Stat(result.Path); !os.IsNotExist(err) {
+		t.Fatalf("Clean run from a linked worktree should have pruned the stale zero-owned worktree, stat err: %v", err)
 	}
 }
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -91,20 +91,27 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 }
 
 func TestReleaseUnlocksWorktree(t *testing.T) {
-	repoRoot := t.TempDir()
-	// gitCommonDir resolves its answer with EvalSymlinks, so the fake
-	// --git-common-dir response needs a real directory behind it.
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o700); err != nil {
-		t.Fatal(err)
-	}
+	// repoRoot must be resolved to its physical spelling up front: on a
+	// platform where the temp dir is itself a symlink (macOS /var ->
+	// /private/var), real `git worktree list --porcelain` reports the
+	// physical spelling, so computing repoKey from the lexical spelling here
+	// would produce a different key than verifyZeroOwnedWorktree derives in
+	// production, and Release would reject this genuinely Zero-owned fixture
+	// as not-zero-managed.
+	repoRoot := physicalTestPath(t, t.TempDir())
 	// path must carry the zero-worktree-<repoKey> ancestor component Prepare
 	// actually creates: Release now refuses to unlock anything else.
 	path := filepath.Join(t.TempDir(), "zero-worktree-"+repoKey(repoRoot), "task-a")
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Fatal(err)
 	}
+	// The target entry carries Zero's own lease reason (as Prepare's lock
+	// call sets it), so the lock-reason check added alongside the ancestor
+	// check must let this release through rather than treating every locked
+	// entry as a manual, non-zero lock (see
+	// TestReleaseRejectsManuallyLockedWorktree for the rejecting case).
 	runner := &fakeRunner{results: []CommandResult{
-		{Stdout: filepath.Join(repoRoot, ".git") + "\n"},
+		{Stdout: "worktree " + repoRoot + "\nworktree " + path + "\nlocked " + leaseReasonPrefix + "\n"},
 		{},
 	}}
 
@@ -114,7 +121,7 @@ func TestReleaseUnlocksWorktree(t *testing.T) {
 	if len(runner.calls) != 2 {
 		t.Fatalf("expected exactly two git calls (ownership check, then unlock), got %#v", runner.calls)
 	}
-	if got := runner.commandLine(0); got != "git rev-parse --git-common-dir" {
+	if got := runner.commandLine(0); got != "git worktree list --porcelain" {
 		t.Fatalf("ownership-check command = %q", got)
 	}
 	if runner.calls[1].dir != path {
@@ -130,13 +137,15 @@ func TestReleaseFallsBackToCwdWhenWorktreeDirMissing(t *testing.T) {
 	// releasing it first leaves path itself gone; Release must still be able
 	// to run `git worktree unlock` (from the main repo, via options.Cwd) so
 	// the orphaned lock can be cleared and the entry later pruned.
-	repoRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o700); err != nil {
-		t.Fatal(err)
-	}
+	// repoRoot is resolved to its physical spelling for the same reason as
+	// TestReleaseUnlocksWorktree: real `git worktree list --porcelain`
+	// reports the physical spelling, so a lexical temp-dir spelling here
+	// would derive a different repoKey than production and reject this
+	// fixture.
+	repoRoot := physicalTestPath(t, t.TempDir())
 	missingPath := filepath.Join(t.TempDir(), "zero-worktree-"+repoKey(repoRoot), "already-deleted")
 	runner := &fakeRunner{results: []CommandResult{
-		{Stdout: filepath.Join(repoRoot, ".git") + "\n"},
+		{Stdout: "worktree " + repoRoot + "\n"},
 		{},
 	}}
 
@@ -161,20 +170,42 @@ func TestReleaseFallsBackToCwdWhenWorktreeDirMissing(t *testing.T) {
 // ancestor component must be refused before any unlock is attempted.
 func TestReleaseRejectsNonZeroOwnedWorktree(t *testing.T) {
 	repoRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o700); err != nil {
-		t.Fatal(err)
-	}
 	manualWorktree := filepath.Join(t.TempDir(), "my-manual-worktree")
 	if err := os.MkdirAll(manualWorktree, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	runner := &fakeRunner{results: []CommandResult{
-		{Stdout: filepath.Join(repoRoot, ".git") + "\n"},
+		{Stdout: "worktree " + repoRoot + "\n"},
 	}}
 
 	err := Release(context.Background(), Options{RunGit: runner.Run}, manualWorktree)
 	if err == nil || !strings.Contains(err.Error(), "not a zero-managed worktree") {
 		t.Fatalf("Release error = %v, want a not-zero-managed rejection", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected only the ownership check, no unlock call, got %#v", runner.calls)
+	}
+}
+
+// TestReleaseRejectsManuallyLockedWorktree pins the fix for Release being
+// usable to clear a lock a user (or another tool) applied by hand to a
+// worktree that otherwise sits inside Zero's zero-worktree-<repoKey>
+// subtree: the ancestor-component check alone can't tell that lock apart
+// from one of Zero's own leases, so Release must also refuse to unlock an
+// entry whose recorded lock reason doesn't carry Zero's lease prefix.
+func TestReleaseRejectsManuallyLockedWorktree(t *testing.T) {
+	repoRoot := physicalTestPath(t, t.TempDir())
+	path := filepath.Join(t.TempDir(), "zero-worktree-"+repoKey(repoRoot), "task-a")
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: "worktree " + repoRoot + "\nworktree " + path + "\nlocked do not touch, in use\n"},
+	}}
+
+	err := Release(context.Background(), Options{RunGit: runner.Run}, path)
+	if err == nil || !strings.Contains(err.Error(), "not a zero lease") {
+		t.Fatalf("Release error = %v, want a not-a-zero-lease rejection", err)
 	}
 	if len(runner.calls) != 1 {
 		t.Fatalf("expected only the ownership check, no unlock call, got %#v", runner.calls)

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -1747,13 +1747,13 @@ func TestParseWorktreeListTracksLockedState(t *testing.T) {
 	if len(entries) != 3 {
 		t.Fatalf("expected 3 entries, got %d: %#v", len(entries), entries)
 	}
-	if entries[0].path != filepath.Clean("/a/one") || entries[0].locked {
+	if entries[0].path != canonicalizePath("/a/one") || entries[0].locked {
 		t.Errorf("entries[0] = %#v", entries[0])
 	}
-	if entries[1].path != filepath.Clean("/a/two") || !entries[1].locked {
+	if entries[1].path != canonicalizePath("/a/two") || !entries[1].locked {
 		t.Errorf("entries[1] = %#v", entries[1])
 	}
-	if entries[2].path != filepath.Clean("/a/three") || !entries[2].locked {
+	if entries[2].path != canonicalizePath("/a/three") || !entries[2].locked {
 		t.Errorf("entries[2] = %#v", entries[2])
 	}
 }

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -199,12 +199,12 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 	}
 }
 
-func TestPrepareReusedWorktreeKeepsExternalLock(t *testing.T) {
-	// A reused worktree that is still locked belongs to a live external
-	// `zero worktrees prepare` caller. Prepare must leave that lease in place
-	// and report LockAcquired=false so `zero exec --worktree` does not release
-	// a lock it never acquired (which would let a later Clean force-delete a
-	// workspace the external caller is still using).
+func TestPrepareRejectsWorktreeLockedByAnotherRun(t *testing.T) {
+	// A reused worktree that is still locked belongs to another live run.
+	// Handing that checkout to a second caller would let two runs edit one
+	// supposedly isolated tree, and whichever exits first would release the
+	// single Git lock out from under the other, so Prepare must reject the
+	// in-use lease instead of returning the path.
 	root := t.TempDir()
 	base := t.TempDir()
 	sourceGit := filepath.Join(root, ".git")
@@ -226,20 +226,66 @@ func TestPrepareReusedWorktreeKeepsExternalLock(t *testing.T) {
 		},
 	}
 
-	result, err := Prepare(context.Background(), Options{
+	_, err := Prepare(context.Background(), Options{
 		Cwd:     root,
 		Name:    "reuse-me",
 		BaseDir: base,
 		RunGit:  runner.Run,
 	})
-	if err != nil {
-		t.Fatalf("Prepare must tolerate an already-held lock, got error: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "locked by another active run") {
+		t.Fatalf("Prepare must reject an in-use lease, got %v", err)
 	}
-	if !result.Reused {
-		t.Fatalf("Reused = false, want true")
+}
+
+// TestPrepareValidatesRequestBeforeCleanup pins the order of validation and
+// the automatic stale-worktree pruning: a rejected request (an invalid
+// --name) must not have destructive cleanup side effects before it reports
+// its error. The second half proves the assertion has teeth: the same stale
+// worktree IS pruned once a valid request runs.
+func TestPrepareValidatesRequestBeforeCleanup(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	mustGit := func(args ...string) string {
+		t.Helper()
+		out, err := gitOutput(ctx, defaultRunGit, repo, args...)
+		if err != nil {
+			t.Skipf("git unavailable or failed (%v): %v", args, err)
+		}
+		return out
 	}
-	if result.LockAcquired {
-		t.Fatalf("LockAcquired = true, want false for a lease another caller holds")
+	mustGit("init")
+	mustGit("-c", "user.email=t@example.invalid", "-c", "user.name=t", "commit", "--allow-empty", "-m", "seed")
+	toplevel := filepath.Clean(mustGit("rev-parse", "--show-toplevel"))
+
+	base := t.TempDir()
+	staleDir := filepath.Join(base, "zero-worktree-"+repoKey(toplevel), "stale-task")
+	if err := os.MkdirAll(filepath.Dir(staleDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	mustGit("worktree", "add", "--detach", staleDir)
+	// Age every filesystem entry past the 24h staleness cutoff.
+	old := time.Now().Add(-48 * time.Hour)
+	if err := filepath.WalkDir(staleDir, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, old, old)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Prepare(ctx, Options{Cwd: repo, BaseDir: base, Name: "../escape"}); err == nil {
+		t.Fatal("expected invalid-name error")
+	}
+	if _, err := os.Stat(staleDir); err != nil {
+		t.Fatalf("rejected request must not prune worktrees, stale dir: %v", err)
+	}
+
+	if _, err := Prepare(ctx, Options{Cwd: repo, BaseDir: base, Name: "fresh-task"}); err != nil {
+		t.Fatalf("valid Prepare: %v", err)
+	}
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Fatalf("valid request should have pruned the stale worktree, stat err: %v", err)
 	}
 }
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -414,6 +414,15 @@ func TestCleanSkipsWorktreeWithRecentNestedActivity(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// activePath/internal was created alongside nestedDir by the MkdirAll
+	// above and never backdated, so it would otherwise still carry a fresh
+	// mtime; WalkDir would hit it and report "not stale" before ever reaching
+	// nestedFile, so the test would pass even if the recursive walk stopped
+	// checking after the first directory level.
+	if err := os.Chtimes(filepath.Join(activePath, "internal"), twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
 	runner := &fakeRunner{
 		results: []CommandResult{
 			{Stdout: repoRoot},

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -312,6 +312,66 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	}
 }
 
+// defaultRunGit deliberately returns a nil error alongside a nonzero
+// CommandResult.ExitCode for a failed git invocation (see its comment), so
+// Clean must check ExitCode itself rather than trusting a nil error to mean
+// the removal succeeded.
+func TestCleanReportsErrorOnFailedRemoval(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+
+	stalePath := filepath.Join(baseDir, "stale-task")
+	if err := os.MkdirAll(stalePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(stalePath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + stalePath + "\n"},
+			{ExitCode: 1, Stderr: "fatal: unable to remove worktree: in use"},
+			{ExitCode: 0},
+		},
+	}
+
+	err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour)
+	if err == nil {
+		t.Fatal("expected Clean to report the failed removal")
+	}
+	if !strings.Contains(err.Error(), "in use") {
+		t.Errorf("error = %q, want it to include the git failure message", err.Error())
+	}
+}
+
+// An inspection failure (the root can't be stat'd or walked) must fail
+// closed: worktreeIsStale reports false rather than true, so an incomplete
+// inspection can never authorize a forced removal.
+func TestWorktreeIsStaleFailsClosedOnInspectionError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if worktreeIsStale(missing, time.Now()) {
+		t.Fatal("expected worktreeIsStale to fail closed for an uninspectable root")
+	}
+}
+
+func TestWorktreeIsStaleTrueForOldUntouchedTree(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if !worktreeIsStale(dir, time.Now().Add(-24*time.Hour)) {
+		t.Fatal("expected an old, untouched directory to be reported stale")
+	}
+}
+
 // A worktree with a stale top-level mtime but a file that was written deep
 // inside the tree more recently must not be pruned: the directory's own mtime
 // only changes when an entry is added/removed/renamed directly inside it, not

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -248,3 +248,66 @@ func fixedTime(value string) func() time.Time {
 	}
 	return func() time.Time { return parsed }
 }
+
+func TestCleanPrunesStaleWorktrees(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+
+	// Create directories representing two worktrees: one young, one stale.
+	youngPath := filepath.Join(baseDir, "young-task")
+	stalePath := filepath.Join(baseDir, "stale-task")
+	if err := os.MkdirAll(youngPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(stalePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change mtime of stale-task to be in the past (e.g. 2 days ago).
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(stalePath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot}, // rev-parse --show-toplevel
+			{Stdout: "worktree " + youngPath + "\nworktree " + stalePath + "\n"}, // worktree list --porcelain
+			{ExitCode: 0}, // worktree remove --force <stalePath>
+			{ExitCode: 0}, // worktree prune
+		},
+	}
+
+	options := Options{
+		Cwd:     repoRoot,
+		BaseDir: baseDir,
+		RunGit:  runner.Run,
+	}
+
+	err := Clean(context.Background(), options, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	// Verify the calls made by Clean
+	if len(runner.calls) != 4 {
+		t.Fatalf("expected 4 git calls, got %d", len(runner.calls))
+	}
+	if runner.commandLine(0) != "git rev-parse --show-toplevel" {
+		t.Errorf("call 0 = %q", runner.commandLine(0))
+	}
+	if runner.commandLine(1) != "git worktree list --porcelain" {
+		t.Errorf("call 1 = %q", runner.commandLine(1))
+	}
+	expectedRemoveCall := "git worktree remove --force " + filepath.Clean(stalePath)
+	if runner.commandLine(2) != expectedRemoveCall {
+		t.Errorf("call 2 = %q, want %q", runner.commandLine(2), expectedRemoveCall)
+	}
+	if runner.commandLine(3) != "git worktree prune" {
+		t.Errorf("call 3 = %q", runner.commandLine(3))
+	}
+}

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -85,6 +85,9 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 	if got := runner.commandLine(4); got != "git worktree lock --reason zero: active task worktree "+result.Path {
 		t.Fatalf("git worktree lock command = %q", got)
 	}
+	if !result.LockAcquired {
+		t.Fatalf("LockAcquired = false, want true for a worktree this call created")
+	}
 }
 
 func TestReleaseUnlocksWorktree(t *testing.T) {
@@ -162,6 +165,7 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 			{Stdout: "abc1234\n"},
 			{Stdout: sourceGit + "\n"},
 			{Stdout: sourceGit + "\n"},
+			{},
 		},
 	}
 
@@ -181,8 +185,61 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 	if result.Path != existing {
 		t.Fatalf("Path = %q, want existing %q", result.Path, existing)
 	}
-	if len(runner.calls) != 5 {
-		t.Fatalf("expected metadata git calls only, got %#v", runner.calls)
+	if len(runner.calls) != 6 {
+		t.Fatalf("expected metadata git calls plus lock, got %#v", runner.calls)
+	}
+	// The original lock may have been released by a prior run's exit, which
+	// would leave the reused worktree exposed to Clean's staleness heuristic
+	// while this caller is still using it: reuse must re-establish the lease.
+	if got := runner.commandLine(5); got != "git worktree lock --reason zero: active task worktree "+existing {
+		t.Fatalf("git worktree lock command = %q", got)
+	}
+	if !result.LockAcquired {
+		t.Fatalf("LockAcquired = false, want true for a lease this call took")
+	}
+}
+
+func TestPrepareReusedWorktreeKeepsExternalLock(t *testing.T) {
+	// A reused worktree that is still locked belongs to a live external
+	// `zero worktrees prepare` caller. Prepare must leave that lease in place
+	// and report LockAcquired=false so `zero exec --worktree` does not release
+	// a lock it never acquired (which would let a later Clean force-delete a
+	// workspace the external caller is still using).
+	root := t.TempDir()
+	base := t.TempDir()
+	sourceGit := filepath.Join(root, ".git")
+	if err := os.MkdirAll(sourceGit, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(base, "zero-worktree-"+repoKey(root), "reuse-me")
+	if err := os.MkdirAll(filepath.Join(existing, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: root + "\n"},
+			{Stdout: "main\n"},
+			{Stdout: "abc1234\n"},
+			{Stdout: sourceGit + "\n"},
+			{Stdout: sourceGit + "\n"},
+			{ExitCode: 128, Stderr: "fatal: '" + existing + "' is already locked, reason: zero: active task worktree"},
+		},
+	}
+
+	result, err := Prepare(context.Background(), Options{
+		Cwd:     root,
+		Name:    "reuse-me",
+		BaseDir: base,
+		RunGit:  runner.Run,
+	})
+	if err != nil {
+		t.Fatalf("Prepare must tolerate an already-held lock, got error: %v", err)
+	}
+	if !result.Reused {
+		t.Fatalf("Reused = false, want true")
+	}
+	if result.LockAcquired {
+		t.Fatalf("LockAcquired = true, want false for a lease another caller holds")
 	}
 }
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -1757,3 +1757,96 @@ func TestParseWorktreeListTracksLockedState(t *testing.T) {
 		t.Errorf("entries[2] = %#v", entries[2])
 	}
 }
+
+func TestCleanUnlocksExpiredLeaseBeforePruningMissingDir(t *testing.T) {
+	deadPID := deadProcessPID(t)
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+	missingPath := filepath.Join(repoDir, "missing-dead-task")
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + repoRoot + "\nworktree " + missingPath + "\nlocked " + leaseReason(deadPID) + "\n"},
+			{ExitCode: 0}, // unlock
+			{ExitCode: 0}, // prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	unlocked := false
+	pruned := false
+	for _, call := range runner.calls {
+		if len(call.args) >= 2 && call.args[0] == "worktree" {
+			if call.args[1] == "unlock" {
+				unlocked = true
+			}
+			if call.args[1] == "prune" {
+				pruned = true
+			}
+		}
+	}
+	if !unlocked || !pruned {
+		t.Errorf("expected unlock and prune for missing expired lease, unlocked=%v, pruned=%v, calls=%#v", unlocked, pruned, runner.calls)
+	}
+}
+
+func TestCleanMigratesAndReclaimsLegacyZeroWorktrees(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	legacyPath := filepath.Join(repoDir, "legacy-task")
+	if err := os.MkdirAll(legacyPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Note: plantOwnershipMarker is explicitly NOT called here, simulating a pre-upgrade worktree
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := filepath.WalkDir(legacyPath, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, twoDaysAgo, twoDaysAgo)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + repoRoot + "\nworktree " + legacyPath + "\n"},
+			{ExitCode: 0},               // status --porcelain --ignored: clean
+			{Stdout: "deadbeef"},        // rev-parse HEAD
+			{Stdout: "refs/heads/main"}, // for-each-ref --contains (reachable)
+			{ExitCode: 0},               // worktree remove --force
+			{ExitCode: 0},               // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	removed := false
+	for _, call := range runner.calls {
+		if len(call.args) >= 2 && call.args[0] == "worktree" && call.args[1] == "remove" {
+			removed = true
+		}
+	}
+	if !removed {
+		t.Fatal("Clean did not reclaim a legacy pre-upgrade Zero worktree lacking an ownership marker")
+	}
+}

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -311,3 +311,172 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 		t.Errorf("call 3 = %q", runner.commandLine(3))
 	}
 }
+
+// A worktree with a stale top-level mtime but a file that was written deep
+// inside the tree more recently must not be pruned: the directory's own mtime
+// only changes when an entry is added/removed/renamed directly inside it, not
+// when a long-running task edits an existing nested file.
+func TestCleanSkipsWorktreeWithRecentNestedActivity(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+
+	activePath := filepath.Join(baseDir, "active-task")
+	nestedDir := filepath.Join(activePath, "internal", "pkg")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(activePath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(nestedDir, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	// The file itself is freshly written (default mtime is now), simulating a
+	// task actively editing code deep in the worktree.
+	nestedFile := filepath.Join(nestedDir, "handler.go")
+	if err := os.WriteFile(nestedFile, []byte("package pkg"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + activePath + "\n"},
+			{ExitCode: 0}, // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && call.args[0] == "remove" {
+			t.Fatalf("Clean removed an actively-edited worktree: %v", call.args)
+		}
+	}
+}
+
+// A worktree explicitly locked via `git worktree lock` must never be pruned,
+// regardless of how stale its mtime looks.
+func TestCleanSkipsLockedWorktree(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+
+	lockedPath := filepath.Join(baseDir, "locked-task")
+	if err := os.MkdirAll(lockedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(lockedPath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + lockedPath + "\nHEAD abc1234\nlocked in use by zero\n"},
+			{ExitCode: 0}, // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && call.args[0] == "remove" {
+			t.Fatalf("Clean removed a locked worktree: %v", call.args)
+		}
+	}
+}
+
+// A sibling directory that merely shares baseDir as a string prefix (e.g.
+// "<baseDir>-other") must not be treated as zero-owned.
+func TestCleanRejectsSiblingDirWithSharedPrefix(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	siblingDir := baseDir + "-other"
+	repoRoot := filepath.Join(tempDir, "repo")
+
+	siblingPath := filepath.Join(siblingDir, "not-ours")
+	if err := os.MkdirAll(siblingPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(siblingPath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + siblingPath + "\n"},
+			{ExitCode: 0}, // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && call.args[0] == "remove" {
+			t.Fatalf("Clean removed a sibling directory outside baseDir: %v", call.args)
+		}
+	}
+}
+
+func TestIsUnderDir(t *testing.T) {
+	base := filepath.Join(string(filepath.Separator), "a", "base")
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{filepath.Join(base, "child"), true},
+		{filepath.Join(base, "nested", "deeper"), true},
+		{base, true},
+		{base + "-other", false},
+		{base + "-other" + string(filepath.Separator) + "child", false},
+		{filepath.Join(string(filepath.Separator), "a", "elsewhere"), false},
+	}
+	for _, c := range cases {
+		if got := isUnderDir(c.path, base); got != c.want {
+			t.Errorf("isUnderDir(%q, %q) = %v, want %v", c.path, base, got, c.want)
+		}
+	}
+}
+
+func TestParseWorktreeListTracksLockedState(t *testing.T) {
+	output := "worktree /a/one\nHEAD abc\nbranch refs/heads/main\n\n" +
+		"worktree /a/two\nHEAD def\nlocked\n\n" +
+		"worktree /a/three\nHEAD ghi\nlocked some reason\ndetached\n"
+
+	entries := parseWorktreeList(output)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %#v", len(entries), entries)
+	}
+	if entries[0].path != filepath.Clean("/a/one") || entries[0].locked {
+		t.Errorf("entries[0] = %#v", entries[0])
+	}
+	if entries[1].path != filepath.Clean("/a/two") || !entries[1].locked {
+		t.Errorf("entries[1] = %#v", entries[1])
+	}
+	if entries[2].path != filepath.Clean("/a/three") || !entries[2].locked {
+		t.Errorf("entries[2] = %#v", entries[2])
+	}
+}

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -595,7 +595,7 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	if runner.commandLine(1) != "git worktree list --porcelain" {
 		t.Errorf("call 1 = %q", runner.commandLine(1))
 	}
-	expectedStatusCall := "git status --porcelain --ignored"
+	expectedStatusCall := "git status --porcelain"
 	if runner.commandLine(2) != expectedStatusCall {
 		t.Errorf("call 2 = %q, want %q", runner.commandLine(2), expectedStatusCall)
 	}
@@ -936,7 +936,12 @@ func TestCleanPreservesUnreachableCommitBeforeRemoval(t *testing.T) {
 	}
 }
 
-func TestCleanSkipsWorktreeWithOnlyIgnoredFiles(t *testing.T) {
+func TestCleanReclaimsReleasedWorktreeWithOnlyIgnoredFiles(t *testing.T) {
+	// An explicit release is the owner's completion signal: an unlocked,
+	// stale worktree holding only gitignored residue (node_modules, build
+	// output) must be reclaimable, or every released worktree with such
+	// artifacts leaks disk forever. The dirty probe for unlocked entries
+	// therefore omits --ignored.
 	tempDir := t.TempDir()
 	baseDir := filepath.Join(tempDir, "zero-worktrees")
 	repoRoot := filepath.Join(tempDir, "repo")
@@ -958,8 +963,11 @@ func TestCleanSkipsWorktreeWithOnlyIgnoredFiles(t *testing.T) {
 		results: []CommandResult{
 			{Stdout: repoRoot},
 			{Stdout: "worktree " + ignoredOnlyPath + "\n"},
-			{Stdout: "!! ignored-data\n"}, // status --porcelain --ignored: ignored file present
-			{ExitCode: 0},                 // worktree prune
+			{ExitCode: 0},               // status --porcelain: ignored files invisible => clean
+			{Stdout: "deadbeef"},        // rev-parse HEAD
+			{Stdout: "refs/heads/main"}, // for-each-ref --contains (reachable)
+			{ExitCode: 0},               // worktree remove --force
+			{ExitCode: 0},               // worktree prune
 		},
 	}
 
@@ -967,17 +975,165 @@ func TestCleanSkipsWorktreeWithOnlyIgnoredFiles(t *testing.T) {
 		t.Fatalf("Clean failed: %v", err)
 	}
 
-	for i, call := range runner.calls {
-		if i == 2 {
-			want := "status --porcelain --ignored"
-			if got := strings.Join(call.args, " "); got != want {
-				t.Fatalf("status call args = %q, want %q", got, want)
-			}
-		}
-		if len(call.args) > 0 && call.args[0] == "remove" {
-			t.Fatalf("Clean removed a worktree with only ignored files: %v", call.args)
+	if got, want := runner.commandLine(2), "git status --porcelain"; got != want {
+		t.Fatalf("status call = %q, want %q (released worktrees must not count ignored residue)", got, want)
+	}
+	removed := false
+	for _, call := range runner.calls {
+		if len(call.args) > 1 && call.args[0] == "worktree" && call.args[1] == "remove" {
+			removed = true
 		}
 	}
+	if !removed {
+		t.Fatal("Clean did not reclaim a released, stale worktree holding only ignored residue")
+	}
+}
+
+// TestCleanRecoversExpiredLease: a Zero lease that records its owning PID is
+// recoverable — if that process died without releasing (SIGKILL, crash), the
+// lock must not protect the worktree forever. A stale, clean worktree behind
+// a dead-owner lease is unlocked and removed; the dirty probe there keeps
+// --ignored because a crashed task never signaled completion.
+func TestCleanRecoversExpiredLease(t *testing.T) {
+	deadPID := deadProcessPID(t)
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	crashedPath := filepath.Join(repoDir, "crashed-task")
+	if err := os.MkdirAll(crashedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(crashedPath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + crashedPath + "\nlocked " + leaseReason(deadPID) + "\n"},
+			{ExitCode: 0},               // status --porcelain --ignored: clean
+			{Stdout: "deadbeef"},        // rev-parse HEAD
+			{Stdout: "refs/heads/main"}, // for-each-ref --contains (reachable)
+			{ExitCode: 0},               // worktree unlock (lease recovery)
+			{ExitCode: 0},               // worktree remove --force
+			{ExitCode: 0},               // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	if got, want := runner.commandLine(2), "git status --porcelain --ignored"; got != want {
+		t.Fatalf("status call = %q, want %q (a crashed lease never signaled completion)", got, want)
+	}
+	if got, want := runner.commandLine(5), "git worktree unlock "+filepath.Clean(crashedPath); got != want {
+		t.Fatalf("call 5 = %q, want lease recovery %q", got, want)
+	}
+	if got, want := runner.commandLine(6), "git worktree remove --force "+filepath.Clean(crashedPath); got != want {
+		t.Fatalf("call 6 = %q, want %q", got, want)
+	}
+}
+
+// TestCleanSkipsExpiredLeaseWithIgnoredData: even behind a dead-owner lease,
+// ignored files (credentials, generated drafts) may be all the crashed task
+// left behind, so they still block removal.
+func TestCleanSkipsExpiredLeaseWithIgnoredData(t *testing.T) {
+	deadPID := deadProcessPID(t)
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	crashedPath := filepath.Join(repoDir, "crashed-task")
+	if err := os.MkdirAll(crashedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(crashedPath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + crashedPath + "\nlocked " + leaseReason(deadPID) + "\n"},
+			{Stdout: "!! ignored-data\n"}, // status --porcelain --ignored
+			{ExitCode: 0},                 // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+	for _, call := range runner.calls {
+		if len(call.args) > 1 && call.args[0] == "worktree" && (call.args[1] == "remove" || call.args[1] == "unlock") {
+			t.Fatalf("Clean touched a crashed worktree holding ignored data: %v", call.args)
+		}
+	}
+}
+
+// TestCleanHonorsLiveLease: a lease whose recorded owner is still running is
+// never expired, regardless of staleness.
+func TestCleanHonorsLiveLease(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	livePath := filepath.Join(repoDir, "live-task")
+	if err := os.MkdirAll(livePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(livePath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + livePath + "\nlocked " + leaseReason(os.Getpid()) + "\n"},
+			{ExitCode: 0}, // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && (call.args[0] == "remove" || call.args[0] == "status") {
+			t.Fatalf("Clean touched a worktree behind a live lease: %v", call.args)
+		}
+	}
+}
+
+// deadProcessPID returns the PID of a process that has already exited, for
+// exercising lease expiry. PID reuse in the instant between exit and the
+// assertion is vanishingly unlikely.
+func deadProcessPID(t *testing.T) int {
+	t.Helper()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not available")
+	}
+	cmd := exec.Command(gitPath, "version")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run git version: %v", err)
+	}
+	return cmd.Process.Pid
 }
 
 // worktreeIsDirty must count files matched by .gitignore as dirty content: a
@@ -1007,7 +1163,7 @@ func TestWorktreeIsDirtyCountsIgnoredFilesAsDirty(t *testing.T) {
 	run("add", ".gitignore")
 	run("commit", "--quiet", "-m", "initial")
 
-	if worktreeIsDirty(context.Background(), defaultRunGit, dir) {
+	if worktreeIsDirty(context.Background(), defaultRunGit, dir, true) {
 		t.Fatal("expected a clean worktree with no ignored files present to report clean")
 	}
 
@@ -1015,7 +1171,7 @@ func TestWorktreeIsDirtyCountsIgnoredFilesAsDirty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !worktreeIsDirty(context.Background(), defaultRunGit, dir) {
+	if !worktreeIsDirty(context.Background(), defaultRunGit, dir, true) {
 		t.Fatal("expected an ignored-but-present file to count as dirty")
 	}
 }
@@ -1149,7 +1305,7 @@ func TestCleanSkipsDirtyStaleWorktree(t *testing.T) {
 // authorize a forced removal.
 func TestWorktreeIsDirtyFailsClosedOnInspectionError(t *testing.T) {
 	runner := &fakeRunner{results: []CommandResult{{ExitCode: 1, Stderr: "fatal: not a git repository"}}}
-	if !worktreeIsDirty(context.Background(), runner.Run, t.TempDir()) {
+	if !worktreeIsDirty(context.Background(), runner.Run, t.TempDir(), true) {
 		t.Fatal("expected worktreeIsDirty to fail closed on a status error")
 	}
 }

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -253,10 +253,11 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	tempDir := t.TempDir()
 	baseDir := filepath.Join(tempDir, "zero-worktrees")
 	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
 
 	// Create directories representing two worktrees: one young, one stale.
-	youngPath := filepath.Join(baseDir, "young-task")
-	stalePath := filepath.Join(baseDir, "stale-task")
+	youngPath := filepath.Join(repoDir, "young-task")
+	stalePath := filepath.Join(repoDir, "stale-task")
 	if err := os.MkdirAll(youngPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -277,6 +278,7 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 		results: []CommandResult{
 			{Stdout: repoRoot}, // rev-parse --show-toplevel
 			{Stdout: "worktree " + youngPath + "\nworktree " + stalePath + "\n"}, // worktree list --porcelain
+			{ExitCode: 0}, // status --porcelain <stalePath> (clean)
 			{ExitCode: 0}, // worktree remove --force <stalePath>
 			{ExitCode: 0}, // worktree prune
 		},
@@ -294,8 +296,8 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	}
 
 	// Verify the calls made by Clean
-	if len(runner.calls) != 4 {
-		t.Fatalf("expected 4 git calls, got %d", len(runner.calls))
+	if len(runner.calls) != 5 {
+		t.Fatalf("expected 5 git calls, got %d", len(runner.calls))
 	}
 	if runner.commandLine(0) != "git rev-parse --show-toplevel" {
 		t.Errorf("call 0 = %q", runner.commandLine(0))
@@ -303,12 +305,16 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	if runner.commandLine(1) != "git worktree list --porcelain" {
 		t.Errorf("call 1 = %q", runner.commandLine(1))
 	}
-	expectedRemoveCall := "git worktree remove --force " + filepath.Clean(stalePath)
-	if runner.commandLine(2) != expectedRemoveCall {
-		t.Errorf("call 2 = %q, want %q", runner.commandLine(2), expectedRemoveCall)
+	expectedStatusCall := "git status --porcelain"
+	if runner.commandLine(2) != expectedStatusCall {
+		t.Errorf("call 2 = %q, want %q", runner.commandLine(2), expectedStatusCall)
 	}
-	if runner.commandLine(3) != "git worktree prune" {
-		t.Errorf("call 3 = %q", runner.commandLine(3))
+	expectedRemoveCall := "git worktree remove --force " + filepath.Clean(stalePath)
+	if runner.commandLine(3) != expectedRemoveCall {
+		t.Errorf("call 3 = %q, want %q", runner.commandLine(3), expectedRemoveCall)
+	}
+	if runner.commandLine(4) != "git worktree prune" {
+		t.Errorf("call 4 = %q", runner.commandLine(4))
 	}
 }
 
@@ -320,8 +326,9 @@ func TestCleanReportsErrorOnFailedRemoval(t *testing.T) {
 	tempDir := t.TempDir()
 	baseDir := filepath.Join(tempDir, "zero-worktrees")
 	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
 
-	stalePath := filepath.Join(baseDir, "stale-task")
+	stalePath := filepath.Join(repoDir, "stale-task")
 	if err := os.MkdirAll(stalePath, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -337,6 +344,7 @@ func TestCleanReportsErrorOnFailedRemoval(t *testing.T) {
 		results: []CommandResult{
 			{Stdout: repoRoot},
 			{Stdout: "worktree " + stalePath + "\n"},
+			{ExitCode: 0}, // status --porcelain <stalePath> (clean)
 			{ExitCode: 1, Stderr: "fatal: unable to remove worktree: in use"},
 			{ExitCode: 0},
 		},
@@ -380,8 +388,9 @@ func TestCleanSkipsWorktreeWithRecentNestedActivity(t *testing.T) {
 	tempDir := t.TempDir()
 	baseDir := filepath.Join(tempDir, "zero-worktrees")
 	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
 
-	activePath := filepath.Join(baseDir, "active-task")
+	activePath := filepath.Join(repoDir, "active-task")
 	nestedDir := filepath.Join(activePath, "internal", "pkg")
 	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -462,13 +471,17 @@ func TestCleanSkipsLockedWorktree(t *testing.T) {
 	}
 }
 
-// A sibling directory that merely shares baseDir as a string prefix (e.g.
-// "<baseDir>-other") must not be treated as zero-owned.
+// A sibling directory that merely shares the per-repository repoDir as a
+// string prefix (e.g. "<repoDir>-other") must not be treated as zero-owned.
+// This also covers a manually managed worktree for the SAME repository that a
+// user placed directly under a shared baseDir rather than inside zero's
+// repoDir subtree: it must not be treated as zero-owned either.
 func TestCleanRejectsSiblingDirWithSharedPrefix(t *testing.T) {
 	tempDir := t.TempDir()
 	baseDir := filepath.Join(tempDir, "zero-worktrees")
-	siblingDir := baseDir + "-other"
 	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+	siblingDir := repoDir + "-other"
 
 	siblingPath := filepath.Join(siblingDir, "not-ours")
 	if err := os.MkdirAll(siblingPath, 0o755); err != nil {
@@ -498,6 +511,97 @@ func TestCleanRejectsSiblingDirWithSharedPrefix(t *testing.T) {
 		if len(call.args) > 0 && call.args[0] == "remove" {
 			t.Fatalf("Clean removed a sibling directory outside baseDir: %v", call.args)
 		}
+	}
+}
+
+// A manually managed worktree that a user placed directly under a shared
+// baseDir, outside zero's own "zero-worktree-<repoKey>" subtree, must never
+// be pruned even though it is technically inside baseDir.
+func TestCleanIgnoresWorktreeOutsideOwnedSubtree(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+
+	manualPath := filepath.Join(baseDir, "hand-managed-checkout")
+	if err := os.MkdirAll(manualPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(manualPath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + manualPath + "\n"},
+			{ExitCode: 0}, // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && (call.args[0] == "remove" || call.args[0] == "status") {
+			t.Fatalf("Clean touched a worktree outside its owned subtree: %v", call.args)
+		}
+	}
+}
+
+// A worktree with a stale top-level mtime but uncommitted or untracked
+// changes must not be force-removed: a task can hold live work in a worktree
+// while waiting on a model, network, or user for far longer than the
+// staleness window, without ever writing to the tree again in that time.
+func TestCleanSkipsDirtyStaleWorktree(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	dirtyPath := filepath.Join(repoDir, "dirty-task")
+	if err := os.MkdirAll(dirtyPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(dirtyPath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + dirtyPath + "\n"},
+			{Stdout: " M internal/pkg/handler.go\n"}, // status --porcelain: dirty
+			{ExitCode: 0},                            // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && call.args[0] == "remove" {
+			t.Fatalf("Clean removed a dirty worktree: %v", call.args)
+		}
+	}
+}
+
+// An inspection failure (git status errors out) must fail closed: treat the
+// worktree as dirty rather than clean, so a broken status check can never
+// authorize a forced removal.
+func TestWorktreeIsDirtyFailsClosedOnInspectionError(t *testing.T) {
+	runner := &fakeRunner{results: []CommandResult{{ExitCode: 1, Stderr: "fatal: not a git repository"}}}
+	if !worktreeIsDirty(context.Background(), runner.Run, t.TempDir()) {
+		t.Fatal("expected worktreeIsDirty to fail closed on a status error")
 	}
 }
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -450,11 +450,11 @@ func TestCleanAggregatesMultipleFailedRemovals(t *testing.T) {
 		results: []CommandResult{
 			{Stdout: repoRoot},
 			{Stdout: "worktree " + stalePathA + "\n\nworktree " + stalePathB + "\n"},
-			{ExitCode: 0},                                             // status --porcelain <stalePathA> (clean)
+			{ExitCode: 0}, // status --porcelain <stalePathA> (clean)
 			{ExitCode: 1, Stderr: "fatal: unable to remove worktree A"}, // remove stalePathA
-			{ExitCode: 0},                                             // status --porcelain <stalePathB> (clean)
+			{ExitCode: 0}, // status --porcelain <stalePathB> (clean)
 			{ExitCode: 1, Stderr: "fatal: unable to remove worktree B"}, // remove stalePathB
-			{ExitCode: 0},                                             // final prune
+			{ExitCode: 0}, // final prune
 		},
 	}
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -237,6 +237,17 @@ func TestPrepareRejectsWorktreeLockedByAnotherRun(t *testing.T) {
 	}
 }
 
+// physicalTestPath resolves a test directory to its physical spelling
+// (symlinks and Windows 8.3 short names), matching how git records paths.
+func physicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", path, err)
+	}
+	return resolved
+}
+
 // TestPrepareValidatesRequestBeforeCleanup pins the order of validation and
 // the automatic stale-worktree pruning: a rejected request (an invalid
 // --name) must not have destructive cleanup side effects before it reports
@@ -244,7 +255,11 @@ func TestPrepareRejectsWorktreeLockedByAnotherRun(t *testing.T) {
 // worktree IS pruned once a valid request runs.
 func TestPrepareValidatesRequestBeforeCleanup(t *testing.T) {
 	ctx := context.Background()
-	repo := t.TempDir()
+	// Canonicalize both roots up front: git records worktree paths in
+	// physical spelling, so a lexically different spelling of the same
+	// directory (macOS /var vs /private/var, Windows 8.3 short names on CI
+	// runners) would make Clean's containment check skip the entry.
+	repo := physicalTestPath(t, t.TempDir())
 	mustGit := func(args ...string) string {
 		t.Helper()
 		out, err := gitOutput(ctx, defaultRunGit, repo, args...)
@@ -257,7 +272,7 @@ func TestPrepareValidatesRequestBeforeCleanup(t *testing.T) {
 	mustGit("-c", "user.email=t@example.invalid", "-c", "user.name=t", "commit", "--allow-empty", "-m", "seed")
 	toplevel := filepath.Clean(mustGit("rev-parse", "--show-toplevel"))
 
-	base := t.TempDir()
+	base := physicalTestPath(t, t.TempDir())
 	staleDir := filepath.Join(base, "zero-worktree-"+repoKey(toplevel), "stale-task")
 	if err := os.MkdirAll(filepath.Dir(staleDir), 0o700); err != nil {
 		t.Fatal(err)

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -109,29 +109,37 @@ func TestReleaseUnlocksWorktree(t *testing.T) {
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Fatal(err)
 	}
+	plantOwnershipMarker(t, path)
 	// The target entry carries Zero's own lease reason (as Prepare's lock
 	// call sets it), so the lock-reason check added alongside the ancestor
 	// check must let this release through rather than treating every locked
 	// entry as a manual, non-zero lock (see
 	// TestReleaseRejectsManuallyLockedWorktree for the rejecting case).
-	runner := &fakeRunner{results: []CommandResult{
-		{Stdout: "worktree " + repoRoot + "\nworktree " + path + "\nlocked " + leaseReasonPrefix + "\n"},
-		{},
-	}}
+	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
+		results: []CommandResult{
+			{Stdout: "worktree " + repoRoot + "\nworktree " + path + "\nlocked " + leaseReasonPrefix + "\n"},
+			{},
+		},
+	}
 
 	if err := Release(context.Background(), Options{RunGit: runner.Run}, path); err != nil {
 		t.Fatalf("Release returned error: %v", err)
 	}
-	if len(runner.calls) != 2 {
-		t.Fatalf("expected exactly two git calls (ownership check, then unlock), got %#v", runner.calls)
+	// list + absolute-git-dir (marker) + unlock
+	if len(runner.calls) != 3 {
+		t.Fatalf("expected list, marker check, then unlock, got %#v", runner.calls)
 	}
 	if got := runner.commandLine(0); got != "git worktree list --porcelain" {
 		t.Fatalf("ownership-check command = %q", got)
 	}
-	if runner.calls[1].dir != path {
-		t.Fatalf("git worktree unlock dir = %q, want %q", runner.calls[1].dir, path)
+	if got := runner.commandLine(1); got != "git rev-parse --absolute-git-dir" {
+		t.Fatalf("marker-check command = %q", got)
 	}
-	if got := runner.commandLine(1); got != "git worktree unlock "+path {
+	if runner.calls[2].dir != path {
+		t.Fatalf("git worktree unlock dir = %q, want %q", runner.calls[2].dir, path)
+	}
+	if got := runner.commandLine(2); got != "git worktree unlock "+path {
 		t.Fatalf("git worktree unlock command = %q", got)
 	}
 }
@@ -271,6 +279,7 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
 		results: []CommandResult{
 			{Stdout: root + "\n"},
 			{Stdout: "worktree " + root + "\n"},
@@ -298,14 +307,18 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 	if result.Path != existing {
 		t.Fatalf("Path = %q, want existing %q", result.Path, existing)
 	}
-	if len(runner.calls) != 7 {
-		t.Fatalf("expected metadata git calls plus lock, got %#v", runner.calls)
+	// metadata calls + lock + ownership marker write (absolute-git-dir)
+	if len(runner.calls) != 8 {
+		t.Fatalf("expected metadata git calls plus lock and marker write, got %#v", runner.calls)
 	}
 	// The original lock may have been released by a prior run's exit, which
 	// would leave the reused worktree exposed to Clean's staleness heuristic
 	// while this caller is still using it: reuse must re-establish the lease.
 	if got := runner.commandLine(6); got != "git worktree lock --reason zero: active task worktree "+existing {
 		t.Fatalf("git worktree lock command = %q", got)
+	}
+	if got := runner.commandLine(7); got != "git rev-parse --absolute-git-dir" {
+		t.Fatalf("marker write command = %q", got)
 	}
 	if !result.LockAcquired {
 		t.Fatalf("LockAcquired = false, want true for a lease this call took")
@@ -571,9 +584,31 @@ func TestPrepareValidatesRequestBeforeCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 	mustGit("worktree", "add", "--detach", staleDir)
+	// Plant the ownership marker Clean requires before it will force-remove a
+	// path: without it, a hand-created worktree under the predictable
+	// zero-worktree-* layout must not be pruned. Real linked worktrees keep
+	// their admin dir behind a .git file (gitdir: ...), so resolve it the
+	// same way writeOwnershipMarker does rather than mkdir path/.git.
+	gitDir, err := gitOutput(ctx, defaultRunGit, staleDir, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		t.Fatalf("resolve stale worktree git dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, zeroOwnerMarkerFile), []byte(zeroOwnerMarkerContent), 0o600); err != nil {
+		t.Fatalf("plant ownership marker: %v", err)
+	}
 	// Age every filesystem entry past the 24h staleness cutoff.
 	old := time.Now().Add(-48 * time.Hour)
 	if err := filepath.WalkDir(staleDir, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, old, old)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Also age the admin dir (outside the worktree tree) so nested activity
+	// under the marker file does not keep the worktree "fresh".
+	if err := filepath.WalkDir(gitDir, func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -694,10 +729,22 @@ func TestDefaultBaseDirFallsBackForWindowsUserProfile(t *testing.T) {
 type fakeRunner struct {
 	calls   []gitCall
 	results []CommandResult
+	// autoAbsoluteGitDir answers `rev-parse --absolute-git-dir` without
+	// consuming a queued result: it ensures dir/.git exists and returns that
+	// path. Tests plant zero-owner markers under that dir when they want
+	// Release/Clean to treat the worktree as Prepare-created.
+	autoAbsoluteGitDir bool
 }
 
 func (runner *fakeRunner) Run(ctx context.Context, dir string, args ...string) (CommandResult, error) {
 	runner.calls = append(runner.calls, gitCall{dir: dir, args: append([]string{}, args...)})
+	if runner.autoAbsoluteGitDir && len(args) >= 2 && args[0] == "rev-parse" && args[1] == "--absolute-git-dir" {
+		gitDir := filepath.Join(dir, ".git")
+		if err := os.MkdirAll(gitDir, 0o700); err != nil {
+			return CommandResult{}, err
+		}
+		return CommandResult{Stdout: gitDir + "\n"}, nil
+	}
 	if len(runner.results) == 0 {
 		return CommandResult{}, nil
 	}
@@ -711,6 +758,19 @@ func (runner *fakeRunner) commandLine(index int) string {
 		return ""
 	}
 	return "git " + strings.Join(runner.calls[index].args, " ")
+}
+
+// plantOwnershipMarker writes Prepare's ownership marker under path's .git
+// admin dir so Release/Clean treat the fixture as zero-created.
+func plantOwnershipMarker(t *testing.T, path string) {
+	t.Helper()
+	gitDir := filepath.Join(path, ".git")
+	if err := os.MkdirAll(gitDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, zeroOwnerMarkerFile), []byte(zeroOwnerMarkerContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 type gitCall struct {
@@ -744,17 +804,28 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// Markers first, then age the whole tree: planting after Chtimes would
+	// refresh the worktree mtime and make worktreeIsStale skip the prune.
+	plantOwnershipMarker(t, youngPath)
+	plantOwnershipMarker(t, stalePath)
 
-	// Change mtime of stale-task to be in the past (e.g. 2 days ago).
+	// Change mtime of stale-task (and its marker files) to be in the past.
 	twoDaysAgo := time.Now().Add(-48 * time.Hour)
-	if err := os.Chtimes(stalePath, twoDaysAgo, twoDaysAgo); err != nil {
+	if err := filepath.WalkDir(stalePath, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, twoDaysAgo, twoDaysAgo)
+	}); err != nil {
 		t.Fatal(err)
 	}
 
 	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
 		results: []CommandResult{
 			{Stdout: repoRoot}, // rev-parse --show-toplevel
-			{Stdout: "worktree " + youngPath + "\nworktree " + stalePath + "\n"}, // worktree list --porcelain
+			// Main worktree must be listed first: Clean keys repoDir off entries[0].
+			{Stdout: "worktree " + repoRoot + "\nworktree " + youngPath + "\nworktree " + stalePath + "\n"},
 			{ExitCode: 0},               // status --porcelain <stalePath> (clean)
 			{Stdout: "deadbeef"},        // rev-parse HEAD <stalePath>
 			{Stdout: "refs/heads/main"}, // for-each-ref --contains=deadbeef (already reachable)
@@ -774,9 +845,10 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 		t.Fatalf("Clean failed: %v", err)
 	}
 
-	// Verify the calls made by Clean
-	if len(runner.calls) != 7 {
-		t.Fatalf("expected 7 git calls, got %d", len(runner.calls))
+	// toplevel + list + status(stale) + marker + HEAD + for-each-ref + remove + prune
+	// young is skipped as not-stale before any status/marker work.
+	if len(runner.calls) != 8 {
+		t.Fatalf("expected 8 git calls, got %d: %#v", len(runner.calls), runner.calls)
 	}
 	if runner.commandLine(0) != "git rev-parse --show-toplevel" {
 		t.Errorf("call 0 = %q", runner.commandLine(0))
@@ -788,15 +860,18 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	if runner.commandLine(2) != expectedStatusCall {
 		t.Errorf("call 2 = %q, want %q", runner.commandLine(2), expectedStatusCall)
 	}
-	if runner.commandLine(3) != "git rev-parse HEAD" {
-		t.Errorf("call 3 = %q, want the pre-removal HEAD-preservation check", runner.commandLine(3))
+	if runner.commandLine(3) != "git rev-parse --absolute-git-dir" {
+		t.Errorf("call 3 = %q, want ownership marker check", runner.commandLine(3))
+	}
+	if runner.commandLine(4) != "git rev-parse HEAD" {
+		t.Errorf("call 4 = %q, want the pre-removal HEAD-preservation check", runner.commandLine(4))
 	}
 	expectedRemoveCall := "git worktree remove --force " + filepath.Clean(stalePath)
-	if runner.commandLine(5) != expectedRemoveCall {
-		t.Errorf("call 5 = %q, want %q", runner.commandLine(5), expectedRemoveCall)
+	if runner.commandLine(6) != expectedRemoveCall {
+		t.Errorf("call 6 = %q, want %q", runner.commandLine(6), expectedRemoveCall)
 	}
-	if runner.commandLine(6) != "git worktree prune" {
-		t.Errorf("call 6 = %q", runner.commandLine(6))
+	if runner.commandLine(7) != "git worktree prune" {
+		t.Errorf("call 7 = %q", runner.commandLine(7))
 	}
 }
 
@@ -817,15 +892,22 @@ func TestCleanReportsErrorOnFailedRemoval(t *testing.T) {
 	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	plantOwnershipMarker(t, stalePath)
 	twoDaysAgo := time.Now().Add(-48 * time.Hour)
-	if err := os.Chtimes(stalePath, twoDaysAgo, twoDaysAgo); err != nil {
+	if err := filepath.WalkDir(stalePath, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, twoDaysAgo, twoDaysAgo)
+	}); err != nil {
 		t.Fatal(err)
 	}
 
 	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
 		results: []CommandResult{
 			{Stdout: repoRoot},
-			{Stdout: "worktree " + stalePath + "\n"},
+			{Stdout: "worktree " + repoRoot + "\nworktree " + stalePath + "\n"},
 			{ExitCode: 0},               // status --porcelain <stalePath> (clean)
 			{Stdout: "deadbeef"},        // rev-parse HEAD <stalePath>
 			{Stdout: "refs/heads/main"}, // for-each-ref --contains=deadbeef (already reachable)
@@ -859,17 +941,26 @@ func TestCleanAggregatesMultipleFailedRemovals(t *testing.T) {
 	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	for _, path := range []string{stalePathA, stalePathB} {
+		plantOwnershipMarker(t, path)
+	}
 	twoDaysAgo := time.Now().Add(-48 * time.Hour)
 	for _, path := range []string{stalePathA, stalePathB} {
-		if err := os.Chtimes(path, twoDaysAgo, twoDaysAgo); err != nil {
+		if err := filepath.WalkDir(path, func(p string, _ os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			return os.Chtimes(p, twoDaysAgo, twoDaysAgo)
+		}); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
 		results: []CommandResult{
 			{Stdout: repoRoot},
-			{Stdout: "worktree " + stalePathA + "\n\nworktree " + stalePathB + "\n"},
+			{Stdout: "worktree " + repoRoot + "\nworktree " + stalePathA + "\n\nworktree " + stalePathB + "\n"},
 			{ExitCode: 0},               // status --porcelain <stalePathA> (clean)
 			{Stdout: "deadbeefa"},       // rev-parse HEAD <stalePathA>
 			{Stdout: "refs/heads/main"}, // for-each-ref --contains=deadbeefa (already reachable)
@@ -1143,15 +1234,22 @@ func TestCleanReclaimsReleasedWorktreeWithOnlyIgnoredFiles(t *testing.T) {
 	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	plantOwnershipMarker(t, ignoredOnlyPath)
 	twoDaysAgo := time.Now().Add(-48 * time.Hour)
-	if err := os.Chtimes(ignoredOnlyPath, twoDaysAgo, twoDaysAgo); err != nil {
+	if err := filepath.WalkDir(ignoredOnlyPath, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, twoDaysAgo, twoDaysAgo)
+	}); err != nil {
 		t.Fatal(err)
 	}
 
 	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
 		results: []CommandResult{
 			{Stdout: repoRoot},
-			{Stdout: "worktree " + ignoredOnlyPath + "\n"},
+			{Stdout: "worktree " + repoRoot + "\nworktree " + ignoredOnlyPath + "\n"},
 			{ExitCode: 0},               // status --porcelain: ignored files invisible => clean
 			{Stdout: "deadbeef"},        // rev-parse HEAD
 			{Stdout: "refs/heads/main"}, // for-each-ref --contains (reachable)
@@ -1197,15 +1295,22 @@ func TestCleanRecoversExpiredLease(t *testing.T) {
 	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	plantOwnershipMarker(t, crashedPath)
 	twoDaysAgo := time.Now().Add(-48 * time.Hour)
-	if err := os.Chtimes(crashedPath, twoDaysAgo, twoDaysAgo); err != nil {
+	if err := filepath.WalkDir(crashedPath, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, twoDaysAgo, twoDaysAgo)
+	}); err != nil {
 		t.Fatal(err)
 	}
 
 	runner := &fakeRunner{
+		autoAbsoluteGitDir: true,
 		results: []CommandResult{
 			{Stdout: repoRoot},
-			{Stdout: "worktree " + crashedPath + "\nlocked " + leaseReason(deadPID) + "\n"},
+			{Stdout: "worktree " + repoRoot + "\nworktree " + crashedPath + "\nlocked " + leaseReason(deadPID) + "\n"},
 			{ExitCode: 0},               // status --porcelain --ignored: clean
 			{Stdout: "deadbeef"},        // rev-parse HEAD
 			{Stdout: "refs/heads/main"}, // for-each-ref --contains (reachable)
@@ -1219,14 +1324,16 @@ func TestCleanRecoversExpiredLease(t *testing.T) {
 		t.Fatalf("Clean failed: %v", err)
 	}
 
+	// status is still call 2; ownership marker check is call 3; then HEAD,
+	// for-each-ref, unlock, remove, prune.
 	if got, want := runner.commandLine(2), "git status --porcelain --ignored"; got != want {
 		t.Fatalf("status call = %q, want %q (a crashed lease never signaled completion)", got, want)
 	}
-	if got, want := runner.commandLine(5), "git worktree unlock "+filepath.Clean(crashedPath); got != want {
-		t.Fatalf("call 5 = %q, want lease recovery %q", got, want)
+	if got, want := runner.commandLine(6), "git worktree unlock "+filepath.Clean(crashedPath); got != want {
+		t.Fatalf("call 6 = %q, want lease recovery %q", got, want)
 	}
-	if got, want := runner.commandLine(6), "git worktree remove --force "+filepath.Clean(crashedPath); got != want {
-		t.Fatalf("call 6 = %q, want %q", got, want)
+	if got, want := runner.commandLine(7), "git worktree remove --force "+filepath.Clean(crashedPath); got != want {
+		t.Fatalf("call 7 = %q, want %q", got, want)
 	}
 }
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -52,6 +52,7 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 			{Stdout: "main\n"},
 			{Stdout: "abc1234\n"},
 			{},
+			{},
 		},
 	}
 
@@ -77,6 +78,12 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 	}
 	if got := runner.commandLine(3); got != "git worktree add --detach "+result.Path+" HEAD" {
 		t.Fatalf("git worktree command = %q", got)
+	}
+	// Prepare must lock every worktree it creates: this is what makes
+	// entry.locked inside Clean protect zero's own worktrees, not just ones a
+	// human locked by hand (see TestCleanSkipsLockedZeroOwnedWorktree).
+	if got := runner.commandLine(4); got != "git worktree lock --reason zero: active task worktree "+result.Path {
+		t.Fatalf("git worktree lock command = %q", got)
 	}
 }
 
@@ -305,7 +312,7 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	if runner.commandLine(1) != "git worktree list --porcelain" {
 		t.Errorf("call 1 = %q", runner.commandLine(1))
 	}
-	expectedStatusCall := "git status --porcelain"
+	expectedStatusCall := "git status --porcelain --ignored"
 	if runner.commandLine(2) != expectedStatusCall {
 		t.Errorf("call 2 = %q, want %q", runner.commandLine(2), expectedStatusCall)
 	}
@@ -477,6 +484,138 @@ func TestCleanSkipsLockedWorktree(t *testing.T) {
 		if len(call.args) > 0 && call.args[0] == "remove" {
 			t.Fatalf("Clean removed a locked worktree: %v", call.args)
 		}
+	}
+}
+
+// A worktree zero created and locked at Prepare time (see the "worktree lock"
+// call added there) must survive Clean even though it looks idle-but-clean: a
+// task can finish committing and then sit waiting on a model, network, or
+// user for far longer than the staleness window without touching the tree
+// again, and mtime alone can't distinguish that from an abandoned worktree.
+// Before this fix, Prepare never locked its own worktrees, so entry.locked
+// only ever protected worktrees a human locked by hand.
+func TestCleanSkipsLockedZeroOwnedWorktree(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	idlePath := filepath.Join(repoDir, "idle-task")
+	if err := os.MkdirAll(idlePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(idlePath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + idlePath + "\nlocked zero: active task worktree\n"},
+			{ExitCode: 0}, // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && (call.args[0] == "remove" || call.args[0] == "status") {
+			t.Fatalf("Clean touched a locked zero-owned worktree: %v", call.args)
+		}
+	}
+}
+
+// A worktree whose only content is matched by .gitignore (credentials,
+// generated drafts, task artifacts) must still block force-removal: plain
+// `git status --porcelain` reports such a worktree as clean, but
+// worktreeIsDirty now also passes --ignored, so Clean must treat it as dirty.
+func TestCleanSkipsWorktreeWithOnlyIgnoredFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	ignoredOnlyPath := filepath.Join(repoDir, "ignored-only-task")
+	if err := os.MkdirAll(ignoredOnlyPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(ignoredOnlyPath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + ignoredOnlyPath + "\n"},
+			{Stdout: "!! ignored-data\n"}, // status --porcelain --ignored: ignored file present
+			{ExitCode: 0},                 // worktree prune
+		},
+	}
+
+	if err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean failed: %v", err)
+	}
+
+	for i, call := range runner.calls {
+		if i == 2 {
+			want := "status --porcelain --ignored"
+			if got := strings.Join(call.args, " "); got != want {
+				t.Fatalf("status call args = %q, want %q", got, want)
+			}
+		}
+		if len(call.args) > 0 && call.args[0] == "remove" {
+			t.Fatalf("Clean removed a worktree with only ignored files: %v", call.args)
+		}
+	}
+}
+
+// worktreeIsDirty must count files matched by .gitignore as dirty content: a
+// worktree holding only ignored task data (credentials, generated drafts) has
+// nothing to show in plain `git status --porcelain` and would otherwise pass
+// as clean and be force-removed by Clean's staleness heuristic. This exercises
+// the real git binary rather than the fake runner, so it also verifies
+// --ignored actually changes git's answer, not just the command we send.
+func TestWorktreeIsDirtyCountsIgnoredFilesAsDirty(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "--quiet")
+	run("config", "user.email", "zero@example.com")
+	run("config", "user.name", "zero")
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("ignored-data\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".gitignore")
+	run("commit", "--quiet", "-m", "initial")
+
+	if worktreeIsDirty(context.Background(), defaultRunGit, dir) {
+		t.Fatal("expected a clean worktree with no ignored files present to report clean")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "ignored-data"), []byte("secret task artifact"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !worktreeIsDirty(context.Background(), defaultRunGit, dir) {
+		t.Fatal("expected an ignored-but-present file to count as dirty")
 	}
 }
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -91,22 +91,36 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 }
 
 func TestReleaseUnlocksWorktree(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "task-a")
-	if err := os.Mkdir(path, 0o700); err != nil {
+	repoRoot := t.TempDir()
+	// gitCommonDir resolves its answer with EvalSymlinks, so the fake
+	// --git-common-dir response needs a real directory behind it.
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	runner := &fakeRunner{results: []CommandResult{{}}}
+	// path must carry the zero-worktree-<repoKey> ancestor component Prepare
+	// actually creates: Release now refuses to unlock anything else.
+	path := filepath.Join(t.TempDir(), "zero-worktree-"+repoKey(repoRoot), "task-a")
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: filepath.Join(repoRoot, ".git") + "\n"},
+		{},
+	}}
 
 	if err := Release(context.Background(), Options{RunGit: runner.Run}, path); err != nil {
 		t.Fatalf("Release returned error: %v", err)
 	}
-	if len(runner.calls) != 1 {
-		t.Fatalf("expected exactly one git call, got %#v", runner.calls)
+	if len(runner.calls) != 2 {
+		t.Fatalf("expected exactly two git calls (ownership check, then unlock), got %#v", runner.calls)
 	}
-	if runner.calls[0].dir != path {
-		t.Fatalf("git worktree unlock dir = %q, want %q", runner.calls[0].dir, path)
+	if got := runner.commandLine(0); got != "git rev-parse --git-common-dir" {
+		t.Fatalf("ownership-check command = %q", got)
 	}
-	if got := runner.commandLine(0); got != "git worktree unlock "+path {
+	if runner.calls[1].dir != path {
+		t.Fatalf("git worktree unlock dir = %q, want %q", runner.calls[1].dir, path)
+	}
+	if got := runner.commandLine(1); got != "git worktree unlock "+path {
 		t.Fatalf("git worktree unlock command = %q", got)
 	}
 }
@@ -116,21 +130,54 @@ func TestReleaseFallsBackToCwdWhenWorktreeDirMissing(t *testing.T) {
 	// releasing it first leaves path itself gone; Release must still be able
 	// to run `git worktree unlock` (from the main repo, via options.Cwd) so
 	// the orphaned lock can be cleared and the entry later pruned.
-	missingPath := filepath.Join(t.TempDir(), "already-deleted")
 	repoRoot := t.TempDir()
-	runner := &fakeRunner{results: []CommandResult{{}}}
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	missingPath := filepath.Join(t.TempDir(), "zero-worktree-"+repoKey(repoRoot), "already-deleted")
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: filepath.Join(repoRoot, ".git") + "\n"},
+		{},
+	}}
 
 	if err := Release(context.Background(), Options{RunGit: runner.Run, Cwd: repoRoot}, missingPath); err != nil {
 		t.Fatalf("Release returned error: %v", err)
 	}
-	if len(runner.calls) != 1 {
-		t.Fatalf("expected exactly one git call, got %#v", runner.calls)
+	if len(runner.calls) != 2 {
+		t.Fatalf("expected exactly two git calls (ownership check, then unlock), got %#v", runner.calls)
 	}
-	if runner.calls[0].dir != repoRoot {
-		t.Fatalf("git worktree unlock dir = %q, want fallback to Cwd %q", runner.calls[0].dir, repoRoot)
+	if runner.calls[0].dir != repoRoot || runner.calls[1].dir != repoRoot {
+		t.Fatalf("git calls = %#v, want both to fall back to Cwd %q", runner.calls, repoRoot)
 	}
-	if got := runner.commandLine(0); got != "git worktree unlock "+missingPath {
+	if got := runner.commandLine(1); got != "git worktree unlock "+missingPath {
 		t.Fatalf("git worktree unlock command = %q, want the original path as the unlock target", got)
+	}
+}
+
+// TestReleaseRejectsNonZeroOwnedWorktree pins the fix for Release being
+// usable to clear the lock on a worktree a user (or another tool) manages by
+// hand: the command is documented as releasing a worktree `prepare` created,
+// not an arbitrary git worktree lock, so a path with no zero-worktree-<repoKey>
+// ancestor component must be refused before any unlock is attempted.
+func TestReleaseRejectsNonZeroOwnedWorktree(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manualWorktree := filepath.Join(t.TempDir(), "my-manual-worktree")
+	if err := os.MkdirAll(manualWorktree, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: filepath.Join(repoRoot, ".git") + "\n"},
+	}}
+
+	err := Release(context.Background(), Options{RunGit: runner.Run}, manualWorktree)
+	if err == nil || !strings.Contains(err.Error(), "not a zero-managed worktree") {
+		t.Fatalf("Release error = %v, want a not-zero-managed rejection", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected only the ownership check, no unlock call, got %#v", runner.calls)
 	}
 }
 
@@ -246,6 +293,65 @@ func physicalTestPath(t *testing.T, path string) string {
 		t.Fatalf("resolve %s: %v", path, err)
 	}
 	return resolved
+}
+
+// TestCleanPrunesStaleWorktreeUnderSymlinkedBaseDir pins the fix for a
+// symlinked --worktree-dir: git worktree list --porcelain reports each
+// worktree's PHYSICAL location, resolving any symlink component, so Clean
+// comparing entries against a merely-absolute (not symlink-resolved) baseDir
+// would reject every worktree created under a symlinked base and never prune
+// it. Unlike the other Clean tests, base is deliberately handed to
+// Prepare/Clean via its symlinked spelling, not its physical one (which
+// physicalTestPath would normally produce), so this actually exercises the
+// mismatch.
+func TestCleanPrunesStaleWorktreeUnderSymlinkedBaseDir(t *testing.T) {
+	ctx := context.Background()
+	repo := physicalTestPath(t, t.TempDir())
+	mustGit := func(args ...string) string {
+		t.Helper()
+		out, err := gitOutput(ctx, defaultRunGit, repo, args...)
+		if err != nil {
+			t.Skipf("git unavailable or failed (%v): %v", args, err)
+		}
+		return out
+	}
+	mustGit("init")
+	mustGit("-c", "user.email=t@example.invalid", "-c", "user.name=t", "commit", "--allow-empty", "-m", "seed")
+
+	realBase := physicalTestPath(t, t.TempDir())
+	base := filepath.Join(t.TempDir(), "base-link")
+	if err := os.Symlink(realBase, base); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	if _, err := Prepare(ctx, Options{Cwd: repo, BaseDir: base, Name: "stale-task"}); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	staleDir := filepath.Join(realBase, "zero-worktree-"+repoKey(repo), "stale-task")
+	if _, err := os.Stat(staleDir); err != nil {
+		t.Fatalf("expected worktree created at physical base path %s: %v", staleDir, err)
+	}
+	// Release the lock Prepare took and age every entry past the cutoff, so
+	// the worktree is both unlocked and stale.
+	if err := Release(ctx, Options{Cwd: repo}, staleDir); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := filepath.WalkDir(staleDir, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, old, old)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Clean(ctx, Options{Cwd: repo, BaseDir: base}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean: %v", err)
+	}
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Fatalf("Clean should have pruned the stale worktree under the symlinked base dir, stat err: %v", err)
+	}
 }
 
 // TestPrepareValidatesRequestBeforeCleanup pins the order of validation and
@@ -460,9 +566,11 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 		results: []CommandResult{
 			{Stdout: repoRoot}, // rev-parse --show-toplevel
 			{Stdout: "worktree " + youngPath + "\nworktree " + stalePath + "\n"}, // worktree list --porcelain
-			{ExitCode: 0}, // status --porcelain <stalePath> (clean)
-			{ExitCode: 0}, // worktree remove --force <stalePath>
-			{ExitCode: 0}, // worktree prune
+			{ExitCode: 0},               // status --porcelain <stalePath> (clean)
+			{Stdout: "deadbeef"},        // rev-parse HEAD <stalePath>
+			{Stdout: "refs/heads/main"}, // for-each-ref --contains=deadbeef (already reachable)
+			{ExitCode: 0},               // worktree remove --force <stalePath>
+			{ExitCode: 0},               // worktree prune
 		},
 	}
 
@@ -478,8 +586,8 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	}
 
 	// Verify the calls made by Clean
-	if len(runner.calls) != 5 {
-		t.Fatalf("expected 5 git calls, got %d", len(runner.calls))
+	if len(runner.calls) != 7 {
+		t.Fatalf("expected 7 git calls, got %d", len(runner.calls))
 	}
 	if runner.commandLine(0) != "git rev-parse --show-toplevel" {
 		t.Errorf("call 0 = %q", runner.commandLine(0))
@@ -491,12 +599,15 @@ func TestCleanPrunesStaleWorktrees(t *testing.T) {
 	if runner.commandLine(2) != expectedStatusCall {
 		t.Errorf("call 2 = %q, want %q", runner.commandLine(2), expectedStatusCall)
 	}
-	expectedRemoveCall := "git worktree remove --force " + filepath.Clean(stalePath)
-	if runner.commandLine(3) != expectedRemoveCall {
-		t.Errorf("call 3 = %q, want %q", runner.commandLine(3), expectedRemoveCall)
+	if runner.commandLine(3) != "git rev-parse HEAD" {
+		t.Errorf("call 3 = %q, want the pre-removal HEAD-preservation check", runner.commandLine(3))
 	}
-	if runner.commandLine(4) != "git worktree prune" {
-		t.Errorf("call 4 = %q", runner.commandLine(4))
+	expectedRemoveCall := "git worktree remove --force " + filepath.Clean(stalePath)
+	if runner.commandLine(5) != expectedRemoveCall {
+		t.Errorf("call 5 = %q, want %q", runner.commandLine(5), expectedRemoveCall)
+	}
+	if runner.commandLine(6) != "git worktree prune" {
+		t.Errorf("call 6 = %q", runner.commandLine(6))
 	}
 }
 
@@ -526,8 +637,10 @@ func TestCleanReportsErrorOnFailedRemoval(t *testing.T) {
 		results: []CommandResult{
 			{Stdout: repoRoot},
 			{Stdout: "worktree " + stalePath + "\n"},
-			{ExitCode: 0}, // status --porcelain <stalePath> (clean)
-			{ExitCode: 1, Stderr: "fatal: unable to remove worktree: in use"},
+			{ExitCode: 0},               // status --porcelain <stalePath> (clean)
+			{Stdout: "deadbeef"},        // rev-parse HEAD <stalePath>
+			{Stdout: "refs/heads/main"}, // for-each-ref --contains=deadbeef (already reachable)
+			{ExitCode: 1, Stderr: "fatal: unable to remove worktree: in use"}, // worktree remove --force <stalePath>
 			{ExitCode: 0},
 		},
 	}
@@ -568,9 +681,13 @@ func TestCleanAggregatesMultipleFailedRemovals(t *testing.T) {
 		results: []CommandResult{
 			{Stdout: repoRoot},
 			{Stdout: "worktree " + stalePathA + "\n\nworktree " + stalePathB + "\n"},
-			{ExitCode: 0}, // status --porcelain <stalePathA> (clean)
+			{ExitCode: 0},               // status --porcelain <stalePathA> (clean)
+			{Stdout: "deadbeefa"},       // rev-parse HEAD <stalePathA>
+			{Stdout: "refs/heads/main"}, // for-each-ref --contains=deadbeefa (already reachable)
 			{ExitCode: 1, Stderr: "fatal: unable to remove worktree A"}, // remove stalePathA
-			{ExitCode: 0}, // status --porcelain <stalePathB> (clean)
+			{ExitCode: 0},               // status --porcelain <stalePathB> (clean)
+			{Stdout: "deadbeefb"},       // rev-parse HEAD <stalePathB>
+			{Stdout: "refs/heads/main"}, // for-each-ref --contains=deadbeefb (already reachable)
 			{ExitCode: 1, Stderr: "fatal: unable to remove worktree B"}, // remove stalePathB
 			{ExitCode: 0}, // final prune
 		},
@@ -760,6 +877,65 @@ func TestCleanSkipsLockedZeroOwnedWorktree(t *testing.T) {
 // generated drafts, task artifacts) must still block force-removal: plain
 // `git status --porcelain` reports such a worktree as clean, but
 // worktreeIsDirty now also passes --ignored, so Clean must treat it as dirty.
+// TestCleanPreservesUnreachableCommitBeforeRemoval pins the fix for a real
+// data-loss case: Prepare creates every worktree with `worktree add --detach`,
+// so a commit made there is reachable only through that worktree's own HEAD.
+// If the worktree goes stale and clean before the commit is otherwise
+// referenced, force-removing it must not let the commit become unreachable —
+// Clean has to preserve it under a durable ref first.
+func TestCleanPreservesUnreachableCommitBeforeRemoval(t *testing.T) {
+	ctx := context.Background()
+	repo := physicalTestPath(t, t.TempDir())
+	mustGit := func(dir string, args ...string) string {
+		t.Helper()
+		out, err := gitOutput(ctx, defaultRunGit, dir, args...)
+		if err != nil {
+			t.Skipf("git unavailable or failed (%v): %v", args, err)
+		}
+		return out
+	}
+	mustGit(repo, "init")
+	mustGit(repo, "-c", "user.email=t@example.invalid", "-c", "user.name=t", "commit", "--allow-empty", "-m", "seed")
+
+	base := physicalTestPath(t, t.TempDir())
+	if _, err := Prepare(ctx, Options{Cwd: repo, BaseDir: base, Name: "orphan-task"}); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	staleDir := filepath.Join(base, "zero-worktree-"+repoKey(repo), "orphan-task")
+
+	// Commit inside the worktree: this HEAD is not on any branch, so nothing
+	// outside the worktree itself points at it yet.
+	mustGit(staleDir, "-c", "user.email=t@example.invalid", "-c", "user.name=t", "commit", "--allow-empty", "-m", "orphaned work")
+	orphanSHA := mustGit(staleDir, "rev-parse", "HEAD")
+
+	if err := Release(ctx, Options{Cwd: repo}, staleDir); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := filepath.WalkDir(staleDir, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(path, old, old)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Clean(ctx, Options{Cwd: repo, BaseDir: base}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean: %v", err)
+	}
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Fatalf("Clean should have pruned the stale worktree, stat err: %v", err)
+	}
+	if _, err := gitOutput(ctx, defaultRunGit, repo, "cat-file", "-e", orphanSHA); err != nil {
+		t.Fatalf("commit %s is no longer reachable after Clean: %v", orphanSHA, err)
+	}
+	preserved := mustGit(repo, "for-each-ref", "--contains="+orphanSHA, "--count=1", "--format=%(refname)")
+	if strings.TrimSpace(preserved) == "" {
+		t.Fatalf("commit %s survived only by luck (not yet GC'd); expected a durable ref to contain it", orphanSHA)
+	}
+}
+
 func TestCleanSkipsWorktreeWithOnlyIgnoredFiles(t *testing.T) {
 	tempDir := t.TempDir()
 	baseDir := filepath.Join(tempDir, "zero-worktrees")

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -89,6 +89,9 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 
 func TestReleaseUnlocksWorktree(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "task-a")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	runner := &fakeRunner{results: []CommandResult{{}}}
 
 	if err := Release(context.Background(), Options{RunGit: runner.Run}, path); err != nil {
@@ -105,8 +108,34 @@ func TestReleaseUnlocksWorktree(t *testing.T) {
 	}
 }
 
+func TestReleaseFallsBackToCwdWhenWorktreeDirMissing(t *testing.T) {
+	// A caller who deletes a locked worktree directory by hand instead of
+	// releasing it first leaves path itself gone; Release must still be able
+	// to run `git worktree unlock` (from the main repo, via options.Cwd) so
+	// the orphaned lock can be cleared and the entry later pruned.
+	missingPath := filepath.Join(t.TempDir(), "already-deleted")
+	repoRoot := t.TempDir()
+	runner := &fakeRunner{results: []CommandResult{{}}}
+
+	if err := Release(context.Background(), Options{RunGit: runner.Run, Cwd: repoRoot}, missingPath); err != nil {
+		t.Fatalf("Release returned error: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected exactly one git call, got %#v", runner.calls)
+	}
+	if runner.calls[0].dir != repoRoot {
+		t.Fatalf("git worktree unlock dir = %q, want fallback to Cwd %q", runner.calls[0].dir, repoRoot)
+	}
+	if got := runner.commandLine(0); got != "git worktree unlock "+missingPath {
+		t.Fatalf("git worktree unlock command = %q, want the original path as the unlock target", got)
+	}
+}
+
 func TestReleasePropagatesGitFailure(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "task-a")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	runner := &fakeRunner{results: []CommandResult{{ExitCode: 1, Stderr: "fatal: not a working tree"}}}
 
 	err := Release(context.Background(), Options{RunGit: runner.Run}, path)
@@ -391,6 +420,56 @@ func TestCleanReportsErrorOnFailedRemoval(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "in use") {
 		t.Errorf("error = %q, want it to include the git failure message", err.Error())
+	}
+}
+
+func TestCleanAggregatesMultipleFailedRemovals(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	stalePathA := filepath.Join(repoDir, "stale-task-a")
+	stalePathB := filepath.Join(repoDir, "stale-task-b")
+	for _, path := range []string{stalePathA, stalePathB} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	for _, path := range []string{stalePathA, stalePathB} {
+		if err := os.Chtimes(path, twoDaysAgo, twoDaysAgo); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + stalePathA + "\n\nworktree " + stalePathB + "\n"},
+			{ExitCode: 0},                                             // status --porcelain <stalePathA> (clean)
+			{ExitCode: 1, Stderr: "fatal: unable to remove worktree A"}, // remove stalePathA
+			{ExitCode: 0},                                             // status --porcelain <stalePathB> (clean)
+			{ExitCode: 1, Stderr: "fatal: unable to remove worktree B"}, // remove stalePathB
+			{ExitCode: 0},                                             // final prune
+		},
+	}
+
+	err := Clean(context.Background(), Options{Cwd: repoRoot, BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour)
+	if err == nil {
+		t.Fatal("expected Clean to report both failed removals")
+	}
+	// Both failures must survive in the returned error, not just the last one
+	// to occur — overwriting lastErr instead of joining would silently drop
+	// worktree A's failure once worktree B's removal is also attempted.
+	if !strings.Contains(err.Error(), "unable to remove worktree A") {
+		t.Errorf("error = %q, missing worktree A's failure", err.Error())
+	}
+	if !strings.Contains(err.Error(), "unable to remove worktree B") {
+		t.Errorf("error = %q, missing worktree B's failure", err.Error())
 	}
 }
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -29,7 +29,7 @@ func TestDefaultRunGitSeparatesStdoutAndStderr(t *testing.T) {
 		t.Fatalf("Stderr should be empty on success, got %q", ok.Stderr)
 	}
 
-	// A failing command's diagnostic must land on Stderr, not Stdout — the prior
+	// A failing command's diagnostic must land on Stderr, not Stdout - the prior
 	// CombinedOutput merged them and left Stderr empty.
 	bad, err := defaultRunGit(context.Background(), dir, "not-a-real-subcommand")
 	if err != nil {
@@ -97,11 +97,14 @@ func TestReleaseUnlocksWorktree(t *testing.T) {
 	// physical spelling, so computing repoKey from the lexical spelling here
 	// would produce a different key than verifyZeroOwnedWorktree derives in
 	// production, and Release would reject this genuinely Zero-owned fixture
-	// as not-zero-managed.
+	// as not-zero-managed. The worktree path itself is physicalized for the
+	// same reason: Release compares the registered entry against the
+	// canonical user path, and a lexical /var spelling would not match.
 	repoRoot := physicalTestPath(t, t.TempDir())
 	// path must carry the zero-worktree-<repoKey> ancestor component Prepare
 	// actually creates: Release now refuses to unlock anything else.
-	path := filepath.Join(t.TempDir(), "zero-worktree-"+repoKey(repoRoot), "task-a")
+	base := physicalTestPath(t, t.TempDir())
+	path := filepath.Join(base, "zero-worktree-"+repoKey(repoRoot), "task-a")
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -141,11 +144,13 @@ func TestReleaseFallsBackToCwdWhenWorktreeDirMissing(t *testing.T) {
 	// TestReleaseUnlocksWorktree: real `git worktree list --porcelain`
 	// reports the physical spelling, so a lexical temp-dir spelling here
 	// would derive a different repoKey than production and reject this
-	// fixture.
+	// fixture. The deleted path must still appear in the porcelain list
+	// (git keeps a prunable entry after a manual rm -rf) with Zero's lease
+	// reason, or the ownership check refuses the unlock.
 	repoRoot := physicalTestPath(t, t.TempDir())
 	missingPath := filepath.Join(t.TempDir(), "zero-worktree-"+repoKey(repoRoot), "already-deleted")
 	runner := &fakeRunner{results: []CommandResult{
-		{Stdout: "worktree " + repoRoot + "\n"},
+		{Stdout: "worktree " + repoRoot + "\nworktree " + missingPath + "\nlocked " + leaseReasonPrefix + "\n"},
 		{},
 	}}
 
@@ -195,7 +200,11 @@ func TestReleaseRejectsNonZeroOwnedWorktree(t *testing.T) {
 // entry whose recorded lock reason doesn't carry Zero's lease prefix.
 func TestReleaseRejectsManuallyLockedWorktree(t *testing.T) {
 	repoRoot := physicalTestPath(t, t.TempDir())
-	path := filepath.Join(t.TempDir(), "zero-worktree-"+repoKey(repoRoot), "task-a")
+	// Use a physical base so the porcelain entry path matches the
+	// canonicalizePath comparison Release uses against git's physical
+	// spelling (macOS /var vs /private/var, symlink TMPDIR layouts).
+	base := physicalTestPath(t, t.TempDir())
+	path := filepath.Join(base, "zero-worktree-"+repoKey(repoRoot), "task-a")
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -206,6 +215,30 @@ func TestReleaseRejectsManuallyLockedWorktree(t *testing.T) {
 	err := Release(context.Background(), Options{RunGit: runner.Run}, path)
 	if err == nil || !strings.Contains(err.Error(), "not a zero lease") {
 		t.Fatalf("Release error = %v, want a not-a-zero-lease rejection", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected only the ownership check, no unlock call, got %#v", runner.calls)
+	}
+}
+
+// TestReleaseRejectsUnregisteredWorktree pins the requirement that Release
+// only unlocks a path git currently has registered for the repository. A
+// same-looking zero-worktree-<repoKey> path that never appeared in
+// `git worktree list` must not reach unlock.
+func TestReleaseRejectsUnregisteredWorktree(t *testing.T) {
+	repoRoot := physicalTestPath(t, t.TempDir())
+	base := physicalTestPath(t, t.TempDir())
+	path := filepath.Join(base, "zero-worktree-"+repoKey(repoRoot), "not-registered")
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: "worktree " + repoRoot + "\n"},
+	}}
+
+	err := Release(context.Background(), Options{RunGit: runner.Run}, path)
+	if err == nil || !strings.Contains(err.Error(), "not a registered worktree") {
+		t.Fatalf("Release error = %v, want a not-registered rejection", err)
 	}
 	if len(runner.calls) != 1 {
 		t.Fatalf("expected only the ownership check, no unlock call, got %#v", runner.calls)
@@ -729,7 +762,7 @@ func TestCleanAggregatesMultipleFailedRemovals(t *testing.T) {
 		t.Fatal("expected Clean to report both failed removals")
 	}
 	// Both failures must survive in the returned error, not just the last one
-	// to occur — overwriting lastErr instead of joining would silently drop
+	// to occur - overwriting lastErr instead of joining would silently drop
 	// worktree A's failure once worktree B's removal is also attempted.
 	if !strings.Contains(err.Error(), "unable to remove worktree A") {
 		t.Errorf("error = %q, missing worktree A's failure", err.Error())
@@ -912,7 +945,7 @@ func TestCleanSkipsLockedZeroOwnedWorktree(t *testing.T) {
 // data-loss case: Prepare creates every worktree with `worktree add --detach`,
 // so a commit made there is reachable only through that worktree's own HEAD.
 // If the worktree goes stale and clean before the commit is otherwise
-// referenced, force-removing it must not let the commit become unreachable —
+// referenced, force-removing it must not let the commit become unreachable -
 // Clean has to preserve it under a durable ref first.
 func TestCleanPreservesUnreachableCommitBeforeRemoval(t *testing.T) {
 	ctx := context.Background()
@@ -1021,7 +1054,7 @@ func TestCleanReclaimsReleasedWorktreeWithOnlyIgnoredFiles(t *testing.T) {
 }
 
 // TestCleanRecoversExpiredLease: a Zero lease that records its owning PID is
-// recoverable — if that process died without releasing (SIGKILL, crash), the
+// recoverable - if that process died without releasing (SIGKILL, crash), the
 // lock must not protect the worktree forever. A stale, clean worktree behind
 // a dead-owner lease is unlocked and removed; the dirty probe there keeps
 // --ignored because a crashed task never signaled completion.

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -87,6 +87,34 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 	}
 }
 
+func TestReleaseUnlocksWorktree(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task-a")
+	runner := &fakeRunner{results: []CommandResult{{}}}
+
+	if err := Release(context.Background(), Options{RunGit: runner.Run}, path); err != nil {
+		t.Fatalf("Release returned error: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected exactly one git call, got %#v", runner.calls)
+	}
+	if runner.calls[0].dir != path {
+		t.Fatalf("git worktree unlock dir = %q, want %q", runner.calls[0].dir, path)
+	}
+	if got := runner.commandLine(0); got != "git worktree unlock "+path {
+		t.Fatalf("git worktree unlock command = %q", got)
+	}
+}
+
+func TestReleasePropagatesGitFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task-a")
+	runner := &fakeRunner{results: []CommandResult{{ExitCode: 1, Stderr: "fatal: not a working tree"}}}
+
+	err := Release(context.Background(), Options{RunGit: runner.Run}, path)
+	if err == nil || !strings.Contains(err.Error(), "not a working tree") {
+		t.Fatalf("Release error = %v, want it to surface the git failure", err)
+	}
+}
+
 func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 	root := t.TempDir()
 	base := t.TempDir()

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -661,7 +661,7 @@ func TestReleaseRecoversDeletedWorktreeUnderSymlinkedBaseDir(t *testing.T) {
 	if err := Release(ctx, Options{RunGit: runner.Run, Cwd: repo}, deletedPath); err != nil {
 		t.Fatalf("Release must recover a deleted worktree under a symlinked base dir: %v", err)
 	}
-	if got := runner.commandLine(1); got != "git worktree unlock "+deletedPath {
+	if got := runner.commandLine(1); got != "git worktree unlock "+physicalPath {
 		t.Fatalf("git worktree unlock command = %q", got)
 	}
 }
@@ -781,8 +781,8 @@ func TestPrepareRejectsExistingWorktreeFromDifferentRepo(t *testing.T) {
 }
 
 func TestPrepareValidatesNameAndExistingDirectory(t *testing.T) {
-	root := t.TempDir()
-	base := t.TempDir()
+	root := physicalTestPath(t, t.TempDir())
+	base := physicalTestPath(t, t.TempDir())
 	runner := &fakeRunner{
 		results: []CommandResult{
 			{Stdout: root + "\n"},
@@ -899,7 +899,7 @@ func fixedTime(value string) func() time.Time {
 }
 
 func TestCleanPrunesStaleWorktrees(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := physicalTestPath(t, t.TempDir())
 	baseDir := filepath.Join(tempDir, "zero-worktrees")
 	repoRoot := filepath.Join(tempDir, "repo")
 	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
@@ -1847,7 +1847,7 @@ func TestCleanUnlocksExpiredLeaseBeforePruningMissingDir(t *testing.T) {
 }
 
 func TestCleanMigratesAndReclaimsLegacyZeroWorktrees(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := physicalTestPath(t, t.TempDir())
 	baseDir := filepath.Join(tempDir, "zero-worktrees")
 	repoRoot := filepath.Join(tempDir, "repo")
 	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -1550,6 +1550,53 @@ func deadProcessPID(t *testing.T) int {
 // as clean and be force-removed by Clean's staleness heuristic. This exercises
 // the real git binary rather than the fake runner, so it also verifies
 // --ignored actually changes git's answer, not just the command we send.
+// TestCleanHonorsTouchLiveness verifies that a stale worktree (mtime older
+// than maxAge) is skipped by Clean when it was recently touched by Prepare,
+// so a long-running but idle task that Prepare is still associated with is
+// not wrongly force-removed.
+func TestCleanHonorsTouchLiveness(t *testing.T) {
+	tempDir := t.TempDir()
+	baseDir := filepath.Join(tempDir, "zero-worktrees")
+	repoRoot := filepath.Join(tempDir, "repo")
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+
+	touchedPath := filepath.Join(repoDir, "touched-task")
+	if err := os.MkdirAll(touchedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Age the worktree past maxAge so it would be pruned without the touch.
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(touchedPath, twoDaysAgo, twoDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+	plantOwnershipMarker(t, touchedPath)
+
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: repoRoot},
+			{Stdout: "worktree " + touchedPath + "\nlocked " + leaseReason(os.Getpid()) + "\n"},
+			{ExitCode: 0}, // worktree prune (no-op)
+		},
+	}
+
+	// Touch the directory now, simulating Prepare being called for this worktree.
+	if err := os.Chtimes(touchedPath, time.Now(), time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Clean(context.Background(), Options{BaseDir: baseDir, RunGit: runner.Run}, 24*time.Hour); err != nil {
+		t.Fatalf("Clean: %v", err)
+	}
+	// The worktree should still exist: Clean skipped it because it's locked
+	// with a live PID, and touching it refreshes mtime.
+	if _, err := os.Stat(touchedPath); err != nil {
+		t.Fatalf("worktree %s was incorrectly removed: %v", touchedPath, err)
+	}
+}
+
 func TestWorktreeIsDirtyCountsIgnoredFilesAsDirty(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")

--- a/internal/worktrees/worktrees_windows.go
+++ b/internal/worktrees/worktrees_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package worktrees
+
+import "golang.org/x/sys/windows"
+
+// osProcessAlive reports whether pid is a live process on Windows. It opens
+// the process for limited query access; a successful open with a
+// non-exited status means the PID is live. OpenProcess succeeding is not
+// enough on its own: a handle can remain valid briefly after the process it
+// named has exited, so GetExitCodeProcess must confirm STILL_ACTIVE before
+// treating the PID as live.
+func osProcessAlive(pid int) bool {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+	var code uint32
+	if err := windows.GetExitCodeProcess(handle, &code); err != nil {
+		// Could not query; treat the open as proof of life (conservative: do
+		// not reclaim a lock we are unsure about).
+		return true
+	}
+	const stillActive = 259 // STILL_ACTIVE
+	return code == stillActive
+}

--- a/internal/worktrees/worktrees_windows.go
+++ b/internal/worktrees/worktrees_windows.go
@@ -2,7 +2,11 @@
 
 package worktrees
 
-import "golang.org/x/sys/windows"
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
 
 // osProcessAlive reports whether pid is a live process on Windows. It opens
 // the process for limited query access; a successful open with a
@@ -13,7 +17,7 @@ import "golang.org/x/sys/windows"
 func osProcessAlive(pid int) bool {
 	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
-		return false
+		return openProcessErrorMeansAlive(err)
 	}
 	defer windows.CloseHandle(handle)
 	var code uint32
@@ -24,4 +28,14 @@ func osProcessAlive(pid int) bool {
 	}
 	const stillActive = 259 // STILL_ACTIVE
 	return code == stillActive
+}
+
+// openProcessErrorMeansAlive classifies an OpenProcess failure. Only
+// ERROR_ACCESS_DENIED means a process with this PID exists (owned by another
+// user, or protected by policy) but we lack rights to query it - fail closed
+// by treating that ambiguity as alive. Any other error (typically
+// ERROR_INVALID_PARAMETER, for a PID that names no running process) means the
+// PID genuinely does not exist.
+func openProcessErrorMeansAlive(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED)
 }

--- a/internal/worktrees/worktrees_windows_test.go
+++ b/internal/worktrees/worktrees_windows_test.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package worktrees
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestOpenProcessErrorMeansAliveOnAccessDenied(t *testing.T) {
+	if !openProcessErrorMeansAlive(windows.ERROR_ACCESS_DENIED) {
+		t.Fatal("ERROR_ACCESS_DENIED must be treated as alive: the PID could belong to a live process this caller lacks rights to query")
+	}
+}
+
+func TestOpenProcessErrorMeansAliveOnInvalidParameter(t *testing.T) {
+	if openProcessErrorMeansAlive(windows.ERROR_INVALID_PARAMETER) {
+		t.Fatal("ERROR_INVALID_PARAMETER means no such process; must be treated as dead")
+	}
+}
+
+func TestOsProcessAliveReportsLiveSelf(t *testing.T) {
+	if !osProcessAlive(os.Getpid()) {
+		t.Fatal("current process must report alive")
+	}
+}
+
+func TestOsProcessAliveReportsDeadAfterExit(t *testing.T) {
+	cmd := exec.Command("cmd", "/C", "exit", "0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait for child process: %v", err)
+	}
+	if osProcessAlive(pid) {
+		t.Fatal("exited process must not report alive")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two Medium-severity issues:

1. **Partial Redaction / Secret Leak on Longer or Appended Keys**:
   - The patterns for `github_token`, `aws_access_key_id`, and `google_api_key` were matching fixed lengths with no trailing boundary anchor. Slightly longer or appended keys would only have their prefix redacted, leaking the tail.
   - Adding a trailing word boundary anchor `\b` and allowing variable lengths (`{36,}` etc.) solves this.
   - Refined the `openai_key` pattern to cleanly distinguish legacy keys (`sk-` + 20+ alnum characters) and modern prefixed keys (`sk-proj-` / `sk-svcacct-`) from ordinary kebab-case phrases.

2. **Git Worktrees Disk Space Leak**:
   - Worktree directories created for detached tasks under `~/.local/state/zero/worktrees` accumulated indefinitely on the user's system, consuming substantial disk space.
   - Implemented `Clean` function which lists worktrees via `git worktree list --porcelain`, identifies zero-owned worktrees, and calls `git worktree remove --force` on those older than 24 hours.
   - Invoked `Clean` automatically at the start of `Prepare` in production.

## Changes

- Modified `internal/secrets/scanner.go` and `internal/secrets/scanner_test.go`.
- Modified `internal/worktrees/worktrees.go` and `internal/worktrees/worktrees_test.go`.

## Test plan

- `go test -race ./internal/secrets/... ./internal/worktrees/...` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `zero worktrees release <path>` and updated shell completions to include `release`.
  - `exec --worktree` now records and releases locks after the command finishes.
  - Added `--exec-profile` and `--no-completion-gate`; `zero --version` output adapts for TTY vs non-TTY.
- **Bug Fixes**
  - Strengthened secret detection/redaction to prevent tail leakage and improve matching for modern key variants and boundaries, including overlapping extra-secret handling.
  - Safer worktree cleanup: more precise stale/dirty/lock handling and contained pruning for zero-managed worktrees.
- **Tests**
  - Expanded coverage for secret redaction edge cases, worktree prepare/release/clean lifecycle, and CLI success/error/TTY behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->