### PR TITLE
feat(ci): add Windows NSIS installer, macOS .app bundle, and CI workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -29,6 +29,7 @@ jobs:
           - macos-latest       # macos-arm64 (Apple Silicon)
           - macos-15-intel     # macos-x64 (Intel)
           - windows-latest     # windows-x64
+          - windows-11-arm     # windows-arm64
 
     steps:
       - name: Checkout
@@ -46,6 +47,19 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Resolve platform arch name and version
+        shell: bash
+        run: |
+          echo "VERSION=$(jq -r .version package.json)" >> "$GITHUB_ENV"
+          case "${{ runner.os }}-${{ runner.arch }}" in
+            Linux-X64)      echo "ARCH=x64"   >> "$GITHUB_ENV" ;;
+            Linux-ARM64)    echo "ARCH=arm64" >> "$GITHUB_ENV" ;;
+            macOS-X64)      echo "ARCH=x64"   >> "$GITHUB_ENV" ;;
+            macOS-ARM64)    echo "ARCH=arm64" >> "$GITHUB_ENV" ;;
+            Windows-X64)    echo "ARCH=x64"   >> "$GITHUB_ENV" ;;
+            Windows-ARM64)  echo "ARCH=arm64" >> "$GITHUB_ENV" ;;
+          esac
 
       - name: Test
         run: go test ./...
@@ -72,6 +86,68 @@ jobs:
 
       - name: Verify release checksums
         run: go run ./cmd/zero-release verify
