### PR TITLE
fix(agent): raise default and deep-mode turn budgets

### DIFF
--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -345,8 +345,8 @@ func TestRunExecModeSeedsModelAndTurnOverrides(t *testing.T) {
 	if gotModel != "claude-opus-4.1" {
 		t.Fatalf("overrides.Provider.Model = %q, want claude-opus-4.1", gotModel)
 	}
-	if gotMaxTurns != 50 {
-		t.Fatalf("overrides.MaxTurns = %d, want 50", gotMaxTurns)
+	if gotMaxTurns != 160 {
+		t.Fatalf("overrides.MaxTurns = %d, want 160 (deep mode)", gotMaxTurns)
 	}
 }
 

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -42,8 +42,10 @@ func (e *setupFixableError) Unwrap() []error { return []error{e.err, e.sentinel}
 
 // defaultMaxTurns is the per-run tool-turn budget when none is configured. 30 was
 // too low for real multi-step agentic work (agents ran out mid-task before reaching
-// later steps); 50 matches the old "deep" preset. Raise per-session with /turns.
-const defaultMaxTurns = 50
+// later steps); 50 was still too low for larger tasks spanning several files (agents
+// hit the ceiling and stopped with a "remaining work" summary instead of finishing).
+// Raise per-session with /turns.
+const defaultMaxTurns = 80
 
 // MaxTurnsCeiling caps the per-run tool-turn budget so a stray env value or typo
 // can't set an absurd ceiling. Shared between applyEnv (read site) and the /turns

--- a/internal/modelregistry/modes.go
+++ b/internal/modelregistry/modes.go
@@ -39,7 +39,7 @@ var defaultModes = []Mode{
 		Description: "Hardest tasks: deep reasoning with a larger turn budget.",
 		Model:       "claude-opus-4.1",
 		Effort:      ReasoningEffortHigh,
-		MaxTurns:    50,
+		MaxTurns:    160,
 	},
 	{
 		Name:        "fast",


### PR DESCRIPTION
## Problem

The default per-run tool-turn budget was 50. For larger multi-step tasks that span several files, agents hit the ceiling and stopped mid-task, returning a "remaining work" summary (via the max-turns final-answer prompt) instead of finishing the job. A user hit exactly this on a multi-file feature (cloud sync, WebSocket bridge, QR pairing, PWA endpoint logic, verification): the agent reported "ran out of turns" with a checklist of unfinished items.

Separately, the `deep` preset also carried `MaxTurns: 50`, identical to the default. Its description promises "a larger turn budget," but on the turn-budget axis it was no different from a normal run.

## Fix

- `defaultMaxTurns`: 50 to 80 (`internal/config/resolver.go`). This is the budget most runs use, including the interactive TUI and plain `zero exec`, so it is the change that addresses the reported case.
- `deep` preset `MaxTurns`: 50 to 160 (`internal/modelregistry/modes.go`), so `deep` is a genuine 2x the default again.

Both remain overridable per-session with `/turns` or `--max-turns`, still bounded by `MaxTurnsCeiling` (500). Precedence is unchanged: an explicit `--max-turns` still wins over a mode preset.

## Testing

- `go build ./...`
- `go test ./internal/config/... ./internal/modelregistry/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased the default tool-turn budget per run from 50 to 80.
  * Increased the maximum turns available in the deep mode from 50 to 160.
  * You can still adjust the per-session turn limit using `/turns`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->