### PR TITLE
fix(config): surface unknown/typo'd config fields instead of silently dropping them

### DIFF
--- a/internal/config/unknownfields.go
+++ b/internal/config/unknownfields.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 )
 
@@ -36,15 +37,24 @@ func collectUnknownFields(t reflect.Type, raw json.RawMessage, path string, allo
 		known := knownJSONFields(t)
 		allowSet := toSet(allow)
 		for key, val := range present {
-			if allowSet[key] {
+			// JSON key matching is case-insensitive, so compare against a
+			// lower-cased key. A differently-cased but valid key (e.g.
+			// "MaxTurns") is still parsed by json and must not be flagged.
+			low := strings.ToLower(key)
+			if allowSet[low] {
 				continue
 			}
-			if ft, ok := known[key]; ok {
-				collectUnknownFields(ft, val, joinPath(path, key), nil, issues)
+			if kf, ok := known[low]; ok {
+				// Alias keys (legacy snake_case forms accepted by a
+				// custom UnmarshalJSON) have no Go type to recurse into;
+				// they are leaves, so skip descent rather than panic.
+				if kf.typ != nil {
+					collectUnknownFields(kf.typ, val, joinPath(path, key), nil, issues)
+				}
 			} else {
 				*issues = append(*issues, Issue{
 					FieldPath: joinPath(path, key),
-					Message:   unknownFieldMessage(joinPath(path, key), key, keysOf(known)),
+					Message:   unknownFieldMessage(joinPath(path, key), key, canonicalKeys(known)),
 				})
 			}
 		}
@@ -67,13 +77,30 @@ func collectUnknownFields(t reflect.Type, raw json.RawMessage, path string, allo
 	}
 }
 
+// legacyJSONAliases lists JSON keys a struct's custom UnmarshalJSON
+// accepts in addition to its declared (camelCase) json tags. Such keys
+// are local fields inside the UnmarshalJSON raw struct, not on the Go
+// type, so the reflection scan would otherwise flag valid legacy configs
+// (e.g. base_url, api_key) as unknown. Keep this in sync with each
+// UnmarshalJSON's raw struct.
+var legacyJSONAliases = map[string][]string{
+	"config.ProviderProfile": {
+		"providerKind", "catalog_id", "base_url", "api_key", "api_key_env",
+		"api_key_stored", "api_format", "auth_header", "auth_scheme",
+		"auth_header_value", "custom_headers", "model_id", "parse_think_tags",
+	},
+}
+
 // knownJSONFields returns the JSON field names of a struct (and their Go
-// types, for recursion) by reading each field's json tag. Fields without a
-// json tag (unexported helpers such as *Set markers) are omitted: they never
-// appear in serialized config and must not be treated as valid keys.
-func knownJSONFields(t reflect.Type) map[string]reflect.Type {
+// types, for recursion) by reading each field's json tag. JSON key
+// matching is case-insensitive, so keys are stored lower-cased and
+// compared lower-cased; canonical preserves the documented casing for
+// the "did you mean" hint. Fields without a json tag (unexported
+// helpers such as *Set markers) are omitted: they never appear in
+// serialized config and must not be treated as valid keys.
+func knownJSONFields(t reflect.Type) map[string]knownField {
 	t = derefType(t)
-	out := make(map[string]reflect.Type, t.NumField())
+	out := make(map[string]knownField, t.NumField())
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		tag := f.Tag.Get("json")
@@ -84,9 +111,23 @@ func knownJSONFields(t reflect.Type) map[string]reflect.Type {
 		if name == "" {
 			continue
 		}
-		out[name] = f.Type
+		low := strings.ToLower(name)
+		out[low] = knownField{canonical: name, typ: f.Type}
+	}
+	for _, alias := range legacyJSONAliases[t.String()] {
+		// No Go type to recurse into: legacy aliases are leaf fields.
+		// canonical preserves the documented casing for the hint.
+		out[strings.ToLower(alias)] = knownField{canonical: alias}
 	}
 	return out
+}
+
+// knownField is one entry of the known-key set: canonical is the
+// documented (correct-case) JSON name, typ is the Go field type used
+// for recursion (nil for leaf/alias keys).
+type knownField struct {
+	canonical string
+	typ       reflect.Type
 }
 
 func derefType(t reflect.Type) reflect.Type {
@@ -106,15 +147,16 @@ func joinPath(path, key string) string {
 func toSet(items []string) map[string]bool {
 	s := make(map[string]bool, len(items))
 	for _, it := range items {
-		s[it] = true
+		// JSON key matching is case-insensitive.
+		s[strings.ToLower(it)] = true
 	}
 	return s
 }
 
-func keysOf(m map[string]reflect.Type) []string {
+func canonicalKeys(m map[string]knownField) []string {
 	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
+	for _, kf := range m {
+		out = append(out, kf.canonical)
 	}
 	return out
 }
@@ -136,6 +178,9 @@ func suggestPath(fullPath, suggestedLeaf string) string {
 }
 
 func nearestKey(key string, candidates []string) string {
+	// Sort so map-range nondeterminism cannot change which candidate
+	// wins a distance tie: the lexically-first winner is stable.
+	sort.Strings(candidates)
 	best := ""
 	bestDist := -1
 	for _, c := range candidates {

--- a/internal/config/unknownfields.go
+++ b/internal/config/unknownfields.go
@@ -1,0 +1,190 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// unknownFieldIssues scans data for JSON object keys that do not correspond to
+// any known config field, recursing into nested objects, arrays, and maps so
+// that typos such as "maxTurn" or "sandbox.network" are surfaced with
+// their full path instead of being silently dropped by json.Unmarshal.
+//
+// The two legacy top-level aliases (mcpServers, mcp_servers) are explicitly
+// allowed because FileConfig.UnmarshalJSON still reads them; nothing else is
+// grandfathered, so a typo in a current or future field name is reported.
+// Detection only inspects the documented JSON schema (struct json tags), so a
+// config written by a newer Zero that carries genuinely new fields is still
+// loaded and merged normally — only validate/doctor call this, and they
+// surface the unknown keys as issues rather than rejecting the file.
+func unknownFieldIssues(data []byte) []Issue {
+	var issues []Issue
+	collectUnknownFields(reflect.TypeOf(FileConfig{}), data, "", []string{"mcpServers", "mcp_servers"}, &issues)
+	return issues
+}
+
+func collectUnknownFields(t reflect.Type, raw json.RawMessage, path string, allow []string, issues *[]Issue) {
+	t = derefType(t)
+	switch t.Kind() {
+	case reflect.Struct:
+		var present map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &present); err != nil {
+			return
+		}
+		known := knownJSONFields(t)
+		allowSet := toSet(allow)
+		for key, val := range present {
+			if allowSet[key] {
+				continue
+			}
+			if ft, ok := known[key]; ok {
+				collectUnknownFields(ft, val, joinPath(path, key), nil, issues)
+			} else {
+				*issues = append(*issues, Issue{
+					FieldPath: joinPath(path, key),
+					Message:   unknownFieldMessage(joinPath(path, key), key, keysOf(known)),
+				})
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		var elems []json.RawMessage
+		if err := json.Unmarshal(raw, &elems); err != nil {
+			return
+		}
+		for i, el := range elems {
+			collectUnknownFields(t.Elem(), el, fmt.Sprintf("%s[%d]", path, i), nil, issues)
+		}
+	case reflect.Map:
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return
+		}
+		for k, v := range m {
+			collectUnknownFields(t.Elem(), v, joinPath(path, k), nil, issues)
+		}
+	}
+}
+
+// knownJSONFields returns the JSON field names of a struct (and their Go
+// types, for recursion) by reading each field's json tag. Fields without a
+// json tag (unexported helpers such as *Set markers) are omitted: they never
+// appear in serialized config and must not be treated as valid keys.
+func knownJSONFields(t reflect.Type) map[string]reflect.Type {
+	t = derefType(t)
+	out := make(map[string]reflect.Type, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "" {
+			continue
+		}
+		out[name] = f.Type
+	}
+	return out
+}
+
+func derefType(t reflect.Type) reflect.Type {
+	for t != nil && t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+func joinPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+func toSet(items []string) map[string]bool {
+	s := make(map[string]bool, len(items))
+	for _, it := range items {
+		s[it] = true
+	}
+	return s
+}
+
+func keysOf(m map[string]reflect.Type) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func unknownFieldMessage(fullPath, key string, candidates []string) string {
+	if near := nearestKey(key, candidates); near != "" {
+		return fmt.Sprintf("unknown config field %q; did you mean %q?", fullPath, suggestPath(fullPath, near))
+	}
+	return fmt.Sprintf("unknown config field %q", fullPath)
+}
+
+// suggestPath rewrites only the leaf of fullPath with the suggested key so the
+// hint reads "sandbox.network" rather than just "network".
+func suggestPath(fullPath, suggestedLeaf string) string {
+	if i := strings.LastIndex(fullPath, "."); i >= 0 {
+		return fullPath[:i+1] + suggestedLeaf
+	}
+	return suggestedLeaf
+}
+
+func nearestKey(key string, candidates []string) string {
+	best := ""
+	bestDist := -1
+	for _, c := range candidates {
+		d := editDistance(key, c)
+		if bestDist == -1 || d < bestDist {
+			bestDist = d
+			best = c
+		}
+	}
+	if bestDist >= 0 && bestDist <= 2 && bestDist < len(key) {
+		return best
+	}
+	return ""
+}
+
+func editDistance(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		cur := make([]int, lb+1)
+		cur[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			cur[j] = min3(cur[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev = cur
+	}
+	return prev[lb]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -31,6 +31,7 @@ func ValidateFile(path string) (FileConfig, []Issue) {
 	}
 
 	issues := validateSemantics(cfg)
+	issues = append(issues, unknownFieldIssues(data)...)
 	return cfg, issues
 }
 
@@ -46,6 +47,7 @@ func ValidateBytes(data []byte) (FileConfig, []Issue) {
 		return FileConfig{}, []Issue{{Message: fmt.Errorf("invalid config JSON: %w", err).Error()}}
 	}
 	issues := validateSemantics(cfg)
+	issues = append(issues, unknownFieldIssues(data)...)
 	return cfg, issues
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -136,9 +136,15 @@ func TestValidateFileFlagsUnknownTopLevelKey(t *testing.T) {
 	if len(issues) == 0 {
 		t.Fatalf("expected unknown-field issue for top-level typo, got none")
 	}
-	got := issues[0]
-	if got.FieldPath != "maxTurn" {
-		t.Fatalf("FieldPath = %q, want %q", got.FieldPath, "maxTurn")
+	var got Issue
+	found := false
+	for _, issue := range issues {
+		if issue.FieldPath == "maxTurn" {
+			got, found = issue, true
+		}
+	}
+	if !found {
+		t.Fatalf("expected unknown-field issue at maxTurn, got %#v", issues)
 	}
 	if !strings.Contains(got.Message, `did you mean "maxTurns"`) {
 		t.Fatalf("expected near-match suggestion, got %q", got.Message)
@@ -210,6 +216,46 @@ func TestValidateFileAllowsLegacyAliases(t *testing.T) {
 	for _, issue := range issues {
 		if strings.Contains(issue.FieldPath, "mcpServers") {
 			t.Fatalf("legacy alias mcpServers reported as unknown: %#v", issues)
+		}
+	}
+}
+
+func TestValidateFileAllowsCaseVariantKey(t *testing.T) {
+	// encoding/json matches object keys case-insensitively, so "MaxTurns"
+	// parses into MaxTurns. The scanner compares lower-cased keys,
+	// so a valid case variant must not be flagged as unknown.
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "model": "gpt-4.1"}
+		],
+		"MaxTurns": 1
+	}`)
+
+	_, issues := ValidateFile(path)
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, "unknown config field") {
+			t.Fatalf("valid case-variant key flagged as unknown: %#v", issues)
+		}
+	}
+}
+
+func TestValidateFileAllowsLegacyProviderKeys(t *testing.T) {
+	// ProviderProfile.UnmarshalJSON accepts snake_case legacy keys
+	// (base_url, api_key, providerKind, ...). These are valid and
+	// must not be flagged as unknown — only the canonical camelCase
+	// tags are visible to the reflection scan, so they are allowlisted.
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "providerKind": "openai", "base_url": "https://example.test/v1", "api_key": "sk-x", "model": "gpt-4.1"}
+		]
+	}`)
+
+	_, issues := ValidateFile(path)
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, "unknown config field") {
+			t.Fatalf("legacy provider key reported as unknown: %#v", issues)
 		}
 	}
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -122,3 +122,94 @@ func TestValidateFileValidConfigHasNoIssues(t *testing.T) {
 		t.Fatalf("expected no issues for valid config, got %#v", issues)
 	}
 }
+
+func TestValidateFileFlagsUnknownTopLevelKey(t *testing.T) {
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "model": "gpt-4.1"}
+		],
+		"maxTurn": 1
+	}`)
+
+	_, issues := ValidateFile(path)
+	if len(issues) == 0 {
+		t.Fatalf("expected unknown-field issue for top-level typo, got none")
+	}
+	got := issues[0]
+	if got.FieldPath != "maxTurn" {
+		t.Fatalf("FieldPath = %q, want %q", got.FieldPath, "maxTurn")
+	}
+	if !strings.Contains(got.Message, `did you mean "maxTurns"`) {
+		t.Fatalf("expected near-match suggestion, got %q", got.Message)
+	}
+}
+
+func TestValidateFileFlagsUnknownNestedKey(t *testing.T) {
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "model": "gpt-4.1"}
+		],
+		"sandbox": {
+			"network": "allow",
+			"blockUnixSocket": true
+		}
+	}`)
+
+	_, issues := ValidateFile(path)
+	var got Issue
+	found := false
+	for _, issue := range issues {
+		if issue.FieldPath == "sandbox.blockUnixSocket" {
+			got, found = issue, true
+		}
+	}
+	if !found {
+		t.Fatalf("expected nested unknown-field issue at sandbox.blockUnixSocket, got %#v", issues)
+	}
+	if !strings.Contains(got.Message, `did you mean "sandbox.blockUnixSockets"`) {
+		t.Fatalf("expected near-match suggestion, got %q", got.Message)
+	}
+}
+
+func TestValidateFileFlagsUnknownInProvider(t *testing.T) {
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "model": "gpt-4.1", "endpoint": "https://example.test/v1"}
+		]
+	}`)
+
+	_, issues := ValidateFile(path)
+	var found bool
+	for _, issue := range issues {
+		if issue.FieldPath == "providers[0].endpoint" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected unknown-field issue for providers[0].endpoint, got %#v", issues)
+	}
+}
+
+func TestValidateFileAllowsLegacyAliases(t *testing.T) {
+	// The legacy mcpServers / mcp_servers aliases are still read by
+	// FileConfig.UnmarshalJSON and must not be reported as unknown.
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "model": "gpt-4.1"}
+		],
+		"mcpServers": {
+			"docs": {"type": "stdio", "command": "docs-mcp"}
+		}
+	}`)
+
+	_, issues := ValidateFile(path)
+	for _, issue := range issues {
+		if strings.Contains(issue.FieldPath, "mcpServers") {
+			t.Fatalf("legacy alias mcpServers reported as unknown: %#v", issues)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #644: unknown/typo'd keys in `config.json` were silently discarded by `json.Unmarshal`, and `zero doctor` reported "config files parsed and validated successfully" even when fields were dropped.

Examples that previously went unnoticed:
- `maxTurn` (should be `maxTurns`)
- `sandbox.network` (should be `sandbox.network`, an actual hardening knob)
- `sandbox.blockUnixSocket` inside a provider entry

## What changed

- Added a reflection-based unknown-field scanner (`internal/config/unknownfields.go`) that walks the `FileConfig` JSON schema and recurses into nested objects, arrays, and maps, reporting each unknown key with its full JSON path and a near-match suggestion (`did you mean "maxTurns"?`).
- The two legacy top-level aliases (`mcpServers`, `mcp_servers`) are allowlisted so they are not flagged.
- Detection only inspects json tags, so a config written by a newer Zero with new fields still loads and merges normally — `validate`/`doctor` just surface the unknown keys as issues rather than rejecting the file (preserves forward compatibility).
- Wired into `ValidateBytes`/`ValidateFile`, which `zero doctor` already calls, so `doctor` now reports the unknown fields instead of "validation passed".

## Test plan

- `TestValidateFileFlagsUnknownTopLevelKey` — `maxTurn` → suggests `maxTurns`
- `TestValidateFileFlagsUnknownNestedKey` — `sandbox.blockUnixSocket` → suggests `sandbox.blockUnixSockets`
- `TestValidateFileFlagsUnknownInProvider` — unknown key inside a provider entry
- `TestValidateFileAllowsLegacyAliases` — `mcpServers`/`mcp_servers` not flagged
- `TestValidateFileValidConfigHasNoIssues` still passes (valid configs produce no issues)
- Full `internal/config` and `internal/doctor` suites pass; `go vet` clean.

## Note
Per CONTRIBUTING.md, PRs require the `issue-approved` label. Please apply it so the merge CI passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now flags unknown JSON keys recursively across nested objects, arrays, and provider entries.
  * Validation issues report the full dotted/bracketed field path and may include “did you mean …?” suggestions for likely misspellings.
  * Known keys are matched case-insensitively, and legacy alias keys (including `mcpServers` / `mcp_servers` and snake_case provider variants) are accepted without warnings.
* **Tests**
  * Added regression coverage for unknown top-level, nested, and provider keys, plus alias and case-variant allowance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->