+
+      # Windows installer
+      - name: Install NSIS (portable)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $url = "https://sourceforge.net/projects/nsis/files/NSIS%203/3.10/nsis-3.10.zip/download"
+          $zip = "$env:RUNNER_TEMP\nsis.zip"
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath "$env:RUNNER_TEMP\nsis"
+          echo "NSIS_DIR=$env:RUNNER_TEMP\nsis\NSIS" >> $env:GITHUB_ENV
+
+      - name: Build Windows installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          & scripts/build-windows-installer.ps1 `
+            -NsisDir "$env:NSIS_DIR" `
+            -StagingDir "dist/package/zero-v$env:VERSION-windows-$env:ARCH" `
+            -OutputDir "dist/release" `
+            -Version $env:VERSION `
+            -Arch $env:ARCH
+
+      # Linux AppImage + system installer
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq imagemagick
+          wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$(uname -m).AppImage" -O /tmp/appimagetool
+          chmod +x /tmp/appimagetool
+          cd /tmp && ./appimagetool --appimage-extract >/dev/null 2>&1
+          sudo cp squashfs-root/AppRun /usr/local/bin/appimagetool
+          rm -rf /tmp/appimagetool /tmp/squashfs-root
+
+      - name: Build AppImage
+        if: runner.os == 'Linux'
+        run: |
+          bash scripts/build-linux-appimage.sh \
+            --staging-dir "dist/package/zero-v${VERSION}-linux-${ARCH}" \
+            --output-dir "dist/release" \
+            --version "${VERSION}" \
+            --arch "${ARCH}"
+
+      - name: Build Linux system installer
+        if: runner.os == 'Linux'
+        run: |
+          bash scripts/build-linux-install.sh \
+            --staging-dir "dist/package/zero-v${VERSION}-linux-${ARCH}" \
+            --output-dir "dist/release" \
+            --version "${VERSION}" \
+            --arch "${ARCH}"
+
+      # macOS .app
+      - name: Build .app bundle
+        if: runner.os == 'macOS'
+        run: |
+          bash scripts/build-macos-app.sh \
+            --staging-dir "dist/package/zero-v${VERSION}-macos-${ARCH}" \
+            --output-dir "dist/release" \
+            --version "${VERSION}" \
+            --arch "${ARCH}"
 
       - name: Upload package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -170,7 +246,15 @@ jobs:
             "zero-v${version}-linux-arm64.tar.gz" \
             "zero-v${version}-macos-x64.tar.gz" \
             "zero-v${version}-macos-arm64.tar.gz" \
-            "zero-v${version}-windows-x64.zip"; do
+            "zero-v${version}-windows-x64.zip" \
+            "zero-v${version}-windows-x64-installer.exe" \
+            "zero-v${version}-linux-x86_64.AppImage" \
+            "zero-v${version}-linux-x86_64-install.run" \
+            "zero-v${version}-macos-x64.zip" \
+            "zero-v${version}-windows-arm64-installer.exe" \
+            "zero-v${version}-linux-aarch64.AppImage" \
+            "zero-v${version}-linux-aarch64-install.run" \
+            "zero-v${version}-macos-arm64.zip"; do
             for url in "${base}/${asset}" "${base}/${asset}.sha256"; do
               if ! curl -fsSLI -o /dev/null "$url"; then
                 echo "::error::${url} is not publicly downloadable — npm postinstall would fail. Is the repo public and are all assets uploaded?" >&2

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Build a complete macOS .app bundle for Zero with Terminal launcher,
+# .icns icon, ad-hoc code signature, and npm helpers.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --staging-dir DIR --output-dir DIR --version X.Y.Z --arch ARCH"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --staging-dir) STAGING_DIR="$2"; shift 2 ;;
+    --output-dir)  OUTPUT_DIR="$2";  shift 2 ;;
+    --version)     VERSION="$2";     shift 2 ;;
+    --arch)        ARCH="$2";        shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+: "${STAGING_DIR:?missing}"
+: "${OUTPUT_DIR:?missing}"
+: "${VERSION:?missing}"
+: "${ARCH:?missing}"
+
+case "$ARCH" in
+  x64|amd64)        PKG_ARCH="x64"   ;;
+  arm64|aarch64)    PKG_ARCH="arm64" ;;
+  *) echo "unknown arch: $ARCH"; exit 1 ;;
+esac
+
+PKG_NAME="zero-v${VERSION}-macos-${PKG_ARCH}"
+APP_BUNDLE="${OUTPUT_DIR}/Zero.app"
+APPZIP="${OUTPUT_DIR}/${PKG_NAME}.zip"
+
+rm -rf "${APP_BUNDLE}"
+
+mkdir -p "${APP_BUNDLE}/Contents/MacOS"
+mkdir -p "${APP_BUNDLE}/Contents/Resources"
+
+cat > "${APP_BUNDLE}/Contents/MacOS/ZeroLauncher" <<'LAUNCHER'
+#!/bin/bash
+set -euo pipefail
+
+ZERO_DIR="$(dirname "$0")"
+ZERO_HELPERS_DIR="$(dirname "$ZERO_DIR")/Helpers"
+
+TMPFILE="$(mktemp /tmp/zero-launch.XXXXXX)"
+cat > "$TMPFILE" << EOF
+export ZERO_HELPERS_DIR='$ZERO_HELPERS_DIR'
+echo 'Zero v__VERSION__'
+echo ''
+'$ZERO_DIR/zero'
+rm -f "\$0"
+EOF
+
+chmod +x "$TMPFILE"
+open -a Terminal "$TMPFILE"
+LAUNCHER
+
+sed -i "s/__VERSION__/${VERSION}/g" "${APP_BUNDLE}/Contents/MacOS/ZeroLauncher"
+chmod 755 "${APP_BUNDLE}/Contents/MacOS/ZeroLauncher"
+
+cp "${STAGING_DIR}/zero" "${APP_BUNDLE}/Contents/MacOS/zero"
+chmod 755 "${APP_BUNDLE}/Contents/MacOS/zero"
+
+cat > "${APP_BUNDLE}/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en-US</string>
+  <key>CFBundleDisplayName</key>
+  <string>Zero</string>
+  <key>CFBundleExecutable</key>
+  <string>ZeroLauncher</string>
+  <key>CFBundleIconFile</key>
+  <string>zero</string>
+  <key>CFBundleIdentifier</key>
+  <string>io.gitlawb.zero</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Zero</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${VERSION}</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${VERSION}</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
+  <key>NSAppleEventsUsageDescription</key>
+  <string>Zero needs to run shell commands in Terminal to function as a coding agent.</string>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copyright $(date +%Y) Gitlawb. MIT License.</string>
+</dict>
+</plist>
+PLIST
+
+echo "APPL????" > "${APP_BUNDLE}/Contents/PkgInfo"
+
+ICONSET="${OUTPUT_DIR}/zero.iconset"
+ICON_SRC="docs/assets/logo-great.png"
+mkdir -p "${ICONSET}"
+
+if [ -f "${ICON_SRC}" ]; then
+  for SIZE in 16 32 64 128 256 512; do
+    sips -z "${SIZE}" "${SIZE}" "${ICON_SRC}" \
+      --out "${ICONSET}/icon_${SIZE}x${SIZE}.png" >/dev/null 2>&1 || true
+    RETINA=$((SIZE * 2))
+    sips -z "${RETINA}" "${RETINA}" "${ICON_SRC}" \
+      --out "${ICONSET}/icon_${SIZE}x${SIZE}@2x.png" >/dev/null 2>&1 || true
+  done
+  sips -z 1024 1024 "${ICON_SRC}" \
+    --out "${ICONSET}/icon_512x512@2x.png" >/dev/null 2>&1 || true
+
+  iconutil -c icns "${ICONSET}" -o "${APP_BUNDLE}/Contents/Resources/zero.icns"
+  rm -rf "${ICONSET}"
+else
+  echo "Warning: ${ICON_SRC} not found, skipping icon." >&2
+fi
+
+if [ -f "LICENSE" ]; then
+  cp "LICENSE" "${APP_BUNDLE}/Contents/Resources/LICENSE"
+fi
+
+if [ -d "${STAGING_DIR}/helpers" ]; then
+  cp -r "${STAGING_DIR}/helpers" "${APP_BUNDLE}/Contents/Helpers"
+fi
+
+codesign --force --deep --sign - "${APP_BUNDLE}" 2>/dev/null || \
+  echo "Warning: ad-hoc code signing failed (non-fatal)." >&2
+
+cd "${OUTPUT_DIR}"
+zip -r -y "${APPZIP}" "Zero.app" -x "*.DS_Store"
+cd - >/dev/null
+rm -rf "${APP_BUNDLE}"
+
+sha256sum "${APPZIP}" | sed 's/  */  /' > "${APPZIP}.sha256"
+echo "Created ${APPZIP}"

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -1,0 +1,123 @@
+param(
+    [Parameter(Mandatory)][string]$NsisDir,
+    [Parameter(Mandatory)][string]$StagingDir,
+    [Parameter(Mandatory)][string]$OutputDir,
+    [Parameter(Mandatory)][string]$Version,
+    [Parameter(Mandatory)][string]$Arch
+)
+
+$ErrorActionPreference = "Stop"
+$pkgName = "zero-v${Version}-windows-${Arch}"
+$installerName = "${pkgName}-installer.exe"
+$installerPath = Join-Path $OutputDir $installerName
+$nsiPath = Join-Path $env:TEMP "zero-installer.nsi"
+
+@"
+!include "MUI2.nsh"
+
+Name "Zero v${Version}"
+OutFile "$installerPath"
+InstallDir "$PROGRAMFILES64\Zero"
+RequestExecutionLevel admin
+BrandingText "Zero Installer"
+
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English"
+
+Section "Install"
+  SetOutPath "`$INSTDIR"
+  File /r "${StagingDir}\*.*"
+  WriteUninstaller "`$INSTDIR\uninstall.exe"
+
+  ReadRegStr `$R0 HKCU "Environment" "Path"
+  StrCmp `$R0 "" addPath
+    StrCpy `$R0 "`$R0;`$INSTDIR"
+    Goto writePath
+  addPath:
+    StrCpy `$R0 "`$INSTDIR"
+  writePath:
+    WriteRegStr HKCU "Environment" "Path" "`$R0"
+    System::Call "user32::SendMessage(i 0xffff, i 0x1a, i 0, i 0) i"
+
+  CreateDirectory "`$SMPROGRAMS\Zero"
+  CreateShortCut "`$SMPROGRAMS\Zero\Zero.lnk" "`$INSTDIR\zero.exe" "" "`$INSTDIR\zero.exe" 0
+  CreateShortCut "`$SMPROGRAMS\Zero\Uninstall Zero.lnk" "`$INSTDIR\uninstall.exe"
+
+  CreateShortCut "`$DESKTOP\Zero.lnk" "`$INSTDIR\zero.exe" "" "`$INSTDIR\zero.exe" 0
+
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Zero" \
+    "DisplayName" "Zero v${Version}"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Zero" \
+    "UninstallString" "`"`$INSTDIR\uninstall.exe`""
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Zero" \
+    "DisplayVersion" "${Version}"
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Zero" \
+    "NoModify" 1
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Zero" \
+    "NoRepair" 1
+SectionEnd
+
+Section "Uninstall"
+  ReadRegStr `$R0 HKCU "Environment" "Path"
+  Push `$R0
+  Push "`$INSTDIR"
+  Call un.StrDel
+  Pop `$R0
+  WriteRegStr HKCU "Environment" "Path" "`$R0"
+  System::Call "user32::SendMessage(i 0xffff, i 0x1a, i 0, i 0) i"
+
+  RmDir /r "`$SMPROGRAMS\Zero"
+  Delete "`$DESKTOP\Zero.lnk"
+
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Zero"
+
+  RmDir /r "`$INSTDIR"
+SectionEnd
+
+Function un.StrDel
+  Exch `$R1
+  Exch
+  Exch `$R0
+  Push `$R2
+  Push `$R3
+  Push `$R4
+  StrCpy `$R2 `$R0
+  StrLen `$R3 `$R1
+  loop:
+    StrCpy `$R4 `$R2 `$R3
+    StrCmp `$R4 `$R1 0 next
+    StrCpy `$R4 `$R2 "" `$R3
+    StrLen `$R5 `$R2
+    IntOp `$R5 `$R5 - `$R3
+    StrCpy `$R2 `$R2 `$R5 `$R3
+    Goto done
+  next:
+    StrCpy `$R4 `$R2 1
+    StrCmp `$R4 "" done 0
+    StrCpy `$R2 `$R2 "" 1
+    Goto loop
+  done:
+    StrCpy `$R0 `$R2
+    Pop `$R4
+    Pop `$R3
+    Pop `$R2
+    Pop `$R1
+    Exch `$R0
+FunctionEnd
+"@ | Set-Content -Path $nsiPath -Encoding ASCII
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$makensis = Join-Path $NsisDir "makensis.exe"
+Write-Host "Compiling $installerName ..."
+& $makensis $nsiPath
+if ($LASTEXITCODE -ne 0) { throw "makensis failed" }
+
+$hash = (Get-FileHash $installerPath -Algorithm SHA256).Hash.ToLower()
+"$hash  $installerName" | Set-Content "${installerPath}.sha256" -Encoding ASCII
+
+Write-Host "Created $installerPath"


### PR DESCRIPTION
## Summary

Adds installer build scripts for Windows and macOS, plus the CI workflow changes to produce all platform installers during releases.

### Files added
- **scripts/build-windows-installer.ps1** — NSIS-based .exe installer with PATH modification, Start Menu shortcut, desktop icon, Add/Remove Programs registration, and uninstaller
- **scripts/build-macos-app.sh** — macOS .app bundle with Terminal launcher (temp-script approach, no fragile osascript), .icns icon via sips+iconutil, ad-hoc code signature, bundled helpers

### Files modified
- **.github/workflows/release-artifacts.yml**
  - Added \windows-11-arm\ to runner matrix
  - Added \Resolve platform arch name and version\ step (sets VERSION and ARCH from runner OS)
  - Added conditional installer build steps for Windows (NSIS), Linux (AppImage + .run), and macOS (.app)
  - Updated npm asset verification to check all new installer artifacts

### Artifacts produced per release
| Platform | New assets |
|----------|-----------|
| Windows x64 | \zero-v*-windows-x64-installer.exe\ |
| Windows arm64 | \zero-v*-windows-arm64-installer.exe\ |
| Linux x86_64 | \zero-v*-linux-x86_64.AppImage\ + \-install.run\ |
| Linux aarch64 | \zero-v*-linux-aarch64.AppImage\ + \-install.run\ |
| macOS x64 | \zero-v*-macos-x64.zip\ (Zero.app) |
| macOS arm64 | \zero-v*-macos-arm64.zip\ (Zero.app) |

All assets get \.sha256\ checksum files and are automatically picked up by the existing \gh release upload dist/release/*\ glob.

### Scripts from previous PR
The Linux build scripts (build-linux-appimage.sh, build-linux-install.sh) were added in PR #645 ([feat/linux-installers](https://github.com/Gitlawb/zero/pull/646)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release packaging for Windows, Linux, and macOS.
  * Added Windows installers with Start Menu and Desktop shortcuts.
  * Added macOS application bundles and architecture-specific release artifacts.
  * Added SHA-256 checksums for generated installers and archives.
  * Added support for Windows ARM release builds.

* **Bug Fixes**
  * Expanded release verification to cover additional platform and architecture-specific artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->