### PR TITLE
feat(aimlapi): AI/ML API provider with guided onboarding (top-up + key issuance)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 /zero
 /zero.exe
-/zero.exe~
 /zero-windows-command-runner.exe
 /zero-windows-sandbox-setup.exe
 /zero-skills

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 /zero
 /zero.exe
+/zero.exe~
 /zero-windows-command-runner.exe
 /zero-windows-sandbox-setup.exe
 /zero-skills

--- a/internal/aimlapi/client.go
+++ b/internal/aimlapi/client.go
@@ -75,6 +75,22 @@ type ExchangeResult struct {
 	APIKeyID string `json:"apiKeyId"`
 }
 
+// TopUpByKeyRequest funds a partner-checkout session with the API key that owns
+// the account (Path A / env key), instead of an email session.
+type TopUpByKeyRequest struct {
+	SessionToken     string
+	AmountUSDMinor   int
+	PaymentSessionID string // idempotency: same id → same checkout, never a second charge
+	AutoTopUp        bool   // enroll the account in automatic top-up at checkout (card, saved off-session)
+	SuccessURL       string
+	CancelURL        string
+}
+
+// TopUpByKeyResult is the hosted checkout returned by TopUpByKey.
+type TopUpByKeyResult struct {
+	Checkout PaymentSession `json:"checkout"`
+}
+
 // APIError is a non-2xx HTTP response from the aimlapi.com API. Status carries the
 // code so callers can branch (e.g. 401 = bad key, 5xx = retryable).
 type APIError struct {
@@ -156,6 +172,41 @@ func (c *Client) Exchange(ctx context.Context, bearer string, sessionToken strin
 	var result ExchangeResult
 	err := c.request(ctx, http.MethodPost, strings.TrimRight(c.endpoints.AppBaseURL, "/")+"/v3/partner-checkout/sessions/"+urlPathEscape(sessionToken)+"/exchange", bearer, nil, &result)
 	return result, err
+}
+
+// TopUpByKey funds a partner-checkout session using the raw API key that owns the
+// account (Path A / env key), returning the hosted checkout. It binds the session
+// to the key's account server-side, so no email session is needed and no key is
+// exchanged. req.PaymentSessionID makes a retry idempotent (same id → same
+// checkout, never a second charge).
+func (c *Client) TopUpByKey(ctx context.Context, apiKey string, req TopUpByKeyRequest) (TopUpByKeyResult, error) {
+	body := map[string]any{
+		"sessionToken":     req.SessionToken,
+		"amountUsdMinor":   req.AmountUSDMinor,
+		"paymentSessionId": req.PaymentSessionID,
+	}
+	if req.AutoTopUp {
+		body["autoTopUp"] = true
+	}
+	if strings.TrimSpace(req.SuccessURL) != "" {
+		body["successUrl"] = strings.TrimSpace(req.SuccessURL)
+	}
+	if strings.TrimSpace(req.CancelURL) != "" {
+		body["cancelUrl"] = strings.TrimSpace(req.CancelURL)
+	}
+	var result TopUpByKeyResult
+	err := c.request(ctx, http.MethodPost, c.billingV2URL("/billing/topup"), apiKey, body, &result)
+	return result, err
+}
+
+// billingV2URL builds a v2 billing API URL from the inference base. The top-up
+// endpoint lives next to the balance endpoint on the API gateway, one version up
+// (".../v1" → ".../v2/billing/..."), so it re-anchors the version while keeping any
+// host/prefix an override supplied.
+func (c *Client) billingV2URL(path string) string {
+	base := strings.TrimRight(strings.TrimSpace(c.endpoints.InferenceBaseURL), "/")
+	base = strings.TrimSuffix(base, "/v1")
+	return strings.TrimRight(base, "/") + "/v2" + path
 }
 
 func (c *Client) request(ctx context.Context, method string, endpoint string, bearer string, body any, out any) error {

--- a/internal/aimlapi/client.go
+++ b/internal/aimlapi/client.go
@@ -1,0 +1,182 @@
+package aimlapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type PaymentMethod string
+
+const (
+	PaymentMethodCard   PaymentMethod = "card"
+	PaymentMethodCrypto PaymentMethod = "crypto"
+)
+
+type SessionStatus string
+
+const (
+	SessionStatusPendingAuth    SessionStatus = "pending_auth"
+	SessionStatusPendingPayment SessionStatus = "pending_payment"
+	SessionStatusPaid           SessionStatus = "paid"
+	SessionStatusExchanging     SessionStatus = "exchanging"
+	SessionStatusExchanged      SessionStatus = "exchanged"
+	SessionStatusCancelled      SessionStatus = "cancelled"
+	SessionStatusExpired        SessionStatus = "expired"
+	SessionStatusFailed         SessionStatus = "failed"
+)
+
+type AuthResult struct {
+	Token string `json:"token"`
+	Exp   int64  `json:"exp"`
+}
+
+type PartnerCheckoutSession struct {
+	ID             string        `json:"id"`
+	SessionToken   string        `json:"sessionToken"`
+	PartnerID      string        `json:"partnerId"`
+	PartnerName    *string       `json:"partnerName"`
+	UserID         *int64        `json:"userId"`
+	AmountUSDMinor *int64        `json:"amountUsdMinor"`
+	Status         SessionStatus `json:"status"`
+	IssuedKeyID    *string       `json:"issuedKeyId"`
+	ReturnURL      *string       `json:"returnUrl"`
+}
+
+type PaymentSession struct {
+	ProviderSessionID string `json:"providerSessionId"`
+	PayURL            string `json:"payUrl"`
+}
+
+type PayResult struct {
+	Checkout        PaymentSession         `json:"checkout"`
+	PartnerCheckout PartnerCheckoutSession `json:"partnerCheckout"`
+}
+
+type ExchangeResult struct {
+	APIKey   string `json:"apiKey"`
+	APIKeyID string `json:"apiKeyId"`
+}
+
+type APIError struct {
+	Message string
+	Status  int
+	Body    string
+}
+
+func (e APIError) Error() string {
+	if strings.TrimSpace(e.Body) != "" {
+		return fmt.Sprintf("%s: HTTP %d: %s", e.Message, e.Status, strings.TrimSpace(e.Body))
+	}
+	return fmt.Sprintf("%s: HTTP %d", e.Message, e.Status)
+}
+
+type Client struct {
+	endpoints  Endpoints
+	httpClient *http.Client
+}
+
+func NewClient(endpoints Endpoints, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &Client{endpoints: endpoints, httpClient: httpClient}
+}
+
+func (c *Client) CreateSession(ctx context.Context, partnerID string, partnerName string, returnURL string) (PartnerCheckoutSession, error) {
+	body := map[string]any{"partnerId": partnerID}
+	if strings.TrimSpace(partnerName) != "" {
+		body["partnerName"] = strings.TrimSpace(partnerName)
+	}
+	if strings.TrimSpace(returnURL) != "" {
+		body["returnUrl"] = strings.TrimSpace(returnURL)
+	}
+	var result PartnerCheckoutSession
+	err := c.request(ctx, http.MethodPost, strings.TrimRight(c.endpoints.AppBaseURL, "/")+"/v3/partner-checkout/sessions", "", body, &result)
+	return result, err
+}
+
+func (c *Client) GetSession(ctx context.Context, sessionToken string) (PartnerCheckoutSession, error) {
+	var result PartnerCheckoutSession
+	err := c.request(ctx, http.MethodGet, strings.TrimRight(c.endpoints.AppBaseURL, "/")+"/v3/partner-checkout/sessions/"+urlPathEscape(sessionToken), "", nil, &result)
+	return result, err
+}
+
+func (c *Client) Pay(ctx context.Context, bearer string, sessionToken string, amountUSDMinor int, method PaymentMethod, successURL string, cancelURL string, autoTopUp bool) (PayResult, error) {
+	body := map[string]any{
+		"amountUsdMinor": amountUSDMinor,
+		"method":         method,
+	}
+	if strings.TrimSpace(successURL) != "" {
+		body["successUrl"] = strings.TrimSpace(successURL)
+	}
+	if strings.TrimSpace(cancelURL) != "" {
+		body["cancelUrl"] = strings.TrimSpace(cancelURL)
+	}
+	// Only sent when enabled: the field enrolls the account in automatic top-up.
+	// The gateway ValidationPipe does not whitelist, so it passes through today and
+	// is honoured once the backend adds support (see AIMLAPI-AUTOTOPUP-TZ.md).
+	if autoTopUp {
+		body["autoTopUp"] = true
+	}
+	var result PayResult
+	err := c.request(ctx, http.MethodPost, strings.TrimRight(c.endpoints.AppBaseURL, "/")+"/v3/partner-checkout/sessions/"+urlPathEscape(sessionToken)+"/pay", bearer, body, &result)
+	return result, err
+}
+
+func (c *Client) Exchange(ctx context.Context, bearer string, sessionToken string) (ExchangeResult, error) {
+	var result ExchangeResult
+	err := c.request(ctx, http.MethodPost, strings.TrimRight(c.endpoints.AppBaseURL, "/")+"/v3/partner-checkout/sessions/"+urlPathEscape(sessionToken)+"/exchange", bearer, nil, &result)
+	return result, err
+}
+
+func (c *Client) request(ctx context.Context, method string, endpoint string, bearer string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(data)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Accept", "application/json")
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if strings.TrimSpace(bearer) != "" {
+		request.Header.Set("Authorization", "Bearer "+strings.TrimSpace(bearer))
+	}
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("network request to %s failed: %w", endpoint, err)
+	}
+	defer response.Body.Close()
+	text, readErr := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if readErr != nil {
+		return readErr
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return APIError{Message: method + " " + endpoint, Status: response.StatusCode, Body: string(text)}
+	}
+	if out == nil || len(text) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(text, out); err != nil {
+		return APIError{Message: method + " " + endpoint + " returned non-JSON body", Status: response.StatusCode, Body: string(text)}
+	}
+	return nil
+}
+
+func urlPathEscape(value string) string {
+	return url.PathEscape(value)
+}

--- a/internal/aimlapi/client.go
+++ b/internal/aimlapi/client.go
@@ -146,10 +146,11 @@ func (c *Client) GetSession(ctx context.Context, sessionToken string) (PartnerCh
 
 // Pay initiates payment for a session and returns the hosted checkout URL.
 // autoTopUp enrolls the account in automatic top-up at checkout time.
-func (c *Client) Pay(ctx context.Context, bearer string, sessionToken string, amountUSDMinor int, method PaymentMethod, successURL string, cancelURL string, autoTopUp bool) (PayResult, error) {
+func (c *Client) Pay(ctx context.Context, bearer string, sessionToken string, amountUSDMinor int, paymentSessionID string, method PaymentMethod, successURL string, cancelURL string, autoTopUp bool) (PayResult, error) {
 	body := map[string]any{
-		"amountUsdMinor": amountUSDMinor,
-		"method":         method,
+		"amountUsdMinor":   amountUSDMinor,
+		"paymentSessionId": paymentSessionID,
+		"method":           method,
 	}
 	if strings.TrimSpace(successURL) != "" {
 		body["successUrl"] = strings.TrimSpace(successURL)

--- a/internal/aimlapi/client.go
+++ b/internal/aimlapi/client.go
@@ -242,8 +242,11 @@ func (c *Client) request(ctx context.Context, method string, endpoint string, be
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return APIError{Message: method + " " + endpoint, Status: response.StatusCode, Body: string(text)}
 	}
-	if out == nil || len(text) == 0 {
+	if out == nil {
 		return nil
+	}
+	if len(bytes.TrimSpace(text)) == 0 {
+		return APIError{Message: method + " " + endpoint + " returned empty body", Status: response.StatusCode}
 	}
 	if err := json.Unmarshal(text, out); err != nil {
 		return APIError{Message: method + " " + endpoint + " returned non-JSON body", Status: response.StatusCode, Body: string(text)}

--- a/internal/aimlapi/client.go
+++ b/internal/aimlapi/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 )
 
+// PaymentMethod selects how a partner-checkout top-up is paid for.
 type PaymentMethod string
 
 const (
@@ -19,6 +20,8 @@ const (
 	PaymentMethodCrypto PaymentMethod = "crypto"
 )
 
+// SessionStatus is the lifecycle state of a partner-checkout session, as reported
+// by the aimlapi.com backend while polling for payment.
 type SessionStatus string
 
 const (
@@ -32,11 +35,14 @@ const (
 	SessionStatusFailed         SessionStatus = "failed"
 )
 
+// AuthResult is the bearer token minted by a passwordless sign-in / sign-up.
 type AuthResult struct {
 	Token string `json:"token"`
 	Exp   int64  `json:"exp"`
 }
 
+// PartnerCheckoutSession is a partner-attributed top-up session; its SessionToken
+// addresses it on later pay/exchange/poll calls.
 type PartnerCheckoutSession struct {
 	ID             string        `json:"id"`
 	SessionToken   string        `json:"sessionToken"`
@@ -49,27 +55,35 @@ type PartnerCheckoutSession struct {
 	ReturnURL      *string       `json:"returnUrl"`
 }
 
+// PaymentSession is the hosted payment-provider checkout; PayURL is the page the
+// user opens to pay.
 type PaymentSession struct {
 	ProviderSessionID string `json:"providerSessionId"`
 	PayURL            string `json:"payUrl"`
 }
 
+// PayResult pairs the hosted checkout with the updated partner-checkout session
+// returned when a top-up payment is initiated.
 type PayResult struct {
 	Checkout        PaymentSession         `json:"checkout"`
 	PartnerCheckout PartnerCheckoutSession `json:"partnerCheckout"`
 }
 
+// ExchangeResult holds the API key minted when a paid session is exchanged.
 type ExchangeResult struct {
 	APIKey   string `json:"apiKey"`
 	APIKeyID string `json:"apiKeyId"`
 }
 
+// APIError is a non-2xx HTTP response from the aimlapi.com API. Status carries the
+// code so callers can branch (e.g. 401 = bad key, 5xx = retryable).
 type APIError struct {
 	Message string
 	Status  int
 	Body    string
 }
 
+// Error renders the method, endpoint, status, and (when present) the response body.
 func (e APIError) Error() string {
 	if strings.TrimSpace(e.Body) != "" {
 		return fmt.Sprintf("%s: HTTP %d: %s", e.Message, e.Status, strings.TrimSpace(e.Body))
@@ -77,6 +91,8 @@ func (e APIError) Error() string {
 	return fmt.Sprintf("%s: HTTP %d", e.Message, e.Status)
 }
 
+// Client talks to the aimlapi.com auth, app, and inference APIs for the onboarding
+// and partner-checkout top-up flows.
 type Client struct {
 	endpoints  Endpoints
 	httpClient *http.Client
@@ -89,6 +105,8 @@ func NewClient(endpoints Endpoints, httpClient *http.Client) *Client {
 	return &Client{endpoints: endpoints, httpClient: httpClient}
 }
 
+// CreateSession opens a partner-checkout session attributed to partnerID; the
+// returned SessionToken addresses it on the pay/exchange/poll calls.
 func (c *Client) CreateSession(ctx context.Context, partnerID string, partnerName string, returnURL string) (PartnerCheckoutSession, error) {
 	body := map[string]any{"partnerId": partnerID}
 	if strings.TrimSpace(partnerName) != "" {
@@ -102,12 +120,16 @@ func (c *Client) CreateSession(ctx context.Context, partnerID string, partnerNam
 	return result, err
 }
 
+// GetSession fetches the current state of a partner-checkout session; used to poll
+// for payment completion.
 func (c *Client) GetSession(ctx context.Context, sessionToken string) (PartnerCheckoutSession, error) {
 	var result PartnerCheckoutSession
 	err := c.request(ctx, http.MethodGet, strings.TrimRight(c.endpoints.AppBaseURL, "/")+"/v3/partner-checkout/sessions/"+urlPathEscape(sessionToken), "", nil, &result)
 	return result, err
 }
 
+// Pay initiates payment for a session and returns the hosted checkout URL.
+// autoTopUp enrolls the account in automatic top-up when the backend supports it.
 func (c *Client) Pay(ctx context.Context, bearer string, sessionToken string, amountUSDMinor int, method PaymentMethod, successURL string, cancelURL string, autoTopUp bool) (PayResult, error) {
 	body := map[string]any{
 		"amountUsdMinor": amountUSDMinor,
@@ -130,6 +152,7 @@ func (c *Client) Pay(ctx context.Context, bearer string, sessionToken string, am
 	return result, err
 }
 
+// Exchange converts a paid session into a freshly minted API key (new-account flow).
 func (c *Client) Exchange(ctx context.Context, bearer string, sessionToken string) (ExchangeResult, error) {
 	var result ExchangeResult
 	err := c.request(ctx, http.MethodPost, strings.TrimRight(c.endpoints.AppBaseURL, "/")+"/v3/partner-checkout/sessions/"+urlPathEscape(sessionToken)+"/exchange", bearer, nil, &result)

--- a/internal/aimlapi/client.go
+++ b/internal/aimlapi/client.go
@@ -129,7 +129,7 @@ func (c *Client) GetSession(ctx context.Context, sessionToken string) (PartnerCh
 }
 
 // Pay initiates payment for a session and returns the hosted checkout URL.
-// autoTopUp enrolls the account in automatic top-up when the backend supports it.
+// autoTopUp enrolls the account in automatic top-up at checkout time.
 func (c *Client) Pay(ctx context.Context, bearer string, sessionToken string, amountUSDMinor int, method PaymentMethod, successURL string, cancelURL string, autoTopUp bool) (PayResult, error) {
 	body := map[string]any{
 		"amountUsdMinor": amountUSDMinor,
@@ -141,9 +141,8 @@ func (c *Client) Pay(ctx context.Context, bearer string, sessionToken string, am
 	if strings.TrimSpace(cancelURL) != "" {
 		body["cancelUrl"] = strings.TrimSpace(cancelURL)
 	}
-	// Only sent when enabled: the field enrolls the account in automatic top-up.
-	// The gateway ValidationPipe does not whitelist, so it passes through today and
-	// is honoured once the backend adds support (see AIMLAPI-AUTOTOPUP-TZ.md).
+	// Only sent when enabled: enrolls the account in automatic top-up. The backend
+	// honours this field at checkout time.
 	if autoTopUp {
 		body["autoTopUp"] = true
 	}

--- a/internal/aimlapi/client_onboard.go
+++ b/internal/aimlapi/client_onboard.go
@@ -15,18 +15,23 @@ import (
 //   - POST {auth}/v1/auth/account/passwordless    (Path B new: email-only signup)
 //   - POST {app}/v1/keys                          (mint a key once we hold a session)
 
+// BalanceResult is the wallet balance returned by GetBalance, with the backend's
+// low-balance flag and threshold.
 type BalanceResult struct {
 	Balance             float64 `json:"balance"`
 	LowBalance          bool    `json:"lowBalance"`
 	LowBalanceThreshold float64 `json:"lowBalanceThreshold"`
 }
 
+// CheckResult reports whether an email already has an account, driving the
+// sign-in vs sign-up branch of the onboarding flow.
 type CheckResult struct {
 	// "sign-in" (account exists) or "sign-up" (no account yet).
 	Action   string  `json:"action"`
 	Provider *string `json:"provider"`
 }
 
+// CreatedKey is an API key minted by CreateKey.
 type CreatedKey struct {
 	Key string `json:"key"`
 	ID  string `json:"id"`
@@ -52,22 +57,28 @@ func (c *Client) GetBalance(ctx context.Context, apiKey string) (BalanceResult, 
 	return result, err
 }
 
+// CheckAccount reports whether an email already has an aimlapi.com account
+// (Action "sign-in") or not ("sign-up").
 func (c *Client) CheckAccount(ctx context.Context, email string) (CheckResult, error) {
 	var result CheckResult
 	err := c.request(ctx, http.MethodPatch, c.authURL("/v1/auth/account"), "", map[string]any{"email": email}, &result)
 	return result, err
 }
 
+// SendSignInCode emails a 6-digit sign-in code to an existing account.
 func (c *Client) SendSignInCode(ctx context.Context, email string) error {
 	return c.request(ctx, http.MethodPost, c.authURL("/v1/auth/sign-in/code"), "", map[string]any{"email": email}, nil)
 }
 
+// VerifySignInCode exchanges an emailed code for a session bearer token.
 func (c *Client) VerifySignInCode(ctx context.Context, email string, code string) (AuthResult, error) {
 	var result AuthResult
 	err := c.request(ctx, http.MethodPost, c.authURL("/v1/auth/sign-in/code/verify"), "", map[string]any{"email": email, "code": code}, &result)
 	return result, err
 }
 
+// CreatePasswordlessAccount registers a new email-only account and returns its
+// session bearer token.
 func (c *Client) CreatePasswordlessAccount(ctx context.Context, email string) (AuthResult, error) {
 	var result AuthResult
 	err := c.request(ctx, http.MethodPost, c.authURL("/v1/auth/account/passwordless"), "", map[string]any{"email": email}, &result)

--- a/internal/aimlapi/client_onboard.go
+++ b/internal/aimlapi/client_onboard.go
@@ -1,0 +1,89 @@
+package aimlapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Additional client methods backing the interactive TUI onboarding flow. They
+// target the endpoints shipped in the aimlapi backend:
+//   - GET  {inference}/billing/balance            (Path A: validate key + balance)
+//   - PATCH{auth}/v1/auth/account                 (Path B: does the account exist?)
+//   - POST {auth}/v1/auth/sign-in/code(/verify)   (Path B existing: passwordless login)
+//   - POST {auth}/v1/auth/account/passwordless    (Path B new: email-only signup)
+//   - POST {app}/v1/keys                          (mint a key once we hold a session)
+
+type BalanceResult struct {
+	Balance             float64 `json:"balance"`
+	LowBalance          bool    `json:"lowBalance"`
+	LowBalanceThreshold float64 `json:"lowBalanceThreshold"`
+}
+
+type CheckResult struct {
+	// "sign-in" (account exists) or "sign-up" (no account yet).
+	Action   string  `json:"action"`
+	Provider *string `json:"provider"`
+}
+
+type CreatedKey struct {
+	Key string `json:"key"`
+	ID  string `json:"id"`
+}
+
+func (c *Client) authURL(path string) string {
+	return strings.TrimRight(c.endpoints.AuthBaseURL, "/") + path
+}
+
+func (c *Client) appURL(path string) string {
+	return strings.TrimRight(c.endpoints.AppBaseURL, "/") + path
+}
+
+func (c *Client) inferenceURL(path string) string {
+	return strings.TrimRight(c.endpoints.InferenceBaseURL, "/") + path
+}
+
+// GetBalance doubles as key validation: a 401 means the key is invalid, a 2xx
+// returns the wallet balance. Auth is the raw API key itself.
+func (c *Client) GetBalance(ctx context.Context, apiKey string) (BalanceResult, error) {
+	var result BalanceResult
+	err := c.request(ctx, http.MethodGet, c.inferenceURL("/billing/balance"), apiKey, nil, &result)
+	return result, err
+}
+
+func (c *Client) CheckAccount(ctx context.Context, email string) (CheckResult, error) {
+	var result CheckResult
+	err := c.request(ctx, http.MethodPatch, c.authURL("/v1/auth/account"), "", map[string]any{"email": email}, &result)
+	return result, err
+}
+
+func (c *Client) SendSignInCode(ctx context.Context, email string) error {
+	return c.request(ctx, http.MethodPost, c.authURL("/v1/auth/sign-in/code"), "", map[string]any{"email": email}, nil)
+}
+
+func (c *Client) VerifySignInCode(ctx context.Context, email string, code string) (AuthResult, error) {
+	var result AuthResult
+	err := c.request(ctx, http.MethodPost, c.authURL("/v1/auth/sign-in/code/verify"), "", map[string]any{"email": email, "code": code}, &result)
+	return result, err
+}
+
+func (c *Client) CreatePasswordlessAccount(ctx context.Context, email string) (AuthResult, error) {
+	var result AuthResult
+	err := c.request(ctx, http.MethodPost, c.authURL("/v1/auth/account/passwordless"), "", map[string]any{"email": email}, &result)
+	return result, err
+}
+
+// CreateKey mints a fresh API key for a session-holding user.
+func (c *Client) CreateKey(ctx context.Context, bearer string, name string) (CreatedKey, error) {
+	body := map[string]any{}
+	if strings.TrimSpace(name) != "" {
+		body["name"] = strings.TrimSpace(name)
+	}
+	var result CreatedKey
+	err := c.request(ctx, http.MethodPost, c.appURL("/v1/keys"), bearer, body, &result)
+	if err == nil && strings.TrimSpace(result.Key) == "" {
+		err = fmt.Errorf("aimlapi.com did not return an API key")
+	}
+	return result, err
+}

--- a/internal/aimlapi/client_onboard.go
+++ b/internal/aimlapi/client_onboard.go
@@ -74,6 +74,9 @@ func (c *Client) SendSignInCode(ctx context.Context, email string) error {
 func (c *Client) VerifySignInCode(ctx context.Context, email string, code string) (AuthResult, error) {
 	var result AuthResult
 	err := c.request(ctx, http.MethodPost, c.authURL("/v1/auth/sign-in/code/verify"), "", map[string]any{"email": email, "code": code}, &result)
+	if err == nil && strings.TrimSpace(result.Token) == "" {
+		err = fmt.Errorf("aimlapi.com did not return an auth token")
+	}
 	return result, err
 }
 
@@ -82,6 +85,9 @@ func (c *Client) VerifySignInCode(ctx context.Context, email string, code string
 func (c *Client) CreatePasswordlessAccount(ctx context.Context, email string) (AuthResult, error) {
 	var result AuthResult
 	err := c.request(ctx, http.MethodPost, c.authURL("/v1/auth/account/passwordless"), "", map[string]any{"email": email}, &result)
+	if err == nil && strings.TrimSpace(result.Token) == "" {
+		err = fmt.Errorf("aimlapi.com did not return an auth token")
+	}
 	return result, err
 }
 

--- a/internal/aimlapi/client_test.go
+++ b/internal/aimlapi/client_test.go
@@ -105,6 +105,30 @@ func TestClientReturnsTypedAPIError(t *testing.T) {
 	}
 }
 
+func TestTypedResponseRejectsEmptySuccessBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(Endpoints{InferenceBaseURL: server.URL}, server.Client())
+	if _, err := client.GetBalance(context.Background(), "key"); err == nil {
+		t.Fatal("GetBalance accepted an empty successful response")
+	}
+}
+
+func TestBodylessOperationAcceptsEmptySuccessBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(Endpoints{AuthBaseURL: server.URL}, server.Client())
+	if err := client.SendSignInCode(context.Background(), "user@example.com"); err != nil {
+		t.Fatalf("SendSignInCode() error = %v", err)
+	}
+}
+
 func TestParseAmountUSD(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/aimlapi/client_test.go
+++ b/internal/aimlapi/client_test.go
@@ -1,0 +1,97 @@
+package aimlapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateKeySendsAuthenticatedRequestAndDecodesKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/keys" {
+			t.Fatalf("request = %s %s, want POST /v1/keys", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer session-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["name"] != "Zero CLI" {
+			t.Fatalf("name = %q", body["name"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"sk-issued","id":"key-id"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Endpoints{AppBaseURL: server.URL}, server.Client())
+	key, err := client.CreateKey(context.Background(), " session-token ", " Zero CLI ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.Key != "sk-issued" || key.ID != "key-id" {
+		t.Fatalf("key = %#v", key)
+	}
+}
+
+func TestCreateKeyRejectsEmptyKeyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"key-id"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Endpoints{AppBaseURL: server.URL}, server.Client())
+	if _, err := client.CreateKey(context.Background(), "session-token", "Zero"); err == nil {
+		t.Fatal("CreateKey accepted a response without an API key")
+	}
+}
+
+func TestClientReturnsTypedAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "invalid key", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClient(Endpoints{InferenceBaseURL: server.URL}, server.Client())
+	_, err := client.GetBalance(context.Background(), "bad-key")
+	var apiErr APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %v, want APIError", err, err)
+	}
+	if apiErr.Status != http.StatusUnauthorized || apiErr.Body != "invalid key\n" {
+		t.Fatalf("APIError = %#v", apiErr)
+	}
+}
+
+func TestParseAmountUSD(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{name: "default", want: DefaultAmountUSDMinor},
+		{name: "minimum", value: "20", want: 2000},
+		{name: "cents", value: "25.49", want: 2549},
+		{name: "below minimum", value: "19.99", wantErr: true},
+		{name: "above maximum", value: "10001", wantErr: true},
+		{name: "not a number", value: "twenty", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseAmountUSD(test.value)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ParseAmountUSD(%q) error = %v", test.value, err)
+			}
+			if got != test.want {
+				t.Fatalf("ParseAmountUSD(%q) = %d, want %d", test.value, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/aimlapi/client_test.go
+++ b/internal/aimlapi/client_test.go
@@ -52,6 +52,42 @@ func TestCreateKeyRejectsEmptyKeyResponse(t *testing.T) {
 	}
 }
 
+func TestAuthMethodsRejectEmptyTokenResponses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":""}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Endpoints{AuthBaseURL: server.URL}, server.Client())
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "verify sign-in code",
+			call: func() error {
+				_, err := client.VerifySignInCode(context.Background(), "user@example.com", "123456")
+				return err
+			},
+		},
+		{
+			name: "create passwordless account",
+			call: func() error {
+				_, err := client.CreatePasswordlessAccount(context.Background(), "user@example.com")
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.call(); err == nil {
+				t.Fatal("accepted a response without an auth token")
+			}
+		})
+	}
+}
+
 func TestClientReturnsTypedAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "invalid key", http.StatusUnauthorized)

--- a/internal/aimlapi/client_test.go
+++ b/internal/aimlapi/client_test.go
@@ -79,13 +79,11 @@ func TestParseAmountUSD(t *testing.T) {
 		{name: "default", want: DefaultAmountUSDMinor},
 		{name: "minimum", value: "20", want: 2000},
 		{name: "cents", value: "25.49", want: 2549},
-		{name: "exact maximum", value: "10000", want: 1000000},
 		{name: "below minimum", value: "19.99", wantErr: true},
 		{name: "above maximum", value: "10001", wantErr: true},
 		{name: "not a number", value: "twenty", wantErr: true},
 		{name: "nan", value: "NaN", wantErr: true},
-		{name: "positive infinity", value: "Inf", wantErr: true},
-		{name: "negative infinity", value: "-Inf", wantErr: true},
+		{name: "infinity", value: "Inf", wantErr: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/aimlapi/client_test.go
+++ b/internal/aimlapi/client_test.go
@@ -79,9 +79,13 @@ func TestParseAmountUSD(t *testing.T) {
 		{name: "default", want: DefaultAmountUSDMinor},
 		{name: "minimum", value: "20", want: 2000},
 		{name: "cents", value: "25.49", want: 2549},
+		{name: "exact maximum", value: "10000", want: 1000000},
 		{name: "below minimum", value: "19.99", wantErr: true},
 		{name: "above maximum", value: "10001", wantErr: true},
 		{name: "not a number", value: "twenty", wantErr: true},
+		{name: "nan", value: "NaN", wantErr: true},
+		{name: "positive infinity", value: "Inf", wantErr: true},
+		{name: "negative infinity", value: "-Inf", wantErr: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/aimlapi/config.go
+++ b/internal/aimlapi/config.go
@@ -21,6 +21,7 @@ type Endpoints struct {
 const (
 	DefaultPartnerID   = "part_62yQoGYDq4Yqnrj2R1iGrDNJ"
 	DefaultPartnerName = "Gitlawb"
+	PartnerHeaderName  = "X-AIMLAPI-Partner-ID"
 	// DefaultReturnURL is the https fallback the browser is sent to after the
 	// checkout / OAuth consent finishes when no frontend base is known. It must be
 	// a real web page the browser can open — NOT a custom scheme like
@@ -43,6 +44,33 @@ func ResolveEndpoints() Endpoints {
 		PayBaseURL:          envOrDefault("AIMLAPI_PAY_URL", "https://pay.aimlapi.com"),
 		VerificationBaseURL: envOrDefault("AIMLAPI_VERIFICATION_BASE_URL", "https://aimlapi.com/app"),
 	}
+}
+
+// ResolvePartnerID applies the same explicit-option, environment, and default
+// precedence everywhere partner attribution is used. Keeping checkout creation
+// and saved inference profiles on one resolver prevents them from attributing
+// the same user to different partners.
+func ResolvePartnerID(explicit string) string {
+	if value := strings.TrimSpace(explicit); value != "" {
+		return value
+	}
+	return envOrDefault("AIMLAPI_PARTNER_ID", DefaultPartnerID)
+}
+
+// WithResolvedPartnerHeader returns a copy with the effective partner ID set.
+// Header matching is case-insensitive so an existing spelling is replaced rather
+// than duplicated. Callers remain responsible for applying catalog attribution
+// only to the canonical AIMLAPI endpoint.
+func WithResolvedPartnerHeader(headers map[string]string) map[string]string {
+	resolved := make(map[string]string, len(headers)+1)
+	for key, value := range headers {
+		if strings.EqualFold(strings.TrimSpace(key), PartnerHeaderName) {
+			continue
+		}
+		resolved[key] = value
+	}
+	resolved[PartnerHeaderName] = ResolvePartnerID("")
+	return resolved
 }
 
 func BuildPartnerCheckoutReturnURLs(appBaseURL string, sessionToken string) (successURL string, cancelURL string) {

--- a/internal/aimlapi/config.go
+++ b/internal/aimlapi/config.go
@@ -47,6 +47,13 @@ func ResolveEndpoints() Endpoints {
 
 func BuildPartnerCheckoutReturnURLs(appBaseURL string, sessionToken string) (successURL string, cancelURL string) {
 	base := strings.TrimRight(strings.TrimSpace(appBaseURL), "/")
+	if base == "" {
+		// With no base there is nothing to anchor an absolute URL to. Return empty
+		// so the caller omits the return URLs entirely (client.Pay skips empty ones,
+		// leaving the backend's generic checkout) instead of emitting a broken
+		// relative "/checkout?...".
+		return "", ""
+	}
 	token := url.QueryEscape(sessionToken)
 	return base + "/checkout?checkout=success&partnerCheckout=1&sessionToken=" + token,
 		base + "/checkout?checkout=cancel&partnerCheckout=1&sessionToken=" + token

--- a/internal/aimlapi/config.go
+++ b/internal/aimlapi/config.go
@@ -1,0 +1,78 @@
+package aimlapi
+
+import (
+	"net/url"
+	"os"
+	"strings"
+)
+
+type Endpoints struct {
+	AuthBaseURL      string
+	AppBaseURL       string
+	InferenceBaseURL string
+	PayBaseURL       string
+	// VerificationBaseURL is the aimlapi web-app frontend base. The browser is sent
+	// back here after the partner checkout completes (see BuildPartnerReturnURL), so
+	// it must point at the same environment's front as the one the CLI is talking to
+	// to land the user there. Empty falls back to DefaultReturnURL.
+	VerificationBaseURL string
+}
+
+const (
+	DefaultPartnerID   = "part_62yQoGYDq4Yqnrj2R1iGrDNJ"
+	DefaultPartnerName = "Gitlawb"
+	// DefaultReturnURL is the https fallback the browser is sent to after the
+	// checkout / OAuth consent finishes when no frontend base is known. It must be
+	// a real web page the browser can open — NOT a custom scheme like
+	// zero://aimlapi/complete, which fails with "the scheme does not have a
+	// registered handler" because the CLI registers no OS protocol handler. The
+	// CLI learns of success by polling; this URL is purely the browser's landing.
+	DefaultReturnURL = "https://aimlapi.com/app"
+	DefaultModel     = "anthropic/claude-sonnet-5"
+
+	MinAmountUSDMinor     = 2000
+	MaxAmountUSDMinor     = 1000000
+	DefaultAmountUSDMinor = 2500
+)
+
+func ResolveEndpoints() Endpoints {
+	return Endpoints{
+		AuthBaseURL:         envOrDefault("AIMLAPI_AUTH_URL", "https://auth.aimlapi.com"),
+		AppBaseURL:          envOrDefault("AIMLAPI_APP_URL", "https://app.aimlapi.com"),
+		InferenceBaseURL:    envOrDefault("AIMLAPI_INFERENCE_URL", "https://api.aimlapi.com/v1"),
+		PayBaseURL:          envOrDefault("AIMLAPI_PAY_URL", "https://pay.aimlapi.com"),
+		VerificationBaseURL: envOrDefault("AIMLAPI_VERIFICATION_BASE_URL", "https://aimlapi.com/app"),
+	}
+}
+
+func BuildPartnerCheckoutReturnURLs(appBaseURL string, sessionToken string) (successURL string, cancelURL string) {
+	base := strings.TrimRight(strings.TrimSpace(appBaseURL), "/")
+	token := url.QueryEscape(sessionToken)
+	return base + "/checkout?checkout=success&partnerCheckout=1&sessionToken=" + token,
+		base + "/checkout?checkout=cancel&partnerCheckout=1&sessionToken=" + token
+}
+
+// BuildPartnerReturnURL returns the https page the browser is sent back to once
+// the partner checkout or OAuth consent completes — the aimlapi web app the user
+// opened the flow from. frontendBaseURL is normally endpoints.VerificationBaseURL
+// (the front that hosts the login/consent page), so the return follows the same
+// environment. AIMLAPI_RETURN_URL overrides it outright; an empty base falls back
+// to DefaultReturnURL. It is deliberately NOT a custom scheme (zero://…): no
+// browser can hand a custom scheme off without an OS-registered handler, which a
+// CLI does not install.
+func BuildPartnerReturnURL(frontendBaseURL string) string {
+	if override := strings.TrimSpace(os.Getenv("AIMLAPI_RETURN_URL")); override != "" {
+		return override
+	}
+	if base := strings.TrimRight(strings.TrimSpace(frontendBaseURL), "/"); base != "" {
+		return base
+	}
+	return DefaultReturnURL
+}
+
+func envOrDefault(name string, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/internal/aimlapi/config_test.go
+++ b/internal/aimlapi/config_test.go
@@ -1,0 +1,36 @@
+package aimlapi
+
+import "testing"
+
+func TestResolveEndpointsDefaults(t *testing.T) {
+	t.Setenv("AIMLAPI_AUTH_URL", "")
+	t.Setenv("AIMLAPI_APP_URL", "")
+	t.Setenv("AIMLAPI_INFERENCE_URL", "")
+	t.Setenv("AIMLAPI_PAY_URL", "")
+
+	endpoints := ResolveEndpoints()
+	if endpoints.AuthBaseURL != "https://auth.aimlapi.com" ||
+		endpoints.AppBaseURL != "https://app.aimlapi.com" ||
+		endpoints.InferenceBaseURL != "https://api.aimlapi.com/v1" ||
+		endpoints.PayBaseURL != "https://pay.aimlapi.com" {
+		t.Fatalf("unexpected endpoints: %#v", endpoints)
+	}
+}
+
+func TestBuildPartnerReturnURL(t *testing.T) {
+	t.Setenv("AIMLAPI_RETURN_URL", "")
+	// The frontend base (the web app the flow was opened from) is returned as-is,
+	// trailing slash trimmed — an https page the browser can actually land on.
+	if got := BuildPartnerReturnURL("https://aimlapi.com/app/"); got != "https://aimlapi.com/app" {
+		t.Fatalf("return URL = %q, want the frontend base", got)
+	}
+	// An empty base falls back to the https default, never a custom scheme.
+	if got := BuildPartnerReturnURL(""); got != DefaultReturnURL {
+		t.Fatalf("empty base return URL = %q, want %q", got, DefaultReturnURL)
+	}
+
+	t.Setenv("AIMLAPI_RETURN_URL", "https://example.test/done")
+	if got := BuildPartnerReturnURL("https://aimlapi.com/app"); got != "https://example.test/done" {
+		t.Fatalf("env override return URL = %q", got)
+	}
+}

--- a/internal/aimlapi/config_test.go
+++ b/internal/aimlapi/config_test.go
@@ -17,6 +17,25 @@ func TestResolveEndpointsDefaults(t *testing.T) {
 	}
 }
 
+func TestResolvedPartnerHeaderUsesEnvironmentOverrideWithoutDuplicates(t *testing.T) {
+	t.Setenv("AIMLAPI_PARTNER_ID", "part_override")
+
+	headers := WithResolvedPartnerHeader(map[string]string{
+		"x-aimlapi-partner-id":       "part_catalog",
+		"X-AIMLAPI-Integration-Repo": "Gitlawb/zero",
+	})
+
+	if got := headers[PartnerHeaderName]; got != "part_override" {
+		t.Fatalf("partner header = %q, want part_override", got)
+	}
+	if _, ok := headers["x-aimlapi-partner-id"]; ok {
+		t.Fatalf("case-insensitive partner header was duplicated: %#v", headers)
+	}
+	if got := headers["X-AIMLAPI-Integration-Repo"]; got != "Gitlawb/zero" {
+		t.Fatalf("unrelated header changed: %#v", headers)
+	}
+}
+
 func TestBuildPartnerReturnURL(t *testing.T) {
 	t.Setenv("AIMLAPI_RETURN_URL", "")
 	// The frontend base (the web app the flow was opened from) is returned as-is,

--- a/internal/aimlapi/messages.go
+++ b/internal/aimlapi/messages.go
@@ -1,0 +1,43 @@
+package aimlapi
+
+// UI strings shared by the first-run and provider-wizard onboarding surfaces.
+
+const (
+	// Path A — existing API key. Pick-path prompt + option labels.
+	MsgAPIKeyInputPrompt = "Enter your aimlapi.com key."
+	MsgAPIKeyInvalid     = "API key is invalid. Please make sure you enter a valid aimlapi.com key."
+	MsgPickPathPrompt    = "Do you have aimlapi.com key?"
+	MsgPickPathHaveKey   = "I already have aimlapi.com key"
+	MsgPickPathHaveHint  = "Proceed to paste the key"
+	MsgPickPathNewUser   = "I am a new user"
+	MsgPickPathNewHint   = "One click set up"
+
+	// Path B — email.
+	MsgEnterEmail   = "Enter your email.\nTo access aimlapi.com dashboard."
+	MsgEmailInvalid = "Email format is incorrect."
+	// %s = email
+	MsgCodeSent      = "We sent a 6-digit code to %s.\nEnter it below to continue."
+	MsgCodeIncorrect = "Code you've entered is incorrect."
+
+	// Balance check.
+	MsgLowBalance     = "Your aimlapi.com balance is running low.\nIt is recommended to top up your balance."
+	MsgEverythingRuns = "Everything is ready."
+	// Low-balance choices (spec wording).
+	MsgLowBalanceTopUp = "Sure, let's do that"
+	MsgLowBalanceSkip  = "I'll skip topping up the balance for now"
+
+	// Top-up workflow.
+	MsgTopUpNewPrompt      = "Add credits.\nEnter an amount (min $20)."
+	MsgTopUpExistingPrompt = "Add credits.\nEnter an amount (min $20)."
+	MsgTopUpTooLow         = "Top up amount is too low."
+	// %s = checkout URL
+	MsgTopUpBrowserFallback = "If the browser did not open automatically please use this link to top up your account: %s"
+	MsgTopUpFailed          = "Top up failed. Please try again."
+	MsgTopUpSuccess         = "Top-up successful."
+
+	// Success — key delivered.
+	// %s = amount in dollars (e.g. "25")
+	MsgTopUpAddedFmt = "$%s has been added to your balance."
+	// %s = email
+	MsgSuccessMagicLink = "We've emailed you a magic link to %s. Use it to access your aimlapi.com account and review your usage and balance."
+)

--- a/internal/aimlapi/messages.go
+++ b/internal/aimlapi/messages.go
@@ -29,7 +29,9 @@ const (
 	// Top-up workflow.
 	MsgTopUpPrompt    = "Add credits.\nEnter an amount (min $20)."
 	MsgTopUpTooLow    = "Top up amount is too low."
+	MsgTopUpTooHigh   = "Top up amount is too high."
 	MsgAmountRequired = "Please enter a top-up amount."
+	MsgAmountInvalid  = "Please enter a valid dollar amount."
 	// %s = checkout URL
 	MsgTopUpBrowserFallback = "If the browser did not open automatically please use this link to top up your account: %s"
 	MsgTopUpFailed          = "Top up failed. Please try again."

--- a/internal/aimlapi/messages.go
+++ b/internal/aimlapi/messages.go
@@ -11,7 +11,6 @@ const (
 	MsgPickPathHaveHint  = "Proceed to paste the key"
 	MsgPickPathNewUser   = "I am a new user"
 	MsgPickPathNewHint   = "One click set up"
-
 	// Path B — email.
 	MsgEnterEmail   = "Enter your email.\nTo access aimlapi.com dashboard."
 	MsgEmailInvalid = "Email format is incorrect."

--- a/internal/aimlapi/messages.go
+++ b/internal/aimlapi/messages.go
@@ -27,13 +27,16 @@ const (
 	MsgLowBalanceSkip  = "I'll skip topping up the balance for now"
 
 	// Top-up workflow.
-	MsgTopUpNewPrompt      = "Add credits.\nEnter an amount (min $20)."
-	MsgTopUpExistingPrompt = "Add credits.\nEnter an amount (min $20)."
-	MsgTopUpTooLow         = "Top up amount is too low."
+	MsgTopUpPrompt    = "Add credits.\nEnter an amount (min $20)."
+	MsgTopUpTooLow    = "Top up amount is too low."
+	MsgAmountRequired = "Please enter a top-up amount."
 	// %s = checkout URL
 	MsgTopUpBrowserFallback = "If the browser did not open automatically please use this link to top up your account: %s"
 	MsgTopUpFailed          = "Top up failed. Please try again."
 	MsgTopUpSuccess         = "Top-up successful."
+	// Shown on the terminal screen when a Path-A top-up can't run because the
+	// entered email has no account: the pasted key is still valid and saved.
+	MsgTopUpNoAccount = "That email has no aimlapi.com account, so the balance wasn't topped up. Your key is saved."
 
 	// Success — key delivered.
 	// %s = amount in dollars (e.g. "25")

--- a/internal/aimlapi/messages.go
+++ b/internal/aimlapi/messages.go
@@ -28,10 +28,7 @@ const (
 
 	// Top-up workflow.
 	MsgTopUpPrompt    = "Add credits.\nEnter an amount (min $20)."
-	MsgTopUpTooLow    = "Top up amount is too low."
-	MsgTopUpTooHigh   = "Top up amount is too high."
 	MsgAmountRequired = "Please enter a top-up amount."
-	MsgAmountInvalid  = "Please enter a valid dollar amount."
 	// %s = checkout URL
 	MsgTopUpBrowserFallback = "If the browser did not open automatically please use this link to top up your account: %s"
 	MsgTopUpFailed          = "Top up failed. Please try again."

--- a/internal/aimlapi/messages.go
+++ b/internal/aimlapi/messages.go
@@ -5,6 +5,7 @@ package aimlapi
 const (
 	// Path A — existing API key. Pick-path prompt + option labels.
 	MsgAPIKeyInputPrompt = "Enter your aimlapi.com key."
+	MsgAPIKeyInvalid     = "API key is invalid. Please make sure you enter a valid aimlapi.com key."
 	MsgPickPathPrompt    = "Do you have aimlapi.com key?"
 	MsgPickPathHaveKey   = "I already have aimlapi.com key"
 	MsgPickPathHaveHint  = "Proceed to paste the key"

--- a/internal/aimlapi/messages.go
+++ b/internal/aimlapi/messages.go
@@ -5,7 +5,6 @@ package aimlapi
 const (
 	// Path A — existing API key. Pick-path prompt + option labels.
 	MsgAPIKeyInputPrompt = "Enter your aimlapi.com key."
-	MsgAPIKeyInvalid     = "API key is invalid. Please make sure you enter a valid aimlapi.com key."
 	MsgPickPathPrompt    = "Do you have aimlapi.com key?"
 	MsgPickPathHaveKey   = "I already have aimlapi.com key"
 	MsgPickPathHaveHint  = "Proceed to paste the key"
@@ -33,9 +32,6 @@ const (
 	MsgTopUpBrowserFallback = "If the browser did not open automatically please use this link to top up your account: %s"
 	MsgTopUpFailed          = "Top up failed. Please try again."
 	MsgTopUpSuccess         = "Top-up successful."
-	// Shown on the terminal screen when a Path-A top-up can't run because the
-	// entered email has no account: the pasted key is still valid and saved.
-	MsgTopUpNoAccount = "That email has no aimlapi.com account, so the balance wasn't topped up. Your key is saved."
 
 	// Success — key delivered.
 	// %s = amount in dollars (e.g. "25")

--- a/internal/aimlapi/messages.go
+++ b/internal/aimlapi/messages.go
@@ -12,8 +12,9 @@ const (
 	MsgPickPathNewUser   = "I am a new user"
 	MsgPickPathNewHint   = "One click set up"
 	// Path B — email.
-	MsgEnterEmail   = "Enter your email.\nTo access aimlapi.com dashboard."
-	MsgEmailInvalid = "Email format is incorrect."
+	MsgEnterEmail           = "Enter your email.\nTo access aimlapi.com dashboard."
+	MsgEmailInvalid         = "Email format is incorrect."
+	MsgAccountActionInvalid = "aimlapi.com returned an unsupported account action. Please try again."
 	// %s = email
 	MsgCodeSent      = "We sent a 6-digit code to %s.\nEnter it below to continue."
 	MsgCodeIncorrect = "Code you've entered is incorrect."

--- a/internal/aimlapi/onboard_test.go
+++ b/internal/aimlapi/onboard_test.go
@@ -1,0 +1,26 @@
+package aimlapi
+
+import "testing"
+
+func TestValidEmailRejectsIncompleteDomains(t *testing.T) {
+	tests := []struct {
+		value string
+		valid bool
+	}{
+		{value: "user@example.com", valid: true},
+		{value: "123@123.com", valid: true},
+		{value: "123@123.", valid: false},
+		{value: "123@123", valid: false},
+		{value: "user@example.c", valid: false},
+		{value: "user@example.123", valid: false},
+		{value: "user@.com", valid: false},
+		{value: "user@example..com", valid: false},
+	}
+	for _, test := range tests {
+		t.Run(test.value, func(t *testing.T) {
+			if got := ValidEmail(test.value); got != test.valid {
+				t.Fatalf("ValidEmail(%q) = %v, want %v", test.value, got, test.valid)
+			}
+		})
+	}
+}

--- a/internal/aimlapi/stream.go
+++ b/internal/aimlapi/stream.go
@@ -31,6 +31,9 @@ type StreamTopUpOptions struct {
 	// of opening a new one, so a retry after an ambiguous failure (a lost Pay/
 	// Exchange response) can never double-charge or strand an already-paid session.
 	ResumeSessionToken string
+	// PaymentSessionID is generated once per amount/auto-top-up intent and reused
+	// on retry so an ambiguous Pay response cannot create a second checkout.
+	PaymentSessionID string
 
 	HTTPClient  *http.Client
 	OpenBrowser func(string) error
@@ -75,6 +78,9 @@ func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKe
 	if strings.TrimSpace(options.SessionToken) == "" {
 		return ProvisionedKey{}, fmt.Errorf("a session is required to top up")
 	}
+	if strings.TrimSpace(options.PaymentSessionID) == "" {
+		return ProvisionedKey{}, fmt.Errorf("a payment session id is required to top up")
+	}
 
 	status(options.OnStatus, StatusCreatingSession, "")
 	sessionToken, phase, err := resolveTopupSession(ctx, client, options, partnerID, partnerName, endpoints)
@@ -88,7 +94,7 @@ func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKe
 	if phase <= phasePay {
 		successURL, cancelURL := BuildPartnerCheckoutReturnURLs(endpoints.PayBaseURL, sessionToken)
 		status(options.OnStatus, StatusOpeningCheckout, "")
-		pay, err := client.Pay(ctx, options.SessionToken, sessionToken, amount, method, successURL, cancelURL, options.AutoTopUp)
+		pay, err := client.Pay(ctx, options.SessionToken, sessionToken, amount, options.PaymentSessionID, method, successURL, cancelURL, options.AutoTopUp)
 		if err != nil {
 			return ProvisionedKey{}, err
 		}
@@ -122,7 +128,7 @@ func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKe
 	if options.Exchange {
 		status(options.OnStatus, StatusProvisioningKey, "")
 		if phase == phaseWaitExchange {
-			return ProvisionedKey{}, pollUntilExchangeSettled(ctx, client, sessionToken)
+			return ProvisionedKey{}, pollUntilExchangeSettled(ctx, client, sessionToken, options.OnSession)
 		}
 		exchange, err := client.Exchange(ctx, options.SessionToken, paidToken)
 		if err != nil {

--- a/internal/aimlapi/stream.go
+++ b/internal/aimlapi/stream.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 )
 
@@ -57,7 +56,7 @@ const (
 func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKey, error) {
 	endpoints := ResolveEndpoints()
 	client := NewClient(endpoints, options.HTTPClient)
-	partnerID := firstNonEmpty(options.PartnerID, os.Getenv("AIMLAPI_PARTNER_ID"), DefaultPartnerID)
+	partnerID := ResolvePartnerID(options.PartnerID)
 	partnerName := firstNonEmpty(options.PartnerName, DefaultPartnerName)
 	method := options.Method
 	if method != PaymentMethodCrypto {
@@ -97,7 +96,7 @@ func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKe
 	paidToken := sessionToken
 	if phase <= phasePoll {
 		status(options.OnStatus, StatusWaitingPayment, "")
-		paid, err := pollUntilPaid(ctx, client, sessionToken)
+		paid, err := pollUntilPaid(ctx, client, sessionToken, options.OnSession)
 		if err != nil {
 			return ProvisionedKey{}, err
 		}
@@ -223,7 +222,7 @@ type StreamTopUpByKeyOptions struct {
 func StreamTopUpByKey(ctx context.Context, options StreamTopUpByKeyOptions) (ProvisionedKey, error) {
 	endpoints := ResolveEndpoints()
 	client := NewClient(endpoints, options.HTTPClient)
-	partnerID := firstNonEmpty(options.PartnerID, os.Getenv("AIMLAPI_PARTNER_ID"), DefaultPartnerID)
+	partnerID := ResolvePartnerID(options.PartnerID)
 	partnerName := firstNonEmpty(options.PartnerName, DefaultPartnerName)
 	amount, err := ParseAmountUSD(options.AmountUSD)
 	if err != nil {
@@ -266,7 +265,7 @@ func StreamTopUpByKey(ctx context.Context, options StreamTopUpByKeyOptions) (Pro
 
 	if phase <= phasePoll {
 		status(options.OnStatus, StatusWaitingPayment, "")
-		if _, err := pollUntilPaid(ctx, client, sessionToken); err != nil {
+		if _, err := pollUntilPaid(ctx, client, sessionToken, options.OnSession); err != nil {
 			return ProvisionedKey{}, err
 		}
 	}

--- a/internal/aimlapi/stream.go
+++ b/internal/aimlapi/stream.go
@@ -25,10 +25,32 @@ type StreamTopUpOptions struct {
 	PartnerName  string
 	NoOpen       bool
 
+	// ResumeSessionToken, when set, resumes that partner-checkout session instead
+	// of opening a new one, so a retry after an ambiguous failure (a lost Pay/
+	// Exchange response) can never double-charge or strand an already-paid session.
+	ResumeSessionToken string
+
 	HTTPClient  *http.Client
 	OpenBrowser func(string) error
 	OnStatus    func(Status, string)
+	// OnSession reports the partner-checkout session token the moment it exists (a
+	// fresh CreateSession, or the resumed one), so the caller can retain it and
+	// resume on a later failure. It fires with "" when the session is dead and the
+	// retained token should be dropped (a fresh run must start over).
+	OnSession func(sessionToken string)
 }
+
+// topupPhase is where StreamTopUp enters its create-checkout → poll → exchange
+// pipeline. A fresh run starts at phasePay; a resume skips ahead to whatever the
+// existing session's status makes safe.
+type topupPhase int
+
+const (
+	phasePay          topupPhase = iota // (re-)open the Stripe checkout, then poll + exchange
+	phasePoll                           // checkout already open; poll for payment, never re-pay
+	phaseExchange                       // already paid; exchange only (recovers a lost key)
+	phaseWaitExchange                   // an exchange claim is in flight; poll, never call Exchange twice
+)
 
 // StreamTopUp performs the browser-checkout top-up and reports progress via
 // OnStatus.
@@ -50,33 +72,42 @@ func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKe
 	}
 
 	status(options.OnStatus, StatusCreatingSession, "")
-	session, err := client.CreateSession(ctx, partnerID, partnerName, BuildPartnerReturnURL(endpoints.VerificationBaseURL))
+	sessionToken, phase, err := resolveTopupSession(ctx, client, options, partnerID, partnerName, endpoints)
 	if err != nil {
 		return ProvisionedKey{}, err
 	}
-	successURL, cancelURL := BuildPartnerCheckoutReturnURLs(endpoints.PayBaseURL, session.SessionToken)
+	// Retain the live token so an ambiguous failure below can resume this session
+	// rather than open a second checkout on the next attempt.
+	reportSession(options.OnSession, sessionToken)
 
-	status(options.OnStatus, StatusOpeningCheckout, "")
-	pay, err := client.Pay(ctx, options.SessionToken, session.SessionToken, amount, method, successURL, cancelURL, options.AutoTopUp)
-	if err != nil {
-		return ProvisionedKey{}, err
-	}
-	checkoutURL := strings.TrimSpace(pay.Checkout.PayURL)
-	if checkoutURL == "" {
-		return ProvisionedKey{}, fmt.Errorf("payment provider did not return a checkout URL")
-	}
-	if options.NoOpen || options.OpenBrowser == nil {
-		status(options.OnStatus, StatusOpeningCheckout, checkoutURL)
-	} else if err := options.OpenBrowser(checkoutURL); err != nil {
-		status(options.OnStatus, StatusOpeningCheckout, "Open manually: "+checkoutURL)
-	} else {
-		status(options.OnStatus, StatusOpeningCheckout, checkoutURL)
+	if phase <= phasePay {
+		successURL, cancelURL := BuildPartnerCheckoutReturnURLs(endpoints.PayBaseURL, sessionToken)
+		status(options.OnStatus, StatusOpeningCheckout, "")
+		pay, err := client.Pay(ctx, options.SessionToken, sessionToken, amount, method, successURL, cancelURL, options.AutoTopUp)
+		if err != nil {
+			return ProvisionedKey{}, err
+		}
+		checkoutURL := strings.TrimSpace(pay.Checkout.PayURL)
+		if checkoutURL == "" {
+			return ProvisionedKey{}, fmt.Errorf("payment provider did not return a checkout URL")
+		}
+		announceCheckout(options.OnStatus, options.OpenBrowser, options.NoOpen, checkoutURL)
 	}
 
-	status(options.OnStatus, StatusWaitingPayment, "")
-	paid, err := pollUntilPaid(ctx, client, session.SessionToken)
-	if err != nil {
-		return ProvisionedKey{}, err
+	paidToken := sessionToken
+	if phase <= phasePoll {
+		status(options.OnStatus, StatusWaitingPayment, "")
+		paid, err := pollUntilPaid(ctx, client, sessionToken)
+		if err != nil {
+			return ProvisionedKey{}, err
+		}
+		paidToken = paid.SessionToken
+		if paid.Status == SessionStatusExchanging {
+			// Another/lost request claimed exchange while we were polling payment.
+			// Carry that fact into the provisioning branch so it follows the claim
+			// instead of issuing a second single-flight Exchange request.
+			phase = phaseWaitExchange
+		}
 	}
 
 	result := ProvisionedKey{
@@ -85,7 +116,10 @@ func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKe
 	}
 	if options.Exchange {
 		status(options.OnStatus, StatusProvisioningKey, "")
-		exchange, err := client.Exchange(ctx, options.SessionToken, paid.SessionToken)
+		if phase == phaseWaitExchange {
+			return ProvisionedKey{}, pollUntilExchangeSettled(ctx, client, sessionToken)
+		}
+		exchange, err := client.Exchange(ctx, options.SessionToken, paidToken)
 		if err != nil {
 			return ProvisionedKey{}, err
 		}
@@ -96,4 +130,175 @@ func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKe
 		result.APIKeyID = exchange.APIKeyID
 	}
 	return result, nil
+}
+
+// resolveTopupSession returns the partner-checkout session token to drive and the
+// phase to enter. A fresh run opens a new session at phasePay. A resume inspects
+// the existing session and enters the earliest phase that cannot re-charge:
+//   - pending_auth    → phasePay: payment never started, so (re-)Pay is safe.
+//   - pending_payment → phasePoll: a checkout is already open; poll, never re-Pay.
+//   - paid            → phaseExchange: exchange the paid session once.
+//   - exchanging      → phaseWaitExchange: another/lost request owns the atomic
+//     exchange claim; poll it, never issue a second Exchange request.
+//   - exchanged       → terminal: the one-shot raw key is gone; point at dashboard
+//     recovery and keep the token so a re-run repeats that guidance, not a charge.
+//   - cancelled/expired/failed → terminal: drop the dead token so a re-run is fresh.
+func resolveTopupSession(ctx context.Context, client *Client, options StreamTopUpOptions, partnerID, partnerName string, endpoints Endpoints) (string, topupPhase, error) {
+	resume := strings.TrimSpace(options.ResumeSessionToken)
+	if resume == "" {
+		session, err := client.CreateSession(ctx, partnerID, partnerName, BuildPartnerReturnURL(endpoints.VerificationBaseURL))
+		if err != nil {
+			return "", phasePay, err
+		}
+		return session.SessionToken, phasePay, nil
+	}
+	session, err := client.GetSession(ctx, resume)
+	if err != nil {
+		return "", phasePay, err
+	}
+	switch session.Status {
+	case SessionStatusPendingAuth:
+		return resume, phasePay, nil
+	case SessionStatusPendingPayment:
+		return resume, phasePoll, nil
+	case SessionStatusPaid:
+		return resume, phaseExchange, nil
+	case SessionStatusExchanging:
+		return resume, phaseWaitExchange, nil
+	case SessionStatusExchanged:
+		return "", phasePay, fmt.Errorf("session was already exchanged; rotate the key from the aimlapi.com dashboard")
+	default:
+		reportSession(options.OnSession, "") // drop the dead token → next run starts fresh
+		return "", phasePay, fmt.Errorf("payment %s; re-run the top-up to try again", session.Status)
+	}
+}
+
+func reportSession(callback func(string), sessionToken string) {
+	if callback != nil {
+		callback(sessionToken)
+	}
+}
+
+// announceCheckout opens the hosted checkout in the browser (unless suppressed)
+// and reports the URL either way, so the TUI can always show the direct link.
+func announceCheckout(onStatus func(Status, string), open func(string) error, noOpen bool, checkoutURL string) {
+	if noOpen || open == nil {
+		status(onStatus, StatusOpeningCheckout, checkoutURL)
+		return
+	}
+	if err := open(checkoutURL); err != nil {
+		status(onStatus, StatusOpeningCheckout, "Open manually: "+checkoutURL)
+		return
+	}
+	status(onStatus, StatusOpeningCheckout, checkoutURL)
+}
+
+// StreamTopUpByKeyOptions drives a top-up funded with the API key that already
+// owns the account (Path A pasted key, or AIMLAPI_API_KEY). Unlike StreamTopUp it
+// needs no email session and never exchanges a key — the caller already holds one,
+// so it only funds the wallet: create-session → pay-by-key → wait-for-payment.
+type StreamTopUpByKeyOptions struct {
+	APIKey      string // raw key that owns the account (required)
+	AmountUSD   string // dollars; parsed via ParseAmountUSD (min $20)
+	AutoTopUp   bool   // enroll the account in automatic top-up at checkout time
+	PartnerID   string
+	PartnerName string
+	NoOpen      bool
+
+	// ResumeSessionToken resumes an existing partner-checkout session instead of
+	// opening a new one. PaymentSessionID is the idempotency handle carried across
+	// retries so a re-issued pay returns the same checkout, never a second charge.
+	ResumeSessionToken string
+	PaymentSessionID   string // required; generate once via NewPaymentSessionID, reuse on retry
+
+	HTTPClient  *http.Client
+	OpenBrowser func(string) error
+	OnStatus    func(Status, string)
+	OnSession   func(sessionToken string)
+}
+
+// StreamTopUpByKey funds the account behind APIKey via the hosted checkout and
+// reports progress through OnStatus. It returns an empty ProvisionedKey: the
+// pasted/env key is unchanged, only the balance grows.
+func StreamTopUpByKey(ctx context.Context, options StreamTopUpByKeyOptions) (ProvisionedKey, error) {
+	endpoints := ResolveEndpoints()
+	client := NewClient(endpoints, options.HTTPClient)
+	partnerID := firstNonEmpty(options.PartnerID, os.Getenv("AIMLAPI_PARTNER_ID"), DefaultPartnerID)
+	partnerName := firstNonEmpty(options.PartnerName, DefaultPartnerName)
+	amount, err := ParseAmountUSD(options.AmountUSD)
+	if err != nil {
+		return ProvisionedKey{}, err
+	}
+	if strings.TrimSpace(options.APIKey) == "" {
+		return ProvisionedKey{}, fmt.Errorf("an API key is required to top up")
+	}
+	if strings.TrimSpace(options.PaymentSessionID) == "" {
+		return ProvisionedKey{}, fmt.Errorf("a payment session id is required to top up")
+	}
+
+	status(options.OnStatus, StatusCreatingSession, "")
+	sessionToken, phase, err := resolveByKeySession(ctx, client, options, partnerID, partnerName, endpoints)
+	if err != nil {
+		return ProvisionedKey{}, err
+	}
+	reportSession(options.OnSession, sessionToken)
+
+	if phase <= phasePay {
+		successURL, cancelURL := BuildPartnerCheckoutReturnURLs(endpoints.PayBaseURL, sessionToken)
+		status(options.OnStatus, StatusOpeningCheckout, "")
+		pay, err := client.TopUpByKey(ctx, options.APIKey, TopUpByKeyRequest{
+			SessionToken:     sessionToken,
+			AmountUSDMinor:   amount,
+			PaymentSessionID: options.PaymentSessionID,
+			AutoTopUp:        options.AutoTopUp,
+			SuccessURL:       successURL,
+			CancelURL:        cancelURL,
+		})
+		if err != nil {
+			return ProvisionedKey{}, err
+		}
+		checkoutURL := strings.TrimSpace(pay.Checkout.PayURL)
+		if checkoutURL == "" {
+			return ProvisionedKey{}, fmt.Errorf("payment provider did not return a checkout URL")
+		}
+		announceCheckout(options.OnStatus, options.OpenBrowser, options.NoOpen, checkoutURL)
+	}
+
+	if phase <= phasePoll {
+		status(options.OnStatus, StatusWaitingPayment, "")
+		if _, err := pollUntilPaid(ctx, client, sessionToken); err != nil {
+			return ProvisionedKey{}, err
+		}
+	}
+	// No exchange: the account is funded and the caller keeps its existing key.
+	return ProvisionedKey{}, nil
+}
+
+// resolveByKeySession mirrors resolveTopupSession for the by-key flow. Because
+// by-key never exchanges, a paid/exchanging/exchanged session all mean "already
+// funded, done" (phaseExchange skips straight past pay + poll to the empty result).
+func resolveByKeySession(ctx context.Context, client *Client, options StreamTopUpByKeyOptions, partnerID, partnerName string, endpoints Endpoints) (string, topupPhase, error) {
+	resume := strings.TrimSpace(options.ResumeSessionToken)
+	if resume == "" {
+		session, err := client.CreateSession(ctx, partnerID, partnerName, BuildPartnerReturnURL(endpoints.VerificationBaseURL))
+		if err != nil {
+			return "", phasePay, err
+		}
+		return session.SessionToken, phasePay, nil
+	}
+	session, err := client.GetSession(ctx, resume)
+	if err != nil {
+		return "", phasePay, err
+	}
+	switch session.Status {
+	case SessionStatusPendingAuth:
+		return resume, phasePay, nil
+	case SessionStatusPendingPayment:
+		return resume, phasePoll, nil
+	case SessionStatusPaid, SessionStatusExchanging, SessionStatusExchanged:
+		return resume, phaseExchange, nil
+	default:
+		reportSession(options.OnSession, "") // drop the dead token → next run starts fresh
+		return "", phasePay, fmt.Errorf("payment %s; re-run the top-up to try again", session.Status)
+	}
 }

--- a/internal/aimlapi/stream.go
+++ b/internal/aimlapi/stream.go
@@ -1,0 +1,99 @@
+package aimlapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// StreamTopUpOptions drives a session-based partner-checkout top-up for the
+// interactive (TUI) onboarding. The caller already holds a user session —
+// obtained from an email-code sign-in (Path B existing) or a
+// passwordless new account (Path B sign-up) — so this skips authentication and
+// runs create-session → pay → wait-for-payment, optionally exchanging the paid
+// session into a fresh key (new accounts) versus keeping the caller's key.
+type StreamTopUpOptions struct {
+	SessionToken string // user session bearer (required)
+	AmountUSD    string // dollars; parsed via ParseAmountUSD (min $20)
+	Method       PaymentMethod
+	AutoTopUp    bool // enroll the account in automatic top-up at checkout time
+	Exchange     bool // exchange the paid session into a new key (new accounts)
+	Model        string
+	PartnerID    string
+	PartnerName  string
+	NoOpen       bool
+
+	HTTPClient  *http.Client
+	OpenBrowser func(string) error
+	OnStatus    func(Status, string)
+}
+
+// StreamTopUp performs the browser-checkout top-up and reports progress via
+// OnStatus.
+func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKey, error) {
+	endpoints := ResolveEndpoints()
+	client := NewClient(endpoints, options.HTTPClient)
+	partnerID := firstNonEmpty(options.PartnerID, os.Getenv("AIMLAPI_PARTNER_ID"), DefaultPartnerID)
+	partnerName := firstNonEmpty(options.PartnerName, DefaultPartnerName)
+	method := options.Method
+	if method != PaymentMethodCrypto {
+		method = PaymentMethodCard
+	}
+	amount, err := ParseAmountUSD(options.AmountUSD)
+	if err != nil {
+		return ProvisionedKey{}, err
+	}
+	if strings.TrimSpace(options.SessionToken) == "" {
+		return ProvisionedKey{}, fmt.Errorf("a session is required to top up")
+	}
+
+	status(options.OnStatus, StatusCreatingSession, "")
+	session, err := client.CreateSession(ctx, partnerID, partnerName, BuildPartnerReturnURL(endpoints.VerificationBaseURL))
+	if err != nil {
+		return ProvisionedKey{}, err
+	}
+	successURL, cancelURL := BuildPartnerCheckoutReturnURLs(endpoints.PayBaseURL, session.SessionToken)
+
+	status(options.OnStatus, StatusOpeningCheckout, "")
+	pay, err := client.Pay(ctx, options.SessionToken, session.SessionToken, amount, method, successURL, cancelURL, options.AutoTopUp)
+	if err != nil {
+		return ProvisionedKey{}, err
+	}
+	checkoutURL := strings.TrimSpace(pay.Checkout.PayURL)
+	if checkoutURL == "" {
+		return ProvisionedKey{}, fmt.Errorf("payment provider did not return a checkout URL")
+	}
+	if options.NoOpen || options.OpenBrowser == nil {
+		status(options.OnStatus, StatusOpeningCheckout, checkoutURL)
+	} else if err := options.OpenBrowser(checkoutURL); err != nil {
+		status(options.OnStatus, StatusOpeningCheckout, "Open manually: "+checkoutURL)
+	} else {
+		status(options.OnStatus, StatusOpeningCheckout, checkoutURL)
+	}
+
+	status(options.OnStatus, StatusWaitingPayment, "")
+	paid, err := pollUntilPaid(ctx, client, session.SessionToken)
+	if err != nil {
+		return ProvisionedKey{}, err
+	}
+
+	result := ProvisionedKey{
+		BaseURL: endpoints.InferenceBaseURL,
+		Model:   firstNonEmpty(options.Model, DefaultModel),
+	}
+	if options.Exchange {
+		status(options.OnStatus, StatusProvisioningKey, "")
+		exchange, err := client.Exchange(ctx, options.SessionToken, paid.SessionToken)
+		if err != nil {
+			return ProvisionedKey{}, err
+		}
+		if strings.TrimSpace(exchange.APIKey) == "" {
+			return ProvisionedKey{}, fmt.Errorf("aimlapi.com did not return an API key")
+		}
+		result.APIKey = exchange.APIKey
+		result.APIKeyID = exchange.APIKeyID
+	}
+	return result, nil
+}

--- a/internal/aimlapi/stream.go
+++ b/internal/aimlapi/stream.go
@@ -159,6 +159,9 @@ func resolveTopupSession(ctx context.Context, client *Client, options StreamTopU
 	}
 	session, err := client.GetSession(ctx, resume)
 	if err != nil {
+		if isTerminalSessionAPIError(err) {
+			reportSession(options.OnSession, "")
+		}
 		return "", phasePay, err
 	}
 	switch session.Status {
@@ -297,6 +300,9 @@ func resolveByKeySession(ctx context.Context, client *Client, options StreamTopU
 	}
 	session, err := client.GetSession(ctx, resume)
 	if err != nil {
+		if isTerminalSessionAPIError(err) {
+			reportSession(options.OnSession, "")
+		}
 		return "", phasePay, err
 	}
 	switch session.Status {

--- a/internal/aimlapi/stream.go
+++ b/internal/aimlapi/stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -98,9 +99,9 @@ func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKe
 		if err != nil {
 			return ProvisionedKey{}, err
 		}
-		checkoutURL := strings.TrimSpace(pay.Checkout.PayURL)
-		if checkoutURL == "" {
-			return ProvisionedKey{}, fmt.Errorf("payment provider did not return a checkout URL")
+		checkoutURL, err := validatedCheckoutURL(pay.Checkout.PayURL)
+		if err != nil {
+			return ProvisionedKey{}, err
 		}
 		announceCheckout(options.OnStatus, options.OpenBrowser, options.NoOpen, checkoutURL)
 	}
@@ -207,6 +208,15 @@ func announceCheckout(onStatus func(Status, string), open func(string) error, no
 	status(onStatus, StatusOpeningCheckout, checkoutURL)
 }
 
+func validatedCheckoutURL(value string) (string, error) {
+	checkoutURL := strings.TrimSpace(value)
+	parsed, err := url.Parse(checkoutURL)
+	if err != nil || !parsed.IsAbs() || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" || parsed.User != nil {
+		return "", fmt.Errorf("payment provider did not return a valid HTTPS checkout URL")
+	}
+	return checkoutURL, nil
+}
+
 // StreamTopUpByKeyOptions drives a top-up funded with the API key that already
 // owns the account (Path A pasted key, or AIMLAPI_API_KEY). Unlike StreamTopUp it
 // needs no email session and never exchanges a key — the caller already holds one,
@@ -275,9 +285,9 @@ func StreamTopUpByKey(ctx context.Context, options StreamTopUpByKeyOptions) (Pro
 		if err != nil {
 			return ProvisionedKey{}, err
 		}
-		checkoutURL := strings.TrimSpace(pay.Checkout.PayURL)
-		if checkoutURL == "" {
-			return ProvisionedKey{}, fmt.Errorf("payment provider did not return a checkout URL")
+		checkoutURL, err := validatedCheckoutURL(pay.Checkout.PayURL)
+		if err != nil {
+			return ProvisionedKey{}, err
 		}
 		announceCheckout(options.OnStatus, options.OpenBrowser, options.NoOpen, checkoutURL)
 	}

--- a/internal/aimlapi/stream.go
+++ b/internal/aimlapi/stream.go
@@ -16,13 +16,16 @@ import (
 type StreamTopUpOptions struct {
 	SessionToken string // user session bearer (required)
 	AmountUSD    string // dollars; parsed via ParseAmountUSD (min $20)
-	Method       PaymentMethod
-	AutoTopUp    bool // enroll the account in automatic top-up at checkout time
-	Exchange     bool // exchange the paid session into a new key (new accounts)
-	Model        string
-	PartnerID    string
-	PartnerName  string
-	NoOpen       bool
+	// InferenceBaseURL pins key-bound billing and the returned provider profile to
+	// the endpoint that validated the credential. Empty uses ResolveEndpoints.
+	InferenceBaseURL string
+	Method           PaymentMethod
+	AutoTopUp        bool // enroll the account in automatic top-up at checkout time
+	Exchange         bool // exchange the paid session into a new key (new accounts)
+	Model            string
+	PartnerID        string
+	PartnerName      string
+	NoOpen           bool
 
 	// ResumeSessionToken, when set, resumes that partner-checkout session instead
 	// of opening a new one, so a retry after an ambiguous failure (a lost Pay/
@@ -55,6 +58,9 @@ const (
 // OnStatus.
 func StreamTopUp(ctx context.Context, options StreamTopUpOptions) (ProvisionedKey, error) {
 	endpoints := ResolveEndpoints()
+	if baseURL := strings.TrimSpace(options.InferenceBaseURL); baseURL != "" {
+		endpoints.InferenceBaseURL = baseURL
+	}
 	client := NewClient(endpoints, options.HTTPClient)
 	partnerID := ResolvePartnerID(options.PartnerID)
 	partnerName := firstNonEmpty(options.PartnerName, DefaultPartnerName)
@@ -197,12 +203,13 @@ func announceCheckout(onStatus func(Status, string), open func(string) error, no
 // needs no email session and never exchanges a key — the caller already holds one,
 // so it only funds the wallet: create-session → pay-by-key → wait-for-payment.
 type StreamTopUpByKeyOptions struct {
-	APIKey      string // raw key that owns the account (required)
-	AmountUSD   string // dollars; parsed via ParseAmountUSD (min $20)
-	AutoTopUp   bool   // enroll the account in automatic top-up at checkout time
-	PartnerID   string
-	PartnerName string
-	NoOpen      bool
+	APIKey           string // raw key that owns the account (required)
+	AmountUSD        string // dollars; parsed via ParseAmountUSD (min $20)
+	InferenceBaseURL string // validated key endpoint; empty uses ResolveEndpoints
+	AutoTopUp        bool   // enroll the account in automatic top-up at checkout time
+	PartnerID        string
+	PartnerName      string
+	NoOpen           bool
 
 	// ResumeSessionToken resumes an existing partner-checkout session instead of
 	// opening a new one. PaymentSessionID is the idempotency handle carried across
@@ -221,6 +228,9 @@ type StreamTopUpByKeyOptions struct {
 // pasted/env key is unchanged, only the balance grows.
 func StreamTopUpByKey(ctx context.Context, options StreamTopUpByKeyOptions) (ProvisionedKey, error) {
 	endpoints := ResolveEndpoints()
+	if baseURL := strings.TrimSpace(options.InferenceBaseURL); baseURL != "" {
+		endpoints.InferenceBaseURL = baseURL
+	}
 	client := NewClient(endpoints, options.HTTPClient)
 	partnerID := ResolvePartnerID(options.PartnerID)
 	partnerName := firstNonEmpty(options.PartnerName, DefaultPartnerName)

--- a/internal/aimlapi/stream_test.go
+++ b/internal/aimlapi/stream_test.go
@@ -230,6 +230,60 @@ func TestPollUntilPaidTerminal4xxClearsRetainedToken(t *testing.T) {
 	}
 }
 
+func TestResumeHelpersClearOnlyRejectedSessions(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		wantClear bool
+	}{
+		{name: "terminal 4xx", status: http.StatusNotFound, wantClear: true},
+		{name: "retryable 5xx", status: http.StatusServiceUnavailable, wantClear: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "session lookup failed", test.status)
+			}))
+			defer server.Close()
+			client := NewClient(Endpoints{AppBaseURL: server.URL}, server.Client())
+
+			for _, flow := range []struct {
+				name    string
+				resolve func(func(string)) error
+			}{
+				{
+					name: "session bearer",
+					resolve: func(onSession func(string)) error {
+						_, _, err := resolveTopupSession(context.Background(), client, StreamTopUpOptions{
+							ResumeSessionToken: "pc_rejected", OnSession: onSession,
+						}, DefaultPartnerID, DefaultPartnerName, Endpoints{})
+						return err
+					},
+				},
+				{
+					name: "api key",
+					resolve: func(onSession func(string)) error {
+						_, _, err := resolveByKeySession(context.Background(), client, StreamTopUpByKeyOptions{
+							ResumeSessionToken: "pc_rejected", OnSession: onSession,
+						}, DefaultPartnerID, DefaultPartnerName, Endpoints{})
+						return err
+					},
+				},
+			} {
+				t.Run(flow.name, func(t *testing.T) {
+					seen := "retained"
+					if err := flow.resolve(func(token string) { seen = token }); err == nil {
+						t.Fatal("resolve error = nil")
+					}
+					if cleared := seen == ""; cleared != test.wantClear {
+						t.Fatalf("session cleared = %v, want %v", cleared, test.wantClear)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestStreamTopUpResumeExchangedReturnsRecoveryError(t *testing.T) {
 	rs := &resumeServer{t: t, statuses: []string{"exchanged"}}
 	server := httptest.NewServer(rs.handler())

--- a/internal/aimlapi/stream_test.go
+++ b/internal/aimlapi/stream_test.go
@@ -58,6 +58,44 @@ func TestStreamTopUpByKeyFundsWithoutExchange(t *testing.T) {
 	}
 }
 
+func TestStreamTopUpByKeyPinsValidatedInferenceEndpoint(t *testing.T) {
+	validatedCalls := 0
+	validated := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/partner-checkout/sessions"):
+			_ = json.NewEncoder(w).Encode(PartnerCheckoutSession{SessionToken: "pcs_tok", Status: SessionStatusPendingAuth})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/v2/billing/topup"):
+			validatedCalls++
+			_ = json.NewEncoder(w).Encode(TopUpByKeyResult{Checkout: PaymentSession{PayURL: "https://pay/checkout"}})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/partner-checkout/sessions/"):
+			_ = json.NewEncoder(w).Encode(PartnerCheckoutSession{SessionToken: "pcs_tok", Status: SessionStatusPaid})
+		default:
+			t.Errorf("unexpected validated-endpoint request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer validated.Close()
+	override := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("validated key leaked to process override: %s %s", r.Method, r.URL.Path)
+	}))
+	defer override.Close()
+	t.Setenv("AIMLAPI_APP_URL", validated.URL)
+	t.Setenv("AIMLAPI_INFERENCE_URL", override.URL)
+
+	_, err := StreamTopUpByKey(context.Background(), StreamTopUpByKeyOptions{
+		APIKey:           "production-key",
+		AmountUSD:        "20",
+		InferenceBaseURL: validated.URL,
+		PaymentSessionID: "payment-1",
+		OpenBrowser:      func(string) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("StreamTopUpByKey() error = %v", err)
+	}
+	if validatedCalls != 1 {
+		t.Fatalf("validated endpoint top-up calls = %d, want 1", validatedCalls)
+	}
+}
+
 // resumeServer is a partner-checkout backend fake that fails the test if the
 // re-charging endpoints (create-session / pay) are ever hit, and serves a
 // scripted GetSession status sequence so a resume can be driven deterministically.
@@ -171,6 +209,24 @@ func TestStreamTopUpPollingDeadSessionClearsRetainedToken(t *testing.T) {
 	}
 	if len(seen) == 0 || seen[len(seen)-1] != "" {
 		t.Fatalf("OnSession events = %#v, want terminal clear", seen)
+	}
+}
+
+func TestPollUntilPaidTerminal4xxClearsRetainedToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "session rejected", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	seen := "retained"
+	_, err := pollUntilPaid(context.Background(), NewClient(Endpoints{AppBaseURL: server.URL}, server.Client()), "pc_missing", func(token string) {
+		seen = token
+	})
+	if err == nil {
+		t.Fatal("pollUntilPaid() error = nil, want terminal 4xx")
+	}
+	if seen != "" {
+		t.Fatalf("retained session = %q, want cleared", seen)
 	}
 }
 

--- a/internal/aimlapi/stream_test.go
+++ b/internal/aimlapi/stream_test.go
@@ -151,6 +151,29 @@ func TestStreamTopUpResumePendingPaymentPollsNeverRepays(t *testing.T) {
 	}
 }
 
+func TestStreamTopUpPollingDeadSessionClearsRetainedToken(t *testing.T) {
+	rs := &resumeServer{t: t, statuses: []string{"pending_payment", "expired"}}
+	server := httptest.NewServer(rs.handler())
+	defer server.Close()
+	t.Setenv("AIMLAPI_APP_URL", server.URL)
+
+	seen := []string{}
+	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
+		SessionToken:       "bearer",
+		ResumeSessionToken: "pc_tok",
+		AmountUSD:          "20",
+		Exchange:           true,
+		NoOpen:             true,
+		OnSession:          func(token string) { seen = append(seen, token) },
+	})
+	if err == nil || !strings.Contains(err.Error(), "payment expired") {
+		t.Fatalf("err = %v, want expired payment error", err)
+	}
+	if len(seen) == 0 || seen[len(seen)-1] != "" {
+		t.Fatalf("OnSession events = %#v, want terminal clear", seen)
+	}
+}
+
 func TestStreamTopUpResumeExchangedReturnsRecoveryError(t *testing.T) {
 	rs := &resumeServer{t: t, statuses: []string{"exchanged"}}
 	server := httptest.NewServer(rs.handler())

--- a/internal/aimlapi/stream_test.go
+++ b/internal/aimlapi/stream_test.go
@@ -96,6 +96,45 @@ func TestStreamTopUpByKeyPinsValidatedInferenceEndpoint(t *testing.T) {
 	}
 }
 
+func TestStreamTopUpEmailRetrySendsStablePaymentSessionID(t *testing.T) {
+	getCalls := 0
+	var paymentSessionID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/partner-checkout/sessions/"):
+			status := SessionStatusPendingAuth
+			if getCalls > 0 {
+				status = SessionStatusPaid
+			}
+			getCalls++
+			_ = json.NewEncoder(w).Encode(PartnerCheckoutSession{SessionToken: "pcs_retry", Status: status})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pay"):
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			paymentSessionID, _ = body["paymentSessionId"].(string)
+			_ = json.NewEncoder(w).Encode(PayResult{Checkout: PaymentSession{PayURL: "https://pay/checkout"}})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("AIMLAPI_APP_URL", server.URL)
+
+	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
+		SessionToken:       "bearer",
+		ResumeSessionToken: "pcs_retry",
+		PaymentSessionID:   "payment-stable",
+		AmountUSD:          "20",
+		NoOpen:             true,
+	})
+	if err != nil {
+		t.Fatalf("StreamTopUp() error = %v", err)
+	}
+	if paymentSessionID != "payment-stable" {
+		t.Fatalf("paymentSessionId = %q, want stable retry id", paymentSessionID)
+	}
+}
+
 // resumeServer is a partner-checkout backend fake that fails the test if the
 // re-charging endpoints (create-session / pay) are ever hit, and serves a
 // scripted GetSession status sequence so a resume can be driven deterministically.
@@ -143,6 +182,7 @@ func TestStreamTopUpResumePaidExchangesWithoutRecharge(t *testing.T) {
 	result, err := StreamTopUp(context.Background(), StreamTopUpOptions{
 		SessionToken:       "bearer",
 		ResumeSessionToken: "pc_tok",
+		PaymentSessionID:   "payment-1",
 		AmountUSD:          "20",
 		Exchange:           true,
 		NoOpen:             true,
@@ -174,6 +214,7 @@ func TestStreamTopUpResumePendingPaymentPollsNeverRepays(t *testing.T) {
 	result, err := StreamTopUp(context.Background(), StreamTopUpOptions{
 		SessionToken:       "bearer",
 		ResumeSessionToken: "pc_tok",
+		PaymentSessionID:   "payment-1",
 		AmountUSD:          "20",
 		Exchange:           true,
 		NoOpen:             true,
@@ -199,6 +240,7 @@ func TestStreamTopUpPollingDeadSessionClearsRetainedToken(t *testing.T) {
 	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
 		SessionToken:       "bearer",
 		ResumeSessionToken: "pc_tok",
+		PaymentSessionID:   "payment-1",
 		AmountUSD:          "20",
 		Exchange:           true,
 		NoOpen:             true,
@@ -227,6 +269,39 @@ func TestPollUntilPaidTerminal4xxClearsRetainedToken(t *testing.T) {
 	}
 	if seen != "" {
 		t.Fatalf("retained session = %q, want cleared", seen)
+	}
+}
+
+func TestPollUntilExchangeSettledClearsDeadSession(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		statusCode int
+		status     SessionStatus
+	}{
+		{name: "terminal API rejection", statusCode: http.StatusNotFound},
+		{name: "expired exchange claim", status: SessionStatusExpired},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if test.statusCode != 0 {
+					http.Error(w, "session rejected", test.statusCode)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(PartnerCheckoutSession{SessionToken: "pcs_dead", Status: test.status})
+			}))
+			defer server.Close()
+
+			seen := "retained"
+			err := pollUntilExchangeSettled(context.Background(), NewClient(Endpoints{AppBaseURL: server.URL}, server.Client()), "pcs_dead", func(token string) {
+				seen = token
+			})
+			if err == nil {
+				t.Fatal("pollUntilExchangeSettled() error = nil")
+			}
+			if seen != "" {
+				t.Fatalf("retained session = %q, want cleared", seen)
+			}
+		})
 	}
 }
 
@@ -293,6 +368,7 @@ func TestStreamTopUpResumeExchangedReturnsRecoveryError(t *testing.T) {
 	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
 		SessionToken:       "bearer",
 		ResumeSessionToken: "pc_tok",
+		PaymentSessionID:   "payment-1",
 		AmountUSD:          "20",
 		Exchange:           true,
 		NoOpen:             true,
@@ -314,6 +390,7 @@ func TestStreamTopUpResumeExchangingPollsWithoutSecondExchange(t *testing.T) {
 	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
 		SessionToken:       "bearer",
 		ResumeSessionToken: "pc_tok",
+		PaymentSessionID:   "payment-1",
 		AmountUSD:          "20",
 		Exchange:           true,
 		NoOpen:             true,
@@ -338,6 +415,7 @@ func TestStreamTopUpPollObservesExchangingWithoutSecondExchange(t *testing.T) {
 	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
 		SessionToken:       "bearer",
 		ResumeSessionToken: "pc_tok",
+		PaymentSessionID:   "payment-1",
 		AmountUSD:          "20",
 		Exchange:           true,
 		NoOpen:             true,

--- a/internal/aimlapi/stream_test.go
+++ b/internal/aimlapi/stream_test.go
@@ -1,0 +1,218 @@
+package aimlapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestStreamTopUpByKeyFundsWithoutExchange(t *testing.T) {
+	var topupCalls, exchangeCalls int
+	var topupBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/partner-checkout/sessions"):
+			_ = json.NewEncoder(w).Encode(PartnerCheckoutSession{SessionToken: "pcs_tok", Status: SessionStatusPendingAuth})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/v2/billing/topup"):
+			topupCalls++
+			_ = json.NewDecoder(r.Body).Decode(&topupBody)
+			_ = json.NewEncoder(w).Encode(TopUpByKeyResult{Checkout: PaymentSession{PayURL: "https://pay/checkout"}})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/partner-checkout/sessions/"):
+			_ = json.NewEncoder(w).Encode(PartnerCheckoutSession{SessionToken: "pcs_tok", Status: SessionStatusPaid})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/exchange"):
+			exchangeCalls++
+			t.Errorf("by-key must never exchange a key")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("AIMLAPI_APP_URL", server.URL)
+	t.Setenv("AIMLAPI_INFERENCE_URL", server.URL+"/v1")
+
+	var opened string
+	result, err := StreamTopUpByKey(context.Background(), StreamTopUpByKeyOptions{
+		APIKey:           "sk-user",
+		AmountUSD:        "20",
+		AutoTopUp:        true,
+		PaymentSessionID: "pay-1",
+		OpenBrowser:      func(u string) error { opened = u; return nil },
+	})
+	if err != nil {
+		t.Fatalf("StreamTopUpByKey = %v", err)
+	}
+	if result.APIKey != "" {
+		t.Fatalf("by-key must not mint a key, got %q", result.APIKey)
+	}
+	if topupCalls != 1 || exchangeCalls != 0 {
+		t.Fatalf("topup=%d exchange=%d, want 1/0", topupCalls, exchangeCalls)
+	}
+	if opened != "https://pay/checkout" {
+		t.Fatalf("opened checkout = %q", opened)
+	}
+	if topupBody["autoTopUp"] != true || topupBody["paymentSessionId"] != "pay-1" {
+		t.Fatalf("topup body missing autoTopUp/paymentSessionId: %#v", topupBody)
+	}
+}
+
+// resumeServer is a partner-checkout backend fake that fails the test if the
+// re-charging endpoints (create-session / pay) are ever hit, and serves a
+// scripted GetSession status sequence so a resume can be driven deterministically.
+type resumeServer struct {
+	t          *testing.T
+	statuses   []string // GetSession status per call, last value repeats
+	getCalls   int
+	payCalls   int
+	createCall int
+	exchanged  int
+}
+
+func (rs *resumeServer) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/partner-checkout/sessions"):
+			rs.createCall++
+			rs.t.Errorf("resume must not create a new session")
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pay"):
+			rs.payCalls++
+			rs.t.Errorf("resume must not re-pay (double charge)")
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/exchange"):
+			rs.exchanged++
+			_ = json.NewEncoder(w).Encode(ExchangeResult{APIKey: "sk-resumed", APIKeyID: "key_1"})
+		case r.Method == http.MethodGet:
+			status := rs.statuses[len(rs.statuses)-1]
+			if rs.getCalls < len(rs.statuses) {
+				status = rs.statuses[rs.getCalls]
+			}
+			rs.getCalls++
+			_ = json.NewEncoder(w).Encode(PartnerCheckoutSession{SessionToken: "pc_tok", Status: SessionStatus(status)})
+		default:
+			rs.t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+}
+
+func TestStreamTopUpResumePaidExchangesWithoutRecharge(t *testing.T) {
+	rs := &resumeServer{t: t, statuses: []string{"paid"}}
+	server := httptest.NewServer(rs.handler())
+	defer server.Close()
+	t.Setenv("AIMLAPI_APP_URL", server.URL)
+
+	var seen string
+	result, err := StreamTopUp(context.Background(), StreamTopUpOptions{
+		SessionToken:       "bearer",
+		ResumeSessionToken: "pc_tok",
+		AmountUSD:          "20",
+		Exchange:           true,
+		NoOpen:             true,
+		OnSession:          func(token string) { seen = token },
+	})
+	if err != nil {
+		t.Fatalf("StreamTopUp resume = %v", err)
+	}
+	if result.APIKey != "sk-resumed" {
+		t.Fatalf("APIKey = %q, want recovered key", result.APIKey)
+	}
+	if rs.exchanged != 1 {
+		t.Fatalf("exchange calls = %d, want 1", rs.exchanged)
+	}
+	if seen != "pc_tok" {
+		t.Fatalf("OnSession token = %q, want retained pc_tok", seen)
+	}
+}
+
+func TestStreamTopUpResumePendingPaymentPollsNeverRepays(t *testing.T) {
+	// First GetSession (resume resolution) sees the still-open checkout; the next
+	// (poll) sees it settle. Pay must never be called — the fake fails the test if
+	// it is.
+	rs := &resumeServer{t: t, statuses: []string{"pending_payment", "paid"}}
+	server := httptest.NewServer(rs.handler())
+	defer server.Close()
+	t.Setenv("AIMLAPI_APP_URL", server.URL)
+
+	result, err := StreamTopUp(context.Background(), StreamTopUpOptions{
+		SessionToken:       "bearer",
+		ResumeSessionToken: "pc_tok",
+		AmountUSD:          "20",
+		Exchange:           true,
+		NoOpen:             true,
+	})
+	if err != nil {
+		t.Fatalf("StreamTopUp resume = %v", err)
+	}
+	if result.APIKey != "sk-resumed" {
+		t.Fatalf("APIKey = %q, want recovered key", result.APIKey)
+	}
+	if rs.payCalls != 0 {
+		t.Fatalf("pay calls = %d, want 0", rs.payCalls)
+	}
+}
+
+func TestStreamTopUpResumeExchangedReturnsRecoveryError(t *testing.T) {
+	rs := &resumeServer{t: t, statuses: []string{"exchanged"}}
+	server := httptest.NewServer(rs.handler())
+	defer server.Close()
+	t.Setenv("AIMLAPI_APP_URL", server.URL)
+
+	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
+		SessionToken:       "bearer",
+		ResumeSessionToken: "pc_tok",
+		AmountUSD:          "20",
+		Exchange:           true,
+		NoOpen:             true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exchanged") {
+		t.Fatalf("err = %v, want an already-exchanged recovery error", err)
+	}
+	if rs.exchanged != 0 {
+		t.Fatalf("exchange calls = %d, want 0 (no second key)", rs.exchanged)
+	}
+}
+
+func TestStreamTopUpResumeExchangingPollsWithoutSecondExchange(t *testing.T) {
+	rs := &resumeServer{t: t, statuses: []string{"exchanging", "exchanged"}}
+	server := httptest.NewServer(rs.handler())
+	defer server.Close()
+	t.Setenv("AIMLAPI_APP_URL", server.URL)
+
+	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
+		SessionToken:       "bearer",
+		ResumeSessionToken: "pc_tok",
+		AmountUSD:          "20",
+		Exchange:           true,
+		NoOpen:             true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exchanged") {
+		t.Fatalf("err = %v, want dashboard recovery guidance", err)
+	}
+	if rs.exchanged != 0 {
+		t.Fatalf("exchange calls = %d, want 0 while an exchange claim is in flight", rs.exchanged)
+	}
+	if rs.createCall != 0 || rs.payCalls != 0 {
+		t.Fatalf("resume created/paid a new checkout: create=%d pay=%d", rs.createCall, rs.payCalls)
+	}
+}
+
+func TestStreamTopUpPollObservesExchangingWithoutSecondExchange(t *testing.T) {
+	rs := &resumeServer{t: t, statuses: []string{"pending_payment", "exchanging", "exchanged"}}
+	server := httptest.NewServer(rs.handler())
+	defer server.Close()
+	t.Setenv("AIMLAPI_APP_URL", server.URL)
+
+	_, err := StreamTopUp(context.Background(), StreamTopUpOptions{
+		SessionToken:       "bearer",
+		ResumeSessionToken: "pc_tok",
+		AmountUSD:          "20",
+		Exchange:           true,
+		NoOpen:             true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exchanged") {
+		t.Fatalf("err = %v, want dashboard recovery guidance", err)
+	}
+	if rs.exchanged != 0 {
+		t.Fatalf("exchange calls = %d, want 0 after poll observed an existing claim", rs.exchanged)
+	}
+}

--- a/internal/aimlapi/stream_test.go
+++ b/internal/aimlapi/stream_test.go
@@ -58,6 +58,34 @@ func TestStreamTopUpByKeyFundsWithoutExchange(t *testing.T) {
 	}
 }
 
+func TestValidatedCheckoutURLRequiresAbsoluteHTTPS(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{name: "https", value: " https://pay.example.test/checkout?id=1 ", want: "https://pay.example.test/checkout?id=1"},
+		{name: "empty", wantErr: true},
+		{name: "relative", value: "/checkout", wantErr: true},
+		{name: "http", value: "http://pay.example.test/checkout", wantErr: true},
+		{name: "file", value: "file:///tmp/checkout", wantErr: true},
+		{name: "custom protocol", value: "wallet://checkout/123", wantErr: true},
+		{name: "userinfo", value: "https://token@pay.example.test/checkout", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := validatedCheckoutURL(test.value)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validatedCheckoutURL(%q) error = %v", test.value, err)
+			}
+			if got != test.want {
+				t.Fatalf("validatedCheckoutURL(%q) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
 func TestStreamTopUpByKeyPinsValidatedInferenceEndpoint(t *testing.T) {
 	validatedCalls := 0
 	validated := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -9,6 +9,7 @@ import (
 	"time"
 )
 
+// Status is a progress phase reported by StreamTopUp through its OnStatus callback.
 type Status string
 
 const (
@@ -18,6 +19,8 @@ const (
 	StatusProvisioningKey Status = "provisioning-key"
 )
 
+// ProvisionedKey is the outcome of a top-up: the (optionally minted) API key plus
+// the inference base URL and model to write into the provider profile.
 type ProvisionedKey struct {
 	APIKey   string
 	APIKeyID string
@@ -30,6 +33,8 @@ const (
 	pollTimeout  = 20 * time.Minute
 )
 
+// ParseAmountUSD parses a dollar string into USD minor units (cents), enforcing the
+// min/max top-up bounds. An empty value yields the default amount.
 func ParseAmountUSD(value string) (int, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -2,6 +2,7 @@ package aimlapi
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"math"
@@ -58,6 +59,20 @@ func ParseAmountUSD(value string) (int, error) {
 	return minor, nil
 }
 
+// NewPaymentSessionID returns a random UUIDv4-shaped idempotency id for a top-up.
+// The caller generates it once per top-up intent and reuses it on retry so the
+// backend (and Stripe) coalesce retries onto the same checkout instead of a
+// second charge.
+func NewPaymentSessionID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
 func pollUntilPaid(ctx context.Context, client *Client, sessionToken string) (PartnerCheckoutSession, error) {
 	deadline := time.Now().Add(pollTimeout)
 	for time.Now().Before(deadline) {
@@ -94,6 +109,43 @@ func pollUntilPaid(ctx context.Context, client *Client, sessionToken string) (Pa
 		}
 	}
 	return PartnerCheckoutSession{}, fmt.Errorf("timed out waiting for payment; re-run once the payment clears")
+}
+
+// pollUntilExchangeSettled follows an exchange claim that was already in flight
+// when a retry resumed the session. Exchange is single-flight and the raw key is
+// returned only to the winning request, so issuing Exchange again is never safe.
+// Once the claim completes, direct the user to the dashboard recovery path.
+func pollUntilExchangeSettled(ctx context.Context, client *Client, sessionToken string) error {
+	deadline := time.Now().Add(pollTimeout)
+	for time.Now().Before(deadline) {
+		session, err := client.GetSession(ctx, sessionToken)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			var apiErr APIError
+			if errors.As(err, &apiErr) && apiErr.Status < 500 {
+				return err
+			}
+			if err := sleepContext(ctx, pollInterval); err != nil {
+				return err
+			}
+			continue
+		}
+		switch session.Status {
+		case SessionStatusExchanged:
+			return fmt.Errorf("session was already exchanged; rotate the key from the aimlapi.com dashboard")
+		case SessionStatusExchanging:
+			if err := sleepContext(ctx, pollInterval); err != nil {
+				return err
+			}
+		case SessionStatusCancelled, SessionStatusExpired, SessionStatusFailed:
+			return fmt.Errorf("key provisioning %s; rotate the key from the aimlapi.com dashboard", session.Status)
+		default:
+			return fmt.Errorf("key provisioning returned to %s; re-run the top-up", session.Status)
+		}
+	}
+	return fmt.Errorf("timed out waiting for key provisioning; retry to check the same session")
 }
 
 func sleepContext(ctx context.Context, delay time.Duration) error {

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -125,7 +125,7 @@ func isTerminalSessionAPIError(err error) bool {
 // when a retry resumed the session. Exchange is single-flight and the raw key is
 // returned only to the winning request, so issuing Exchange again is never safe.
 // Once the claim completes, direct the user to the dashboard recovery path.
-func pollUntilExchangeSettled(ctx context.Context, client *Client, sessionToken string) error {
+func pollUntilExchangeSettled(ctx context.Context, client *Client, sessionToken string, onSession func(string)) error {
 	deadline := time.Now().Add(pollTimeout)
 	for time.Now().Before(deadline) {
 		session, err := client.GetSession(ctx, sessionToken)
@@ -133,8 +133,8 @@ func pollUntilExchangeSettled(ctx context.Context, client *Client, sessionToken 
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return err
 			}
-			var apiErr APIError
-			if errors.As(err, &apiErr) && apiErr.Status < 500 {
+			if isTerminalSessionAPIError(err) {
+				reportSession(onSession, "")
 				return err
 			}
 			if err := sleepContext(ctx, pollInterval); err != nil {
@@ -150,6 +150,7 @@ func pollUntilExchangeSettled(ctx context.Context, client *Client, sessionToken 
 				return err
 			}
 		case SessionStatusCancelled, SessionStatusExpired, SessionStatusFailed:
+			reportSession(onSession, "")
 			return fmt.Errorf("key provisioning %s; rotate the key from the aimlapi.com dashboard", session.Status)
 		default:
 			return fmt.Errorf("key provisioning returned to %s; re-run the top-up", session.Status)

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -73,7 +73,7 @@ func NewPaymentSessionID() (string, error) {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
 }
 
-func pollUntilPaid(ctx context.Context, client *Client, sessionToken string) (PartnerCheckoutSession, error) {
+func pollUntilPaid(ctx context.Context, client *Client, sessionToken string, onSession func(string)) (PartnerCheckoutSession, error) {
 	deadline := time.Now().Add(pollTimeout)
 	for time.Now().Before(deadline) {
 		session, err := client.GetSession(ctx, sessionToken)
@@ -101,6 +101,10 @@ func pollUntilPaid(ctx context.Context, client *Client, sessionToken string) (Pa
 		case SessionStatusExchanged:
 			return PartnerCheckoutSession{}, fmt.Errorf("session was already exchanged; rotate the key from the aimlapi.com dashboard")
 		case SessionStatusCancelled, SessionStatusExpired, SessionStatusFailed:
+			// The checkout cannot recover from these states. Drop the retained token
+			// (and the TUI's paired by-key idempotency ID) now so the very next retry
+			// creates a fresh payment intent.
+			reportSession(onSession, "")
 			return PartnerCheckoutSession{}, fmt.Errorf("payment %s; re-run the top-up to try again", session.Status)
 		default:
 			if err := sleepContext(ctx, pollInterval); err != nil {

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -2,6 +2,7 @@ package aimlapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -53,7 +54,8 @@ func pollUntilPaid(ctx context.Context, client *Client, sessionToken string) (Pa
 	for time.Now().Before(deadline) {
 		session, err := client.GetSession(ctx, sessionToken)
 		if err != nil {
-			if apiErr, ok := err.(APIError); ok && apiErr.Status >= 500 {
+			var apiErr APIError
+			if errors.As(err, &apiErr) && apiErr.Status >= 500 {
 				if err := sleepContext(ctx, pollInterval); err != nil {
 					return PartnerCheckoutSession{}, err
 				}

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -88,6 +88,7 @@ func pollUntilPaid(ctx context.Context, client *Client, sessionToken string, onS
 			// wait) — is retried until the poll deadline.
 			var apiErr APIError
 			if errors.As(err, &apiErr) && apiErr.Status < 500 {
+				reportSession(onSession, "")
 				return PartnerCheckoutSession{}, err
 			}
 			if err := sleepContext(ctx, pollInterval); err != nil {

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -41,7 +42,10 @@ func ParseAmountUSD(value string) (int, error) {
 		return DefaultAmountUSDMinor, nil
 	}
 	dollars, err := strconv.ParseFloat(value, 64)
-	if err != nil || dollars <= 0 {
+	// NaN/±Inf parse without error and slip past the min/max comparisons below
+	// (every ordered comparison with NaN is false), so reject them explicitly
+	// before the cents conversion turns them into a garbage minor-unit amount.
+	if err != nil || math.IsNaN(dollars) || math.IsInf(dollars, 0) || dollars <= 0 {
 		return 0, fmt.Errorf("invalid amount %q; pass a positive USD amount", value)
 	}
 	minor := int(dollars*100 + 0.5)

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -30,13 +30,6 @@ const (
 	pollTimeout  = 20 * time.Minute
 )
 
-// Sentinel amount-validation errors so callers can tell an out-of-range amount
-// apart from a non-numeric one and surface the right message.
-var (
-	ErrAmountTooLow  = errors.New("top-up amount is below the minimum")
-	ErrAmountTooHigh = errors.New("top-up amount is above the maximum")
-)
-
 func ParseAmountUSD(value string) (int, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -48,10 +41,10 @@ func ParseAmountUSD(value string) (int, error) {
 	}
 	minor := int(dollars*100 + 0.5)
 	if minor < MinAmountUSDMinor {
-		return 0, fmt.Errorf("%w of $%d", ErrAmountTooLow, MinAmountUSDMinor/100)
+		return 0, fmt.Errorf("minimum top-up is $%d", MinAmountUSDMinor/100)
 	}
 	if minor > MaxAmountUSDMinor {
-		return 0, fmt.Errorf("%w of $%d", ErrAmountTooHigh, MaxAmountUSDMinor/100)
+		return 0, fmt.Errorf("maximum top-up is $%d", MaxAmountUSDMinor/100)
 	}
 	return minor, nil
 }

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -1,0 +1,104 @@
+package aimlapi
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Status string
+
+const (
+	StatusCreatingSession Status = "creating-session"
+	StatusOpeningCheckout Status = "opening-checkout"
+	StatusWaitingPayment  Status = "waiting-payment"
+	StatusProvisioningKey Status = "provisioning-key"
+)
+
+type ProvisionedKey struct {
+	APIKey   string
+	APIKeyID string
+	BaseURL  string
+	Model    string
+}
+
+const (
+	pollInterval = 3 * time.Second
+	pollTimeout  = 20 * time.Minute
+)
+
+func ParseAmountUSD(value string) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return DefaultAmountUSDMinor, nil
+	}
+	dollars, err := strconv.ParseFloat(value, 64)
+	if err != nil || dollars <= 0 {
+		return 0, fmt.Errorf("invalid amount %q; pass a positive USD amount", value)
+	}
+	minor := int(dollars*100 + 0.5)
+	if minor < MinAmountUSDMinor {
+		return 0, fmt.Errorf("minimum top-up is $%d", MinAmountUSDMinor/100)
+	}
+	if minor > MaxAmountUSDMinor {
+		return 0, fmt.Errorf("maximum top-up is $%d", MaxAmountUSDMinor/100)
+	}
+	return minor, nil
+}
+
+func pollUntilPaid(ctx context.Context, client *Client, sessionToken string) (PartnerCheckoutSession, error) {
+	deadline := time.Now().Add(pollTimeout)
+	for time.Now().Before(deadline) {
+		session, err := client.GetSession(ctx, sessionToken)
+		if err != nil {
+			if apiErr, ok := err.(APIError); ok && apiErr.Status >= 500 {
+				if err := sleepContext(ctx, pollInterval); err != nil {
+					return PartnerCheckoutSession{}, err
+				}
+				continue
+			}
+			return PartnerCheckoutSession{}, err
+		}
+		switch session.Status {
+		case SessionStatusPaid, SessionStatusExchanging:
+			return session, nil
+		case SessionStatusExchanged:
+			return PartnerCheckoutSession{}, fmt.Errorf("session was already exchanged; rotate the key from the aimlapi.com dashboard")
+		case SessionStatusCancelled, SessionStatusExpired, SessionStatusFailed:
+			return PartnerCheckoutSession{}, fmt.Errorf("payment %s; re-run the top-up to try again", session.Status)
+		default:
+			if err := sleepContext(ctx, pollInterval); err != nil {
+				return PartnerCheckoutSession{}, err
+			}
+		}
+	}
+	return PartnerCheckoutSession{}, fmt.Errorf("timed out waiting for payment; re-run once the payment clears")
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func status(callback func(Status, string), value Status, detail string) {
+	if callback != nil {
+		callback(value, detail)
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -86,8 +87,7 @@ func pollUntilPaid(ctx context.Context, client *Client, sessionToken string, onS
 			// A 4xx API response is terminal. Everything else — a 5xx or a transient
 			// transport error (non-APIError, e.g. a dropped connection during the
 			// wait) — is retried until the poll deadline.
-			var apiErr APIError
-			if errors.As(err, &apiErr) && apiErr.Status < 500 {
+			if isTerminalSessionAPIError(err) {
 				reportSession(onSession, "")
 				return PartnerCheckoutSession{}, err
 			}
@@ -114,6 +114,11 @@ func pollUntilPaid(ctx context.Context, client *Client, sessionToken string, onS
 		}
 	}
 	return PartnerCheckoutSession{}, fmt.Errorf("timed out waiting for payment; re-run once the payment clears")
+}
+
+func isTerminalSessionAPIError(err error) bool {
+	var apiErr APIError
+	return errors.As(err, &apiErr) && apiErr.Status >= http.StatusBadRequest && apiErr.Status < http.StatusInternalServerError
 }
 
 // pollUntilExchangeSettled follows an exchange claim that was already in flight

--- a/internal/aimlapi/topup.go
+++ b/internal/aimlapi/topup.go
@@ -30,6 +30,13 @@ const (
 	pollTimeout  = 20 * time.Minute
 )
 
+// Sentinel amount-validation errors so callers can tell an out-of-range amount
+// apart from a non-numeric one and surface the right message.
+var (
+	ErrAmountTooLow  = errors.New("top-up amount is below the minimum")
+	ErrAmountTooHigh = errors.New("top-up amount is above the maximum")
+)
+
 func ParseAmountUSD(value string) (int, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -41,10 +48,10 @@ func ParseAmountUSD(value string) (int, error) {
 	}
 	minor := int(dollars*100 + 0.5)
 	if minor < MinAmountUSDMinor {
-		return 0, fmt.Errorf("minimum top-up is $%d", MinAmountUSDMinor/100)
+		return 0, fmt.Errorf("%w of $%d", ErrAmountTooLow, MinAmountUSDMinor/100)
 	}
 	if minor > MaxAmountUSDMinor {
-		return 0, fmt.Errorf("maximum top-up is $%d", MaxAmountUSDMinor/100)
+		return 0, fmt.Errorf("%w of $%d", ErrAmountTooHigh, MaxAmountUSDMinor/100)
 	}
 	return minor, nil
 }
@@ -54,14 +61,22 @@ func pollUntilPaid(ctx context.Context, client *Client, sessionToken string) (Pa
 	for time.Now().Before(deadline) {
 		session, err := client.GetSession(ctx, sessionToken)
 		if err != nil {
-			var apiErr APIError
-			if errors.As(err, &apiErr) && apiErr.Status >= 500 {
-				if err := sleepContext(ctx, pollInterval); err != nil {
-					return PartnerCheckoutSession{}, err
-				}
-				continue
+			// Context cancellation/deadline is terminal (also covers an in-flight
+			// request cancelled mid-poll, whose transport error wraps ctx.Err()).
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return PartnerCheckoutSession{}, err
 			}
-			return PartnerCheckoutSession{}, err
+			// A 4xx API response is terminal. Everything else — a 5xx or a transient
+			// transport error (non-APIError, e.g. a dropped connection during the
+			// wait) — is retried until the poll deadline.
+			var apiErr APIError
+			if errors.As(err, &apiErr) && apiErr.Status < 500 {
+				return PartnerCheckoutSession{}, err
+			}
+			if err := sleepContext(ctx, pollInterval); err != nil {
+				return PartnerCheckoutSession{}, err
+			}
+			continue
 		}
 		switch session.Status {
 		case SessionStatusPaid, SessionStatusExchanging:

--- a/internal/aimlapi/validation.go
+++ b/internal/aimlapi/validation.go
@@ -1,0 +1,38 @@
+package aimlapi
+
+import (
+	"net/mail"
+	"strings"
+)
+
+// ValidEmail performs the lightweight validation used before starting the
+// passwordless onboarding request.
+func ValidEmail(value string) bool {
+	value = strings.TrimSpace(value)
+	address, err := mail.ParseAddress(value)
+	if err != nil || address.Address != value {
+		return false
+	}
+	at := strings.LastIndexByte(value, '@')
+	if at <= 0 || at == len(value)-1 {
+		return false
+	}
+	domain := value[at+1:]
+	if strings.HasPrefix(domain, ".") || strings.HasSuffix(domain, ".") || strings.Contains(domain, "..") {
+		return false
+	}
+	dot := strings.LastIndexByte(domain, '.')
+	if dot <= 0 || dot == len(domain)-1 {
+		return false
+	}
+	tld := domain[dot+1:]
+	if len(tld) < 2 {
+		return false
+	}
+	for _, char := range tld {
+		if char < 'A' || char > 'Z' && char < 'a' || char > 'z' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -376,6 +376,55 @@ func TestRunProvidersAddAimlapiWritesDefaultHeaders(t *testing.T) {
 	}
 }
 
+func TestRunProvidersAddAimlapiMixedCaseHeaderOverride(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	// A differently-cased override must replace the catalog header in place, not
+	// leave both spellings behind to race when request construction canonicalizes.
+	exitCode := runWithDeps([]string{
+		"providers", "add", "aimlapi",
+		"--header", "x-aimlapi-partner-id=part_override",
+	}, &stdout, &stderr, providerSetupDeps(configPath))
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	profile := readFileConfig(t, configPath).Providers[0]
+	if _, ok := profile.CustomHeaders["x-aimlapi-partner-id"]; ok {
+		t.Fatalf("lowercase override left a duplicate key: %#v", profile.CustomHeaders)
+	}
+	if profile.CustomHeaders["X-AIMLAPI-Partner-ID"] != "part_override" {
+		t.Fatalf("override did not win on the canonical key: %#v", profile.CustomHeaders)
+	}
+}
+
+func TestRunProvidersAddAimlapiOverrideDropsCatalogHeaders(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	exitCode := runWithDeps([]string{
+		"providers", "add", "aimlapi",
+		"--base-url", "https://staging.example/v1",
+		"--header", "X-Environment=staging",
+	}, &stdout, &stderr, providerSetupDeps(configPath))
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	profile := readFileConfig(t, configPath).Providers[0]
+	if _, ok := profile.CustomHeaders["X-AIMLAPI-Partner-ID"]; ok {
+		t.Fatalf("partner attribution leaked to overridden endpoint: %#v", profile.CustomHeaders)
+	}
+	if _, ok := profile.CustomHeaders["X-AIMLAPI-Integration-Repo"]; ok {
+		t.Fatalf("integration attribution leaked to overridden endpoint: %#v", profile.CustomHeaders)
+	}
+	if profile.CustomHeaders["X-Environment"] != "staging" {
+		t.Fatalf("explicit user header was dropped: %#v", profile.CustomHeaders)
+	}
+}
+
 func TestRunProvidersAddWritesCustomHeaders(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -348,6 +348,34 @@ func TestRunProvidersAddWritesCatalogProfile(t *testing.T) {
 	}
 }
 
+func TestRunProvidersAddAimlapiWritesDefaultHeaders(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	exitCode := runWithDeps([]string{"providers", "add", "aimlapi"}, &stdout, &stderr, providerSetupDeps(configPath))
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	cfg := readFileConfig(t, configPath)
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("providers = %#v, want one provider", cfg.Providers)
+	}
+	profile := cfg.Providers[0]
+	if profile.Name != "aimlapi" ||
+		profile.CatalogID != "aimlapi" ||
+		profile.BaseURL != "https://api.aimlapi.com/v1" ||
+		profile.Model != "anthropic/claude-sonnet-5" ||
+		profile.APIKeyEnv != "AIMLAPI_API_KEY" {
+		t.Fatalf("unexpected provider profile: %#v", profile)
+	}
+	if profile.CustomHeaders["X-AIMLAPI-Partner-ID"] != "part_62yQoGYDq4Yqnrj2R1iGrDNJ" ||
+		profile.CustomHeaders["X-AIMLAPI-Integration-Repo"] != "Gitlawb/zero" {
+		t.Fatalf("missing aimlapi.com default headers: %#v", profile.CustomHeaders)
+	}
+}
+
 func TestRunProvidersAddWritesCustomHeaders(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/provider_catalog_onboarding_test.go
+++ b/internal/cli/provider_catalog_onboarding_test.go
@@ -17,7 +17,6 @@ func TestProviderCatalogRuntimeProvidersShowOnboardingSetupHints(t *testing.T) {
 		defaultModel string
 	}{
 		{id: "openai", name: "OpenAI", transport: "openai", defaultModel: "gpt-4.1"},
-		{id: "aimlapi", name: "AI/ML API", transport: "openai-compatible", defaultModel: "openai/gpt-5-chat"},
 		{id: "groq", name: "Groq", transport: "openai-compatible", defaultModel: "llama-3.3-70b-versatile"},
 		{id: "longcat", name: "LongCat", transport: "openai-compatible", defaultModel: "LongCat-2.0"},
 		{id: "ollama-cloud", name: "Ollama Cloud", transport: "openai-compatible", defaultModel: "qwen3-coder:480b"},
@@ -45,21 +44,6 @@ func TestProviderCatalogRuntimeProvidersShowOnboardingSetupHints(t *testing.T) {
 				t.Fatalf("runtime-supported provider %s should not show unsupported reason, got:\n%s", tt.id, block)
 			}
 		})
-	}
-}
-
-func TestProviderCatalogAIMLAPIRequiresAPIKey(t *testing.T) {
-	output := runProviderCatalogOnboarding(t)
-	block := providerCatalogOnboardingBlock(t, output, "aimlapi")
-
-	for _, want := range []string{
-		"requiresAuth=true",
-		"authEnvVars=AIMLAPI_API_KEY",
-		"setup: zero providers setup aimlapi --set-active",
-	} {
-		if !strings.Contains(block, want) {
-			t.Fatalf("expected AIMLAPI catalog block to contain %q, got:\n%s", want, block)
-		}
 	}
 }
 

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -434,7 +434,7 @@ func providerProfileForAdd(options providerAddOptions) (config.ProviderProfile, 
 		AuthHeader:      strings.TrimSpace(options.authHeader),
 		AuthScheme:      normalizeAuthScheme(options.authScheme),
 		AuthHeaderValue: strings.TrimSpace(options.authHeaderValue),
-		CustomHeaders:   copyProviderHeaders(options.customHeaders),
+		CustomHeaders:   mergeProviderHeaders(descriptor.CustomHeaders, options.customHeaders),
 		Model:           firstNonEmptyCLI(options.model, descriptor.DefaultModel),
 	}
 	return profile, nil
@@ -543,4 +543,18 @@ func copyProviderHeaders(headers map[string]string) map[string]string {
 		copied[key] = value
 	}
 	return copied
+}
+
+func mergeProviderHeaders(base map[string]string, overrides map[string]string) map[string]string {
+	merged := copyProviderHeaders(base)
+	if len(overrides) == 0 {
+		return merged
+	}
+	if merged == nil {
+		merged = map[string]string{}
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	return merged
 }

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/config"
@@ -424,20 +425,34 @@ func providerProfileForAdd(options providerAddOptions) (config.ProviderProfile, 
 	if apiKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 {
 		apiKeyEnv = descriptor.AuthEnvVars[0]
 	}
+	baseURL := firstNonEmptyCLI(options.baseURL, descriptor.DefaultBaseURL)
+	var catalogHeaders map[string]string
+	if sameProviderSetupBaseURL(baseURL, descriptor.DefaultBaseURL) {
+		catalogHeaders = descriptor.CustomHeaders
+	}
 	profile := config.ProviderProfile{
 		Name:            name,
 		ProviderKind:    providerKindForDescriptor(descriptor),
 		CatalogID:       descriptor.ID,
-		BaseURL:         firstNonEmptyCLI(options.baseURL, descriptor.DefaultBaseURL),
+		BaseURL:         baseURL,
 		APIKeyEnv:       apiKeyEnv,
 		APIFormat:       firstAPIFormat(descriptor),
 		AuthHeader:      strings.TrimSpace(options.authHeader),
 		AuthScheme:      normalizeAuthScheme(options.authScheme),
 		AuthHeaderValue: strings.TrimSpace(options.authHeaderValue),
-		CustomHeaders:   mergeProviderHeaders(descriptor.CustomHeaders, options.customHeaders),
-		Model:           firstNonEmptyCLI(options.model, descriptor.DefaultModel),
+		// Catalog attribution belongs only to the catalog endpoint. Explicit
+		// user headers still apply to an override/staging/proxy endpoint.
+		CustomHeaders: mergeProviderHeaders(catalogHeaders, options.customHeaders),
+		Model:         firstNonEmptyCLI(options.model, descriptor.DefaultModel),
 	}
 	return profile, nil
+}
+
+func sameProviderSetupBaseURL(left string, right string) bool {
+	return strings.EqualFold(
+		strings.TrimRight(strings.TrimSpace(left), "/"),
+		strings.TrimRight(strings.TrimSpace(right), "/"),
+	)
 }
 
 func selectProviderForCheck(resolved config.ResolvedConfig, name string) (config.ProviderProfile, error) {
@@ -554,7 +569,33 @@ func mergeProviderHeaders(base map[string]string, overrides map[string]string) m
 		merged = map[string]string{}
 	}
 	for key, value := range overrides {
+		// HTTP header names are case-insensitive and request construction
+		// canonicalizes them (http.Header.Set), so an override that differs from a
+		// base key only in case must replace that key's value in place — otherwise
+		// both survive as distinct map entries and race non-deterministically at
+		// build time. Keep the existing spelling (the catalog's, which the resolver
+		// re-merges verbatim); only a genuinely new header is added as typed.
+		if existing, ok := headerKeyFold(merged, key); ok {
+			merged[existing] = value
+			continue
+		}
 		merged[key] = value
 	}
 	return merged
+}
+
+// headerKeyFold returns the key in headers whose canonical HTTP form matches key,
+// so a case-insensitive override lands on the existing entry instead of adding a
+// colliding duplicate.
+func headerKeyFold(headers map[string]string, key string) (string, bool) {
+	if _, ok := headers[key]; ok {
+		return key, true
+	}
+	canonical := http.CanonicalHeaderKey(key)
+	for existing := range headers {
+		if http.CanonicalHeaderKey(existing) == canonical {
+			return existing, true
+		}
+	}
+	return "", false
 }

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/aimlapi"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providerhealth"
@@ -429,6 +430,9 @@ func providerProfileForAdd(options providerAddOptions) (config.ProviderProfile, 
 	var catalogHeaders map[string]string
 	if sameProviderSetupBaseURL(baseURL, descriptor.DefaultBaseURL) {
 		catalogHeaders = descriptor.CustomHeaders
+		if strings.EqualFold(strings.TrimSpace(descriptor.ID), "aimlapi") {
+			catalogHeaders = aimlapi.WithResolvedPartnerHeader(catalogHeaders)
+		}
 	}
 	profile := config.ProviderProfile{
 		Name:            name,

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -227,6 +227,27 @@ func TestSaveSetupProviderAimlapiEnvReferenceAndOverrideHeaders(t *testing.T) {
 	}
 }
 
+func TestSaveSetupProviderAimlapiUsesResolvedPartnerOverride(t *testing.T) {
+	t.Setenv("AIMLAPI_PARTNER_ID", "part_override")
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	result, err := saveSetupProvider(appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	}, tui.SetupSelection{
+		CatalogID: "aimlapi",
+		BaseURL:   "https://api.aimlapi.com/v1",
+		Model:     "anthropic/claude-sonnet-5",
+	}, setupSaveOptions{})
+	if err != nil {
+		t.Fatalf("saveSetupProvider() error = %v", err)
+	}
+	if got := result.Provider.CustomHeaders["X-AIMLAPI-Partner-ID"]; got != "part_override" {
+		t.Fatalf("runtime partner header = %q, want part_override", got)
+	}
+	if got := readFileConfig(t, configPath).Providers[0].CustomHeaders["X-AIMLAPI-Partner-ID"]; got != "part_override" {
+		t.Fatalf("persisted partner header = %q, want part_override", got)
+	}
+}
+
 func TestSaveSetupProviderStoresCustomEndpointSelection(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -200,6 +200,33 @@ func TestSaveSetupProviderStoresPastedAPIKey(t *testing.T) {
 	}
 }
 
+func TestSaveSetupProviderAimlapiEnvReferenceAndOverrideHeaders(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	result, err := saveSetupProvider(appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	}, tui.SetupSelection{
+		CatalogID: "aimlapi",
+		BaseURL:   "https://staging.example/v1",
+		Model:     "anthropic/claude-sonnet-5",
+	}, setupSaveOptions{})
+	if err != nil {
+		t.Fatalf("saveSetupProvider() error = %v", err)
+	}
+	if result.Provider.APIKey != "" || result.Provider.APIKeyEnv != "AIMLAPI_API_KEY" {
+		t.Fatalf("runtime profile did not retain AIMLAPI_API_KEY reference: %+v", result.Provider)
+	}
+	if len(result.Provider.CustomHeaders) != 0 {
+		t.Fatalf("catalog headers leaked to first-run override: %#v", result.Provider.CustomHeaders)
+	}
+	persisted := readFileConfig(t, configPath).Providers[0]
+	if persisted.APIKey != "" || persisted.APIKeyEnv != "AIMLAPI_API_KEY" || persisted.APIKeyStored {
+		t.Fatalf("persisted credential source changed: %+v", persisted)
+	}
+	if len(persisted.CustomHeaders) != 0 {
+		t.Fatalf("persisted override contains catalog headers: %#v", persisted.CustomHeaders)
+	}
+}
+
 func TestSaveSetupProviderStoresCustomEndpointSelection(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -1040,7 +1040,8 @@ func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog
 	if profile.APIKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 && (!explicitBaseURL || sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)) {
 		profile.APIKeyEnv = descriptor.AuthEnvVars[0]
 	}
-	if len(descriptor.CustomHeaders) > 0 && (!explicitBaseURL || sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)) {
+	canonicalCatalogEndpoint := !explicitBaseURL || sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)
+	if len(descriptor.CustomHeaders) > 0 && canonicalCatalogEndpoint {
 		catalogHeaders := descriptor.CustomHeaders
 		if strings.EqualFold(strings.TrimSpace(descriptor.ID), "aimlapi") {
 			catalogHeaders = aimlapi.WithResolvedPartnerHeader(catalogHeaders)
@@ -1064,6 +1065,19 @@ func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog
 			merged[key] = value
 		}
 		profile.CustomHeaders = merged
+	} else if strings.EqualFold(strings.TrimSpace(descriptor.ID), "aimlapi") && !canonicalCatalogEndpoint {
+		// AIMLAPI attribution is owned by the catalog endpoint. A profile can retain
+		// those generated headers after its base URL is edited; strip their names
+		// before sending requests to an arbitrary staging/proxy host while preserving
+		// unrelated headers explicitly supplied by the user.
+		for profileKey := range profile.CustomHeaders {
+			for catalogKey := range descriptor.CustomHeaders {
+				if strings.EqualFold(profileKey, catalogKey) {
+					delete(profile.CustomHeaders, profileKey)
+					break
+				}
+			}
+		}
 	}
 }
 

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/aimlapi"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/notify"
 	"github.com/Gitlawb/zero/internal/providercatalog"
@@ -1040,7 +1041,11 @@ func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog
 		profile.APIKeyEnv = descriptor.AuthEnvVars[0]
 	}
 	if len(descriptor.CustomHeaders) > 0 && (!explicitBaseURL || sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)) {
-		merged := copyStringMap(descriptor.CustomHeaders)
+		catalogHeaders := descriptor.CustomHeaders
+		if strings.EqualFold(strings.TrimSpace(descriptor.ID), "aimlapi") {
+			catalogHeaders = aimlapi.WithResolvedPartnerHeader(catalogHeaders)
+		}
+		merged := copyStringMap(catalogHeaders)
 		for key, value := range profile.CustomHeaders {
 			// Header names are case-insensitive. Preserve the catalog spelling while
 			// replacing its value so request construction cannot see two colliding

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -1042,6 +1042,20 @@ func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog
 	if len(descriptor.CustomHeaders) > 0 && (!explicitBaseURL || sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)) {
 		merged := copyStringMap(descriptor.CustomHeaders)
 		for key, value := range profile.CustomHeaders {
+			// Header names are case-insensitive. Preserve the catalog spelling while
+			// replacing its value so request construction cannot see two colliding
+			// map entries whose eventual winner depends on iteration order.
+			existingKey := ""
+			for candidate := range merged {
+				if strings.EqualFold(candidate, key) {
+					existingKey = candidate
+					break
+				}
+			}
+			if existingKey != "" {
+				merged[existingKey] = value
+				continue
+			}
 			merged[key] = value
 		}
 		profile.CustomHeaders = merged

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -1039,6 +1039,13 @@ func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog
 	if profile.APIKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 && (!explicitBaseURL || sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)) {
 		profile.APIKeyEnv = descriptor.AuthEnvVars[0]
 	}
+	if len(descriptor.CustomHeaders) > 0 && (!explicitBaseURL || sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)) {
+		merged := copyStringMap(descriptor.CustomHeaders)
+		for key, value := range profile.CustomHeaders {
+			merged[key] = value
+		}
+		profile.CustomHeaders = merged
+	}
 }
 
 func sameBaseURL(left string, right string) bool {

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1413,6 +1413,33 @@ func TestApplyCatalogDescriptorUsesAimlapiPartnerEnvironmentOverride(t *testing.
 	}
 }
 
+func TestApplyCatalogDescriptorStripsAimlapiAttributionFromRetargetedProfile(t *testing.T) {
+	descriptor, err := providercatalog.Require("aimlapi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := ProviderProfile{
+		BaseURL: "https://proxy.example.test/v1",
+		CustomHeaders: map[string]string{
+			"x-aimlapi-partner-id":          "persisted-partner",
+			"X-AIMLAPI-Integration-Repo":    "Gitlawb/zero",
+			"X-AIMLAPI-Integration-Version": "zero",
+			"X-Environment":                 "staging",
+		},
+	}
+
+	applyCatalogDescriptor(&profile, descriptor, true)
+
+	for key := range profile.CustomHeaders {
+		if strings.HasPrefix(strings.ToLower(key), "x-aimlapi-") {
+			t.Fatalf("catalog attribution survived retargeting: %#v", profile.CustomHeaders)
+		}
+	}
+	if profile.CustomHeaders["X-Environment"] != "staging" {
+		t.Fatalf("user header was removed: %#v", profile.CustomHeaders)
+	}
+}
+
 func TestResolveProviderProfileParseThinkTagsFalseAlias(t *testing.T) {
 	path := writeConfig(t, `{
 		"activeProvider": "custom",

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1376,6 +1376,7 @@ func TestResolveProviderProfileExtendedJSONAliases(t *testing.T) {
 }
 
 func TestApplyCatalogDescriptorFoldsCustomHeadersCaseInsensitively(t *testing.T) {
+	t.Setenv("AIMLAPI_PARTNER_ID", "part_env")
 	descriptor, err := providercatalog.Require("aimlapi")
 	if err != nil {
 		t.Fatal(err)
@@ -1394,6 +1395,21 @@ func TestApplyCatalogDescriptorFoldsCustomHeadersCaseInsensitively(t *testing.T)
 	}
 	if _, duplicate := profile.CustomHeaders["x-aimlapi-partner-id"]; duplicate {
 		t.Fatalf("case-colliding header survived merge: %#v", profile.CustomHeaders)
+	}
+}
+
+func TestApplyCatalogDescriptorUsesAimlapiPartnerEnvironmentOverride(t *testing.T) {
+	t.Setenv("AIMLAPI_PARTNER_ID", "part_env")
+	descriptor, err := providercatalog.Require("aimlapi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := ProviderProfile{BaseURL: descriptor.DefaultBaseURL}
+
+	applyCatalogDescriptor(&profile, descriptor, true)
+
+	if got := profile.CustomHeaders["X-AIMLAPI-Partner-ID"]; got != "part_env" {
+		t.Fatalf("partner header = %q, want part_env", got)
 	}
 }
 

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providercatalog"
 )
 
 func TestResolveAppliesLayerPrecedence(t *testing.T) {
@@ -1371,6 +1372,28 @@ func TestResolveProviderProfileExtendedJSONAliases(t *testing.T) {
 	}
 	if profile.ParseThinkTags == nil || !*profile.ParseThinkTags {
 		t.Fatalf("ParseThinkTags = %#v, want true", profile.ParseThinkTags)
+	}
+}
+
+func TestApplyCatalogDescriptorFoldsCustomHeadersCaseInsensitively(t *testing.T) {
+	descriptor, err := providercatalog.Require("aimlapi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := ProviderProfile{
+		BaseURL: descriptor.DefaultBaseURL,
+		CustomHeaders: map[string]string{
+			"x-aimlapi-partner-id": "part_override",
+		},
+	}
+
+	applyCatalogDescriptor(&profile, descriptor, true)
+
+	if got := profile.CustomHeaders["X-AIMLAPI-Partner-ID"]; got != "part_override" {
+		t.Fatalf("canonical header value = %q, want override", got)
+	}
+	if _, duplicate := profile.CustomHeaders["x-aimlapi-partner-id"]; duplicate {
+		t.Fatalf("case-colliding header survived merge: %#v", profile.CustomHeaders)
 	}
 }
 

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -44,6 +44,7 @@ type Descriptor struct {
 	DefaultBaseURL      string
 	DefaultModel        string
 	AuthEnvVars         []string
+	CustomHeaders       map[string]string
 	RequiresAuth        bool
 	UsesAmbientAuth     bool
 	Public              bool
@@ -70,9 +71,9 @@ type Descriptor struct {
 	// headless / SSH use) in addition to the browser flow.
 	OAuthDeviceFlow bool
 
-	// Recommended marks the provider that should be surfaced first and badged
-	// (★ … (recommended)) in every catalog-ordered list and picker. At most one
-	// descriptor should set this.
+	// Recommended marks a provider surfaced at the top and badged in
+	// catalog-ordered lists and pickers. The recommended descriptors are the first
+	// entries in the catalog, in order.
 	Recommended bool
 }
 
@@ -103,6 +104,11 @@ var descriptors = []Descriptor{
 	// minimax, qwen, google, nvidia, tencent, z-ai). Flat /v1/chat/completions
 	// with a Bearer ogw_live_… key; listed first and badged in every picker.
 	recommended(openAICompat("gitlawb-opengateway", "GitLawb OpenGateway", "https://opengateway.gitlawb.com/v1", "mimo-v2.5-pro", []string{"GITLAWB_OPENGATEWAY_API_KEY"}, "gitlawb opengateway", "opengateway")),
+	// aimlapi.com — OpenAI-compatible aggregating gateway, also badged as
+	// recommended (second, right after the OpenGateway default). The built-in TUI
+	// onboarding can register/top up an account and save the issued key; the partner
+	// headers attribute usage for the rebate.
+	recommended(aimlapi()),
 	openAI("openai", "OpenAI", "https://api.openai.com/v1", "gpt-4.1", []string{"OPENAI_API_KEY"}),
 	anthropic("anthropic", "Anthropic", "https://api.anthropic.com", "claude-sonnet-4.5", []string{"ANTHROPIC_API_KEY"}),
 	google("google", "Google", "https://generativelanguage.googleapis.com", "gemini-2.5-pro", []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}, "gemini"),
@@ -302,8 +308,21 @@ func google(id string, name string, baseURL string, model string, env []string, 
 	}
 }
 
-// recommended marks a descriptor as the recommended default so list/picker
-// surfaces sort it first and render the ★ … (recommended) badge.
+func aimlapi() Descriptor {
+	descriptor := openAICompat("aimlapi", "aimlapi.com", "https://api.aimlapi.com/v1", "anthropic/claude-sonnet-5", []string{"AIMLAPI_API_KEY"}, "aimlapi.com", "aimlapi", "ai ml api")
+	descriptor.CustomHeaders = map[string]string{
+		"X-AIMLAPI-Partner-ID":          "part_62yQoGYDq4Yqnrj2R1iGrDNJ",
+		"X-AIMLAPI-Integration-Repo":    "Gitlawb/zero",
+		"X-AIMLAPI-Integration-Version": "zero",
+	}
+	// Onboarding is key-based only: the TUI sub-flow takes an existing key or an
+	// email top-up (internal/aimlapi Paths A/B). Not flagged
+	// OAuth-capable, so it does not appear in the wizard's "Sign in with OAuth" list.
+	return descriptor
+}
+
+// recommended marks a descriptor as a recommended default so list/picker
+// surfaces sort it to the top and render a provider-specific badge.
 func recommended(descriptor Descriptor) Descriptor {
 	descriptor.Recommended = true
 	return descriptor
@@ -384,5 +403,19 @@ func cloneDescriptor(descriptor Descriptor) Descriptor {
 	descriptor.AuthEnvVars = append([]string{}, descriptor.AuthEnvVars...)
 	descriptor.SupportedAPIFormats = append([]APIFormat{}, descriptor.SupportedAPIFormats...)
 	descriptor.Aliases = append([]string{}, descriptor.Aliases...)
+	if descriptor.CustomHeaders != nil {
+		descriptor.CustomHeaders = copyStringMap(descriptor.CustomHeaders)
+	}
 	return descriptor
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
 }

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -34,7 +34,7 @@ const (
 
 var ErrUnknownProvider = errors.New("unknown provider")
 
-// AIMLAPIID is the provider catalog identifier for the AI/ML API preset.
+// AIMLAPIID is the provider catalog identifier for the aimlapi.com preset.
 const AIMLAPIID = "aimlapi"
 
 type Descriptor struct {
@@ -116,7 +116,6 @@ var descriptors = []Descriptor{
 	localOpenAI("ollama", "Ollama Local", "http://localhost:11434/v1", "llama3.1", "ollama local"),
 	localOpenAI("lmstudio", "LM Studio", "http://localhost:1234/v1", "local-model", "lm-studio", "lm studio"),
 	oauthProvider(openAICompat("openrouter", "OpenRouter", "https://openrouter.ai/api/v1", "openai/gpt-4.1", []string{"OPENROUTER_API_KEY"}), true, false),
-	openAICompat(AIMLAPIID, "AI/ML API", "https://api.aimlapi.com/v1", "openai/gpt-5-chat", []string{"AIMLAPI_API_KEY"}, "aiml api", "ai/ml api"),
 	// Hugging Face Inference Providers — OpenAI-compatible router at
 	// https://router.huggingface.co/v1 exposes hundreds of OSS models. OAuth
 	// requires a one-time app registration at huggingface.co/settings/applications/new
@@ -309,7 +308,7 @@ func google(id string, name string, baseURL string, model string, env []string, 
 }
 
 func aimlapi() Descriptor {
-	descriptor := openAICompat("aimlapi", "aimlapi.com", "https://api.aimlapi.com/v1", "anthropic/claude-sonnet-5", []string{"AIMLAPI_API_KEY"}, "aimlapi.com", "aimlapi", "ai ml api")
+	descriptor := openAICompat(AIMLAPIID, "aimlapi.com", "https://api.aimlapi.com/v1", "anthropic/claude-sonnet-5", []string{"AIMLAPI_API_KEY"}, "aimlapi", "aiml api", "ai/ml api", "ai ml api")
 	descriptor.CustomHeaders = map[string]string{
 		"X-AIMLAPI-Partner-ID":          "part_62yQoGYDq4Yqnrj2R1iGrDNJ",
 		"X-AIMLAPI-Integration-Repo":    "Gitlawb/zero",

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -9,6 +9,7 @@ import (
 
 var expectedCatalogIDs = []string{
 	"gitlawb-opengateway",
+	"aimlapi",
 	"openai",
 	"anthropic",
 	"google",
@@ -69,25 +70,31 @@ func TestAllHasStableUniqueIDs(t *testing.T) {
 	}
 }
 
-func TestRecommendedProviderIsFirstAndUnique(t *testing.T) {
+func TestRecommendedProvidersAreTopOfCatalog(t *testing.T) {
 	descriptors := All()
-	if len(descriptors) == 0 {
-		t.Fatal("All() returned no descriptors")
+	// The recommended providers are badged and pinned to the top of the catalog,
+	// in this order (OpenGateway remains the default; aimlapi.com is also badged).
+	wantTop := []string{"gitlawb-opengateway", "aimlapi"}
+	if len(descriptors) < len(wantTop) {
+		t.Fatalf("All() returned %d descriptors, want at least %d", len(descriptors), len(wantTop))
 	}
-	if !descriptors[0].Recommended {
-		t.Fatalf("All()[0] = %q, want it to be the recommended provider", descriptors[0].ID)
+	for index, id := range wantTop {
+		if descriptors[index].ID != id {
+			t.Fatalf("descriptors[%d] = %q, want %q", index, descriptors[index].ID, id)
+		}
+		if !descriptors[index].Recommended {
+			t.Fatalf("descriptors[%d] (%q) should be recommended", index, id)
+		}
 	}
-	if descriptors[0].ID != "gitlawb-opengateway" {
-		t.Fatalf("recommended provider = %q, want %q", descriptors[0].ID, "gitlawb-opengateway")
-	}
+	// Exactly those are recommended, and they are contiguous at the top.
 	recommended := 0
 	for _, descriptor := range descriptors {
 		if descriptor.Recommended {
 			recommended++
 		}
 	}
-	if recommended != 1 {
-		t.Fatalf("recommended descriptor count = %d, want exactly 1", recommended)
+	if recommended != len(wantTop) {
+		t.Fatalf("recommended descriptor count = %d, want %d", recommended, len(wantTop))
 	}
 }
 

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -17,7 +17,6 @@ var expectedCatalogIDs = []string{
 	"ollama",
 	"lmstudio",
 	"openrouter",
-	"aimlapi",
 	"huggingface",
 	"chatgpt",
 	"groq",
@@ -116,14 +115,14 @@ func TestAIMLAPIDescriptor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Require(aimlapi) error = %v", err)
 	}
-	if descriptor.Name != "AI/ML API" {
-		t.Fatalf("Name = %q, want AI/ML API", descriptor.Name)
+	if descriptor.Name != "aimlapi.com" {
+		t.Fatalf("Name = %q, want aimlapi.com", descriptor.Name)
 	}
 	if descriptor.DefaultBaseURL != "https://api.aimlapi.com/v1" {
-		t.Fatalf("DefaultBaseURL = %q, want AI/ML API endpoint", descriptor.DefaultBaseURL)
+		t.Fatalf("DefaultBaseURL = %q, want aimlapi.com endpoint", descriptor.DefaultBaseURL)
 	}
-	if descriptor.DefaultModel != "openai/gpt-5-chat" {
-		t.Fatalf("DefaultModel = %q, want openai/gpt-5-chat", descriptor.DefaultModel)
+	if descriptor.DefaultModel != "anthropic/claude-sonnet-5" {
+		t.Fatalf("DefaultModel = %q, want anthropic/claude-sonnet-5", descriptor.DefaultModel)
 	}
 	if descriptor.Transport != TransportOpenAICompatible {
 		t.Fatalf("Transport = %q, want %q", descriptor.Transport, TransportOpenAICompatible)
@@ -323,7 +322,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
 		TransportAnthropicCompat: {"minimax", "minimaxi-cn", "opencode-go-anthropic-compatible", "custom-anthropic-compatible"},
-		TransportOpenAICompat:    {"gitlawb-opengateway", "ollama-cloud", "ollama", "lmstudio", "openrouter", "aimlapi", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "longcat", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "zai-cn", "kilocode", "opencode", "opencode-go", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
+		TransportOpenAICompat:    {"gitlawb-opengateway", "aimlapi", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "longcat", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "zai-cn", "kilocode", "opencode", "opencode-go", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 
 	for transport, wantIDs := range cases {

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -61,6 +61,17 @@ var zaiCuratedModels = []Model{
 }
 
 var curatedModels = map[string][]Model{
+	// aimlapi.com aggregates every upstream provider behind one OpenAI-compatible
+	// endpoint, so the curated defaults are a cross-provider "best of" flagship
+	// list. The live /v1/models discovery (when a key is present) replaces this;
+	// these are the offline/pre-key fallback and the picker's default order.
+	"aimlapi": {
+		{ID: "anthropic/claude-sonnet-5", Description: "catalog default (Anthropic Claude Sonnet 5)"},
+		{ID: "google/gemini-3.5-flash", Description: "Google Gemini Flash 3.5"},
+		{ID: "openai/gpt-5.5-2026-04-23", Description: "OpenAI GPT-5.5"},
+		{ID: "qwen/qwen-3.7-max", Description: "Qwen 3.7 Max"},
+		{ID: "deepseek/deepseek-v4-pro", Description: "DeepSeek V4"},
+	},
 	"ollama-cloud": {
 		{ID: "qwen3-coder:480b", Description: "catalog default"},
 		{ID: "gpt-oss:120b", Description: "agentic coding model"},

--- a/internal/providermodelcatalog/catalog_test.go
+++ b/internal/providermodelcatalog/catalog_test.go
@@ -34,6 +34,11 @@ func TestModelsAreProviderScoped(t *testing.T) {
 			notWant:  []string{"gpt-5", "gpt-4.1", "openai/gpt-4.1"},
 		},
 		{
+			provider: "aimlapi",
+			want:     []string{"anthropic/claude-sonnet-5", "google/gemini-3.5-flash", "openai/gpt-5.5-2026-04-23", "qwen/qwen-3.7-max", "deepseek/deepseek-v4-pro"},
+			notWant:  []string{"gpt-4o", "openai/gpt-4o", "anthropic/claude-opus-4.8", "x-ai/grok-4-5"},
+		},
+		{
 			provider: "mistral",
 			want:     []string{"mistral-large-latest", "codestral-latest"},
 			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5"},

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -2,9 +2,7 @@ package tui
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -30,18 +28,18 @@ type aimlapiOnboardState struct {
 	pathCursor int
 	lowCursor  int
 
-	apiKey string // Path A input, and the key that ends up saved
-	email  string
-	code   string
-	amount string
-	model  string
+	apiKey  string // Path A input, and the key that ends up saved
+	email   string
+	code    string
+	amount  string
+	model   string
+	baseURL string // resolved inference endpoint written into the saved profile
 
 	autoTopUp   bool // amount screen "auto top up" toggle; defaults to on
 	amountField int  // amount screen focus: 0 = amount input, 1 = auto top-up toggle
 
-	sessionToken   string // acquired via email code / passwordless; enables top-up
-	newAccount     bool   // Path B sign-up: exchange the paid session into a key
-	signinForTopup bool   // Path A: the email sub-flow is only to fund a top-up
+	sessionToken string // acquired via email code / passwordless; enables top-up
+	newAccount   bool   // Path B sign-up: exchange the paid session into a key
 
 	busy    bool
 	detail  string // checkout / verification URL
@@ -51,6 +49,11 @@ type aimlapiOnboardState struct {
 
 	topupCh     chan aimlapiTopupEvent
 	topupCancel context.CancelFunc
+
+	// opCancel cancels the single in-flight account/key request (balance, check,
+	// code, passwordless, key-mint). Only one runs at a time (input is gated while
+	// busy); it is cancelled when the request completes or the flow is abandoned.
+	opCancel context.CancelFunc
 
 	noOpen      bool
 	openBrowser func(string) error
@@ -80,9 +83,13 @@ const (
 
 func newAimlapiOnboard(openBrowser func(string) error) *aimlapiOnboardState {
 	return &aimlapiOnboardState{
-		step:        aimlapiStepPickPath,
-		amount:      "25",
-		autoTopUp:   true, // default the "auto top up" toggle to on (matches the mockup)
+		step:      aimlapiStepPickPath,
+		amount:    "25",
+		autoTopUp: true, // default the "auto top up" toggle to on (matches the mockup)
+		// Seed the base URL from the resolved endpoints so a staging / custom
+		// AIMLAPI_INFERENCE_URL override is carried into the saved profile for every
+		// path (pasted key or top-up), not silently replaced by the catalog default.
+		baseURL:     aimlapi.ResolveEndpoints().InferenceBaseURL,
 		openBrowser: openBrowser,
 	}
 }
@@ -92,8 +99,7 @@ func newAimlapiOnboard(openBrowser func(string) error) *aimlapiOnboardState {
 type aimlapiMsgKind int
 
 const (
-	aimlapiMsgBalance    aimlapiMsgKind = iota // Path A: validate pasted key
-	aimlapiMsgCheck                            // Path B: does the account exist?
+	aimlapiMsgCheck      aimlapiMsgKind = iota // Path B: does the account exist?
 	aimlapiMsgToken                            // Path B: session from code / passwordless
 	aimlapiMsgKey                              // Path B existing: minted key
 	aimlapiMsgKeyBalance                       // Path B existing: balance of the minted key
@@ -161,19 +167,11 @@ func (s *aimlapiOnboardState) msg(kind aimlapiMsgKind) aimlapiOnboardMsg {
 	return aimlapiOnboardMsg{state: s, gen: s.gen, kind: kind}
 }
 
-func (s *aimlapiOnboardState) balanceCmd(key string) tea.Cmd {
-	m := s.msg(aimlapiMsgBalance)
-	return func() tea.Msg {
-		res, err := aimlapiOnboardClient().GetBalance(context.Background(), key)
-		m.balance, m.err = res, err
-		return m
-	}
-}
-
 func (s *aimlapiOnboardState) keyBalanceCmd(key string) tea.Cmd {
 	m := s.msg(aimlapiMsgKeyBalance)
+	ctx := s.opContext()
 	return func() tea.Msg {
-		res, err := aimlapiOnboardClient().GetBalance(context.Background(), key)
+		res, err := aimlapiOnboardClient().GetBalance(ctx, key)
 		m.balance, m.err = res, err
 		return m
 	}
@@ -181,8 +179,9 @@ func (s *aimlapiOnboardState) keyBalanceCmd(key string) tea.Cmd {
 
 func (s *aimlapiOnboardState) checkAccountCmd(email string) tea.Cmd {
 	m := s.msg(aimlapiMsgCheck)
+	ctx := s.opContext()
 	return func() tea.Msg {
-		res, err := aimlapiOnboardClient().CheckAccount(context.Background(), email)
+		res, err := aimlapiOnboardClient().CheckAccount(ctx, email)
 		m.check, m.err = res, err
 		return m
 	}
@@ -192,8 +191,9 @@ func (s *aimlapiOnboardState) checkAccountCmd(email string) tea.Cmd {
 // happens later once the user types the code; this only requests it.
 func (s *aimlapiOnboardState) sendCodeCmd(email string) tea.Cmd {
 	m := s.msg(aimlapiMsgToken) // token kind reused: no session yet, err-only signal
+	ctx := s.opContext()
 	return func() tea.Msg {
-		err := aimlapiOnboardClient().SendSignInCode(context.Background(), email)
+		err := aimlapiOnboardClient().SendSignInCode(ctx, email)
 		m.err = err
 		m.token = "" // sentinel: code sent, still need verify
 		return m
@@ -202,8 +202,9 @@ func (s *aimlapiOnboardState) sendCodeCmd(email string) tea.Cmd {
 
 func (s *aimlapiOnboardState) verifyCodeCmd(email, code string) tea.Cmd {
 	m := s.msg(aimlapiMsgToken)
+	ctx := s.opContext()
 	return func() tea.Msg {
-		res, err := aimlapiOnboardClient().VerifySignInCode(context.Background(), email, code)
+		res, err := aimlapiOnboardClient().VerifySignInCode(ctx, email, code)
 		m.token, m.err = res.Token, err
 		return m
 	}
@@ -211,8 +212,9 @@ func (s *aimlapiOnboardState) verifyCodeCmd(email, code string) tea.Cmd {
 
 func (s *aimlapiOnboardState) passwordlessCmd(email string) tea.Cmd {
 	m := s.msg(aimlapiMsgToken)
+	ctx := s.opContext()
 	return func() tea.Msg {
-		res, err := aimlapiOnboardClient().CreatePasswordlessAccount(context.Background(), email)
+		res, err := aimlapiOnboardClient().CreatePasswordlessAccount(ctx, email)
 		m.token, m.err = res.Token, err
 		return m
 	}
@@ -220,8 +222,9 @@ func (s *aimlapiOnboardState) passwordlessCmd(email string) tea.Cmd {
 
 func (s *aimlapiOnboardState) createKeyCmd(token string) tea.Cmd {
 	m := s.msg(aimlapiMsgKey)
+	ctx := s.opContext()
 	return func() tea.Msg {
-		res, err := aimlapiOnboardClient().CreateKey(context.Background(), token, "zero CLI")
+		res, err := aimlapiOnboardClient().CreateKey(ctx, token, "zero CLI")
 		m.key, m.err = res, err
 		return m
 	}
@@ -320,8 +323,13 @@ func (s *aimlapiOnboardState) handleKeyInputKey(msg tea.KeyMsg) (tea.Cmd, aimlap
 		if strings.TrimSpace(s.apiKey) == "" {
 			return nil, aimlapiContinue
 		}
-		s.startBusy()
-		return s.balanceCmd(strings.TrimSpace(s.apiKey)), aimlapiContinue
+		// Path A saves the pasted key as-is: no balance read and no in-CLI top-up.
+		// Funding a key requires signing in, and the pasted key need not belong to
+		// whatever account the user would then authenticate as — so offering a
+		// top-up here risks funding the wrong account. A bad key just surfaces on
+		// first use, exactly like every other provider's paste-a-key flow.
+		s.apiKey = strings.TrimSpace(s.apiKey)
+		return s.finishEverythingRuns(), aimlapiContinue
 	case keyText(msg) != "":
 		s.apiKey += keyText(msg)
 		s.errText = ""
@@ -332,11 +340,7 @@ func (s *aimlapiOnboardState) handleKeyInputKey(msg tea.KeyMsg) (tea.Cmd, aimlap
 func (s *aimlapiOnboardState) handleEmailInputKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
 	switch {
 	case keyIs(msg, tea.KeyLeft):
-		if s.signinForTopup {
-			s.step = aimlapiStepLowBalance
-		} else {
-			s.step = aimlapiStepPickPath
-		}
+		s.step = aimlapiStepPickPath
 		s.errText = ""
 	case keyBackspace(msg):
 		s.email = trimLastRune(s.email)
@@ -390,14 +394,8 @@ func (s *aimlapiOnboardState) handleLowBalanceKey(msg tea.KeyMsg) (tea.Cmd, aiml
 		if s.lowCursor == 1 { // skip topping up
 			return s.finishEverythingRuns(), aimlapiContinue
 		}
-		// Top up now.
-		if s.sessionToken == "" {
-			// Path A holds only a key, not a session — sign in by email to fund it.
-			s.signinForTopup = true
-			s.step = aimlapiStepEmailInput
-			s.errText = ""
-			return nil, aimlapiContinue
-		}
+		// Top up now. Low balance is only reachable from Path B existing, where we
+		// already hold a session for the minted key's own account.
 		s.step = aimlapiStepAmountInput
 		s.errText = ""
 	}
@@ -470,8 +468,6 @@ func (s *aimlapiOnboardState) apply(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutc
 		return nil, aimlapiContinue // stale: user moved on
 	}
 	switch msg.kind {
-	case aimlapiMsgBalance:
-		return s.applyBalance(msg)
 	case aimlapiMsgKeyBalance:
 		return s.applyKeyBalance(msg)
 	case aimlapiMsgCheck:
@@ -484,28 +480,6 @@ func (s *aimlapiOnboardState) apply(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutc
 		return s.applyTopup(msg)
 	}
 	return nil, aimlapiContinue
-}
-
-func (s *aimlapiOnboardState) applyBalance(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
-	s.stopBusy()
-	if msg.err != nil {
-		if aimlapiIsUnauthorized(msg.err) {
-			s.apiKey = ""
-			s.errText = aimlapi.MsgAPIKeyInvalid
-			s.step = aimlapiStepKeyInput
-			return nil, aimlapiContinue
-		}
-		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
-		s.step = aimlapiStepKeyInput
-		return nil, aimlapiContinue
-	}
-	s.apiKey = strings.TrimSpace(s.apiKey)
-	if msg.balance.LowBalance {
-		s.lowCursor = 0
-		s.step = aimlapiStepLowBalance
-		return nil, aimlapiContinue
-	}
-	return s.finishEverythingRuns(), aimlapiContinue
 }
 
 func (s *aimlapiOnboardState) applyKeyBalance(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
@@ -528,21 +502,6 @@ func (s *aimlapiOnboardState) applyCheck(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
 		s.step = aimlapiStepEmailInput
 		return nil, aimlapiContinue
-	}
-	if s.signinForTopup {
-		// Path A funding: only an existing account can top up the pasted key.
-		if msg.check.Action != "sign-in" {
-			// The pasted key is valid and still saved; we just can't fund it because
-			// this email has no account. Land on the terminal screen with one coherent
-			// note instead of a green "ready" plus a red error.
-			s.errText = ""
-			s.successLines = []string{aimlapi.MsgEverythingRuns, "", aimlapi.MsgTopUpNoAccount}
-			s.step = aimlapiStepDone
-			return nil, aimlapiContinue
-		}
-		s.newAccount = false
-		s.startBusy()
-		return s.sendCodeCmd(s.email), aimlapiContinue
 	}
 	if msg.check.Action == "sign-in" {
 		s.newAccount = false
@@ -581,12 +540,6 @@ func (s *aimlapiOnboardState) applyToken(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 	s.sessionToken = msg.token
 	if s.newAccount {
 		// New account: fund it (top-up will exchange for the key).
-		s.step = aimlapiStepAmountInput
-		s.errText = ""
-		return nil, aimlapiContinue
-	}
-	if s.signinForTopup {
-		// Path A: session obtained only to fund the existing key — go pay.
 		s.step = aimlapiStepAmountInput
 		s.errText = ""
 		return nil, aimlapiContinue
@@ -631,6 +584,9 @@ func (s *aimlapiOnboardState) applyTopup(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 	}
 	if strings.TrimSpace(event.result.Model) != "" {
 		s.model = event.result.Model
+	}
+	if strings.TrimSpace(event.result.BaseURL) != "" {
+		s.baseURL = event.result.BaseURL
 	}
 	s.successLines = s.topUpSuccessLines()
 	s.step = aimlapiStepDone
@@ -711,6 +667,26 @@ func (s *aimlapiOnboardState) startBusy() {
 
 func (s *aimlapiOnboardState) stopBusy() {
 	s.busy = false
+	// The result has arrived; release the request's context.
+	s.cancelPendingOp()
+}
+
+// opContext returns a cancellable context for the next account/key request and
+// records its cancel so an abandoned flow (Esc) or the next request can stop the
+// in-flight one. Only one request runs at a time, so replacing the prior cancel
+// is safe.
+func (s *aimlapiOnboardState) opContext() context.Context {
+	s.cancelPendingOp()
+	ctx, cancel := context.WithCancel(context.Background())
+	s.opCancel = cancel
+	return ctx
+}
+
+func (s *aimlapiOnboardState) cancelPendingOp() {
+	if s.opCancel != nil {
+		s.opCancel()
+		s.opCancel = nil
+	}
 }
 
 func (s *aimlapiOnboardState) cancelStream() {
@@ -719,12 +695,9 @@ func (s *aimlapiOnboardState) cancelStream() {
 		s.topupCancel = nil
 	}
 	s.topupCh = nil
+	// Also stop any pending account/key request the user is abandoning.
+	s.cancelPendingOp()
 	s.gen++ // drop any late stream/poll events
-}
-
-func aimlapiIsUnauthorized(err error) bool {
-	var apiErr aimlapi.APIError
-	return errors.As(err, &apiErr) && apiErr.Status == http.StatusUnauthorized
 }
 
 func aimlapiValidEmail(value string) bool {

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -546,8 +546,15 @@ func (s *aimlapiOnboardState) applyToken(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 	s.stopBusy()
 	if msg.err != nil {
 		if wasVerifying {
-			// A wrong 6-digit code — re-prompt with the spec wording.
-			s.errText = aimlapi.MsgCodeIncorrect
+			// Stay on the code screen so the user can retry, but only claim the
+			// code was wrong for the backend's actual rejection. A timeout, 429,
+			// 5xx, or dropped connection keeps the code they typed valid, so surface
+			// the real error instead of sending them to re-enter a good code.
+			if aimlapiIsInvalidCode(msg.err) {
+				s.errText = aimlapi.MsgCodeIncorrect
+			} else {
+				s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+			}
 			s.step = aimlapiStepCodeInput
 			return nil, aimlapiContinue
 		}
@@ -735,6 +742,15 @@ func aimlapiIsUnauthorized(err error) bool {
 	var apiErr aimlapi.APIError
 	return errors.As(err, &apiErr) &&
 		(apiErr.Status == http.StatusUnauthorized || apiErr.Status == http.StatusForbidden)
+}
+
+// aimlapiIsInvalidCode reports whether err is the backend rejecting the sign-in
+// code itself. The backend contract uses 400 for "Invalid or expired code";
+// every other status (including auth, throttling and service failures) must be
+// surfaced as itself instead of being mislabeled as user input.
+func aimlapiIsInvalidCode(err error) bool {
+	var apiErr aimlapi.APIError
+	return errors.As(err, &apiErr) && apiErr.Status == http.StatusBadRequest
 }
 
 // ---- rendering ------------------------------------------------------------

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -734,20 +734,22 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 	s.step = aimlapiStepProgress
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
 	s.topupCancel = cancel
-	if s.byKey {
-		// Path A / env key: fund the account bound to apiKey. Generate the
-		// idempotency id once and keep it, so a retry re-issues the same pay.
-		if strings.TrimSpace(s.paymentSessionID) == "" {
-			id, err := aimlapi.NewPaymentSessionID()
-			if err != nil {
-				cancel()
-				s.errText = aimlapi.MsgTopUpFailed
-				s.step = aimlapiStepAmountInput
-				s.amountField = 0
-				return nil, aimlapiContinue
-			}
-			s.paymentSessionID = id
+	// Both checkout paths use the same intent id. Retain it across ambiguous
+	// failures, and replace it only when the amount/auto-top-up intent changes or
+	// the backend reports that the prior session is dead.
+	if strings.TrimSpace(s.paymentSessionID) == "" {
+		id, err := aimlapi.NewPaymentSessionID()
+		if err != nil {
+			cancel()
+			s.errText = aimlapi.MsgTopUpFailed
+			s.step = aimlapiStepAmountInput
+			s.amountField = 0
+			return nil, aimlapiContinue
 		}
+		s.paymentSessionID = id
+	}
+	if s.byKey {
+		// Path A / env key: fund the account bound to apiKey.
 		s.topupCh = startAimlapiStreamTopUpByKey(ctx, aimlapi.StreamTopUpByKeyOptions{
 			APIKey:             s.apiKey,
 			AmountUSD:          normalizedAmount,
@@ -762,6 +764,7 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		s.topupCh = startAimlapiStreamTopUp(ctx, aimlapi.StreamTopUpOptions{
 			SessionToken:       s.sessionToken,
 			ResumeSessionToken: s.resumeSessionToken,
+			PaymentSessionID:   s.paymentSessionID,
 			AmountUSD:          normalizedAmount,
 			InferenceBaseURL:   s.baseURL,
 			Method:             aimlapi.PaymentMethodCard,

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -649,7 +649,14 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		return nil, aimlapiContinue
 	}
 	if _, err := aimlapi.ParseAmountUSD(s.amount); err != nil {
-		s.errText = aimlapi.MsgTopUpTooLow
+		switch {
+		case errors.Is(err, aimlapi.ErrAmountTooLow):
+			s.errText = aimlapi.MsgTopUpTooLow
+		case errors.Is(err, aimlapi.ErrAmountTooHigh):
+			s.errText = aimlapi.MsgTopUpTooHigh
+		default:
+			s.errText = aimlapi.MsgAmountInvalid
+		}
 		s.step = aimlapiStepAmountInput
 		s.amountField = 0
 		return nil, aimlapiContinue

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -648,12 +648,18 @@ func (s *aimlapiOnboardState) applyTopup(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 		return nil, aimlapiContinue
 	}
 	event := msg.topup
-	if !event.done {
-		if event.hasSession {
-			// Retain (or, on "", drop) the live partner-checkout token so a retry
-			// resumes this session rather than opening a second checkout.
-			s.resumeSessionToken = event.session
+	if event.hasSession {
+		// Retain (or, on "", drop) the live partner-checkout token so a retry
+		// resumes this session rather than opening a second checkout.
+		s.resumeSessionToken = event.session
+		if strings.TrimSpace(event.session) == "" {
+			// An empty token marks a terminal checkout. Its by-key idempotency ID
+			// belongs to that dead session too; reusing it would return or reject
+			// the old checkout instead of allowing a fresh payment attempt.
+			s.paymentSessionID = ""
 		}
+	}
+	if !event.done {
 		if strings.TrimSpace(event.detail) != "" {
 			s.detail = event.detail
 		}

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -1,0 +1,1006 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/aimlapi"
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+// aimlapiOnboardState is the shared, event-driven aimlapi.com onboarding sub-flow
+// (the spec's Paths A/B: existing key or email) embedded by BOTH TUI surfaces: the first-run setup
+// (onboarding.go) and the /provider wizard (provider_wizard.go). It owns all of
+// its own state and transitions; the host surface only routes key + async
+// messages into it and, on a terminal outcome, reads result{APIKey, Model}.
+//
+// It is always held behind a pointer so async command results mutate the same
+// object regardless of whether the host model is copied by value (setup) or
+// pointer (providerWizard).
+type aimlapiOnboardState struct {
+	step aimlapiOnboardStep
+	gen  int // bumped on each user-initiated async op; stale results are dropped
+
+	pathCursor int
+	lowCursor  int
+
+	apiKey string // Path A input, and the key that ends up saved
+	email  string
+	code   string
+	amount string
+	model  string
+
+	autoTopUp   bool // amount screen "auto top up" toggle; defaults to on
+	amountField int  // amount screen focus: 0 = amount input, 1 = auto top-up toggle
+
+	sessionToken   string // acquired via email code / passwordless; enables top-up
+	newAccount     bool   // Path B sign-up: exchange the paid session into a key
+	signinForTopup bool   // Path A: the email sub-flow is only to fund a top-up
+
+	busy    bool
+	detail  string // checkout / verification URL
+	errText string
+
+	successLines []string // shown on the terminal "done" screen
+
+	topupCh     chan aimlapiTopupEvent
+	topupCancel context.CancelFunc
+
+	noOpen      bool
+	openBrowser func(string) error
+}
+
+type aimlapiOnboardStep int
+
+const (
+	aimlapiStepPickPath aimlapiOnboardStep = iota
+	aimlapiStepKeyInput
+	aimlapiStepEmailInput
+	aimlapiStepCodeInput
+	aimlapiStepLowBalance
+	aimlapiStepAmountInput
+	aimlapiStepProgress
+	aimlapiStepDone
+)
+
+// aimlapiOutcome tells the host surface what to do after handling a key/message.
+type aimlapiOutcome int
+
+const (
+	aimlapiContinue aimlapiOutcome = iota // stay in the sub-flow
+	aimlapiDone                           // key acquired: read result and finalize
+	aimlapiCancel                         // back out to the host's provider picker
+)
+
+func newAimlapiOnboard(openBrowser func(string) error) *aimlapiOnboardState {
+	return &aimlapiOnboardState{
+		step:        aimlapiStepPickPath,
+		amount:      "25",
+		autoTopUp:   true, // default the "auto top up" toggle to on (matches the mockup)
+		openBrowser: openBrowser,
+	}
+}
+
+// ---- async messages -------------------------------------------------------
+
+type aimlapiMsgKind int
+
+const (
+	aimlapiMsgBalance    aimlapiMsgKind = iota // Path A: validate pasted key
+	aimlapiMsgCheck                            // Path B: does the account exist?
+	aimlapiMsgToken                            // Path B: session from code / passwordless
+	aimlapiMsgKey                              // Path B existing: minted key
+	aimlapiMsgKeyBalance                       // Path B existing: balance of the minted key
+	aimlapiMsgTopup                            // shared: one streamed top-up event
+)
+
+// aimlapiOnboardMsg carries one async result back to the owning sub-model. The
+// state pointer lets the host route it to the right surface; gen drops results
+// from an attempt the user has since abandoned.
+type aimlapiOnboardMsg struct {
+	state *aimlapiOnboardState
+	gen   int
+	kind  aimlapiMsgKind
+
+	balance aimlapi.BalanceResult
+	check   aimlapi.CheckResult
+	token   string
+	key     aimlapi.CreatedKey
+	topup   aimlapiTopupEvent
+	topupOK bool
+	err     error
+}
+
+func aimlapiOnboardClient() *aimlapi.Client {
+	return aimlapi.NewClient(aimlapi.ResolveEndpoints(), nil)
+}
+
+// applyAimlapiOnboard routes an async aimlapi.com onboarding result to whichever
+// surface (the /provider wizard or the first-run setup) owns the sub-flow. The
+// state pointer identifies the owner; a result whose sub-flow was replaced is
+// silently dropped.
+func (m model) applyAimlapiOnboard(msg aimlapiOnboardMsg) (tea.Model, tea.Cmd) {
+	if msg.state == nil {
+		return m, nil
+	}
+	if m.providerWizard != nil && m.providerWizard.aimlapi == msg.state {
+		return m.applyProviderWizardAimlapiOnboard(msg)
+	}
+	if m.setup.aimlapi == msg.state {
+		return m.applySetupAimlapiOnboard(msg)
+	}
+	return m, nil
+}
+
+// aimlapiOnboardAnimating reports whether an aimlapi.com onboarding sub-flow (in
+// first-run setup or the /provider wizard) is in a state whose spinner needs the
+// shared tick loop to keep advancing: a pending async round-trip or the streamed
+// top-up progress screen. It lets the tick stay alive during onboarding even
+// though no agent run is in flight.
+func (m model) aimlapiOnboardAnimating() bool {
+	if aimlapiStateAnimating(m.setup.aimlapi) {
+		return true
+	}
+	return m.providerWizard != nil && aimlapiStateAnimating(m.providerWizard.aimlapi)
+}
+
+func aimlapiStateAnimating(s *aimlapiOnboardState) bool {
+	if s == nil {
+		return false
+	}
+	return s.busy || s.step == aimlapiStepProgress
+}
+
+func (s *aimlapiOnboardState) msg(kind aimlapiMsgKind) aimlapiOnboardMsg {
+	return aimlapiOnboardMsg{state: s, gen: s.gen, kind: kind}
+}
+
+func (s *aimlapiOnboardState) balanceCmd(key string) tea.Cmd {
+	m := s.msg(aimlapiMsgBalance)
+	return func() tea.Msg {
+		res, err := aimlapiOnboardClient().GetBalance(context.Background(), key)
+		m.balance, m.err = res, err
+		return m
+	}
+}
+
+func (s *aimlapiOnboardState) keyBalanceCmd(key string) tea.Cmd {
+	m := s.msg(aimlapiMsgKeyBalance)
+	return func() tea.Msg {
+		res, err := aimlapiOnboardClient().GetBalance(context.Background(), key)
+		m.balance, m.err = res, err
+		return m
+	}
+}
+
+func (s *aimlapiOnboardState) checkAccountCmd(email string) tea.Cmd {
+	m := s.msg(aimlapiMsgCheck)
+	return func() tea.Msg {
+		res, err := aimlapiOnboardClient().CheckAccount(context.Background(), email)
+		m.check, m.err = res, err
+		return m
+	}
+}
+
+// sendCodeThenVerifyCmd sends the sign-in code (Path B existing). The verify step
+// happens later once the user types the code; this only requests it.
+func (s *aimlapiOnboardState) sendCodeCmd(email string) tea.Cmd {
+	m := s.msg(aimlapiMsgToken) // token kind reused: no session yet, err-only signal
+	return func() tea.Msg {
+		err := aimlapiOnboardClient().SendSignInCode(context.Background(), email)
+		m.err = err
+		m.token = "" // sentinel: code sent, still need verify
+		return m
+	}
+}
+
+func (s *aimlapiOnboardState) verifyCodeCmd(email, code string) tea.Cmd {
+	m := s.msg(aimlapiMsgToken)
+	return func() tea.Msg {
+		res, err := aimlapiOnboardClient().VerifySignInCode(context.Background(), email, code)
+		m.token, m.err = res.Token, err
+		return m
+	}
+}
+
+func (s *aimlapiOnboardState) passwordlessCmd(email string) tea.Cmd {
+	m := s.msg(aimlapiMsgToken)
+	return func() tea.Msg {
+		res, err := aimlapiOnboardClient().CreatePasswordlessAccount(context.Background(), email)
+		m.token, m.err = res.Token, err
+		return m
+	}
+}
+
+func (s *aimlapiOnboardState) createKeyCmd(token string) tea.Cmd {
+	m := s.msg(aimlapiMsgKey)
+	return func() tea.Msg {
+		res, err := aimlapiOnboardClient().CreateKey(context.Background(), token, "zero CLI")
+		m.key, m.err = res, err
+		return m
+	}
+}
+
+func startAimlapiStreamTopUp(ctx context.Context, options aimlapi.StreamTopUpOptions) chan aimlapiTopupEvent {
+	ch := make(chan aimlapiTopupEvent, 16)
+	go func() {
+		opts := options
+		opts.OnStatus = func(_ aimlapi.Status, detail string) {
+			ch <- aimlapiTopupEvent{detail: detail}
+		}
+		result, err := aimlapi.StreamTopUp(ctx, opts)
+		ch <- aimlapiTopupEvent{done: true, result: result, err: err}
+	}()
+	return ch
+}
+
+func waitForAimlapiTopupEvent(s *aimlapiOnboardState, gen int, ch chan aimlapiTopupEvent) tea.Cmd {
+	return func() tea.Msg {
+		event, ok := <-ch
+		return aimlapiOnboardMsg{state: s, gen: gen, kind: aimlapiMsgTopup, topup: event, topupOK: ok}
+	}
+}
+
+// ---- key handling ---------------------------------------------------------
+
+func (s *aimlapiOnboardState) handleKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
+	// Esc always abandons the sub-flow; the streamed top-up is cancelled first.
+	if keyIs(msg, tea.KeyEsc) {
+		s.cancelStream()
+		return nil, aimlapiCancel
+	}
+	// While an async round-trip or a streamed top-up is in flight, swallow input.
+	if s.busy {
+		return nil, aimlapiContinue
+	}
+	if s.step == aimlapiStepProgress {
+		return nil, aimlapiContinue
+	}
+
+	switch s.step {
+	case aimlapiStepPickPath:
+		return s.handlePickPathKey(msg)
+	case aimlapiStepKeyInput:
+		return s.handleKeyInputKey(msg)
+	case aimlapiStepEmailInput:
+		return s.handleEmailInputKey(msg)
+	case aimlapiStepCodeInput:
+		return s.handleCodeInputKey(msg)
+	case aimlapiStepLowBalance:
+		return s.handleLowBalanceKey(msg)
+	case aimlapiStepAmountInput:
+		return s.handleAmountInputKey(msg)
+	case aimlapiStepDone:
+		if keyIs(msg, tea.KeyLeft) {
+			return nil, aimlapiCancel
+		}
+		if keyIs(msg, tea.KeyEnter) || keyIs(msg, tea.KeyRight) {
+			return nil, aimlapiDone
+		}
+	}
+	return nil, aimlapiContinue
+}
+
+// handlePickPathKey drives the key/email picker: the two onboarding options
+// (paste an existing key, or go through email).
+func (s *aimlapiOnboardState) handlePickPathKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
+	switch {
+	case keyIs(msg, tea.KeyUp) || keyIs(msg, tea.KeyDown) || keyIs(msg, tea.KeyTab):
+		s.pathCursor = (s.pathCursor + 1) % 2
+	case keyIs(msg, tea.KeyLeft):
+		return nil, aimlapiCancel
+	case keyIs(msg, tea.KeyEnter) || keyIs(msg, tea.KeyRight):
+		s.errText = ""
+		if s.pathCursor == 0 {
+			s.step = aimlapiStepEmailInput
+		} else {
+			s.step = aimlapiStepKeyInput
+		}
+	}
+	return nil, aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) handleKeyInputKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
+	switch {
+	case keyIs(msg, tea.KeyLeft):
+		s.step = aimlapiStepPickPath
+		s.errText = ""
+	case keyBackspace(msg):
+		s.apiKey = trimLastRune(s.apiKey)
+	case keyCtrl(msg, 'u'):
+		s.apiKey = ""
+		s.errText = ""
+	case keyIs(msg, tea.KeyEnter) || keyIs(msg, tea.KeyRight):
+		if strings.TrimSpace(s.apiKey) == "" {
+			return nil, aimlapiContinue
+		}
+		s.startBusy()
+		return s.balanceCmd(strings.TrimSpace(s.apiKey)), aimlapiContinue
+	case keyText(msg) != "":
+		s.apiKey += keyText(msg)
+		s.errText = ""
+	}
+	return nil, aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) handleEmailInputKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
+	switch {
+	case keyIs(msg, tea.KeyLeft):
+		if s.signinForTopup {
+			s.step = aimlapiStepLowBalance
+		} else {
+			s.step = aimlapiStepPickPath
+		}
+		s.errText = ""
+	case keyBackspace(msg):
+		s.email = trimLastRune(s.email)
+	case keyCtrl(msg, 'u'):
+		s.email = ""
+		s.errText = ""
+	case keyIs(msg, tea.KeyEnter) || keyIs(msg, tea.KeyRight):
+		email := strings.TrimSpace(s.email)
+		if !aimlapiValidEmail(email) {
+			s.errText = aimlapi.MsgEmailInvalid
+			return nil, aimlapiContinue
+		}
+		s.email = email
+		s.startBusy()
+		return s.checkAccountCmd(email), aimlapiContinue
+	case keyText(msg) != "":
+		s.email += keyText(msg)
+		s.errText = ""
+	}
+	return nil, aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) handleCodeInputKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
+	switch {
+	case keyIs(msg, tea.KeyLeft):
+		s.step = aimlapiStepEmailInput
+		s.errText = ""
+	case keyBackspace(msg):
+		s.code = trimLastRune(s.code)
+	case keyCtrl(msg, 'u'):
+		s.code = ""
+		s.errText = ""
+	case keyIs(msg, tea.KeyEnter) || keyIs(msg, tea.KeyRight):
+		if strings.TrimSpace(s.code) == "" {
+			return nil, aimlapiContinue
+		}
+		s.startBusy()
+		return s.verifyCodeCmd(s.email, strings.TrimSpace(s.code)), aimlapiContinue
+	case keyText(msg) != "":
+		s.code += keyText(msg)
+		s.errText = ""
+	}
+	return nil, aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) handleLowBalanceKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
+	switch {
+	case keyIs(msg, tea.KeyUp) || keyIs(msg, tea.KeyDown) || keyIs(msg, tea.KeyTab):
+		s.lowCursor = (s.lowCursor + 1) % 2
+	case keyIs(msg, tea.KeyEnter) || keyIs(msg, tea.KeyRight):
+		if s.lowCursor == 1 { // skip topping up
+			return s.finishEverythingRuns(), aimlapiContinue
+		}
+		// Top up now.
+		if s.sessionToken == "" {
+			// Path A holds only a key, not a session — sign in by email to fund it.
+			s.signinForTopup = true
+			s.step = aimlapiStepEmailInput
+			s.errText = ""
+			return nil, aimlapiContinue
+		}
+		s.step = aimlapiStepAmountInput
+		s.errText = ""
+	}
+	return nil, aimlapiContinue
+}
+
+// handleAmountInputKey drives the "Add credits" screen, which has two focusable
+// fields: the dollar amount and the "auto top up" yes/no toggle. Tab/↑/↓ move
+// focus between them; Enter continues from either. On the amount field ← is
+// ignored so the top-up selection cannot retreat into an invalid previous screen;
+// digits edit the value. On the toggle field ←/→/Space flip it.
+func (s *aimlapiOnboardState) handleAmountInputKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
+	switch {
+	case keyIs(msg, tea.KeyLeft) && s.amountField == 0:
+		return nil, aimlapiContinue
+	case keyIs(msg, tea.KeyTab) || keyIs(msg, tea.KeyUp) || keyIs(msg, tea.KeyDown):
+		s.amountField = (s.amountField + 1) % 2
+		return nil, aimlapiContinue
+	case keyIs(msg, tea.KeyEnter):
+		// A valid amount goes straight to the Stripe (card) checkout. startTopUp
+		// re-validates and re-prompts on a bad amount.
+		return s.startTopUp()
+	}
+	if s.amountField == 1 {
+		// Auto top-up toggle focused: either horizontal arrow or Space flips yes↔no.
+		if keyIs(msg, tea.KeyLeft) || keyIs(msg, tea.KeyRight) || keyText(msg) == " " {
+			s.autoTopUp = !s.autoTopUp
+			s.errText = ""
+		}
+		return nil, aimlapiContinue
+	}
+	// Amount field focused.
+	switch {
+	case keyIs(msg, tea.KeyRight):
+		return s.startTopUp()
+	case keyBackspace(msg):
+		s.amount = trimLastRune(s.amount)
+	case keyCtrl(msg, 'u'):
+		s.amount = ""
+		s.errText = ""
+	case keyText(msg) != "":
+		s.amount += keyText(msg)
+		s.errText = ""
+	}
+	return nil, aimlapiContinue
+}
+
+// appendInput folds pasted text into the sub-flow's currently focused field.
+func (s *aimlapiOnboardState) appendInput(content string) {
+	if s.busy {
+		return
+	}
+	content = strings.TrimRight(content, "\r\n")
+	switch s.step {
+	case aimlapiStepKeyInput:
+		s.apiKey += content
+	case aimlapiStepEmailInput:
+		s.email += content
+	case aimlapiStepCodeInput:
+		s.code += content
+	case aimlapiStepAmountInput:
+		s.amount += content
+	}
+}
+
+// ---- async application ----------------------------------------------------
+
+func (s *aimlapiOnboardState) apply(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
+	if msg.gen != s.gen {
+		return nil, aimlapiContinue // stale: user moved on
+	}
+	switch msg.kind {
+	case aimlapiMsgBalance:
+		return s.applyBalance(msg)
+	case aimlapiMsgKeyBalance:
+		return s.applyKeyBalance(msg)
+	case aimlapiMsgCheck:
+		return s.applyCheck(msg)
+	case aimlapiMsgToken:
+		return s.applyToken(msg)
+	case aimlapiMsgKey:
+		return s.applyKey(msg)
+	case aimlapiMsgTopup:
+		return s.applyTopup(msg)
+	}
+	return nil, aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) applyBalance(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
+	s.stopBusy()
+	if msg.err != nil {
+		if aimlapiIsUnauthorized(msg.err) {
+			s.apiKey = ""
+			s.errText = aimlapi.MsgAPIKeyInvalid
+			s.step = aimlapiStepKeyInput
+			return nil, aimlapiContinue
+		}
+		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.step = aimlapiStepKeyInput
+		return nil, aimlapiContinue
+	}
+	s.apiKey = strings.TrimSpace(s.apiKey)
+	if msg.balance.LowBalance {
+		s.lowCursor = 0
+		s.step = aimlapiStepLowBalance
+		return nil, aimlapiContinue
+	}
+	return s.finishEverythingRuns(), aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) applyKeyBalance(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
+	s.stopBusy()
+	if msg.err != nil {
+		// The key is already minted; a balance read failure shouldn't block it.
+		return s.finishEverythingRuns(), aimlapiContinue
+	}
+	if msg.balance.LowBalance {
+		s.lowCursor = 0
+		s.step = aimlapiStepLowBalance
+		return nil, aimlapiContinue
+	}
+	return s.finishEverythingRuns(), aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) applyCheck(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
+	s.stopBusy()
+	if msg.err != nil {
+		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.step = aimlapiStepEmailInput
+		return nil, aimlapiContinue
+	}
+	if s.signinForTopup {
+		// Path A funding: only an existing account can top up the pasted key.
+		if msg.check.Action != "sign-in" {
+			s.errText = "That email has no aimlapi.com account, so it can't top up this key."
+			return s.finishEverythingRuns(), aimlapiContinue
+		}
+		s.newAccount = false
+		s.startBusy()
+		return s.sendCodeCmd(s.email), aimlapiContinue
+	}
+	if msg.check.Action == "sign-in" {
+		s.newAccount = false
+		s.startBusy()
+		return s.sendCodeCmd(s.email), aimlapiContinue
+	}
+	// No account yet: passwordless sign-up, then fund via top-up (min $20).
+	s.newAccount = true
+	s.startBusy()
+	return s.passwordlessCmd(s.email), aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) applyToken(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
+	wasVerifying := s.step == aimlapiStepCodeInput
+	s.stopBusy()
+	if msg.err != nil {
+		if wasVerifying {
+			// A wrong 6-digit code — re-prompt with the spec wording.
+			s.errText = aimlapi.MsgCodeIncorrect
+			s.step = aimlapiStepCodeInput
+			return nil, aimlapiContinue
+		}
+		// send-code or passwordless sign-up failed — back to the email prompt.
+		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.step = aimlapiStepEmailInput
+		return nil, aimlapiContinue
+	}
+	if msg.token == "" {
+		// Sentinel from sendCodeCmd: the code was sent, collect it now.
+		s.step = aimlapiStepCodeInput
+		s.code = ""
+		s.errText = ""
+		return nil, aimlapiContinue
+	}
+	// We hold a session now.
+	s.sessionToken = msg.token
+	if s.newAccount {
+		// New account: fund it (top-up will exchange for the key).
+		s.step = aimlapiStepAmountInput
+		s.errText = ""
+		return nil, aimlapiContinue
+	}
+	if s.signinForTopup {
+		// Path A: session obtained only to fund the existing key — go pay.
+		s.step = aimlapiStepAmountInput
+		s.errText = ""
+		return nil, aimlapiContinue
+	}
+	// Path B existing: mint a persistable key from the session.
+	s.startBusy()
+	return s.createKeyCmd(s.sessionToken), aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) applyKey(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
+	s.stopBusy()
+	if msg.err != nil {
+		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.step = aimlapiStepEmailInput
+		return nil, aimlapiContinue
+	}
+	s.apiKey = msg.key.Key
+	s.startBusy()
+	return s.keyBalanceCmd(s.apiKey), aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) applyTopup(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
+	if !msg.topupOK {
+		return nil, aimlapiContinue
+	}
+	event := msg.topup
+	if !event.done {
+		if strings.TrimSpace(event.detail) != "" {
+			s.detail = event.detail
+		}
+		return waitForAimlapiTopupEvent(s, s.gen, s.topupCh), aimlapiContinue
+	}
+	s.cancelStream()
+	if event.err != nil {
+		s.errText = aimlapi.MsgTopUpFailed
+		s.step = aimlapiStepAmountInput
+		s.amountField = 0
+		return nil, aimlapiContinue
+	}
+	if s.newAccount {
+		s.apiKey = event.result.APIKey
+	}
+	if strings.TrimSpace(event.result.Model) != "" {
+		s.model = event.result.Model
+	}
+	s.successLines = s.topUpSuccessLines()
+	s.step = aimlapiStepDone
+	return nil, aimlapiContinue
+}
+
+// ---- transitions & helpers ------------------------------------------------
+
+func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
+	if _, err := aimlapi.ParseAmountUSD(s.amount); err != nil {
+		s.errText = aimlapi.MsgTopUpTooLow
+		s.step = aimlapiStepAmountInput
+		s.amountField = 0
+		return nil, aimlapiContinue
+	}
+	s.gen++
+	gen := s.gen
+	s.detail = ""
+	s.errText = ""
+	s.step = aimlapiStepProgress
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	s.topupCancel = cancel
+	s.topupCh = startAimlapiStreamTopUp(ctx, aimlapi.StreamTopUpOptions{
+		SessionToken: s.sessionToken,
+		AmountUSD:    s.amount,
+		Method:       aimlapi.PaymentMethodCard,
+		AutoTopUp:    s.autoTopUp,
+		Exchange:     s.newAccount,
+		OpenBrowser:  s.openBrowser,
+		NoOpen:       s.noOpen,
+	})
+	return waitForAimlapiTopupEvent(s, gen, s.topupCh), aimlapiContinue
+}
+
+// finishEverythingRuns lands on the terminal "Everything is ready" screen with the
+// key already in hand (Path A ok/skip, or Path B existing after balance/top-up).
+func (s *aimlapiOnboardState) finishEverythingRuns() tea.Cmd {
+	s.successLines = []string{aimlapi.MsgEverythingRuns}
+	s.step = aimlapiStepDone
+	return nil
+}
+
+// topUpSuccessLines builds the terminal "done" body. For a new account the
+// magic-link note follows the balance line after a blank spacer row; an existing
+// key just gets the top-up confirmation.
+func (s *aimlapiOnboardState) topUpSuccessLines() []string {
+	amount := fmt.Sprintf(aimlapi.MsgTopUpAddedFmt, strings.TrimSpace(s.amount))
+	if s.newAccount {
+		return []string{
+			aimlapi.MsgTopUpSuccess,
+			amount,
+			"",
+			fmt.Sprintf(aimlapi.MsgSuccessMagicLink, s.email),
+		}
+	}
+	return []string{
+		aimlapi.MsgTopUpSuccess,
+		amount,
+	}
+}
+
+func (s *aimlapiOnboardState) startBusy() {
+	s.gen++
+	s.busy = true
+	s.errText = ""
+}
+
+func (s *aimlapiOnboardState) stopBusy() {
+	s.busy = false
+}
+
+func (s *aimlapiOnboardState) cancelStream() {
+	if s.topupCancel != nil {
+		s.topupCancel()
+		s.topupCancel = nil
+	}
+	s.topupCh = nil
+	s.gen++ // drop any late stream/poll events
+}
+
+func aimlapiIsUnauthorized(err error) bool {
+	var apiErr aimlapi.APIError
+	return errors.As(err, &apiErr) && apiErr.Status == http.StatusUnauthorized
+}
+
+func aimlapiValidEmail(value string) bool {
+	return aimlapi.ValidEmail(value)
+}
+
+// ---- rendering ------------------------------------------------------------
+
+// aimlapiBlockWidth is the centered-block width for the aimlapi.com onboarding
+// screens. It mirrors the other first-run setup stages (setupMethodBlockWidth et
+// al.) so the sub-flow renders as one centered column in the same visual system
+// instead of a left-aligned outlier — never wider than the surface it draws on.
+func aimlapiBlockWidth(width int) int {
+	if width <= 0 {
+		width = 64
+	}
+	return maxInt(24, minInt(width, 64))
+}
+
+// view renders the current sub-flow screen. spinner is the host model's live
+// liveness glyph (m.spinnerGlyph()); it drives the animated spinner that stands
+// in for the streamed top-up's status lines and for every in-flight async wait.
+func (s *aimlapiOnboardState) view(width int, spinner string) []string {
+	rowWidth := aimlapiBlockWidth(width)
+	var lines []string
+	switch s.step {
+	case aimlapiStepPickPath:
+		lines = s.viewPickPath(width)
+	case aimlapiStepKeyInput:
+		lines = aimlapiInputScreen(rowWidth, aimlapi.MsgAPIKeyInputPrompt,
+			"api key > ", maskedProviderWizardKey(s.apiKey), "paste your key",
+			"Your API key will be hidden and verified automatically.")
+	case aimlapiStepEmailInput:
+		lines = aimlapiInputScreen(rowWidth, aimlapi.MsgEnterEmail,
+			"email > ", strings.TrimSpace(s.email), "name@example.com", "")
+	case aimlapiStepCodeInput:
+		lines = aimlapiInputScreen(rowWidth, fmt.Sprintf(aimlapi.MsgCodeSent, s.email),
+			"code > ", strings.TrimSpace(s.code), "6-digit code", "")
+	case aimlapiStepLowBalance:
+		lines = s.viewLowBalance(width)
+	case aimlapiStepAmountInput:
+		lines = s.viewAmount(width)
+	case aimlapiStepProgress:
+		lines = s.viewProgress(width, spinner)
+	case aimlapiStepDone:
+		lines = s.viewDone(width)
+	}
+	// A pending async round-trip shows a spinner (not a status line) beneath the
+	// current screen, so the wait always reads as live motion.
+	if s.busy {
+		lines = append(lines, blankSetupBlockLine(rowWidth))
+		lines = append(lines, aimlapiSpinnerLine(spinner, rowWidth))
+	}
+	if s.errText != "" {
+		lines = append(lines, blankSetupBlockLine(rowWidth))
+		lines = append(lines, aimlapiBlockText(s.errText, zeroTheme.red.Render, rowWidth)...)
+	}
+	return lines
+}
+
+// aimlapiSpinnerLine renders the animated liveness glyph as one block row at the
+// shared content indent, in accent colour. It replaces the sub-flow's textual
+// status lines: the glyph advances on every spinner tick (the host keeps the tick
+// loop alive while the sub-flow is busy or on the progress screen), so it never
+// reads as a frozen screen. Under reduced motion the host passes a steady dot.
+func aimlapiSpinnerLine(spinner string, width int) string {
+	glyph := strings.TrimSpace(spinner)
+	if glyph == "" {
+		glyph = "•"
+	}
+	return padSetupLine("  "+zeroTheme.accent.Render(glyph), width)
+}
+
+// aimlapiBlockText renders a plain-text message as one or more block rows: the
+// text is word-wrapped to the block width (so long copy is never cut off with an
+// ellipsis), given the shared two-space content indent, styled, and padded to
+// width so every row shares the block's left edge as one centered column.
+func aimlapiBlockText(text string, render func(...string) string, width int) []string {
+	segments := wrapPlainText(text, maxInt(1, width-2))
+	if len(segments) == 0 {
+		segments = []string{""}
+	}
+	lines := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		lines = append(lines, padSetupLine("  "+render(segment), width))
+	}
+	return lines
+}
+
+// aimlapiPromptLines renders the first line as the primary instruction and any
+// following lines as faint supporting copy.
+func aimlapiPromptLines(prompt string, width int) []string {
+	lines := []string{}
+	for index, promptLine := range strings.Split(prompt, "\n") {
+		render := zeroTheme.ink.Render
+		if index > 0 {
+			render = zeroTheme.faint.Render
+		}
+		lines = append(lines, aimlapiBlockText(promptLine, render, width)...)
+	}
+	return lines
+}
+
+// aimlapiInputScreen renders one of the sub-flow's single-field prompts as a
+// centered block with an optional faint footnote.
+func aimlapiInputScreen(width int, prompt, inputPrompt, value, placeholder, footnote string) []string {
+	lines := []string{}
+	// Input prompts use their first line as the instruction and any following
+	// lines as supporting copy. Render that supporting copy faint so messages such
+	// as "To access aimlapi.com dashboard" read as subtitles, not another heading.
+	lines = append(lines, aimlapiPromptLines(prompt, width)...)
+	lines = append(lines, blankSetupBlockLine(width))
+	lines = append(lines, padSetupLine("  "+providerWizardInputLine(inputPrompt, value, placeholder, maxInt(1, width-2)), width))
+	if footnote != "" {
+		lines = append(lines, aimlapiBlockText(footnote, zeroTheme.faint.Render, width)...)
+	}
+	return lines
+}
+
+func (s *aimlapiOnboardState) amountPrompt() string {
+	if s.newAccount {
+		return aimlapi.MsgTopUpNewPrompt
+	}
+	return aimlapi.MsgTopUpExistingPrompt
+}
+
+// aimlapiOptionRows renders one selectable option as a marker+label line with an
+// optional faint subtitle beneath it, block-padded to width so the picker centers
+// as one column. The selected row is marked with ❯ and drawn in bold accent — the
+// same treatment the other setup stages use (setupMethodLines).
+func aimlapiOptionRows(label, hint string, selected bool, width int) []string {
+	marker := "  "
+	style := zeroTheme.ink
+	if selected {
+		marker = "❯ "
+		style = zeroTheme.accent.Bold(true)
+	}
+	rows := []string{padSetupLine(marker+style.Render(label), width)}
+	if hint != "" {
+		rows = append(rows, padSetupLine("    "+zeroTheme.faint.Render(hint), width))
+	}
+	return rows
+}
+
+func (s *aimlapiOnboardState) viewPickPath(width int) []string {
+	rowWidth := aimlapiBlockWidth(width)
+	options := []struct{ label, hint string }{
+		{aimlapi.MsgPickPathNewUser, aimlapi.MsgPickPathNewHint},
+		{aimlapi.MsgPickPathHaveKey, aimlapi.MsgPickPathHaveHint},
+	}
+	lines := []string{}
+	lines = append(lines, aimlapiBlockText(aimlapi.MsgPickPathPrompt, zeroTheme.ink.Render, rowWidth)...)
+	lines = append(lines, blankSetupBlockLine(rowWidth))
+	for index, option := range options {
+		lines = append(lines, aimlapiOptionRows(option.label, option.hint, index == s.pathCursor, rowWidth)...)
+	}
+	return lines
+}
+
+func (s *aimlapiOnboardState) viewLowBalance(width int) []string {
+	rowWidth := aimlapiBlockWidth(width)
+	lines := []string{}
+	lines = append(lines, aimlapiPromptLines(aimlapi.MsgLowBalance, rowWidth)...)
+	lines = append(lines, blankSetupBlockLine(rowWidth))
+	lines = append(lines, aimlapiOptionRows(aimlapi.MsgLowBalanceTopUp, "", s.lowCursor == 0, rowWidth)...)
+	lines = append(lines, aimlapiOptionRows(aimlapi.MsgLowBalanceSkip, "", s.lowCursor == 1, rowWidth)...)
+	return lines
+}
+
+// viewAmount renders the "Add credits" screen: the dollar amount input and the
+// "auto top up" on/off toggle beneath it. The focused field carries the ❯ marker
+// (the same idiom as the pick-path / low-balance pickers).
+func (s *aimlapiOnboardState) viewAmount(width int) []string {
+	rowWidth := aimlapiBlockWidth(width)
+	fieldWidth := maxInt(1, rowWidth-4)
+	lines := []string{}
+	lines = append(lines, aimlapiPromptLines(s.amountPrompt(), rowWidth)...)
+	lines = append(lines, blankSetupBlockLine(rowWidth))
+	lines = append(lines,
+		padSetupLine("  "+aimlapiFieldMarker(s.amountField == 0)+
+			aimlapiAmountInputLine(strings.TrimSpace(s.amount), "25", fieldWidth, s.amountField == 0), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+aimlapiFieldMarker(s.amountField == 1)+
+			aimlapiToggleLine("auto top up > ", s.autoTopUp, s.amountField == 1), rowWidth),
+	)
+	return lines
+}
+
+// aimlapiFieldMarker returns the fixed-width focus marker for a form field: a bold
+// accent ❯ when selected, two spaces otherwise, so switching focus never shifts
+// the surrounding columns.
+func aimlapiFieldMarker(selected bool) string {
+	if selected {
+		return zeroTheme.accent.Bold(true).Render("❯") + " "
+	}
+	return "  "
+}
+
+// aimlapiAmountInputLine highlights only the prompt and cursor while this field
+// has focus. The dollar sign and entered amount remain white in either state.
+func aimlapiAmountInputLine(value string, placeholder string, width int, focused bool) string {
+	promptStyle := zeroTheme.ink
+	if focused {
+		promptStyle = zeroTheme.accent
+	}
+	prompt := promptStyle.Render("amount > ") + zeroTheme.ink.Render("$")
+	cursor := promptStyle.Render("▌")
+	if value == "" {
+		return fitStyledLine(prompt+cursor+zeroTheme.faint.Render(placeholder), width)
+	}
+	return fitStyledLine(prompt+zeroTheme.ink.Render(value)+cursor, width)
+}
+
+// aimlapiToggleLine highlights only the prompt on focus. The selected choice is
+// white; the other uses the same faint style as supporting copy.
+func aimlapiToggleLine(prompt string, on bool, focused bool) string {
+	promptStyle := zeroTheme.ink
+	if focused {
+		promptStyle = zeroTheme.accent
+	}
+	onText, offText := zeroTheme.faint.Render("on"), zeroTheme.faint.Render("off")
+	if on {
+		onText = zeroTheme.ink.Render("on")
+	} else {
+		offText = zeroTheme.ink.Render("off")
+	}
+	return promptStyle.Render(prompt) + onText + zeroTheme.ink.Render("/") + offText
+}
+
+// viewProgress is the streamed top-up screen. Per the design it is a spinner only
+// — the per-step status lines (registering / signing in / creating session /
+// waiting for payment / issuing key) are gone. The direct checkout link is still
+// shown once it arrives, since the user must open it to pay.
+func (s *aimlapiOnboardState) viewProgress(width int, spinner string) []string {
+	rowWidth := aimlapiBlockWidth(width)
+	lines := []string{}
+	if link := strings.TrimSpace(s.detail); link != "" {
+		lines = append(lines, aimlapiBlockText("Opening checkout in browser...", zeroTheme.ink.Render, rowWidth)...)
+		lines = append(lines, blankSetupBlockLine(rowWidth))
+		lines = append(lines, aimlapiBlockText(fmt.Sprintf(aimlapi.MsgTopUpBrowserFallback, ""), zeroTheme.faint.Render, rowWidth)...)
+		lines = append(lines, blankSetupBlockLine(rowWidth))
+		lines = append(lines, aimlapiLinkLines(link, rowWidth)...)
+		return lines
+	}
+	lines = append(lines, aimlapiSpinnerLine(spinner, rowWidth))
+	return lines
+}
+
+// aimlapiLinkLines wraps a checkout / verification URL inside the centered block
+// instead of truncating it, so fallback links stay copyable even when long.
+func aimlapiLinkLines(link string, width int) []string {
+	remaining := strings.TrimSpace(link)
+	measure := maxInt(1, width-2)
+	if remaining == "" {
+		return nil
+	}
+	lines := []string{}
+	// Keep the scheme and its slashes on separate terminal rows. Otherwise the
+	// terminal auto-detects the visible https:// URL and adds its own hover
+	// underline even though the TUI emits no hyperlink escape sequences.
+	if schemeEnd := strings.Index(remaining, "://"); schemeEnd > 0 {
+		head := remaining[:schemeEnd+1]
+		lines = append(lines, padSetupLine("  "+zeroTheme.accent.Render(head), width))
+		remaining = remaining[schemeEnd+1:]
+	}
+	for remaining != "" {
+		head, tail := splitPlainAtDisplayWidth(remaining, measure)
+		if head == "" {
+			head, tail = string([]rune(remaining)[0]), string([]rune(remaining)[1:])
+		}
+		lines = append(lines, padSetupLine("  "+zeroTheme.accent.Render(head), width))
+		remaining = tail
+	}
+	return lines
+}
+
+func (s *aimlapiOnboardState) viewDone(width int) []string {
+	rowWidth := aimlapiBlockWidth(width)
+	lines := []string{}
+	for _, line := range s.successLines {
+		if line == "" {
+			lines = append(lines, blankSetupBlockLine(rowWidth))
+			continue
+		}
+		render := zeroTheme.ink.Render
+		if line == aimlapi.MsgEverythingRuns || line == aimlapi.MsgTopUpSuccess ||
+			line == fmt.Sprintf(aimlapi.MsgTopUpAddedFmt, strings.TrimSpace(s.amount)) {
+			render = zeroTheme.accent.Render
+		}
+		lines = append(lines, aimlapiBlockText(line, render, rowWidth)...)
+	}
+	lines = append(lines, blankSetupBlockLine(rowWidth))
+	lines = append(lines, aimlapiBlockText("Press Enter to continue.", zeroTheme.faint.Render, rowWidth)...)
+	return lines
+}

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -2,7 +2,9 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -99,11 +101,12 @@ func newAimlapiOnboard(openBrowser func(string) error) *aimlapiOnboardState {
 type aimlapiMsgKind int
 
 const (
-	aimlapiMsgCheck      aimlapiMsgKind = iota // Path B: does the account exist?
-	aimlapiMsgToken                            // Path B: session from code / passwordless
-	aimlapiMsgKey                              // Path B existing: minted key
-	aimlapiMsgKeyBalance                       // Path B existing: balance of the minted key
-	aimlapiMsgTopup                            // shared: one streamed top-up event
+	aimlapiMsgKeyValidation aimlapiMsgKind = iota // Path A: validate pasted key via balance endpoint
+	aimlapiMsgCheck                               // Path B: does the account exist?
+	aimlapiMsgToken                               // Path B: session from code / passwordless
+	aimlapiMsgKey                                 // Path B existing: minted key
+	aimlapiMsgKeyBalance                          // Path B existing: balance of the minted key
+	aimlapiMsgTopup                               // shared: one streamed top-up event
 )
 
 // aimlapiOnboardMsg carries one async result back to the owning sub-model. The
@@ -173,6 +176,16 @@ func (s *aimlapiOnboardState) keyBalanceCmd(key string) tea.Cmd {
 	return func() tea.Msg {
 		res, err := aimlapiOnboardClient().GetBalance(ctx, key)
 		m.balance, m.err = res, err
+		return m
+	}
+}
+
+func (s *aimlapiOnboardState) keyValidationCmd(key string) tea.Cmd {
+	m := s.msg(aimlapiMsgKeyValidation)
+	ctx := s.opContext()
+	return func() tea.Msg {
+		_, err := aimlapiOnboardClient().GetBalance(ctx, key)
+		m.err = err
 		return m
 	}
 }
@@ -323,13 +336,8 @@ func (s *aimlapiOnboardState) handleKeyInputKey(msg tea.KeyMsg) (tea.Cmd, aimlap
 		if strings.TrimSpace(s.apiKey) == "" {
 			return nil, aimlapiContinue
 		}
-		// Path A saves the pasted key as-is: no balance read and no in-CLI top-up.
-		// Funding a key requires signing in, and the pasted key need not belong to
-		// whatever account the user would then authenticate as — so offering a
-		// top-up here risks funding the wrong account. A bad key just surfaces on
-		// first use, exactly like every other provider's paste-a-key flow.
-		s.apiKey = strings.TrimSpace(s.apiKey)
-		return s.finishEverythingRuns(), aimlapiContinue
+		s.startBusy()
+		return s.keyValidationCmd(strings.TrimSpace(s.apiKey)), aimlapiContinue
 	case keyText(msg) != "":
 		s.apiKey += keyText(msg)
 		s.errText = ""
@@ -468,6 +476,8 @@ func (s *aimlapiOnboardState) apply(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutc
 		return nil, aimlapiContinue // stale: user moved on
 	}
 	switch msg.kind {
+	case aimlapiMsgKeyValidation:
+		return s.applyKeyValidation(msg)
 	case aimlapiMsgKeyBalance:
 		return s.applyKeyBalance(msg)
 	case aimlapiMsgCheck:
@@ -480,6 +490,23 @@ func (s *aimlapiOnboardState) apply(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutc
 		return s.applyTopup(msg)
 	}
 	return nil, aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) applyKeyValidation(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
+	s.stopBusy()
+	if msg.err != nil {
+		if aimlapiIsUnauthorized(msg.err) {
+			s.apiKey = ""
+			s.errText = aimlapi.MsgAPIKeyInvalid
+			s.step = aimlapiStepKeyInput
+			return nil, aimlapiContinue
+		}
+		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.step = aimlapiStepKeyInput
+		return nil, aimlapiContinue
+	}
+	s.apiKey = strings.TrimSpace(s.apiKey)
+	return s.finishEverythingRuns(), aimlapiContinue
 }
 
 func (s *aimlapiOnboardState) applyKeyBalance(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
@@ -702,6 +729,12 @@ func (s *aimlapiOnboardState) cancelStream() {
 
 func aimlapiValidEmail(value string) bool {
 	return aimlapi.ValidEmail(value)
+}
+
+func aimlapiIsUnauthorized(err error) bool {
+	var apiErr aimlapi.APIError
+	return errors.As(err, &apiErr) &&
+		(apiErr.Status == http.StatusUnauthorized || apiErr.Status == http.StatusForbidden)
 }
 
 // ---- rendering ------------------------------------------------------------

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -649,14 +649,10 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		return nil, aimlapiContinue
 	}
 	if _, err := aimlapi.ParseAmountUSD(s.amount); err != nil {
-		switch {
-		case errors.Is(err, aimlapi.ErrAmountTooLow):
-			s.errText = aimlapi.MsgTopUpTooLow
-		case errors.Is(err, aimlapi.ErrAmountTooHigh):
-			s.errText = aimlapi.MsgTopUpTooHigh
-		default:
-			s.errText = aimlapi.MsgAmountInvalid
-		}
+		// Surface the actual validation error (below-min / above-max / non-numeric),
+		// the same way this sub-flow renders its other errors, instead of a single
+		// catch-all "too low".
+		s.errText = redaction.ErrorMessage(err, redaction.Options{})
 		s.step = aimlapiStepAmountInput
 		s.amountField = 0
 		return nil, aimlapiContinue

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -541,7 +541,7 @@ func (s *aimlapiOnboardState) applyKeyValidation(msg aimlapiOnboardMsg) (tea.Cmd
 			s.step = aimlapiStepKeyInput
 			return nil, aimlapiContinue
 		}
-		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.errText = s.safeErrorMessage(msg.err)
 		s.step = aimlapiStepKeyInput
 		return nil, aimlapiContinue
 	}
@@ -574,7 +574,7 @@ func (s *aimlapiOnboardState) applyKeyBalance(msg aimlapiOnboardMsg) (tea.Cmd, a
 func (s *aimlapiOnboardState) applyCheck(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
 	s.stopBusy()
 	if msg.err != nil {
-		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.errText = s.safeErrorMessage(msg.err)
 		s.step = aimlapiStepEmailInput
 		return nil, aimlapiContinue
 	}
@@ -601,13 +601,13 @@ func (s *aimlapiOnboardState) applyToken(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 			if aimlapiIsInvalidCode(msg.err) {
 				s.errText = aimlapi.MsgCodeIncorrect
 			} else {
-				s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+				s.errText = s.safeErrorMessage(msg.err)
 			}
 			s.step = aimlapiStepCodeInput
 			return nil, aimlapiContinue
 		}
 		// send-code or passwordless sign-up failed — back to the email prompt.
-		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.errText = s.safeErrorMessage(msg.err)
 		s.step = aimlapiStepEmailInput
 		return nil, aimlapiContinue
 	}
@@ -634,7 +634,7 @@ func (s *aimlapiOnboardState) applyToken(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 func (s *aimlapiOnboardState) applyKey(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
 	s.stopBusy()
 	if msg.err != nil {
-		s.errText = redaction.ErrorMessage(msg.err, redaction.Options{})
+		s.errText = s.safeErrorMessage(msg.err)
 		s.step = aimlapiStepEmailInput
 		return nil, aimlapiContinue
 	}
@@ -736,6 +736,7 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		s.topupCh = startAimlapiStreamTopUpByKey(ctx, aimlapi.StreamTopUpByKeyOptions{
 			APIKey:             s.apiKey,
 			AmountUSD:          s.amount,
+			InferenceBaseURL:   s.baseURL,
 			AutoTopUp:          s.autoTopUp,
 			ResumeSessionToken: s.resumeSessionToken,
 			PaymentSessionID:   s.paymentSessionID,
@@ -747,6 +748,7 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 			SessionToken:       s.sessionToken,
 			ResumeSessionToken: s.resumeSessionToken,
 			AmountUSD:          s.amount,
+			InferenceBaseURL:   s.baseURL,
 			Method:             aimlapi.PaymentMethodCard,
 			AutoTopUp:          s.autoTopUp,
 			Exchange:           s.newAccount,
@@ -763,6 +765,23 @@ func (s *aimlapiOnboardState) finishEverythingRuns() tea.Cmd {
 	s.successLines = []string{aimlapi.MsgEverythingRuns}
 	s.step = aimlapiStepDone
 	return nil
+}
+
+// safeErrorMessage strips server-controlled API response bodies before display
+// and redacts every credential that can be active in the onboarding state. This
+// keeps echoed keys, verification codes, and session bearers out of terminal
+// scrollback while retaining the operation and HTTP status for diagnosis.
+func (s *aimlapiOnboardState) safeErrorMessage(err error) string {
+	var apiErr aimlapi.APIError
+	if errors.As(err, &apiErr) {
+		err = aimlapi.APIError{Message: apiErr.Message, Status: apiErr.Status}
+	}
+	return redaction.ErrorMessage(err, redaction.Options{ExtraSecretValues: []string{
+		s.apiKey,
+		s.email,
+		s.code,
+		s.sessionToken,
+	}})
 }
 
 // topUpSuccessLines builds the terminal "done" body. For a new account the

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -532,8 +532,13 @@ func (s *aimlapiOnboardState) applyCheck(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 	if s.signinForTopup {
 		// Path A funding: only an existing account can top up the pasted key.
 		if msg.check.Action != "sign-in" {
-			s.errText = "That email has no aimlapi.com account, so it can't top up this key."
-			return s.finishEverythingRuns(), aimlapiContinue
+			// The pasted key is valid and still saved; we just can't fund it because
+			// this email has no account. Land on the terminal screen with one coherent
+			// note instead of a green "ready" plus a red error.
+			s.errText = ""
+			s.successLines = []string{aimlapi.MsgEverythingRuns, "", aimlapi.MsgTopUpNoAccount}
+			s.step = aimlapiStepDone
+			return nil, aimlapiContinue
 		}
 		s.newAccount = false
 		s.startBusy()
@@ -635,6 +640,14 @@ func (s *aimlapiOnboardState) applyTopup(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 // ---- transitions & helpers ------------------------------------------------
 
 func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
+	if strings.TrimSpace(s.amount) == "" {
+		// An empty field would otherwise fall through to the $25 default inside
+		// ParseAmountUSD and silently start a checkout the user never typed.
+		s.errText = aimlapi.MsgAmountRequired
+		s.step = aimlapiStepAmountInput
+		s.amountField = 0
+		return nil, aimlapiContinue
+	}
 	if _, err := aimlapi.ParseAmountUSD(s.amount); err != nil {
 		s.errText = aimlapi.MsgTopUpTooLow
 		s.step = aimlapiStepAmountInput
@@ -828,13 +841,6 @@ func aimlapiInputScreen(width int, prompt, inputPrompt, value, placeholder, foot
 	return lines
 }
 
-func (s *aimlapiOnboardState) amountPrompt() string {
-	if s.newAccount {
-		return aimlapi.MsgTopUpNewPrompt
-	}
-	return aimlapi.MsgTopUpExistingPrompt
-}
-
 // aimlapiOptionRows renders one selectable option as a marker+label line with an
 // optional faint subtitle beneath it, block-padded to width so the picker centers
 // as one column. The selected row is marked with ❯ and drawn in bold accent — the
@@ -885,7 +891,7 @@ func (s *aimlapiOnboardState) viewAmount(width int) []string {
 	rowWidth := aimlapiBlockWidth(width)
 	fieldWidth := maxInt(1, rowWidth-4)
 	lines := []string{}
-	lines = append(lines, aimlapiPromptLines(s.amountPrompt(), rowWidth)...)
+	lines = append(lines, aimlapiPromptLines(aimlapi.MsgTopUpPrompt, rowWidth)...)
 	lines = append(lines, blankSetupBlockLine(rowWidth))
 	lines = append(lines,
 		padSetupLine("  "+aimlapiFieldMarker(s.amountField == 0)+

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -341,8 +341,9 @@ func (s *aimlapiOnboardState) handleKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome
 	return nil, aimlapiContinue
 }
 
-// handlePickPathKey drives the key/email picker: the two onboarding options
-// (paste an existing key, or go through email).
+// handlePickPathKey drives new configuration: create an account or paste a key.
+// Reusing an already configured/env credential is a /provider preflight, not a
+// third onboarding identity path.
 func (s *aimlapiOnboardState) handlePickPathKey(msg tea.KeyMsg) (tea.Cmd, aimlapiOutcome) {
 	switch {
 	case keyIs(msg, tea.KeyUp) || keyIs(msg, tea.KeyDown) || keyIs(msg, tea.KeyTab):

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -64,6 +64,11 @@ type aimlapiOnboardState struct {
 	// handle, generated once and reused on retry so a re-issued pay never double-charges.
 	byKey            bool
 	paymentSessionID string
+	// payment intent attributes bind resumable checkout state to the normalized
+	// amount and auto-top-up selection that created it. Changing either starts a
+	// fresh intent instead of silently reusing the old checkout.
+	paymentAmountUSDMinor int
+	paymentAutoTopUp      bool
 
 	// opCancel cancels the single in-flight account/key request (balance, check,
 	// code, passwordless, key-mint). Only one runs at a time (input is gated while
@@ -578,15 +583,22 @@ func (s *aimlapiOnboardState) applyCheck(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 		s.step = aimlapiStepEmailInput
 		return nil, aimlapiContinue
 	}
-	if msg.check.Action == "sign-in" {
+	switch msg.check.Action {
+	case "sign-in":
 		s.newAccount = false
 		s.startBusy()
 		return s.sendCodeCmd(s.email), aimlapiContinue
+	case "sign-up":
+		// No account yet: passwordless sign-up, then fund via top-up (min $20).
+		s.newAccount = true
+		s.startBusy()
+		return s.passwordlessCmd(s.email), aimlapiContinue
+	default:
+		s.newAccount = false
+		s.errText = aimlapi.MsgAccountActionInvalid
+		s.step = aimlapiStepEmailInput
+		return nil, aimlapiContinue
 	}
-	// No account yet: passwordless sign-up, then fund via top-up (min $20).
-	s.newAccount = true
-	s.startBusy()
-	return s.passwordlessCmd(s.email), aimlapiContinue
 }
 
 func (s *aimlapiOnboardState) applyToken(msg aimlapiOnboardMsg) (tea.Cmd, aimlapiOutcome) {
@@ -703,7 +715,8 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		s.amountField = 0
 		return nil, aimlapiContinue
 	}
-	if _, err := aimlapi.ParseAmountUSD(s.amount); err != nil {
+	amountUSDMinor, err := aimlapi.ParseAmountUSD(s.amount)
+	if err != nil {
 		// Surface the actual validation error (below-min / above-max / non-numeric),
 		// the same way this sub-flow renders its other errors, instead of a single
 		// catch-all "too low".
@@ -712,6 +725,8 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		s.amountField = 0
 		return nil, aimlapiContinue
 	}
+	s.prepareTopUpIntent(amountUSDMinor)
+	normalizedAmount := formatUSDMinor(amountUSDMinor)
 	s.gen++
 	gen := s.gen
 	s.detail = ""
@@ -735,7 +750,7 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		}
 		s.topupCh = startAimlapiStreamTopUpByKey(ctx, aimlapi.StreamTopUpByKeyOptions{
 			APIKey:             s.apiKey,
-			AmountUSD:          s.amount,
+			AmountUSD:          normalizedAmount,
 			InferenceBaseURL:   s.baseURL,
 			AutoTopUp:          s.autoTopUp,
 			ResumeSessionToken: s.resumeSessionToken,
@@ -747,7 +762,7 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		s.topupCh = startAimlapiStreamTopUp(ctx, aimlapi.StreamTopUpOptions{
 			SessionToken:       s.sessionToken,
 			ResumeSessionToken: s.resumeSessionToken,
-			AmountUSD:          s.amount,
+			AmountUSD:          normalizedAmount,
 			InferenceBaseURL:   s.baseURL,
 			Method:             aimlapi.PaymentMethodCard,
 			AutoTopUp:          s.autoTopUp,
@@ -757,6 +772,20 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 		})
 	}
 	return waitForAimlapiTopupEvent(s, gen, s.topupCh), aimlapiContinue
+}
+
+func (s *aimlapiOnboardState) prepareTopUpIntent(amountUSDMinor int) {
+	if s.paymentAmountUSDMinor != 0 &&
+		(s.paymentAmountUSDMinor != amountUSDMinor || s.paymentAutoTopUp != s.autoTopUp) {
+		s.resumeSessionToken = ""
+		s.paymentSessionID = ""
+	}
+	s.paymentAmountUSDMinor = amountUSDMinor
+	s.paymentAutoTopUp = s.autoTopUp
+}
+
+func formatUSDMinor(amount int) string {
+	return fmt.Sprintf("%d.%02d", amount/100, amount%100)
 }
 
 // finishEverythingRuns lands on the terminal "Everything is ready" screen with the
@@ -788,7 +817,7 @@ func (s *aimlapiOnboardState) safeErrorMessage(err error) string {
 // magic-link note follows the balance line after a blank spacer row; an existing
 // key just gets the top-up confirmation.
 func (s *aimlapiOnboardState) topUpSuccessLines() []string {
-	amount := fmt.Sprintf(aimlapi.MsgTopUpAddedFmt, strings.TrimSpace(s.amount))
+	amount := fmt.Sprintf(aimlapi.MsgTopUpAddedFmt, formatUSDMinor(s.paymentAmountUSDMinor))
 	if s.newAccount {
 		return []string{
 			aimlapi.MsgTopUpSuccess,

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -52,6 +52,19 @@ type aimlapiOnboardState struct {
 	topupCh     chan aimlapiTopupEvent
 	topupCancel context.CancelFunc
 
+	// resumeSessionToken is the partner-checkout session token of the last top-up
+	// attempt. It is retained across a failure so a retry resumes that session
+	// (recovering a paid-but-unexchanged key, never re-charging) instead of opening
+	// a second checkout; cleared once the session is dead or the top-up succeeds.
+	resumeSessionToken string
+
+	// byKey routes the top-up through the API-key-bound flow (Path A pasted key /
+	// AIMLAPI_API_KEY) instead of the email session: the top-up funds the account
+	// that owns apiKey, with no exchange. paymentSessionID is that flow's idempotency
+	// handle, generated once and reused on retry so a re-issued pay never double-charges.
+	byKey            bool
+	paymentSessionID string
+
 	// opCancel cancels the single in-flight account/key request (balance, check,
 	// code, passwordless, key-mint). Only one runs at a time (input is gated while
 	// busy); it is cancelled when the request completes or the flow is abandoned.
@@ -180,12 +193,16 @@ func (s *aimlapiOnboardState) keyBalanceCmd(key string) tea.Cmd {
 	}
 }
 
+// keyValidationCmd validates a pasted/env key (Path A) via GetBalance, capturing
+// both the error and the balance. A low balance can now be topped up safely with
+// the key itself — the by-key checkout binds the top-up to this key's own account —
+// so applyKeyValidation offers the optional top-up chooser instead of discarding it.
 func (s *aimlapiOnboardState) keyValidationCmd(key string) tea.Cmd {
 	m := s.msg(aimlapiMsgKeyValidation)
 	ctx := s.opContext()
 	return func() tea.Msg {
-		_, err := aimlapiOnboardClient().GetBalance(ctx, key)
-		m.err = err
+		res, err := aimlapiOnboardClient().GetBalance(ctx, key)
+		m.balance, m.err = res, err
 		return m
 	}
 }
@@ -250,7 +267,28 @@ func startAimlapiStreamTopUp(ctx context.Context, options aimlapi.StreamTopUpOpt
 		opts.OnStatus = func(_ aimlapi.Status, detail string) {
 			ch <- aimlapiTopupEvent{detail: detail}
 		}
+		opts.OnSession = func(token string) {
+			ch <- aimlapiTopupEvent{session: token, hasSession: true}
+		}
 		result, err := aimlapi.StreamTopUp(ctx, opts)
+		ch <- aimlapiTopupEvent{done: true, result: result, err: err}
+	}()
+	return ch
+}
+
+// startAimlapiStreamTopUpByKey runs the API-key-bound top-up (Path A / env key)
+// and streams the same progress events, so applyTopup handles both flows uniformly.
+func startAimlapiStreamTopUpByKey(ctx context.Context, options aimlapi.StreamTopUpByKeyOptions) chan aimlapiTopupEvent {
+	ch := make(chan aimlapiTopupEvent, 16)
+	go func() {
+		opts := options
+		opts.OnStatus = func(_ aimlapi.Status, detail string) {
+			ch <- aimlapiTopupEvent{detail: detail}
+		}
+		opts.OnSession = func(token string) {
+			ch <- aimlapiTopupEvent{session: token, hasSession: true}
+		}
+		result, err := aimlapi.StreamTopUpByKey(ctx, opts)
 		ch <- aimlapiTopupEvent{done: true, result: result, err: err}
 	}()
 	return ch
@@ -402,8 +440,9 @@ func (s *aimlapiOnboardState) handleLowBalanceKey(msg tea.KeyMsg) (tea.Cmd, aiml
 		if s.lowCursor == 1 { // skip topping up
 			return s.finishEverythingRuns(), aimlapiContinue
 		}
-		// Top up now. Low balance is only reachable from Path B existing, where we
-		// already hold a session for the minted key's own account.
+		// Top up now, against the account that owns the key: Path B existing (email
+		// session) or Path A (byKey, bound to the pasted/env key). startTopUp routes
+		// to the right flow.
 		s.step = aimlapiStepAmountInput
 		s.errText = ""
 	}
@@ -506,6 +545,14 @@ func (s *aimlapiOnboardState) applyKeyValidation(msg aimlapiOnboardMsg) (tea.Cmd
 		return nil, aimlapiContinue
 	}
 	s.apiKey = strings.TrimSpace(s.apiKey)
+	// A valid key with a low balance can fund its own account via the by-key
+	// checkout (bound to this key), so offer the optional top-up chooser.
+	if msg.balance.LowBalance {
+		s.byKey = true
+		s.lowCursor = 0
+		s.step = aimlapiStepLowBalance
+		return nil, aimlapiContinue
+	}
 	return s.finishEverythingRuns(), aimlapiContinue
 }
 
@@ -601,6 +648,11 @@ func (s *aimlapiOnboardState) applyTopup(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 	}
 	event := msg.topup
 	if !event.done {
+		if event.hasSession {
+			// Retain (or, on "", drop) the live partner-checkout token so a retry
+			// resumes this session rather than opening a second checkout.
+			s.resumeSessionToken = event.session
+		}
 		if strings.TrimSpace(event.detail) != "" {
 			s.detail = event.detail
 		}
@@ -608,11 +660,17 @@ func (s *aimlapiOnboardState) applyTopup(msg aimlapiOnboardMsg) (tea.Cmd, aimlap
 	}
 	s.cancelStream()
 	if event.err != nil {
+		// Keep resumeSessionToken: the next startTopUp resumes this session (poll a
+		// pending payment / recover a paid-but-unexchanged key) instead of charging
+		// again.
 		s.errText = aimlapi.MsgTopUpFailed
 		s.step = aimlapiStepAmountInput
 		s.amountField = 0
 		return nil, aimlapiContinue
 	}
+	// Top-up completed; nothing left to resume or re-fund idempotently.
+	s.resumeSessionToken = ""
+	s.paymentSessionID = ""
 	if s.newAccount {
 		s.apiKey = event.result.APIKey
 	}
@@ -654,15 +712,41 @@ func (s *aimlapiOnboardState) startTopUp() (tea.Cmd, aimlapiOutcome) {
 	s.step = aimlapiStepProgress
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
 	s.topupCancel = cancel
-	s.topupCh = startAimlapiStreamTopUp(ctx, aimlapi.StreamTopUpOptions{
-		SessionToken: s.sessionToken,
-		AmountUSD:    s.amount,
-		Method:       aimlapi.PaymentMethodCard,
-		AutoTopUp:    s.autoTopUp,
-		Exchange:     s.newAccount,
-		OpenBrowser:  s.openBrowser,
-		NoOpen:       s.noOpen,
-	})
+	if s.byKey {
+		// Path A / env key: fund the account bound to apiKey. Generate the
+		// idempotency id once and keep it, so a retry re-issues the same pay.
+		if strings.TrimSpace(s.paymentSessionID) == "" {
+			id, err := aimlapi.NewPaymentSessionID()
+			if err != nil {
+				cancel()
+				s.errText = aimlapi.MsgTopUpFailed
+				s.step = aimlapiStepAmountInput
+				s.amountField = 0
+				return nil, aimlapiContinue
+			}
+			s.paymentSessionID = id
+		}
+		s.topupCh = startAimlapiStreamTopUpByKey(ctx, aimlapi.StreamTopUpByKeyOptions{
+			APIKey:             s.apiKey,
+			AmountUSD:          s.amount,
+			AutoTopUp:          s.autoTopUp,
+			ResumeSessionToken: s.resumeSessionToken,
+			PaymentSessionID:   s.paymentSessionID,
+			OpenBrowser:        s.openBrowser,
+			NoOpen:             s.noOpen,
+		})
+	} else {
+		s.topupCh = startAimlapiStreamTopUp(ctx, aimlapi.StreamTopUpOptions{
+			SessionToken:       s.sessionToken,
+			ResumeSessionToken: s.resumeSessionToken,
+			AmountUSD:          s.amount,
+			Method:             aimlapi.PaymentMethodCard,
+			AutoTopUp:          s.autoTopUp,
+			Exchange:           s.newAccount,
+			OpenBrowser:        s.openBrowser,
+			NoOpen:             s.noOpen,
+		})
+	}
 	return waitForAimlapiTopupEvent(s, gen, s.topupCh), aimlapiContinue
 }
 

--- a/internal/tui/aimlapi_onboard.go
+++ b/internal/tui/aimlapi_onboard.go
@@ -169,7 +169,7 @@ func (m model) aimlapiOnboardAnimating() bool {
 	if aimlapiStateAnimating(m.setup.aimlapi) {
 		return true
 	}
-	return m.providerWizard != nil && aimlapiStateAnimating(m.providerWizard.aimlapi)
+	return m.providerWizard != nil && (m.providerWizard.aimlapiExistingBusy || aimlapiStateAnimating(m.providerWizard.aimlapi))
 }
 
 func aimlapiStateAnimating(s *aimlapiOnboardState) bool {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1126,6 +1126,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, dragEdgeScrollTickCmd(m.edgeScrollSeq)
 	case providerWizardOAuthMsg:
 		return m.applyProviderWizardOAuth(msg)
+	case aimlapiOnboardMsg:
+		return m.applyAimlapiOnboard(msg)
 	case providerWizardDeviceCodeMsg:
 		return m.applyProviderWizardDeviceCode(msg)
 	case providerManagerCredsMsg:
@@ -1952,11 +1954,21 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// advancing even when no run is pending, so the tick loop stays alive while
 		// sidebarHasAgents() holds (and stops the moment the agents/sidebar clear).
 		if !m.pending && !m.compactInFlight && !m.doctorInFlight {
-			if m.sidebarHasAgents() && !m.reducedMotion {
-				m.spinner, _ = m.spinner.Update(msg)
+			// The tick also keeps advancing while the aimlapi.com onboarding sub-flow is
+			// busy (its progress screen is spinner-only), even though no agent run is in
+			// flight, so its shared MiniDot spinner keeps animating.
+			//
+			// Return the FPS-throttled tick that Update hands back — NOT m.spinner.Tick,
+			// which fires immediately and busy-loops the frame at event-loop speed. That
+			// makes the glyph spin far too fast (and burns CPU) on screens that sit here
+			// for a while, e.g. the aimlapi checkout wait. The active-run path below
+			// already does this; this keeps idle animation at the same cadence.
+			if (m.sidebarHasAgents() || m.aimlapiOnboardAnimating()) && !m.reducedMotion {
+				var cmd tea.Cmd
+				m.spinner, cmd = m.spinner.Update(msg)
 				m.spinnerPhase++
 				m.spinnerTicking = true
-				return m, m.spinner.Tick
+				return m, cmd
 			}
 			m.spinnerTicking = false
 			return m, nil
@@ -4562,7 +4574,10 @@ func (m model) beginRun(cancel context.CancelFunc) model {
 // loop is already alive, when reduced motion is set, or when there is nothing to
 // animate, so an idle plain session schedules no timer.
 func (m *model) ensureSpinnerTick() tea.Cmd {
-	if m.spinnerTicking || m.reducedMotion || !m.sidebarHasAgents() {
+	if m.spinnerTicking || m.reducedMotion {
+		return nil
+	}
+	if !m.sidebarHasAgents() && !m.aimlapiOnboardAnimating() {
 		return nil
 	}
 	m.spinnerTicking = true

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -970,6 +970,9 @@ func (m model) noBlockingModal() bool {
 }
 
 func (m model) quit() (tea.Model, tea.Cmd) {
+	if m.providerWizard != nil {
+		m.providerWizard.resetAimlapiOnboard()
+	}
 	m.stopPRWatcher()
 	m.stopAllBackgroundTerminalSessions()
 	m.shutdownLSPManager()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1128,6 +1128,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applyProviderWizardOAuth(msg)
 	case aimlapiOnboardMsg:
 		return m.applyAimlapiOnboard(msg)
+	case aimlapiExistingBalanceMsg:
+		return m.applyExistingAimlapiBalance(msg)
 	case providerWizardDeviceCodeMsg:
 		return m.applyProviderWizardDeviceCode(msg)
 	case providerManagerCredsMsg:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1964,6 +1964,35 @@ func TestCtrlCRequiresSecondPressToExit(t *testing.T) {
 	}
 }
 
+func TestConfirmedCtrlCCancelsProviderAimlapiOnboarding(t *testing.T) {
+	cancelled := false
+	m := newModel(context.Background(), Options{ProviderName: "tokenrouter"})
+	m.providerWizard = &providerWizardState{
+		step: providerWizardStepAimlapi,
+		aimlapi: &aimlapiOnboardState{
+			topupCancel: func() { cancelled = true },
+		},
+	}
+
+	updated, _ := m.Update(testKeyCtrl('c'))
+	next := updated.(model)
+	if cancelled {
+		t.Fatal("first Ctrl+C should only arm exit confirmation")
+	}
+
+	updated, cmd := next.Update(testKeyCtrl('c'))
+	next = updated.(model)
+	if !cancelled {
+		t.Fatal("confirmed Ctrl+C did not cancel AIMLAPI onboarding")
+	}
+	if next.providerWizard.aimlapi != nil {
+		t.Fatal("confirmed Ctrl+C retained AIMLAPI onboarding state")
+	}
+	if cmd == nil {
+		t.Fatal("confirmed Ctrl+C should return quit command")
+	}
+}
+
 func TestCtrlCExitConfirmationDisarmsOnInterveningKey(t *testing.T) {
 	m := newModel(context.Background(), Options{ProviderName: "tokenrouter"})
 

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -80,6 +80,11 @@ type aimlapiTopupEvent struct {
 	done   bool
 	result aimlapi.ProvisionedKey
 	err    error
+
+	// session carries the live partner-checkout session token (empty string means
+	// "drop the retained token"); hasSession distinguishes it from a status update.
+	session    string
+	hasSession bool
 }
 
 // setupOAuthMsg carries the result of a first-run browser OAuth login.

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 	"unicode"
@@ -460,6 +461,13 @@ func (m model) setupStages() []setupStage {
 	}
 	stages = append(stages, setupStageProvider)
 	if setupProviderIsAimlapi(m.setupProvider()) {
+		// Preserve the catalog's normal env-credential path in first-run setup.
+		// A ready AIMLAPI_API_KEY needs no guided identity flow: model discovery
+		// resolves it at runtime and saveSetupProvider persists APIKeyEnv, not the
+		// materialized secret. /provider owns the richer balance/top-up preflight.
+		if setupAimlapiEnvKey() != "" {
+			return append(stages, setupStageModel, setupStageSafety, setupStageReady)
+		}
 		stages = append(stages, setupStageAimlapi, setupStageModel, setupStageSafety, setupStageReady)
 		return stages
 	}
@@ -468,6 +476,10 @@ func (m model) setupStages() []setupStage {
 	}
 	stages = append(stages, setupStageCredentials, setupStageModel, setupStageSafety, setupStageReady)
 	return stages
+}
+
+func setupAimlapiEnvKey() string {
+	return strings.TrimSpace(os.Getenv("AIMLAPI_API_KEY"))
 }
 
 func setupProviderIsAimlapi(option SetupProviderOption) bool {

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -671,6 +671,7 @@ func (m model) resolveSetupAimlapi(cmd tea.Cmd, outcome aimlapiOutcome) (tea.Mod
 	switch outcome {
 	case aimlapiDone:
 		m.setup.apiKey.SetValue(m.setup.aimlapi.apiKey)
+		m.setup.baseURL = m.setup.aimlapi.baseURL
 		m.setup.aimlapi = nil
 		m.setup.err = ""
 		m.setup.stage = setupStageModel
@@ -1194,6 +1195,13 @@ func (m model) setupCredentialAPIKey(option SetupProviderOption) string {
 }
 
 func (m model) setupBaseURL(option SetupProviderOption) string {
+	// aimlapi.com never shows the endpoint field, but its onboarding resolves the
+	// inference endpoint (honoring an AIMLAPI_INFERENCE_URL override) onto
+	// m.setup.baseURL. Persist that so an override reaches the saved profile instead
+	// of being replaced by the catalog default at save time.
+	if providerWizardIsAimlapi(setupProviderDescriptor(option)) {
+		return strings.TrimSpace(m.setup.baseURL)
+	}
 	if !setupProviderNeedsEndpoint(option) {
 		return ""
 	}

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -948,7 +948,7 @@ func (m model) setupModelDiscoveryCmd(gen uint64) tea.Cmd {
 				apiKey = resolved
 			}
 		}
-		profile := providerWizardDiscoveryProfile(provider, apiKey)
+		profile := providerWizardDiscoveryProfile(provider, apiKey, m.setupBaseURL(option))
 		secrets := append(append([]string{}, baseSecrets...), apiKey, profile.APIKey)
 		models, err := discover(ctx, profile)
 		return setupModelsDiscoveredMsg{providerID: providerID, gen: gen, redactionSecrets: secrets, models: models, err: err}

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/Gitlawb/zero/internal/aimlapi"
 	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
@@ -29,6 +30,9 @@ const (
 	setupStageEndpoint
 	setupStageName
 	setupStageCredentials
+	// aimlapi.com onboarding sub-flow, reached when the selected
+	// provider is aimlapi. Delegated to the shared aimlapiOnboardState.
+	setupStageAimlapi
 	setupStageModel
 	setupStageSafety
 	setupStageReady
@@ -62,6 +66,20 @@ type setupState struct {
 	modelErr              string
 	modelSrc              string
 	modelGen              uint64
+	// aimlapi holds the shared aimlapi.com onboarding sub-flow while
+	// setup is on setupStageAimlapi.
+	aimlapi *aimlapiOnboardState
+}
+
+// aimlapiTopupEvent is one live update from a running partner checkout, streamed
+// over a channel so the TUI can show progress (and the direct checkout link) as
+// it happens instead of blocking on a single result. Mirrors openclaude's
+// onStatus-driven progress screen.
+type aimlapiTopupEvent struct {
+	detail string // for opening-checkout this is the direct checkout URL
+	done   bool
+	result aimlapi.ProvisionedKey
+	err    error
 }
 
 // setupOAuthMsg carries the result of a first-run browser OAuth login.
@@ -136,6 +154,13 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.setup.oauthDevice = false
 		}
 		return m, nil
+	}
+	// The aimlapi.com sub-flow owns all of its keys; Ctrl+C still quits.
+	if m.setup.stage == setupStageAimlapi {
+		if keyCtrl(msg, 'c') {
+			return m, tea.Quit
+		}
+		return m.handleSetupAimlapiKey(msg)
 	}
 	if m.setupEndpointInputActive() {
 		return m.handleSetupEndpointKey(msg)
@@ -269,6 +294,10 @@ func (m model) handleSetupPaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 		m.appendSetupBaseURL([]rune(msg.Content))
 	case m.setupNameInputActive():
 		m.appendSetupName([]rune(msg.Content))
+	case m.setup.stage == setupStageAimlapi:
+		if m.setup.aimlapi != nil {
+			m.setup.aimlapi.appendInput(msg.Content)
+		}
 	case m.setupCredentialInputActive():
 		previousAPIKey := m.setup.apiKey.Value()
 		var cmd tea.Cmd
@@ -421,15 +450,23 @@ func setupContentTop(height int, contentLines int, hasError bool) int {
 func (m model) setupStages() []setupStage {
 	stages := []setupStage{setupStageWelcome, setupStageMethod}
 	if m.setup.oauthMode {
-		// OAuth path skips endpoint/name/credentials (the login provides the credential).
+		// OAuth path skips endpoint/name/credentials because login provides the credential.
 		return append(stages, setupStageProvider, setupStageModel, setupStageSafety, setupStageReady)
 	}
 	stages = append(stages, setupStageProvider)
+	if setupProviderIsAimlapi(m.setupProvider()) {
+		stages = append(stages, setupStageAimlapi, setupStageModel, setupStageSafety, setupStageReady)
+		return stages
+	}
 	if setupProviderNeedsEndpoint(m.setupProvider()) {
 		stages = append(stages, setupStageEndpoint, setupStageName)
 	}
 	stages = append(stages, setupStageCredentials, setupStageModel, setupStageSafety, setupStageReady)
 	return stages
+}
+
+func setupProviderIsAimlapi(option SetupProviderOption) bool {
+	return strings.EqualFold(strings.TrimSpace(option.ID), "aimlapi")
 }
 
 // setupReturnToMethod resets the OAuth selection when navigating back to the
@@ -607,6 +644,53 @@ func (m model) applySetupOAuth(msg setupOAuthMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// handleSetupAimlapiKey delegates a key press to first-run setup's aimlapi.com
+// sub-flow and reacts to its outcome.
+func (m model) handleSetupAimlapiKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.setup.aimlapi == nil {
+		return m, nil
+	}
+	cmd, outcome := m.setup.aimlapi.handleKey(msg)
+	return m.resolveSetupAimlapi(cmd, outcome)
+}
+
+// applySetupAimlapiOnboard routes an async aimlapi.com onboarding result into
+// first-run setup's sub-flow and reacts to its outcome.
+func (m model) applySetupAimlapiOnboard(msg aimlapiOnboardMsg) (tea.Model, tea.Cmd) {
+	if m.setup.aimlapi == nil || m.setup.aimlapi != msg.state {
+		return m, nil
+	}
+	cmd, outcome := m.setup.aimlapi.apply(msg)
+	return m.resolveSetupAimlapi(cmd, outcome)
+}
+
+// resolveSetupAimlapi lands the sub-flow outcome on first-run setup: a terminal
+// key moves the issued key into the setup and jumps to model selection; a cancel
+// backs out to the provider list.
+func (m model) resolveSetupAimlapi(cmd tea.Cmd, outcome aimlapiOutcome) (tea.Model, tea.Cmd) {
+	switch outcome {
+	case aimlapiDone:
+		m.setup.apiKey.SetValue(m.setup.aimlapi.apiKey)
+		m.setup.aimlapi = nil
+		m.setup.err = ""
+		m.setup.stage = setupStageModel
+		m.resetSetupModels()
+		m.setup.modelErr = ""
+		m.setup.modelGen++
+		discoverCmd := m.setupModelDiscoveryCmd(m.setup.modelGen)
+		m.setup.modelLoad = discoverCmd != nil
+		return m, discoverCmd
+	case aimlapiCancel:
+		m.setup.aimlapi = nil
+		m.setup.err = ""
+		m.setup.stage = setupStageProvider
+		return m, nil
+	}
+	// Keep the shared spinner tick alive whenever the sub-flow just entered a busy
+	// or progress state, so its animated spinner advances during onboarding.
+	return m, tea.Batch(cmd, m.ensureSpinnerTick())
+}
+
 func (m model) nextSetupStage() setupStage {
 	stages := m.setupStages()
 	for index, stage := range stages {
@@ -621,6 +705,14 @@ func (m model) nextSetupStage() setupStage {
 }
 
 func (m model) previousSetupStage() setupStage {
+	// The aimlapi.com connect flow is terminal: once it has issued a key, its
+	// transient state is cleared. Going back from model selection or Safety can
+	// otherwise strand the user on an empty intermediate screen. Return to the
+	// provider list so choosing aimlapi.com again starts a fresh connect flow.
+	if (m.setup.stage == setupStageModel || m.setup.stage == setupStageSafety) &&
+		setupProviderIsAimlapi(m.setupProvider()) {
+		return setupStageProvider
+	}
 	stages := m.setupStages()
 	for index, stage := range stages {
 		if stage == m.setup.stage {
@@ -699,6 +791,9 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 		}
 		m.setup.stage = m.nextSetupStage()
 		m.setup.err = ""
+		if m.setup.stage == setupStageAimlapi && m.setup.aimlapi == nil {
+			m.setup.aimlapi = newAimlapiOnboard(browser.OpenURL)
+		}
 		if m.setup.stage == setupStageModel {
 			m.resetSetupModels()
 			m.setup.modelErr = ""
@@ -1226,6 +1321,11 @@ func (m model) setupStageLines(width int, height int) []string {
 		return m.setupNameLines(width)
 	case setupStageCredentials:
 		return m.setupCredentialLines(width)
+	case setupStageAimlapi:
+		if m.setup.aimlapi != nil {
+			return m.setup.aimlapi.view(width, m.spinnerGlyph())
+		}
+		return nil
 	case setupStageModel:
 		return m.setupModelLines(width, height)
 	case setupStageSafety:
@@ -1537,13 +1637,10 @@ func (m model) setupProviderLines(width int, height int) []string {
 			marker = "❯ "
 			style = zeroTheme.accent.Bold(true)
 		}
-		label := displayValue(option.Name, option.ID)
-		if option.Recommended {
-			label = "★ " + label
-		}
+		label := providerRecommendedRowLabel(option.ID, option.Name, option.Recommended)
 		line := marker + style.Render(label)
-		if option.Recommended {
-			line += zeroTheme.faint.Render("  (recommended)")
+		if badge := providerRecommendedRowBadge(option.ID, option.Recommended); badge != "" {
+			line += zeroTheme.faint.Render("  " + badge)
 		}
 		lines = append(lines, padSetupLine(line, rowWidth))
 	}
@@ -1606,7 +1703,11 @@ func setupProviderBlockWidth(terminalWidth int, providers []SetupProviderOption)
 	available := maxInt(24, minInt(terminalWidth-8, 44))
 	target := maxInt(lipgloss.Width("  2/6"), lipgloss.Width("  Choose a provider"))
 	for _, provider := range providers {
-		target = maxInt(target, 2+lipgloss.Width(displayValue(provider.Name, provider.ID)))
+		label := providerRecommendedRowLabel(provider.ID, provider.Name, provider.Recommended)
+		if badge := providerRecommendedRowBadge(provider.ID, provider.Recommended); badge != "" {
+			label += "  " + badge
+		}
+		target = maxInt(target, 2+lipgloss.Width(label))
 	}
 	target = maxInt(target, 32)
 	return minInt(target, available)
@@ -1694,6 +1795,8 @@ func (m model) setupFooter() string {
 			return zeroTheme.faint.Render("paste key optional   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   left back")
 		}
 		return zeroTheme.accent.Render("Space") + zeroTheme.faint.Render(" to continue")
+	case setupStageAimlapi:
+		return zeroTheme.faint.Render("type/↑↓ choose   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   left back   Esc cancel")
 	case setupStageProvider:
 		if m.setup.oauthMode && m.setupProviderDescriptor().OAuthDeviceFlow {
 			return zeroTheme.faint.Render("↑/↓ choose   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" sign in   ") + zeroTheme.accent.Render("d") + zeroTheme.faint.Render(" device code   q quit")

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -164,6 +164,9 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// The aimlapi.com sub-flow owns all of its keys; Ctrl+C still quits.
 	if m.setup.stage == setupStageAimlapi {
 		if keyCtrl(msg, 'c') {
+			if m.setup.aimlapi != nil {
+				m.setup.aimlapi.cancelStream()
+			}
 			return m, tea.Quit
 		}
 		return m.handleSetupAimlapiKey(msg)
@@ -1217,7 +1220,10 @@ func (m model) setupBaseURL(option SetupProviderOption) string {
 	// m.setup.baseURL. Persist that so an override reaches the saved profile instead
 	// of being replaced by the catalog default at save time.
 	if providerWizardIsAimlapi(setupProviderDescriptor(option)) {
-		return strings.TrimSpace(m.setup.baseURL)
+		if baseURL := strings.TrimSpace(m.setup.baseURL); baseURL != "" {
+			return baseURL
+		}
+		return strings.TrimSpace(aimlapi.ResolveEndpoints().InferenceBaseURL)
 	}
 	if !setupProviderNeedsEndpoint(option) {
 		return ""

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -1637,10 +1637,13 @@ func (m model) setupProviderLines(width int, height int) []string {
 			marker = "❯ "
 			style = zeroTheme.accent.Bold(true)
 		}
-		label := providerRecommendedRowLabel(option.ID, option.Name, option.Recommended)
+		label := displayValue(option.Name, option.ID)
+		if option.Recommended {
+			label = "★ " + label
+		}
 		line := marker + style.Render(label)
-		if badge := providerRecommendedRowBadge(option.ID, option.Recommended); badge != "" {
-			line += zeroTheme.faint.Render("  " + badge)
+		if option.Recommended {
+			line += zeroTheme.faint.Render("  (recommended)")
 		}
 		lines = append(lines, padSetupLine(line, rowWidth))
 	}
@@ -1703,9 +1706,9 @@ func setupProviderBlockWidth(terminalWidth int, providers []SetupProviderOption)
 	available := maxInt(24, minInt(terminalWidth-8, 44))
 	target := maxInt(lipgloss.Width("  2/6"), lipgloss.Width("  Choose a provider"))
 	for _, provider := range providers {
-		label := providerRecommendedRowLabel(provider.ID, provider.Name, provider.Recommended)
-		if badge := providerRecommendedRowBadge(provider.ID, provider.Recommended); badge != "" {
-			label += "  " + badge
+		label := displayValue(provider.Name, provider.ID)
+		if provider.Recommended {
+			label = "★ " + label + "  (recommended)"
 		}
 		target = maxInt(target, 2+lipgloss.Width(label))
 	}

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/Gitlawb/zero/internal/aimlapi"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 )
@@ -46,6 +47,320 @@ func TestSetupMethodOptionsDropsOAuthWithoutOAuthProviders(t *testing.T) {
 	}
 	if !hasOAuth {
 		t.Fatal("OAuth method must be offered when the setup has an OAuth provider")
+	}
+}
+
+func TestAimlapiCheckoutLinkWrapsWithoutTruncation(t *testing.T) {
+	link := "https://checkout.stripe.com/c/pay/cs_test_abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789#fidkdWxOYHwnPyd1blpxYHZxWjA0"
+	lines := aimlapiLinkLines(link, 32)
+	if len(lines) < 2 {
+		t.Fatalf("expected long checkout link to wrap, got %d line(s): %#v", len(lines), lines)
+	}
+	plain := plainRender(t, strings.Join(lines, "\n"))
+	for index, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "://") {
+			t.Fatalf("line %d still exposes an auto-detectable URL scheme: %q", index, line)
+		}
+	}
+	if strings.Contains(plain, "…") {
+		t.Fatalf("wrapped checkout link should not be truncated:\n%s", plain)
+	}
+	var joined strings.Builder
+	for _, line := range strings.Split(plain, "\n") {
+		joined.WriteString(strings.TrimSpace(line))
+	}
+	if got := joined.String(); got != link {
+		t.Fatalf("wrapped checkout link changed:\ngot  %q\nwant %q", got, link)
+	}
+	for index, line := range strings.Split(plain, "\n") {
+		if got := lipgloss.Width(line); got > 32 {
+			t.Fatalf("line %d width = %d, want <= 32: %q", index, got, line)
+		}
+	}
+}
+
+func TestAimlapiCheckoutLinkReplacesProgressSpinner(t *testing.T) {
+	link := "https://checkout.stripe.com/c/pay/cs_test_abcdefghijklmnopqrstuvwxyz0123456789"
+	state := &aimlapiOnboardState{
+		step:   aimlapiStepProgress,
+		detail: link,
+	}
+	view := plainRender(t, strings.Join(state.viewProgress(40, "spin"), "\n"))
+	assertContains(t, view, "Opening checkout in browser...")
+	assertContains(t, view, "https:")
+	assertContains(t, view, "//checkout.stripe.com")
+	assertNotContains(t, view, "spin")
+}
+
+func TestAimlapiEmailInputRejectsIncompleteDomain(t *testing.T) {
+	state := &aimlapiOnboardState{
+		step:  aimlapiStepEmailInput,
+		email: "123@123.",
+	}
+
+	cmd, outcome := state.handleKey(testKey(tea.KeyEnter))
+
+	if cmd != nil {
+		t.Fatal("invalid email should not start an account request")
+	}
+	if outcome != aimlapiContinue || state.busy {
+		t.Fatalf("invalid email returned outcome=%v busy=%v, want continue/false", outcome, state.busy)
+	}
+	if state.errText != aimlapi.MsgEmailInvalid {
+		t.Fatalf("error = %q, want %q", state.errText, aimlapi.MsgEmailInvalid)
+	}
+}
+
+func TestAimlapiEverythingReadyBackReturnsToProviderList(t *testing.T) {
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible: true,
+		Providers: []SetupProviderOption{
+			{ID: "openai", Name: "OpenAI"},
+			{ID: "aimlapi", Name: "aimlapi.com"},
+		},
+	}})
+	m.setup.selected = 1
+	m.setup.stage = setupStageAimlapi
+	m.setup.aimlapi = &aimlapiOnboardState{
+		step:         aimlapiStepDone,
+		successLines: []string{aimlapi.MsgEverythingRuns},
+	}
+
+	updated, cmd := m.Update(testKey(tea.KeyLeft))
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("back from Everything is ready should not start a command")
+	}
+	if next.setup.stage != setupStageProvider {
+		t.Fatalf("stage = %v, want provider list", next.setup.stage)
+	}
+	if next.setup.aimlapi != nil {
+		t.Fatal("completed AIMLAPI sub-flow should be cleared when returning to providers")
+	}
+	if got := next.setupProvider().ID; got != "aimlapi" {
+		t.Fatalf("selected provider = %q, want aimlapi", got)
+	}
+}
+
+func TestAimlapiKeyInputUsesAutomaticVerificationHint(t *testing.T) {
+	state := &aimlapiOnboardState{step: aimlapiStepKeyInput}
+	view := plainRender(t, strings.Join(state.view(64, ""), "\n"))
+	assertContains(t, view, "Your API key will be hidden and verified automatically.")
+	assertNotContains(t, view, "Pasted keys are hidden")
+}
+
+func TestAimlapiOnboardingKeepsSharedTickAlive(t *testing.T) {
+	m := newModel(context.Background(), Options{Setup: SetupOptions{Visible: true}})
+	m.reducedMotion = false
+	m.setup.stage = setupStageAimlapi
+	m.setup.aimlapi = &aimlapiOnboardState{step: aimlapiStepProgress}
+
+	// No agent run is in flight, but the aimlapi onboarding sub-flow must keep the
+	// shared tick loop alive so its spinner-only progress screen keeps re-rendering.
+	updated, cmd := m.Update(m.spinner.Tick())
+	next := updated.(model)
+	if cmd == nil || !next.spinnerTicking {
+		t.Fatal("aimlapi onboarding should keep the shared spinner tick loop alive")
+	}
+}
+
+func TestAimlapiAmountInputIgnoresLeft(t *testing.T) {
+	for _, newAccount := range []bool{false, true} {
+		t.Run(map[bool]string{false: "existing account", true: "new account"}[newAccount], func(t *testing.T) {
+			state := &aimlapiOnboardState{
+				step:       aimlapiStepAmountInput,
+				newAccount: newAccount,
+				errText:    "keep this error",
+			}
+
+			cmd, outcome := state.handleKey(testKey(tea.KeyLeft))
+
+			if cmd != nil {
+				t.Fatal("left on the top-up amount screen should not start a command")
+			}
+			if outcome != aimlapiContinue {
+				t.Fatalf("outcome = %v, want aimlapiContinue", outcome)
+			}
+			if state.step != aimlapiStepAmountInput {
+				t.Fatalf("step = %v, want amount input", state.step)
+			}
+			if state.amountField != 0 || state.errText != "keep this error" {
+				t.Fatalf("left changed amount-screen state: field=%d error=%q", state.amountField, state.errText)
+			}
+		})
+	}
+}
+
+func TestAimlapiAutoTopUpToggleUsesBothArrowKeys(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		key  rune
+	}{
+		{name: "left", key: tea.KeyLeft},
+		{name: "right", key: tea.KeyRight},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			state := &aimlapiOnboardState{
+				step:        aimlapiStepAmountInput,
+				amountField: 1,
+				autoTopUp:   true,
+			}
+
+			cmd, outcome := state.handleKey(testKey(test.key))
+
+			if cmd != nil || outcome != aimlapiContinue {
+				t.Fatalf("arrow returned cmd=%v outcome=%v, want nil/continue", cmd != nil, outcome)
+			}
+			if state.autoTopUp {
+				t.Fatalf("%s did not toggle auto top-up", test.name)
+			}
+			if state.step != aimlapiStepAmountInput {
+				t.Fatalf("step = %v, want amount input", state.step)
+			}
+		})
+	}
+}
+
+func TestAimlapiAutoTopUpRendersOnOff(t *testing.T) {
+	idle := aimlapiToggleLine("auto top up > ", true, false)
+	view := plainRender(t, idle)
+	assertContains(t, view, "on/off")
+	assertNotContains(t, view, "yes/no")
+	if !strings.Contains(idle, zeroTheme.ink.Render("on")) ||
+		!strings.Contains(idle, zeroTheme.faint.Render("off")) {
+		t.Fatalf("idle toggle should render selected on white and unselected off faint: %q", idle)
+	}
+
+	focused := aimlapiToggleLine("auto top up > ", false, true)
+	if !strings.Contains(focused, zeroTheme.accent.Render("auto top up > ")) ||
+		!strings.Contains(focused, zeroTheme.faint.Render("on")) ||
+		!strings.Contains(focused, zeroTheme.ink.Render("off")) {
+		t.Fatalf("focused toggle should highlight its prompt, selected off, and dim unselected on: %q", focused)
+	}
+}
+
+func TestAimlapiPickPathShowsNewUserFirstAndRoutesSelections(t *testing.T) {
+	state := &aimlapiOnboardState{step: aimlapiStepPickPath}
+	view := plainRender(t, strings.Join(state.viewPickPath(64), "\n"))
+	newUserIndex := strings.Index(view, aimlapi.MsgPickPathNewUser)
+	haveKeyIndex := strings.Index(view, aimlapi.MsgPickPathHaveKey)
+	if newUserIndex < 0 || haveKeyIndex < 0 || newUserIndex >= haveKeyIndex {
+		t.Fatalf("new-user option should precede have-key option:\n%s", view)
+	}
+
+	state.pathCursor = 0
+	state.handlePickPathKey(testKey(tea.KeyEnter))
+	if state.step != aimlapiStepEmailInput {
+		t.Fatalf("first option routes to %v, want email input", state.step)
+	}
+	state.step = aimlapiStepPickPath
+	state.pathCursor = 1
+	state.handlePickPathKey(testKey(tea.KeyEnter))
+	if state.step != aimlapiStepKeyInput {
+		t.Fatalf("second option routes to %v, want key input", state.step)
+	}
+}
+
+func TestAimlapiWizardDoesNotFilterDiscoveredModelsByDefault(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.selectedProvider = providerWizardProviderIndex(t, m.providerWizard, "aimlapi")
+	m.providerWizard.aimlapi = &aimlapiOnboardState{
+		apiKey: "sk-issued",
+		model:  "anthropic/claude-sonnet-5",
+	}
+
+	next, cmd := m.resolveProviderWizardAimlapi(nil, aimlapiDone)
+	if next.providerWizard.step != providerWizardStepModel || cmd == nil {
+		t.Fatalf("AIMLAPI completion should enter model discovery: step=%v cmd=%v", next.providerWizard.step, cmd != nil)
+	}
+	if next.providerWizard.modelSearch != "" {
+		t.Fatalf("model search = %q, want empty so the full discovered list is visible", next.providerWizard.modelSearch)
+	}
+}
+
+func TestAimlapiAmountDollarUsesInkStyle(t *testing.T) {
+	line := aimlapiAmountInputLine("", "25", 40, true)
+	if !strings.Contains(line, zeroTheme.ink.Render("$")) {
+		t.Fatalf("amount dollar is not rendered with ink style: %q", line)
+	}
+	idle := aimlapiAmountInputLine("25", "25", 40, false)
+	if !strings.Contains(idle, zeroTheme.ink.Render("amount > ")) ||
+		strings.Contains(idle, zeroTheme.accent.Render("amount > ")) {
+		t.Fatalf("unfocused amount prompt should be white: %q", idle)
+	}
+}
+
+func TestAimlapiSafetyBackReturnsToProviderList(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		key  rune
+	}{
+		{name: "left", key: tea.KeyLeft},
+		{name: "escape", key: tea.KeyEsc},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			m := newModel(context.Background(), Options{Setup: SetupOptions{
+				Visible: true,
+				Providers: []SetupProviderOption{
+					{ID: "openai", Name: "OpenAI"},
+					{ID: "aimlapi", Name: "aimlapi.com"},
+				},
+			}})
+			m.setup.selected = 1
+			m.setup.stage = setupStageSafety
+			m.setup.aimlapi = nil // Cleared after the AIMLAPI connect flow completes.
+
+			updated, cmd := m.Update(testKey(test.key))
+			next := updated.(model)
+
+			if cmd != nil {
+				t.Fatal("back from Safety should not start a command")
+			}
+			if next.setup.stage != setupStageProvider {
+				t.Fatalf("stage = %v, want provider list", next.setup.stage)
+			}
+			if got := next.setupProvider().ID; got != "aimlapi" {
+				t.Fatalf("selected provider = %q, want aimlapi", got)
+			}
+		})
+	}
+}
+
+func TestAimlapiModelBackReturnsToProviderList(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		key  rune
+	}{
+		{name: "left", key: tea.KeyLeft},
+		{name: "escape", key: tea.KeyEsc},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			m := newModel(context.Background(), Options{Setup: SetupOptions{
+				Visible: true,
+				Providers: []SetupProviderOption{
+					{ID: "openai", Name: "OpenAI"},
+					{ID: "aimlapi", Name: "aimlapi.com"},
+				},
+			}})
+			m.setup.selected = 1
+			m.setup.stage = setupStageModel
+			m.setup.aimlapi = nil // Cleared once AIMLAPI has issued the key.
+
+			updated, cmd := m.Update(testKey(test.key))
+			next := updated.(model)
+
+			if cmd != nil {
+				t.Fatal("back from AIMLAPI model selection should not start a command")
+			}
+			if next.setup.stage != setupStageProvider {
+				t.Fatalf("stage = %v, want provider list", next.setup.stage)
+			}
+			if got := next.setupProvider().ID; got != "aimlapi" {
+				t.Fatalf("selected provider = %q, want aimlapi", got)
+			}
+		})
 	}
 }
 

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -258,7 +258,7 @@ func TestAimlapiKeyBalanceLowBalanceOffersTopUp(t *testing.T) {
 }
 
 func TestAimlapiTopUpFailureRetainsSessionForRetry(t *testing.T) {
-	state := &aimlapiOnboardState{step: aimlapiStepProgress}
+	state := &aimlapiOnboardState{step: aimlapiStepProgress, paymentSessionID: "payment-live"}
 	state.applyTopup(aimlapiOnboardMsg{
 		topupOK: true,
 		topup:   aimlapiTopupEvent{session: "pcs_resume", hasSession: true},
@@ -269,6 +269,30 @@ func TestAimlapiTopUpFailureRetainsSessionForRetry(t *testing.T) {
 	})
 	if state.resumeSessionToken != "pcs_resume" {
 		t.Fatalf("resume token = %q, want retained session", state.resumeSessionToken)
+	}
+	if state.paymentSessionID != "payment-live" {
+		t.Fatalf("payment session id = %q, want retained live id", state.paymentSessionID)
+	}
+	if state.step != aimlapiStepAmountInput {
+		t.Fatalf("step = %v, want retryable amount input", state.step)
+	}
+}
+
+func TestAimlapiTerminalTopUpDropsByKeyIdempotencyID(t *testing.T) {
+	state := &aimlapiOnboardState{
+		step:               aimlapiStepProgress,
+		resumeSessionToken: "pcs_old",
+		paymentSessionID:   "payment-old",
+	}
+	state.applyTopup(aimlapiOnboardMsg{
+		topupOK: true,
+		topup: aimlapiTopupEvent{
+			done: true, err: errors.New("checkout expired"), session: "", hasSession: true,
+		},
+	})
+
+	if state.resumeSessionToken != "" || state.paymentSessionID != "" {
+		t.Fatalf("terminal checkout retained session ids: resume=%q payment=%q", state.resumeSessionToken, state.paymentSessionID)
 	}
 	if state.step != aimlapiStepAmountInput {
 		t.Fatalf("step = %v, want retryable amount input", state.step)

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -197,6 +197,41 @@ func TestAimlapiPastedKeyStartsBalanceValidation(t *testing.T) {
 	}
 }
 
+func TestAimlapiOnboardingErrorsStripBodiesAndRedactActiveSecrets(t *testing.T) {
+	const (
+		apiKey = "sk-super-secret"
+		code   = "654321"
+		bearer = "session-super-secret"
+		body   = "server echoed sk-super-secret 654321 session-super-secret"
+	)
+	newState := func(step aimlapiOnboardStep) *aimlapiOnboardState {
+		return &aimlapiOnboardState{step: step, apiKey: apiKey, code: code, sessionToken: bearer, busy: true}
+	}
+	err := aimlapi.APIError{Message: "onboarding request failed", Status: http.StatusInternalServerError, Body: body}
+	tests := []struct {
+		name  string
+		state *aimlapiOnboardState
+		apply func(*aimlapiOnboardState)
+	}{
+		{name: "key validation", state: newState(aimlapiStepKeyInput), apply: func(s *aimlapiOnboardState) { s.applyKeyValidation(aimlapiOnboardMsg{err: err}) }},
+		{name: "account check", state: newState(aimlapiStepEmailInput), apply: func(s *aimlapiOnboardState) { s.applyCheck(aimlapiOnboardMsg{err: err}) }},
+		{name: "code verification", state: newState(aimlapiStepCodeInput), apply: func(s *aimlapiOnboardState) { s.applyToken(aimlapiOnboardMsg{err: err}) }},
+		{name: "key mint", state: newState(aimlapiStepEmailInput), apply: func(s *aimlapiOnboardState) { s.applyKey(aimlapiOnboardMsg{err: err}) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.apply(test.state)
+			if strings.Contains(test.state.errText, body) || strings.Contains(test.state.errText, apiKey) ||
+				strings.Contains(test.state.errText, code) || strings.Contains(test.state.errText, bearer) {
+				t.Fatalf("credential leaked in error: %q", test.state.errText)
+			}
+			if !strings.Contains(test.state.errText, "HTTP 500") {
+				t.Fatalf("safe status missing from error: %q", test.state.errText)
+			}
+		})
+	}
+}
+
 func TestAimlapiPastedKeyRejectsUnauthorized(t *testing.T) {
 	state := &aimlapiOnboardState{
 		step:   aimlapiStepKeyInput,

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -211,6 +211,27 @@ func TestAimlapiPastedKeyValidationCompletesForValidKey(t *testing.T) {
 	}
 }
 
+func TestAimlapiKeyBalanceLowBalanceOffersTopUp(t *testing.T) {
+	state := &aimlapiOnboardState{
+		step:   aimlapiStepProgress,
+		apiKey: "key_minted",
+		busy:   true,
+	}
+
+	_, outcome := state.apply(aimlapiOnboardMsg{
+		state:   state,
+		kind:    aimlapiMsgKeyBalance,
+		balance: aimlapi.BalanceResult{LowBalance: true},
+	})
+
+	if outcome != aimlapiContinue || state.busy {
+		t.Fatalf("low balance returned outcome=%v busy=%v, want continue/false", outcome, state.busy)
+	}
+	if state.step != aimlapiStepLowBalance || state.lowCursor != 0 {
+		t.Fatalf("low balance left step=%v cursor=%d, want low-balance prompt with cursor 0", state.step, state.lowCursor)
+	}
+}
+
 func TestAimlapiOnboardingKeepsSharedTickAlive(t *testing.T) {
 	m := newModel(context.Background(), Options{Setup: SetupOptions{Visible: true}})
 	m.reducedMotion = false

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -188,6 +188,33 @@ func TestAimlapiPastedKeyRejectsUnauthorized(t *testing.T) {
 	}
 }
 
+func TestAimlapiVerifyCodeLabelsOnlyBadRequestAsIncorrect(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantIncorrect bool
+	}{
+		{name: "invalid code", err: aimlapi.APIError{Status: http.StatusBadRequest}, wantIncorrect: true},
+		{name: "unauthorized", err: aimlapi.APIError{Status: http.StatusUnauthorized}},
+		{name: "forbidden", err: aimlapi.APIError{Status: http.StatusForbidden}},
+		{name: "throttled", err: aimlapi.APIError{Status: http.StatusTooManyRequests}},
+		{name: "server failure", err: aimlapi.APIError{Status: http.StatusInternalServerError}},
+		{name: "network failure", err: errors.New("connection reset")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &aimlapiOnboardState{step: aimlapiStepCodeInput, code: "123456", busy: true}
+			state.applyToken(aimlapiOnboardMsg{err: tt.err})
+			if got := state.errText == aimlapi.MsgCodeIncorrect; got != tt.wantIncorrect {
+				t.Fatalf("incorrect-code label = %v, error text %q", got, state.errText)
+			}
+			if state.step != aimlapiStepCodeInput || state.code != "123456" {
+				t.Fatalf("verification retry lost its screen/code: step=%v code=%q", state.step, state.code)
+			}
+		})
+	}
+}
+
 func TestAimlapiPastedKeyValidationCompletesForValidKey(t *testing.T) {
 	state := &aimlapiOnboardState{
 		step:   aimlapiStepKeyInput,

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -195,8 +195,6 @@ func TestAimlapiVerifyCodeLabelsOnlyBadRequestAsIncorrect(t *testing.T) {
 		wantIncorrect bool
 	}{
 		{name: "invalid code", err: aimlapi.APIError{Status: http.StatusBadRequest}, wantIncorrect: true},
-		{name: "unauthorized", err: aimlapi.APIError{Status: http.StatusUnauthorized}},
-		{name: "forbidden", err: aimlapi.APIError{Status: http.StatusForbidden}},
 		{name: "throttled", err: aimlapi.APIError{Status: http.StatusTooManyRequests}},
 		{name: "server failure", err: aimlapi.APIError{Status: http.StatusInternalServerError}},
 		{name: "network failure", err: errors.New("connection reset")},
@@ -368,7 +366,6 @@ func TestAimlapiAutoTopUpRendersOnOff(t *testing.T) {
 }
 
 func TestAimlapiPickPathShowsNewUserFirstAndRoutesSelections(t *testing.T) {
-	t.Setenv("AIMLAPI_API_KEY", "already-configured")
 	state := &aimlapiOnboardState{step: aimlapiStepPickPath}
 	view := plainRender(t, strings.Join(state.viewPickPath(64), "\n"))
 	newUserIndex := strings.Index(view, aimlapi.MsgPickPathNewUser)
@@ -376,10 +373,6 @@ func TestAimlapiPickPathShowsNewUserFirstAndRoutesSelections(t *testing.T) {
 	if newUserIndex < 0 || haveKeyIndex < 0 || newUserIndex >= haveKeyIndex {
 		t.Fatalf("new-user option should precede have-key option:\n%s", view)
 	}
-	if strings.Contains(view, "Use AIMLAPI_API_KEY") {
-		t.Fatalf("existing env credentials belong to /provider preflight, not onboarding:\n%s", view)
-	}
-
 	state.pathCursor = 0
 	state.handlePickPathKey(testKey(tea.KeyEnter))
 	if state.step != aimlapiStepEmailInput {
@@ -414,10 +407,6 @@ func TestFirstRunAimlapiEnvSkipsGuidedOnboarding(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("env credential should start authenticated model discovery")
-	}
-	profile := providerWizardDiscoveryProfile(setupProviderDescriptor(next.setupProvider()), "")
-	if profile.APIKey != "env-runtime-secret" || profile.APIKeyEnv != "AIMLAPI_API_KEY" {
-		t.Fatalf("discovery profile did not preserve env credential: %+v", profile)
 	}
 }
 

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -259,6 +259,24 @@ func TestAimlapiKeyBalanceLowBalanceOffersTopUp(t *testing.T) {
 	}
 }
 
+func TestAimlapiTopUpFailureRetainsSessionForRetry(t *testing.T) {
+	state := &aimlapiOnboardState{step: aimlapiStepProgress}
+	state.applyTopup(aimlapiOnboardMsg{
+		topupOK: true,
+		topup:   aimlapiTopupEvent{session: "pcs_resume", hasSession: true},
+	})
+	state.applyTopup(aimlapiOnboardMsg{
+		topupOK: true,
+		topup:   aimlapiTopupEvent{done: true, err: errors.New("lost response")},
+	})
+	if state.resumeSessionToken != "pcs_resume" {
+		t.Fatalf("resume token = %q, want retained session", state.resumeSessionToken)
+	}
+	if state.step != aimlapiStepAmountInput {
+		t.Fatalf("step = %v, want retryable amount input", state.step)
+	}
+}
+
 func TestAimlapiOnboardingKeepsSharedTickAlive(t *testing.T) {
 	m := newModel(context.Background(), Options{Setup: SetupOptions{Visible: true}})
 	m.reducedMotion = false

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -188,7 +188,7 @@ func TestAimlapiPastedKeyRejectsUnauthorized(t *testing.T) {
 	}
 }
 
-func TestAimlapiPastedKeyValidationDoesNotStartLowBalanceFlow(t *testing.T) {
+func TestAimlapiPastedKeyValidationCompletesForValidKey(t *testing.T) {
 	state := &aimlapiOnboardState{
 		step:   aimlapiStepKeyInput,
 		apiKey: " key_test ",
@@ -196,9 +196,8 @@ func TestAimlapiPastedKeyValidationDoesNotStartLowBalanceFlow(t *testing.T) {
 	}
 
 	_, outcome := state.apply(aimlapiOnboardMsg{
-		state:   state,
-		kind:    aimlapiMsgKeyValidation,
-		balance: aimlapi.BalanceResult{LowBalance: true},
+		state: state,
+		kind:  aimlapiMsgKeyValidation,
 	})
 
 	if outcome != aimlapiContinue || state.busy {

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -346,6 +346,58 @@ func TestAimlapiTopUpFailureRetainsSessionForRetry(t *testing.T) {
 	}
 }
 
+func TestAimlapiRejectsUnknownAccountAction(t *testing.T) {
+	state := &aimlapiOnboardState{step: aimlapiStepProgress, email: "user@example.com", busy: true}
+	cmd, outcome := state.applyCheck(aimlapiOnboardMsg{check: aimlapi.CheckResult{Action: "future-action"}})
+
+	if cmd != nil || outcome != aimlapiContinue {
+		t.Fatalf("unknown action returned cmd=%v outcome=%v", cmd != nil, outcome)
+	}
+	if state.step != aimlapiStepEmailInput || state.newAccount || state.busy {
+		t.Fatalf("unknown action state = step %v new=%v busy=%v", state.step, state.newAccount, state.busy)
+	}
+	if state.errText != aimlapi.MsgAccountActionInvalid {
+		t.Fatalf("error = %q", state.errText)
+	}
+}
+
+func TestAimlapiChangedTopUpIntentDropsRetainedCheckout(t *testing.T) {
+	tests := []struct {
+		name      string
+		amount    int
+		autoTopUp bool
+		wantDrop  bool
+	}{
+		{name: "same intent", amount: 2500, autoTopUp: true, wantDrop: false},
+		{name: "changed amount", amount: 5000, autoTopUp: true, wantDrop: true},
+		{name: "changed auto top-up", amount: 2500, autoTopUp: false, wantDrop: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := &aimlapiOnboardState{
+				resumeSessionToken:    "pcs_old",
+				paymentSessionID:      "payment-old",
+				paymentAmountUSDMinor: 2500,
+				paymentAutoTopUp:      true,
+				autoTopUp:             test.autoTopUp,
+			}
+			state.prepareTopUpIntent(test.amount)
+			dropped := state.resumeSessionToken == "" && state.paymentSessionID == ""
+			if dropped != test.wantDrop {
+				t.Fatalf("checkout dropped = %v, want %v", dropped, test.wantDrop)
+			}
+		})
+	}
+}
+
+func TestAimlapiTopUpSuccessShowsChargedCentAmount(t *testing.T) {
+	state := &aimlapiOnboardState{amount: "20.999", paymentAmountUSDMinor: 2100}
+	lines := state.topUpSuccessLines()
+	if got := strings.Join(lines, "\n"); !strings.Contains(got, "$21.00 has been added") || strings.Contains(got, "20.999") {
+		t.Fatalf("success lines do not show normalized charge: %q", got)
+	}
+}
+
 func TestAimlapiTerminalTopUpDropsByKeyIdempotencyID(t *testing.T) {
 	state := &aimlapiOnboardState{
 		step:               aimlapiStepProgress,

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -144,6 +144,39 @@ func TestAimlapiEverythingReadyBackReturnsToProviderList(t *testing.T) {
 	}
 }
 
+func TestSetupAimlapiCtrlCCancelsInFlightCheckout(t *testing.T) {
+	cancelled := false
+	m := newModel(context.Background(), Options{Setup: SetupOptions{Visible: true}})
+	m.setup.stage = setupStageAimlapi
+	m.setup.aimlapi = &aimlapiOnboardState{
+		step:        aimlapiStepProgress,
+		topupCancel: func() { cancelled = true },
+	}
+
+	_, cmd := m.Update(testKeyCtrl('c'))
+	if !cancelled {
+		t.Fatal("Ctrl+C did not cancel the in-flight AIMLAPI checkout")
+	}
+	if cmd == nil {
+		t.Fatal("Ctrl+C should still quit after cancelling the checkout")
+	}
+}
+
+func TestSetupAimlapiEnvKeyUsesResolvedInferenceEndpoint(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "env-secret")
+	t.Setenv("AIMLAPI_INFERENCE_URL", "https://staging.example.test/v1")
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible: true,
+		Providers: []SetupProviderOption{{
+			ID: "aimlapi", Name: "aimlapi.com", EnvVar: "AIMLAPI_API_KEY", RequiresAuth: true,
+		}},
+	}})
+
+	if got := m.setupBaseURL(m.setupProvider()); got != "https://staging.example.test/v1" {
+		t.Fatalf("setup base URL = %q, want resolved override", got)
+	}
+}
+
 func TestAimlapiKeyInputUsesAutomaticVerificationHint(t *testing.T) {
 	state := &aimlapiOnboardState{step: aimlapiStepKeyInput}
 	view := plainRender(t, strings.Join(state.view(64, ""), "\n"))

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -368,12 +368,16 @@ func TestAimlapiAutoTopUpRendersOnOff(t *testing.T) {
 }
 
 func TestAimlapiPickPathShowsNewUserFirstAndRoutesSelections(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "already-configured")
 	state := &aimlapiOnboardState{step: aimlapiStepPickPath}
 	view := plainRender(t, strings.Join(state.viewPickPath(64), "\n"))
 	newUserIndex := strings.Index(view, aimlapi.MsgPickPathNewUser)
 	haveKeyIndex := strings.Index(view, aimlapi.MsgPickPathHaveKey)
 	if newUserIndex < 0 || haveKeyIndex < 0 || newUserIndex >= haveKeyIndex {
 		t.Fatalf("new-user option should precede have-key option:\n%s", view)
+	}
+	if strings.Contains(view, "Use AIMLAPI_API_KEY") {
+		t.Fatalf("existing env credentials belong to /provider preflight, not onboarding:\n%s", view)
 	}
 
 	state.pathCursor = 0
@@ -386,6 +390,34 @@ func TestAimlapiPickPathShowsNewUserFirstAndRoutesSelections(t *testing.T) {
 	state.handlePickPathKey(testKey(tea.KeyEnter))
 	if state.step != aimlapiStepKeyInput {
 		t.Fatalf("second option routes to %v, want key input", state.step)
+	}
+}
+
+func TestFirstRunAimlapiEnvSkipsGuidedOnboarding(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "env-runtime-secret")
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible: true,
+		Providers: []SetupProviderOption{{
+			ID: "aimlapi", Name: "aimlapi.com", DefaultModel: "anthropic/claude-sonnet-5",
+		}},
+	}})
+	m.setup.stage = setupStageProvider
+	m.setup.selected = 0
+
+	updated, cmd := m.advanceSetup()
+	next := updated.(model)
+	if next.setup.stage != setupStageModel {
+		t.Fatalf("stage = %v, want model selection", next.setup.stage)
+	}
+	if next.setup.aimlapi != nil {
+		t.Fatal("env credential should not create the guided onboarding state")
+	}
+	if cmd == nil {
+		t.Fatal("env credential should start authenticated model discovery")
+	}
+	profile := providerWizardDiscoveryProfile(setupProviderDescriptor(next.setupProvider()), "")
+	if profile.APIKey != "env-runtime-secret" || profile.APIKeyEnv != "AIMLAPI_API_KEY" {
+		t.Fatalf("discovery profile did not preserve env credential: %+v", profile)
 	}
 }
 

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -148,6 +149,67 @@ func TestAimlapiKeyInputUsesAutomaticVerificationHint(t *testing.T) {
 	view := plainRender(t, strings.Join(state.view(64, ""), "\n"))
 	assertContains(t, view, "Your API key will be hidden and verified automatically.")
 	assertNotContains(t, view, "Pasted keys are hidden")
+}
+
+func TestAimlapiPastedKeyStartsBalanceValidation(t *testing.T) {
+	state := &aimlapiOnboardState{step: aimlapiStepKeyInput, apiKey: " key_test "}
+
+	cmd, outcome := state.handleKey(testKey(tea.KeyEnter))
+
+	if cmd == nil {
+		t.Fatal("pasted key should start balance validation")
+	}
+	if outcome != aimlapiContinue || !state.busy {
+		t.Fatalf("validation returned outcome=%v busy=%v, want continue/true", outcome, state.busy)
+	}
+}
+
+func TestAimlapiPastedKeyRejectsUnauthorized(t *testing.T) {
+	state := &aimlapiOnboardState{
+		step:   aimlapiStepKeyInput,
+		apiKey: "bad-key",
+		busy:   true,
+	}
+
+	_, outcome := state.apply(aimlapiOnboardMsg{
+		state: state,
+		kind:  aimlapiMsgKeyValidation,
+		err:   aimlapi.APIError{Status: http.StatusUnauthorized},
+	})
+
+	if outcome != aimlapiContinue || state.busy {
+		t.Fatalf("invalid key returned outcome=%v busy=%v, want continue/false", outcome, state.busy)
+	}
+	if state.step != aimlapiStepKeyInput || state.apiKey != "" {
+		t.Fatalf("invalid key left step=%v key=%q, want key input with cleared key", state.step, state.apiKey)
+	}
+	if state.errText != aimlapi.MsgAPIKeyInvalid {
+		t.Fatalf("error = %q, want %q", state.errText, aimlapi.MsgAPIKeyInvalid)
+	}
+}
+
+func TestAimlapiPastedKeyValidationDoesNotStartLowBalanceFlow(t *testing.T) {
+	state := &aimlapiOnboardState{
+		step:   aimlapiStepKeyInput,
+		apiKey: " key_test ",
+		busy:   true,
+	}
+
+	_, outcome := state.apply(aimlapiOnboardMsg{
+		state:   state,
+		kind:    aimlapiMsgKeyValidation,
+		balance: aimlapi.BalanceResult{LowBalance: true},
+	})
+
+	if outcome != aimlapiContinue || state.busy {
+		t.Fatalf("valid key returned outcome=%v busy=%v, want continue/false", outcome, state.busy)
+	}
+	if state.step != aimlapiStepDone || state.apiKey != "key_test" {
+		t.Fatalf("valid key left step=%v key=%q, want done with trimmed key", state.step, state.apiKey)
+	}
+	if len(state.successLines) != 1 || state.successLines[0] != aimlapi.MsgEverythingRuns {
+		t.Fatalf("success lines = %#v", state.successLines)
+	}
 }
 
 func TestAimlapiOnboardingKeepsSharedTickAlive(t *testing.T) {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -420,7 +420,7 @@ func (m model) modelPickerProviderDiscoveryCmd(descriptor providercatalog.Descri
 				k = resolved
 			}
 		}
-		models, err := discover(ctx, providerWizardDiscoveryProfile(descriptor, k))
+		models, err := discover(ctx, providerWizardDiscoveryProfile(descriptor, k, authed.BaseURL))
 		return modelPickerModelsDiscoveredMsg{providerID: providerID, models: models, err: err}
 	}
 }

--- a/internal/tui/provider_manager_test.go
+++ b/internal/tui/provider_manager_test.go
@@ -72,7 +72,7 @@ func TestOpenProviderManagerListsSavedProviders(t *testing.T) {
 	if len(m.providerWizard.manageRows) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(m.providerWizard.manageRows))
 	}
-	rendered := m.providerWizard.render(m.width)
+	rendered := m.providerWizard.render(m.width, m.spinnerGlyph())
 	for _, want := range []string{"opengateway", "backup", "active", "Enter activate"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("manager render missing %q:\n%s", want, rendered)

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -347,6 +347,7 @@ const (
 	providerWizardStepManageKey
 	providerWizardStepEndpoint
 	providerWizardStepName
+	providerWizardStepAimlapiConfigured
 	providerWizardStepAimlapi
 	providerWizardStepCredential
 	providerWizardStepModel
@@ -419,10 +420,19 @@ type providerWizardState struct {
 	// Manage-key step: shown when the selected provider already has a stored key.
 	manageKeyCursor    int
 	manageProviderName string
-	oauthMode          bool
-	oauthPending       bool
-	oauthAttemptID     int
-	oauthErr           string
+	// aimlapiExistingProfile is the persisted credential source selected by the
+	// "Use existing configuration" preflight. aimlapiRuntimeKey is resolved only
+	// for balance/top-up/model requests; it must never replace APIKeyEnv or an
+	// APIKeyStored marker when the profile is saved again.
+	aimlapiConfiguredCursor int
+	aimlapiExistingProfile  config.ProviderProfile
+	aimlapiRuntimeKey       string
+	aimlapiExistingBusy     bool
+	aimlapiExistingGen      int
+	oauthMode               bool
+	oauthPending            bool
+	oauthAttemptID          int
+	oauthErr                string
 	// Device-code login (RFC 8628) state while an OAuth login is in flight.
 	oauthDevice           bool
 	deviceUserCode        string
@@ -511,12 +521,21 @@ func (wizard *providerWizardState) resetAimlapiOnboard() {
 		wizard.aimlapi.cancelStream()
 		wizard.aimlapi = nil
 	}
+	wizard.clearAimlapiExisting()
 }
 
 // enterAimlapi starts the shared aimlapi.com onboarding sub-flow.
 func (wizard *providerWizardState) enterAimlapi() {
+	wizard.clearAimlapiExisting()
 	wizard.aimlapi = newAimlapiOnboard(browser.OpenURL)
 	wizard.step = providerWizardStepAimlapi
+}
+
+func (wizard *providerWizardState) clearAimlapiExisting() {
+	wizard.aimlapiExistingProfile = config.ProviderProfile{}
+	wizard.aimlapiRuntimeKey = ""
+	wizard.aimlapiExistingBusy = false
+	wizard.aimlapiConfiguredCursor = 0
 }
 
 func (wizard *providerWizardState) currentModel() providerWizardModel {
@@ -708,7 +727,11 @@ func (wizard *providerWizardState) retreat() {
 		}
 	case providerWizardStepModel:
 		if providerWizardIsAimlapi(wizard.currentProvider()) {
-			wizard.step = providerWizardStepProvider
+			if aimlapiProfile(wizard.aimlapiExistingProfile) {
+				wizard.step = providerWizardStepAimlapiConfigured
+			} else {
+				wizard.step = providerWizardStepProvider
+			}
 		} else if providerWizardNeedsCredential(wizard.currentProvider()) {
 			wizard.step = providerWizardStepCredential
 		} else if providerWizardNeedsEndpoint(wizard.currentProvider()) {
@@ -799,6 +822,10 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		wizard.oauthDevice = false
 		wizard.deviceUserCode = ""
 		wizard.deviceVerificationURI = ""
+		// This branch preempts the aimlapi.com key delegation below, so cancel the
+		// embedded sub-flow here too — otherwise its in-flight CreateKey/checkout
+		// keeps running against a background context and mints a key we discard.
+		wizard.resetAimlapiOnboard()
 		wizard.err = ""
 		wizard.oauthErr = ""
 		wizard.step = providerWizardStepManage
@@ -900,6 +927,31 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 	}
 	if m.providerWizard.step == providerWizardStepAimlapi {
 		return m.handleProviderWizardAimlapiKey(msg)
+	}
+	if m.providerWizard.step == providerWizardStepAimlapiConfigured {
+		if m.providerWizard.aimlapiExistingBusy {
+			if keyIs(msg, tea.KeyEsc) || keyIs(msg, tea.KeyLeft) {
+				m.providerWizard.aimlapiExistingGen++
+				m.providerWizard.aimlapiExistingBusy = false
+				m.providerWizard.step = providerWizardStepProvider
+			}
+			return m, nil
+		}
+		switch {
+		case keyIs(msg, tea.KeyEsc):
+			m.providerWizard = nil
+		case keyIs(msg, tea.KeyLeft):
+			m.providerWizard.clearAimlapiExisting()
+			m.providerWizard.step = providerWizardStepProvider
+		case keyIs(msg, tea.KeyUp) || keyIs(msg, tea.KeyDown) || keyIs(msg, tea.KeyTab):
+			m.providerWizard.aimlapiConfiguredCursor = (m.providerWizard.aimlapiConfiguredCursor + 1) % 2
+		case keyIs(msg, tea.KeyEnter) || keyIs(msg, tea.KeyRight):
+			if m.providerWizard.aimlapiConfiguredCursor == 0 {
+				return m.checkExistingAimlapiBalance()
+			}
+			m.providerWizard.enterAimlapi()
+		}
+		return m, nil
 	}
 	if m.providerWizard.step == providerWizardStepCredential {
 		switch {
@@ -1175,6 +1227,18 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 	modelChoice := wizard.currentModel()
 	profile := providerWizardProfile(provider, modelChoice.ID, wizard.apiKey, wizard.baseURL, wizard.profileName)
 	runtimeProfile := providerWizardRuntimeProfile(profile)
+	usingExistingAimlapi := aimlapiProfile(wizard.aimlapiExistingProfile)
+	preserveExistingCredentialReference := false
+	if usingExistingAimlapi {
+		// Preserve the configured credential source exactly. The resolved key is
+		// runtime-only and must not turn APIKeyEnv or APIKeyStored into a captured
+		// secret merely because the user changed models or topped up.
+		profile = wizard.aimlapiExistingProfile
+		profile.Model = modelChoice.ID
+		runtimeProfile = profile
+		runtimeProfile.APIKey = wizard.aimlapiRuntimeKey
+		preserveExistingCredentialReference = strings.TrimSpace(profile.APIKeyEnv) != "" || profile.APIKeyStored
+	}
 
 	// Build and persist into LOCALS first, committing live state only once BOTH
 	// succeed. A persist failure (read-only config, disk full) must not leave the
@@ -1195,7 +1259,9 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 		// store before persisting, so config.json never holds the cleartext. The
 		// provider was already built above from runtimeProfile, which has the key.
 		secret := profile.APIKey
-		profile = config.SecureProviderProfile(profile, m.userConfigPath)
+		if !preserveExistingCredentialReference {
+			profile = config.SecureProviderProfile(profile, m.userConfigPath)
+		}
 		if _, err := config.UpsertProvider(m.userConfigPath, profile, true); err != nil {
 			wizard.err = redaction.RedactString(err.Error(), redaction.Options{ExtraSecretValues: []string{secret, profile.APIKey}})
 			return m, nil // nothing committed to live state yet
@@ -1328,6 +1394,8 @@ func (wizard *providerWizardState) render(width int, spinner string) string {
 		lines = append(lines, wizard.renderEndpointStep(innerWidth)...)
 	case providerWizardStepName:
 		lines = append(lines, wizard.renderNameStep(innerWidth)...)
+	case providerWizardStepAimlapiConfigured:
+		lines = append(lines, wizard.renderAimlapiConfiguredStep(innerWidth, spinner)...)
 	case providerWizardStepAimlapi:
 		if wizard.aimlapi != nil {
 			lines = append(lines, wizard.aimlapi.view(innerWidth, spinner)...)
@@ -1405,6 +1473,8 @@ func (wizard *providerWizardState) footerText() string {
 		return "Enter continue   ← back   Esc close"
 	case providerWizardStepName:
 		return "Enter/→ continue   ← back   Esc close"
+	case providerWizardStepAimlapiConfigured:
+		return "↑/↓ move   Enter/→ select   ← back   Esc close"
 	case providerWizardStepAimlapi:
 		return "type/↑↓ choose   Enter/→ continue   ← back   Esc close"
 	case providerWizardStepModel:
@@ -1430,7 +1500,7 @@ func providerWizardOverlayWidth(width int, step providerWizardStep) int {
 	switch step {
 	case providerWizardStepProvider:
 		target = providerWizardProviderWidth
-	case providerWizardStepModel, providerWizardStepManage, providerWizardStepAimlapi:
+	case providerWizardStepModel, providerWizardStepManage, providerWizardStepAimlapi, providerWizardStepAimlapiConfigured:
 		target = providerWizardModelWidth
 	}
 	target = minInt(target, width)
@@ -1469,8 +1539,12 @@ func providerWizardStepLine(wizard *providerWizardState) string {
 			stepLabel{providerWizardStepDone, "4 ready"},
 		)
 	case providerWizardIsAimlapi(wizard.currentProvider()):
+		connectStep := providerWizardStepAimlapi
+		if aimlapiProfile(wizard.aimlapiExistingProfile) {
+			connectStep = providerWizardStepAimlapiConfigured
+		}
 		steps = append(steps,
-			stepLabel{providerWizardStepAimlapi, "3 connect"},
+			stepLabel{connectStep, "3 connect"},
 			stepLabel{providerWizardStepModel, "4 model"},
 			stepLabel{providerWizardStepDone, "5 ready"},
 		)
@@ -1514,6 +1588,36 @@ func (wizard *providerWizardState) renderMethodStep(width int) []string {
 		}
 		lines = append(lines, fitStyledLine(marker+surface(zeroTheme.ink).Render(option.label), width))
 		lines = append(lines, fitStyledLine("    "+zeroTheme.faint.Render(option.subtitle), width))
+	}
+	return lines
+}
+
+func (wizard *providerWizardState) renderAimlapiConfiguredStep(width int, spinner string) []string {
+	profileName := strings.TrimSpace(wizard.aimlapiExistingProfile.Name)
+	if profileName == "" {
+		profileName = "aimlapi"
+	}
+	lines := []string{zeroTheme.accent.Render("aimlapi.com is already configured")}
+	if wizard.aimlapiExistingBusy {
+		glyph := strings.TrimSpace(spinner)
+		if glyph == "" {
+			glyph = "•"
+		}
+		return append(lines, "", zeroTheme.faint.Render(glyph+" checking balance"))
+	}
+	options := []struct{ label, hint string }{
+		{"Use existing configuration", profileName},
+		{"Configure again", "New user or another API key"},
+	}
+	for index, option := range options {
+		marker := "  "
+		style := zeroTheme.ink
+		if index == wizard.aimlapiConfiguredCursor {
+			marker = "❯ "
+			style = zeroTheme.accent.Bold(true)
+		}
+		lines = append(lines, marker+style.Render(option.label))
+		lines = append(lines, "    "+zeroTheme.faint.Render(option.hint))
 	}
 	return lines
 }
@@ -1931,14 +2035,21 @@ func maskedProviderWizardKey(value string) string {
 }
 
 func providerWizardProfile(provider providercatalog.Descriptor, model string, apiKey string, baseURL string, profileName string) config.ProviderProfile {
+	resolvedBaseURL := firstProviderDisplayValue(strings.TrimSpace(baseURL), provider.DefaultBaseURL)
 	profile := config.ProviderProfile{
-		Name:          providerWizardDisplayName(provider, baseURL, profileName),
-		ProviderKind:  providerWizardProviderKind(provider),
-		CatalogID:     provider.ID,
-		BaseURL:       firstProviderDisplayValue(strings.TrimSpace(baseURL), provider.DefaultBaseURL),
-		APIFormat:     providerWizardAPIFormat(provider),
-		CustomHeaders: maps.Clone(provider.CustomHeaders),
-		Model:         firstProviderDisplayValue(model, provider.DefaultModel),
+		Name:         providerWizardDisplayName(provider, baseURL, profileName),
+		ProviderKind: providerWizardProviderKind(provider),
+		CatalogID:    provider.ID,
+		BaseURL:      resolvedBaseURL,
+		APIFormat:    providerWizardAPIFormat(provider),
+		Model:        firstProviderDisplayValue(model, provider.DefaultModel),
+	}
+	// Catalog custom headers (e.g. aimlapi.com's partner attribution) belong to the
+	// catalog endpoint: the resolver only applies them when the base URL is the
+	// default, so a profile built against a staging/proxy/custom override must not
+	// bake them in either — otherwise attribution leaks to an arbitrary host.
+	if sameProviderBaseURL(resolvedBaseURL, provider.DefaultBaseURL) {
+		profile.CustomHeaders = maps.Clone(provider.CustomHeaders)
 	}
 	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
 		profile.APIKey = apiKey
@@ -1951,6 +2062,16 @@ func providerWizardProfile(provider providercatalog.Descriptor, model string, ap
 		profile.APIKeyEnv = env
 	}
 	return profile
+}
+
+// sameProviderBaseURL reports whether two base URLs address the same endpoint,
+// normalizing case and a trailing slash — mirroring the resolver's sameBaseURL so
+// the wizard bakes catalog headers on exactly the endpoints the resolver would.
+func sameProviderBaseURL(left string, right string) bool {
+	return strings.EqualFold(
+		strings.TrimRight(strings.TrimSpace(left), "/"),
+		strings.TrimRight(strings.TrimSpace(right), "/"),
+	)
 }
 
 func providerWizardEndpointError(value string) string {

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -1952,7 +1953,7 @@ func providerWizardProfile(provider providercatalog.Descriptor, model string, ap
 		CatalogID:     provider.ID,
 		BaseURL:       firstProviderDisplayValue(strings.TrimSpace(baseURL), provider.DefaultBaseURL),
 		APIFormat:     providerWizardAPIFormat(provider),
-		CustomHeaders: copyProviderWizardHeaders(provider.CustomHeaders),
+		CustomHeaders: maps.Clone(provider.CustomHeaders),
 		Model:         firstProviderDisplayValue(model, provider.DefaultModel),
 	}
 	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
@@ -1966,17 +1967,6 @@ func providerWizardProfile(provider providercatalog.Descriptor, model string, ap
 		profile.APIKeyEnv = env
 	}
 	return profile
-}
-
-func copyProviderWizardHeaders(headers map[string]string) map[string]string {
-	if headers == nil {
-		return nil
-	}
-	copied := make(map[string]string, len(headers))
-	for key, value := range headers {
-		copied[key] = value
-	}
-	return copied
 }
 
 func providerWizardEndpointError(value string) string {

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -105,6 +105,7 @@ func (m model) resolveProviderWizardAimlapi(cmd tea.Cmd, outcome aimlapiOutcome)
 	switch outcome {
 	case aimlapiDone:
 		wizard.apiKey = wizard.aimlapi.apiKey
+		wizard.baseURL = wizard.aimlapi.baseURL
 		wizard.aimlapi = nil
 		wizard.err = ""
 		wizard.step = providerWizardStepModel

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1638,7 +1638,10 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 		surface = zeroTheme.onSel
 		marker = surface(zeroTheme.accent).Render("❯ ")
 	}
-	name := providerRecommendedRowLabel(provider.ID, provider.Name, provider.Recommended)
+	name := provider.Name
+	if provider.Recommended {
+		name = "★ " + name
+	}
 	left := marker + surface(zeroTheme.ink).Render(name)
 	if badge := providerWizardBadge(provider); badge != "" {
 		left += surface(zeroTheme.faint).Render("   " + badge)
@@ -1649,30 +1652,10 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 // providerWizardBadge is the faint hint shown next to a provider row. The
 // recommended provider takes precedence over the OAuth hint.
 func providerWizardBadge(provider providercatalog.Descriptor) string {
-	if badge := providerRecommendedRowBadge(provider.ID, provider.Recommended); badge != "" {
-		return badge
+	if provider.Recommended {
+		return "(recommended)"
 	}
 	return providerWizardOAuthBadge(provider)
-}
-
-const aimlapiRecommendedProviderLabel = "(~) aimlapi.com (1000+ models)"
-
-func providerRecommendedRowLabel(id, name string, recommended bool) string {
-	label := displayValue(name, id)
-	if !recommended {
-		return label
-	}
-	if strings.EqualFold(strings.TrimSpace(id), "aimlapi") {
-		return aimlapiRecommendedProviderLabel
-	}
-	return "★ " + label
-}
-
-func providerRecommendedRowBadge(id string, recommended bool) string {
-	if !recommended || strings.EqualFold(strings.TrimSpace(id), "aimlapi") {
-		return ""
-	}
-	return "(recommended)"
 }
 
 // providerWizardOAuthBadge is the faint mode hint shown next to OAuth providers.

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -932,7 +932,7 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		if m.providerWizard.aimlapiExistingBusy {
 			if keyIs(msg, tea.KeyEsc) || keyIs(msg, tea.KeyLeft) {
 				m.providerWizard.aimlapiExistingGen++
-				m.providerWizard.aimlapiExistingBusy = false
+				m.providerWizard.clearAimlapiExisting()
 				m.providerWizard.step = providerWizardStepProvider
 			}
 			return m, nil

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1599,10 +1599,6 @@ func (wizard *providerWizardState) renderMethodStep(width int) []string {
 }
 
 func (wizard *providerWizardState) renderAimlapiConfiguredStep(width int, spinner string) []string {
-	profileName := strings.TrimSpace(wizard.aimlapiExistingProfile.Name)
-	if profileName == "" {
-		profileName = "aimlapi"
-	}
 	lines := []string{zeroTheme.accent.Render("aimlapi.com is already configured")}
 	if wizard.aimlapiExistingBusy {
 		glyph := strings.TrimSpace(spinner)
@@ -1612,8 +1608,8 @@ func (wizard *providerWizardState) renderAimlapiConfiguredStep(width int, spinne
 		return append(lines, "", zeroTheme.faint.Render(glyph+" checking balance"))
 	}
 	options := []struct{ label, hint string }{
-		{"Use existing configuration", profileName},
-		{"Configure again", "New user or another API key"},
+		{"Use existing configuration", "Continue with your saved API key"},
+		{"Configure again", "Set up a new key or switch accounts"},
 	}
 	for index, option := range options {
 		marker := "  "

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -74,6 +74,51 @@ func (m model) applyProviderWizardOAuth(msg providerWizardOAuthMsg) (model, tea.
 	return m, m.providerModelDiscoveryCmd()
 }
 
+// applyProviderWizardAimlapiOnboard routes an async aimlapi.com onboarding result
+// into the wizard's shared sub-flow and reacts to its outcome.
+func (m model) applyProviderWizardAimlapiOnboard(msg aimlapiOnboardMsg) (model, tea.Cmd) {
+	wizard := m.providerWizard
+	if wizard == nil || wizard.aimlapi == nil || wizard.aimlapi != msg.state {
+		return m, nil
+	}
+	cmd, outcome := wizard.aimlapi.apply(msg)
+	return m.resolveProviderWizardAimlapi(cmd, outcome)
+}
+
+// handleProviderWizardAimlapiKey delegates a key press to the wizard's aimlapi.com
+// sub-flow and reacts to its outcome.
+func (m model) handleProviderWizardAimlapiKey(msg tea.KeyMsg) (model, tea.Cmd) {
+	wizard := m.providerWizard
+	if wizard == nil || wizard.aimlapi == nil {
+		return m, nil
+	}
+	cmd, outcome := wizard.aimlapi.handleKey(msg)
+	return m.resolveProviderWizardAimlapi(cmd, outcome)
+}
+
+// resolveProviderWizardAimlapi lands the sub-flow's outcome on the wizard: on a
+// terminal key it moves the freshly acquired key into the wizard and advances to
+// model selection (reusing the standard finalize); on cancel it backs out.
+func (m model) resolveProviderWizardAimlapi(cmd tea.Cmd, outcome aimlapiOutcome) (model, tea.Cmd) {
+	wizard := m.providerWizard
+	switch outcome {
+	case aimlapiDone:
+		wizard.apiKey = wizard.aimlapi.apiKey
+		wizard.aimlapi = nil
+		wizard.err = ""
+		wizard.step = providerWizardStepModel
+		return m, m.providerModelDiscoveryCmd()
+	case aimlapiCancel:
+		wizard.aimlapi = nil
+		wizard.err = ""
+		wizard.step = providerWizardStepProvider
+		return m, nil
+	}
+	// Keep the shared spinner tick alive whenever the sub-flow just entered a busy
+	// or progress state, so its animated spinner advances during onboarding.
+	return m, tea.Batch(cmd, m.ensureSpinnerTick())
+}
+
 // applyProviderWizardDeviceCode handles phase 1 of device-code login: show the
 // user_code + verification URI, then kick off phase 2 (the token poll). On error
 // the redacted message is surfaced and the login is abandoned.
@@ -300,6 +345,7 @@ const (
 	providerWizardStepManageKey
 	providerWizardStepEndpoint
 	providerWizardStepName
+	providerWizardStepAimlapi
 	providerWizardStepCredential
 	providerWizardStepModel
 	providerWizardStepDone
@@ -379,6 +425,9 @@ type providerWizardState struct {
 	oauthDevice           bool
 	deviceUserCode        string
 	deviceVerificationURI string
+	// aimlapi holds the shared aimlapi.com onboarding sub-flow while
+	// the wizard is on providerWizardStepAimlapi.
+	aimlapi *aimlapiOnboardState
 	// Manager state (provider_manager.go): the list-first /provider surface.
 	manage           bool
 	manageRows       []providerManagerRow
@@ -453,6 +502,21 @@ func (wizard *providerWizardState) oauthResultMatches(providerID string, attempt
 	return wizard.currentProvider().ID == providerID && wizard.oauthAttemptID == attemptID
 }
 
+// resetAimlapiOnboard drops any in-flight aimlapi.com sub-flow (cancelling a
+// running top-up stream) when the selected provider changes.
+func (wizard *providerWizardState) resetAimlapiOnboard() {
+	if wizard.aimlapi != nil {
+		wizard.aimlapi.cancelStream()
+		wizard.aimlapi = nil
+	}
+}
+
+// enterAimlapi starts the shared aimlapi.com onboarding sub-flow.
+func (wizard *providerWizardState) enterAimlapi() {
+	wizard.aimlapi = newAimlapiOnboard(browser.OpenURL)
+	wizard.step = providerWizardStepAimlapi
+}
+
 func (wizard *providerWizardState) currentModel() providerWizardModel {
 	if wizard == nil {
 		return providerWizardModel{}
@@ -501,6 +565,7 @@ func (wizard *providerWizardState) move(delta int) {
 		wizard.modelLoadError = ""
 		wizard.oauthPending = false
 		wizard.oauthErr = ""
+		wizard.resetAimlapiOnboard()
 		wizard.refreshModels()
 	case providerWizardStepModel:
 		wizard.refreshModels()
@@ -556,6 +621,8 @@ func (wizard *providerWizardState) advance() {
 		wizard.err = ""
 		if providerWizardNeedsEndpoint(wizard.currentProvider()) {
 			wizard.step = providerWizardStepEndpoint
+		} else if providerWizardIsAimlapi(wizard.currentProvider()) {
+			wizard.enterAimlapi()
 		} else if providerWizardNeedsCredential(wizard.currentProvider()) {
 			wizard.step = providerWizardStepCredential
 		} else {
@@ -570,7 +637,9 @@ func (wizard *providerWizardState) advance() {
 		wizard.step = providerWizardStepName
 	case providerWizardStepName:
 		wizard.err = ""
-		if providerWizardNeedsCredential(wizard.currentProvider()) {
+		if providerWizardIsAimlapi(wizard.currentProvider()) {
+			wizard.enterAimlapi()
+		} else if providerWizardNeedsCredential(wizard.currentProvider()) {
 			wizard.step = providerWizardStepCredential
 		} else {
 			wizard.step = providerWizardStepModel
@@ -618,6 +687,15 @@ func (wizard *providerWizardState) retreat() {
 		wizard.providerSearch = ""
 	case providerWizardStepName:
 		wizard.step = providerWizardStepEndpoint
+	case providerWizardStepAimlapi:
+		wizard.resetAimlapiOnboard()
+		if providerWizardNeedsProfileName(wizard.currentProvider()) {
+			wizard.step = providerWizardStepName
+		} else if providerWizardNeedsEndpoint(wizard.currentProvider()) {
+			wizard.step = providerWizardStepEndpoint
+		} else {
+			wizard.step = providerWizardStepProvider
+		}
 	case providerWizardStepCredential:
 		if providerWizardNeedsProfileName(wizard.currentProvider()) {
 			wizard.step = providerWizardStepName
@@ -627,7 +705,9 @@ func (wizard *providerWizardState) retreat() {
 			wizard.step = providerWizardStepProvider
 		}
 	case providerWizardStepModel:
-		if providerWizardNeedsCredential(wizard.currentProvider()) {
+		if providerWizardIsAimlapi(wizard.currentProvider()) {
+			wizard.step = providerWizardStepProvider
+		} else if providerWizardNeedsCredential(wizard.currentProvider()) {
 			wizard.step = providerWizardStepCredential
 		} else if providerWizardNeedsEndpoint(wizard.currentProvider()) {
 			wizard.step = providerWizardStepEndpoint
@@ -675,6 +755,10 @@ func sameProviderWizardModels(a, b []providerWizardModel) bool {
 
 func providerWizardNeedsCredential(provider providercatalog.Descriptor) bool {
 	return provider.RequiresAuth && !provider.Local && len(provider.AuthEnvVars) > 0
+}
+
+func providerWizardIsAimlapi(provider providercatalog.Descriptor) bool {
+	return strings.EqualFold(strings.TrimSpace(provider.ID), "aimlapi")
 }
 
 func providerWizardNeedsEndpoint(provider providercatalog.Descriptor) bool {
@@ -812,6 +896,9 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 			return m.advanceProviderWizard()
 		}
 	}
+	if m.providerWizard.step == providerWizardStepAimlapi {
+		return m.handleProviderWizardAimlapiKey(msg)
+	}
 	if m.providerWizard.step == providerWizardStepCredential {
 		switch {
 		case keyIs(msg, tea.KeyEsc):
@@ -893,6 +980,10 @@ func (m model) handleProviderWizardPaste(content string) (model, tea.Cmd) {
 		m.providerWizard.appendBaseURL([]rune(content))
 	case providerWizardStepName:
 		m.providerWizard.appendProfileName([]rune(content))
+	case providerWizardStepAimlapi:
+		if m.providerWizard.aimlapi != nil {
+			m.providerWizard.aimlapi.appendInput(content)
+		}
 	case providerWizardStepCredential:
 		m.providerWizard.appendAPIKey([]rune(content))
 	case providerWizardStepModel:
@@ -1193,10 +1284,12 @@ func (m model) providerWizardOverlay(width int) string {
 	if m.providerWizard == nil {
 		return ""
 	}
-	return m.providerWizard.render(width)
+	return m.providerWizard.render(width, m.spinnerGlyph())
 }
 
-func (wizard *providerWizardState) render(width int) string {
+// render's spinner glyph is used only by the embedded aimlapi.com onboarding
+// sub-view; it is the shared global run spinner (spinnerGlyph()), same as everywhere.
+func (wizard *providerWizardState) render(width int, spinner string) string {
 	if wizard == nil {
 		return ""
 	}
@@ -1233,6 +1326,10 @@ func (wizard *providerWizardState) render(width int) string {
 		lines = append(lines, wizard.renderEndpointStep(innerWidth)...)
 	case providerWizardStepName:
 		lines = append(lines, wizard.renderNameStep(innerWidth)...)
+	case providerWizardStepAimlapi:
+		if wizard.aimlapi != nil {
+			lines = append(lines, wizard.aimlapi.view(innerWidth, spinner)...)
+		}
 	case providerWizardStepCredential:
 		lines = append(lines, wizard.renderCredentialStep(innerWidth)...)
 	case providerWizardStepModel:
@@ -1306,6 +1403,8 @@ func (wizard *providerWizardState) footerText() string {
 		return "Enter continue   ← back   Esc close"
 	case providerWizardStepName:
 		return "Enter/→ continue   ← back   Esc close"
+	case providerWizardStepAimlapi:
+		return "type/↑↓ choose   Enter/→ continue   ← back   Esc close"
 	case providerWizardStepModel:
 		if canRight {
 			return "↑/↓ move   Enter/→ continue   ← back   Esc close"
@@ -1329,7 +1428,7 @@ func providerWizardOverlayWidth(width int, step providerWizardStep) int {
 	switch step {
 	case providerWizardStepProvider:
 		target = providerWizardProviderWidth
-	case providerWizardStepModel, providerWizardStepManage:
+	case providerWizardStepModel, providerWizardStepManage, providerWizardStepAimlapi:
 		target = providerWizardModelWidth
 	}
 	target = minInt(target, width)
@@ -1366,6 +1465,12 @@ func providerWizardStepLine(wizard *providerWizardState) string {
 		steps = append(steps,
 			stepLabel{providerWizardStepModel, "3 model"},
 			stepLabel{providerWizardStepDone, "4 ready"},
+		)
+	case providerWizardIsAimlapi(wizard.currentProvider()):
+		steps = append(steps,
+			stepLabel{providerWizardStepAimlapi, "3 connect"},
+			stepLabel{providerWizardStepModel, "4 model"},
+			stepLabel{providerWizardStepDone, "5 ready"},
 		)
 	case providerWizardNeedsEndpoint(wizard.currentProvider()):
 		steps = append(steps,
@@ -1532,10 +1637,7 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 		surface = zeroTheme.onSel
 		marker = surface(zeroTheme.accent).Render("❯ ")
 	}
-	name := provider.Name
-	if provider.Recommended {
-		name = "★ " + name
-	}
+	name := providerRecommendedRowLabel(provider.ID, provider.Name, provider.Recommended)
 	left := marker + surface(zeroTheme.ink).Render(name)
 	if badge := providerWizardBadge(provider); badge != "" {
 		left += surface(zeroTheme.faint).Render("   " + badge)
@@ -1546,10 +1648,30 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 // providerWizardBadge is the faint hint shown next to a provider row. The
 // recommended provider takes precedence over the OAuth hint.
 func providerWizardBadge(provider providercatalog.Descriptor) string {
-	if provider.Recommended {
-		return "(recommended)"
+	if badge := providerRecommendedRowBadge(provider.ID, provider.Recommended); badge != "" {
+		return badge
 	}
 	return providerWizardOAuthBadge(provider)
+}
+
+const aimlapiRecommendedProviderLabel = "(~) aimlapi.com (1000+ models)"
+
+func providerRecommendedRowLabel(id, name string, recommended bool) string {
+	label := displayValue(name, id)
+	if !recommended {
+		return label
+	}
+	if strings.EqualFold(strings.TrimSpace(id), "aimlapi") {
+		return aimlapiRecommendedProviderLabel
+	}
+	return "★ " + label
+}
+
+func providerRecommendedRowBadge(id string, recommended bool) string {
+	if !recommended || strings.EqualFold(strings.TrimSpace(id), "aimlapi") {
+		return ""
+	}
+	return "(recommended)"
 }
 
 // providerWizardOAuthBadge is the faint mode hint shown next to OAuth providers.
@@ -1825,12 +1947,13 @@ func maskedProviderWizardKey(value string) string {
 
 func providerWizardProfile(provider providercatalog.Descriptor, model string, apiKey string, baseURL string, profileName string) config.ProviderProfile {
 	profile := config.ProviderProfile{
-		Name:         providerWizardDisplayName(provider, baseURL, profileName),
-		ProviderKind: providerWizardProviderKind(provider),
-		CatalogID:    provider.ID,
-		BaseURL:      firstProviderDisplayValue(strings.TrimSpace(baseURL), provider.DefaultBaseURL),
-		APIFormat:    providerWizardAPIFormat(provider),
-		Model:        firstProviderDisplayValue(model, provider.DefaultModel),
+		Name:          providerWizardDisplayName(provider, baseURL, profileName),
+		ProviderKind:  providerWizardProviderKind(provider),
+		CatalogID:     provider.ID,
+		BaseURL:       firstProviderDisplayValue(strings.TrimSpace(baseURL), provider.DefaultBaseURL),
+		APIFormat:     providerWizardAPIFormat(provider),
+		CustomHeaders: copyProviderWizardHeaders(provider.CustomHeaders),
+		Model:         firstProviderDisplayValue(model, provider.DefaultModel),
 	}
 	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
 		profile.APIKey = apiKey
@@ -1843,6 +1966,17 @@ func providerWizardProfile(provider providercatalog.Descriptor, model string, ap
 		profile.APIKeyEnv = env
 	}
 	return profile
+}
+
+func copyProviderWizardHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(headers))
+	for key, value := range headers {
+		copied[key] = value
+	}
+	return copied
 }
 
 func providerWizardEndpointError(value string) string {

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -15,6 +15,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/Gitlawb/zero/internal/aimlapi"
 	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
@@ -429,6 +430,7 @@ type providerWizardState struct {
 	aimlapiRuntimeKey       string
 	aimlapiExistingBusy     bool
 	aimlapiExistingGen      int
+	aimlapiExistingCancel   context.CancelFunc
 	oauthMode               bool
 	oauthPending            bool
 	oauthAttemptID          int
@@ -532,6 +534,10 @@ func (wizard *providerWizardState) enterAimlapi() {
 }
 
 func (wizard *providerWizardState) clearAimlapiExisting() {
+	if wizard.aimlapiExistingCancel != nil {
+		wizard.aimlapiExistingCancel()
+		wizard.aimlapiExistingCancel = nil
+	}
 	wizard.aimlapiExistingProfile = config.ProviderProfile{}
 	wizard.aimlapiRuntimeKey = ""
 	wizard.aimlapiExistingBusy = false
@@ -2050,6 +2056,9 @@ func providerWizardProfile(provider providercatalog.Descriptor, model string, ap
 	// bake them in either — otherwise attribution leaks to an arbitrary host.
 	if sameProviderBaseURL(resolvedBaseURL, provider.DefaultBaseURL) {
 		profile.CustomHeaders = maps.Clone(provider.CustomHeaders)
+		if providerWizardIsAimlapi(provider) {
+			profile.CustomHeaders = aimlapi.WithResolvedPartnerHeader(profile.CustomHeaders)
+		}
 	}
 	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
 		profile.APIKey = apiKey

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,9 +131,16 @@ func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, b
 	if key := strings.TrimSpace(os.Getenv("AIMLAPI_API_KEY")); key != "" {
 		descriptor, err := providercatalog.Require("aimlapi")
 		if err == nil {
-			profile := providerWizardProfile(descriptor, descriptor.DefaultModel, "", "", "")
-			profile.Name = descriptor.ID
-			return profile, key, true
+			return config.ProviderProfile{
+				Name:          descriptor.ID,
+				CatalogID:     descriptor.ID,
+				ProviderKind:  providerWizardProviderKind(descriptor),
+				BaseURL:       descriptor.DefaultBaseURL,
+				APIKeyEnv:     "AIMLAPI_API_KEY",
+				APIFormat:     providerWizardAPIFormat(descriptor),
+				Model:         descriptor.DefaultModel,
+				CustomHeaders: maps.Clone(descriptor.CustomHeaders),
+			}, key, true
 		}
 	}
 	return config.ProviderProfile{}, "", false

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -130,15 +130,9 @@ func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, b
 	if key := strings.TrimSpace(os.Getenv("AIMLAPI_API_KEY")); key != "" {
 		descriptor, err := providercatalog.Require("aimlapi")
 		if err == nil {
-			return config.ProviderProfile{
-				Name:         descriptor.ID,
-				CatalogID:    descriptor.ID,
-				ProviderKind: providerWizardProviderKind(descriptor),
-				BaseURL:      descriptor.DefaultBaseURL,
-				APIKeyEnv:    "AIMLAPI_API_KEY",
-				APIFormat:    providerWizardAPIFormat(descriptor),
-				Model:        descriptor.DefaultModel,
-			}, key, true
+			profile := providerWizardProfile(descriptor, descriptor.DefaultModel, "", "", "")
+			profile.Name = descriptor.ID
+			return profile, key, true
 		}
 	}
 	return config.ProviderProfile{}, "", false
@@ -183,6 +177,7 @@ func (m model) applyExistingAimlapiBalance(msg aimlapiExistingBalanceMsg) (model
 		return m, nil
 	}
 	wizard.apiKey = wizard.aimlapiRuntimeKey
+	wizard.baseURL = wizard.aimlapiExistingProfile.BaseURL
 	if msg.balance.LowBalance {
 		state := newAimlapiOnboard(browser.OpenURL)
 		state.apiKey = wizard.aimlapiRuntimeKey
@@ -225,6 +220,7 @@ func (m model) providerModelDiscoveryCmd() tea.Cmd {
 	wizard.discoveryToken++
 	token := wizard.discoveryToken
 	providerID := provider.ID
+	baseURL := wizard.baseURL
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(m.ctx, 12*time.Second)
 		defer cancel()
@@ -234,7 +230,7 @@ func (m model) providerModelDiscoveryCmd() tea.Cmd {
 				apiKey = resolved
 			}
 		}
-		profile := providerWizardDiscoveryProfile(provider, apiKey)
+		profile := providerWizardDiscoveryProfile(provider, apiKey, baseURL)
 		models, err := discover(ctx, profile)
 		return providerModelsDiscoveredMsg{providerID: providerID, token: token, models: models, err: err, secrets: []string{apiKey, profile.APIKey}}
 	}
@@ -294,8 +290,8 @@ func providerWizardModelsSource(models []providermodeldiscovery.Model) string {
 	return ""
 }
 
-func providerWizardDiscoveryProfile(provider providercatalog.Descriptor, apiKey string) config.ProviderProfile {
-	profile := providerWizardProfile(provider, provider.DefaultModel, apiKey, "", "")
+func providerWizardDiscoveryProfile(provider providercatalog.Descriptor, apiKey string, baseURL string) config.ProviderProfile {
+	profile := providerWizardProfile(provider, provider.DefaultModel, apiKey, baseURL, "")
 	if strings.TrimSpace(profile.APIKey) == "" && strings.TrimSpace(profile.APIKeyEnv) != "" {
 		profile.APIKey = strings.TrimSpace(os.Getenv(profile.APIKeyEnv))
 	}

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"context"
-	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,16 +137,14 @@ func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, b
 	}
 	if key := strings.TrimSpace(os.Getenv("AIMLAPI_API_KEY")); key != "" {
 		if descriptorErr == nil {
-			return config.ProviderProfile{
-				Name:          descriptor.ID,
-				CatalogID:     descriptor.ID,
-				ProviderKind:  providerWizardProviderKind(descriptor),
-				BaseURL:       descriptor.DefaultBaseURL,
-				APIKeyEnv:     "AIMLAPI_API_KEY",
-				APIFormat:     providerWizardAPIFormat(descriptor),
-				Model:         descriptor.DefaultModel,
-				CustomHeaders: maps.Clone(descriptor.CustomHeaders),
-			}, key, true
+			profile := providerWizardProfile(
+				descriptor,
+				descriptor.DefaultModel,
+				"",
+				aimlapi.ResolveEndpoints().InferenceBaseURL,
+				"",
+			)
+			return profile, key, true
 		}
 	}
 	return config.ProviderProfile{}, "", false
@@ -168,10 +165,18 @@ func (m model) checkExistingAimlapiBalance() (model, tea.Cmd) {
 	wizard.aimlapiExistingGen++
 	gen := wizard.aimlapiExistingGen
 	key := wizard.aimlapiRuntimeKey
+	endpoints := aimlapi.ResolveEndpoints()
+	if baseURL := strings.TrimSpace(wizard.aimlapiExistingProfile.BaseURL); baseURL != "" {
+		endpoints.InferenceBaseURL = baseURL
+	} else if descriptor, ok := providercatalog.Get("aimlapi"); ok {
+		// An empty stored BaseURL means the catalog endpoint. Pin it explicitly so
+		// a process-wide inference override cannot redirect this saved key.
+		endpoints.InferenceBaseURL = descriptor.DefaultBaseURL
+	}
+	ctx, cancel := context.WithTimeout(m.ctx, 12*time.Second)
+	wizard.aimlapiExistingCancel = cancel
 	cmd := func() tea.Msg {
-		ctx, cancel := context.WithTimeout(m.ctx, 12*time.Second)
-		defer cancel()
-		balance, err := aimlapiOnboardClient().GetBalance(ctx, key)
+		balance, err := aimlapi.NewClient(endpoints, nil).GetBalance(ctx, key)
 		return aimlapiExistingBalanceMsg{wizard: wizard, gen: gen, balance: balance, err: err}
 	}
 	return m, tea.Batch(cmd, m.ensureSpinnerTick())
@@ -181,6 +186,10 @@ func (m model) applyExistingAimlapiBalance(msg aimlapiExistingBalanceMsg) (model
 	wizard := m.providerWizard
 	if wizard == nil || wizard != msg.wizard || wizard.step != providerWizardStepAimlapiConfigured || msg.gen != wizard.aimlapiExistingGen {
 		return m, nil
+	}
+	if wizard.aimlapiExistingCancel != nil {
+		wizard.aimlapiExistingCancel()
+		wizard.aimlapiExistingCancel = nil
 	}
 	wizard.aimlapiExistingBusy = false
 	if msg.err != nil {

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -3,11 +3,14 @@ package tui
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/Gitlawb/zero/internal/aimlapi"
+	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
@@ -22,6 +25,13 @@ type providerModelsDiscoveredMsg struct {
 	// secrets are redacted from any surfaced error (e.g. a resolved OAuth token
 	// used to authenticate discovery, which must never be logged or shown).
 	secrets []string
+}
+
+type aimlapiExistingBalanceMsg struct {
+	wizard  *providerWizardState
+	gen     int
+	balance aimlapi.BalanceResult
+	err     error
 }
 
 func (m model) advanceProviderWizard() (model, tea.Cmd) {
@@ -43,6 +53,18 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 	// A non-OAuth provider that already has a key in the credential store: offer
 	// keep/replace/remove before re-entering credentials.
 	if m.providerWizard.step == providerWizardStepProvider && !m.providerWizard.oauthMode {
+		if providerWizardIsAimlapi(m.providerWizard.currentProvider()) {
+			if profile, runtimeKey, ok := m.existingAimlapiConfiguration(); ok {
+				m.providerWizard.aimlapiExistingProfile = profile
+				m.providerWizard.aimlapiRuntimeKey = runtimeKey
+				m.providerWizard.aimlapiConfiguredCursor = 0
+				m.providerWizard.err = ""
+				m.providerWizard.step = providerWizardStepAimlapiConfigured
+				return m, nil
+			}
+			m.providerWizard.enterAimlapi()
+			return m, nil
+		}
 		if name, ok := m.wizardProviderStoredKey(m.providerWizard.currentProvider()); ok {
 			// Generic/custom providers (custom-openai-compatible etc.) all share
 			// the same CatalogID — matching on CatalogID would block creating a
@@ -65,6 +87,113 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 		return m, m.providerModelDiscoveryCmd()
 	}
 	return m, nil
+}
+
+// existingAimlapiConfiguration returns a usable persisted credential source and
+// its current runtime key. The active aimlapi profile wins; otherwise the first
+// usable saved profile is used. A bare AIMLAPI_API_KEY is represented as an env
+// profile so choosing it never snapshots the secret into the credential store.
+func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, bool) {
+	profiles := append([]config.ProviderProfile(nil), m.savedProviders...)
+	activeName := strings.TrimSpace(m.providerProfile.Name)
+	if activeName != "" {
+		for index, profile := range profiles {
+			if strings.EqualFold(strings.TrimSpace(profile.Name), activeName) && aimlapiProfile(profile) {
+				profiles[0], profiles[index] = profiles[index], profiles[0]
+				break
+			}
+		}
+	}
+	var store config.APIKeyGetter
+	if strings.TrimSpace(m.userConfigPath) != "" {
+		store, _ = config.ProviderKeyStoreAt(filepath.Dir(m.userConfigPath))
+	}
+	for _, persisted := range profiles {
+		if !aimlapiProfile(persisted) {
+			continue
+		}
+		resolved := persisted
+		if strings.TrimSpace(resolved.APIKey) == "" && strings.TrimSpace(resolved.APIKeyEnv) != "" {
+			resolved.APIKey = strings.TrimSpace(os.Getenv(resolved.APIKeyEnv))
+		}
+		resolved = config.ApplyStoredAPIKey(resolved, store)
+		if key := strings.TrimSpace(resolved.APIKey); key != "" {
+			// ResolvedConfig materializes APIKeyEnv into APIKey for runtime use.
+			// Strip that materialized value (and any loaded stored key) from the
+			// persisted copy so finalization retains the reference, not the secret.
+			if strings.TrimSpace(persisted.APIKeyEnv) != "" || persisted.APIKeyStored {
+				persisted.APIKey = ""
+			}
+			return persisted, key, true
+		}
+	}
+	if key := strings.TrimSpace(os.Getenv("AIMLAPI_API_KEY")); key != "" {
+		descriptor, err := providercatalog.Require("aimlapi")
+		if err == nil {
+			return config.ProviderProfile{
+				Name:         descriptor.ID,
+				CatalogID:    descriptor.ID,
+				ProviderKind: providerWizardProviderKind(descriptor),
+				BaseURL:      descriptor.DefaultBaseURL,
+				APIKeyEnv:    "AIMLAPI_API_KEY",
+				APIFormat:    providerWizardAPIFormat(descriptor),
+				Model:        descriptor.DefaultModel,
+			}, key, true
+		}
+	}
+	return config.ProviderProfile{}, "", false
+}
+
+func aimlapiProfile(profile config.ProviderProfile) bool {
+	return strings.EqualFold(strings.TrimSpace(profile.CatalogID), "aimlapi") ||
+		strings.EqualFold(strings.TrimSpace(profile.Name), "aimlapi")
+}
+
+func (m model) checkExistingAimlapiBalance() (model, tea.Cmd) {
+	wizard := m.providerWizard
+	if wizard == nil || wizard.step != providerWizardStepAimlapiConfigured || wizard.aimlapiExistingBusy {
+		return m, nil
+	}
+	wizard.aimlapiExistingBusy = true
+	wizard.err = ""
+	wizard.aimlapiExistingGen++
+	gen := wizard.aimlapiExistingGen
+	key := wizard.aimlapiRuntimeKey
+	cmd := func() tea.Msg {
+		ctx, cancel := context.WithTimeout(m.ctx, 12*time.Second)
+		defer cancel()
+		balance, err := aimlapiOnboardClient().GetBalance(ctx, key)
+		return aimlapiExistingBalanceMsg{wizard: wizard, gen: gen, balance: balance, err: err}
+	}
+	return m, tea.Batch(cmd, m.ensureSpinnerTick())
+}
+
+func (m model) applyExistingAimlapiBalance(msg aimlapiExistingBalanceMsg) (model, tea.Cmd) {
+	wizard := m.providerWizard
+	if wizard == nil || wizard != msg.wizard || wizard.step != providerWizardStepAimlapiConfigured || msg.gen != wizard.aimlapiExistingGen {
+		return m, nil
+	}
+	wizard.aimlapiExistingBusy = false
+	if msg.err != nil {
+		if aimlapiIsUnauthorized(msg.err) {
+			wizard.err = "The existing AIMLAPI API key is invalid. Choose Configure again."
+		} else {
+			wizard.err = redaction.ErrorMessage(msg.err, redaction.Options{ExtraSecretValues: []string{wizard.aimlapiRuntimeKey}})
+		}
+		return m, nil
+	}
+	wizard.apiKey = wizard.aimlapiRuntimeKey
+	if msg.balance.LowBalance {
+		state := newAimlapiOnboard(browser.OpenURL)
+		state.apiKey = wizard.aimlapiRuntimeKey
+		state.byKey = true
+		state.step = aimlapiStepLowBalance
+		wizard.aimlapi = state
+		wizard.step = providerWizardStepAimlapi
+		return m, nil
+	}
+	wizard.step = providerWizardStepModel
+	return m, m.providerModelDiscoveryCmd()
 }
 
 func (m model) providerModelDiscoveryCmd() tea.Cmd {

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -173,6 +173,7 @@ func (m model) checkExistingAimlapiBalance() (model, tea.Cmd) {
 		// a process-wide inference override cannot redirect this saved key.
 		endpoints.InferenceBaseURL = descriptor.DefaultBaseURL
 	}
+	wizard.baseURL = endpoints.InferenceBaseURL
 	ctx, cancel := context.WithTimeout(m.ctx, 12*time.Second)
 	wizard.aimlapiExistingCancel = cancel
 	cmd := func() tea.Msg {
@@ -201,10 +202,10 @@ func (m model) applyExistingAimlapiBalance(msg aimlapiExistingBalanceMsg) (model
 		return m, nil
 	}
 	wizard.apiKey = wizard.aimlapiRuntimeKey
-	wizard.baseURL = wizard.aimlapiExistingProfile.BaseURL
 	if msg.balance.LowBalance {
 		state := newAimlapiOnboard(browser.OpenURL)
 		state.apiKey = wizard.aimlapiRuntimeKey
+		state.baseURL = wizard.baseURL
 		state.byKey = true
 		state.step = aimlapiStepLowBalance
 		wizard.aimlapi = state

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -95,6 +95,7 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 // usable saved profile is used. A bare AIMLAPI_API_KEY is represented as an env
 // profile so choosing it never snapshots the secret into the credential store.
 func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, bool) {
+	descriptor, descriptorErr := providercatalog.Require("aimlapi")
 	profiles := append([]config.ProviderProfile(nil), m.savedProviders...)
 	activeName := strings.TrimSpace(m.providerProfile.Name)
 	if activeName != "" {
@@ -113,6 +114,13 @@ func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, b
 		if !aimlapiProfile(persisted) {
 			continue
 		}
+		// The guided balance/top-up client talks to AIMLAPI's production account
+		// API. Never send a credential saved for a proxy, staging service, or other
+		// custom inference endpoint to that API. Such profiles remain available to
+		// the normal provider runtime; they are simply ineligible for this preflight.
+		if descriptorErr != nil || (strings.TrimSpace(persisted.BaseURL) != "" && !sameProviderBaseURL(persisted.BaseURL, descriptor.DefaultBaseURL)) {
+			continue
+		}
 		resolved := persisted
 		if strings.TrimSpace(resolved.APIKey) == "" && strings.TrimSpace(resolved.APIKeyEnv) != "" {
 			resolved.APIKey = strings.TrimSpace(os.Getenv(resolved.APIKeyEnv))
@@ -129,8 +137,7 @@ func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, b
 		}
 	}
 	if key := strings.TrimSpace(os.Getenv("AIMLAPI_API_KEY")); key != "" {
-		descriptor, err := providercatalog.Require("aimlapi")
-		if err == nil {
+		if descriptorErr == nil {
 			return config.ProviderProfile{
 				Name:          descriptor.ID,
 				CatalogID:     descriptor.ID,

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1347,11 +1347,6 @@ func TestAimlapiConfigureAgainUsesTwoPathOnboarding(t *testing.T) {
 	if next.providerWizard.aimlapiExistingProfile.Name != "" || next.providerWizard.aimlapiRuntimeKey != "" {
 		t.Fatal("configure again must discard the old credential context")
 	}
-	next.providerWizard.aimlapi.pathCursor = 1
-	_, outcome := next.providerWizard.aimlapi.handlePickPathKey(testKey(tea.KeyDown))
-	if outcome != aimlapiContinue || next.providerWizard.aimlapi.pathCursor != 0 {
-		t.Fatal("onboarding picker must wrap across exactly new-user and API-key paths")
-	}
 }
 
 func TestExistingAimlapiLowBalanceReusesByKeyTopUp(t *testing.T) {

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -12,6 +12,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/Gitlawb/zero/internal/aimlapi"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
@@ -1167,6 +1168,39 @@ func TestProviderWizardManageKeyReplaceAndKeep(t *testing.T) {
 	}
 }
 
+func TestProviderManagerEscCancelsEmbeddedAimlapiFlow(t *testing.T) {
+	opCtx, opCancel := context.WithCancel(context.Background())
+	topupCtx, topupCancel := context.WithCancel(context.Background())
+	state := &aimlapiOnboardState{
+		step:        aimlapiStepProgress,
+		opCancel:    opCancel,
+		topupCancel: topupCancel,
+	}
+	m := model{providerWizard: &providerWizardState{
+		manage:  true,
+		step:    providerWizardStepAimlapi,
+		aimlapi: state,
+	}}
+
+	next, _ := m.handleProviderWizardKey(testKey(tea.KeyEsc))
+	if next.providerWizard == nil || next.providerWizard.step != providerWizardStepManage {
+		t.Fatalf("manager escape did not return to provider list: %+v", next.providerWizard)
+	}
+	if next.providerWizard.aimlapi != nil {
+		t.Fatal("manager escape retained embedded aimlapi state")
+	}
+	select {
+	case <-opCtx.Done():
+	default:
+		t.Fatal("pending account/key operation was not cancelled")
+	}
+	select {
+	case <-topupCtx.Done():
+	default:
+		t.Fatal("pending top-up stream was not cancelled")
+	}
+}
+
 func TestAdvanceProviderWizardCustomSkipsManageKey(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1229,6 +1263,159 @@ func TestAdvanceProviderWizardNamedShowsManageKey(t *testing.T) {
 	}
 	if next.providerWizard.step != providerWizardStepManageKey {
 		t.Fatalf("named provider should route to ManageKey step, got step: %v", next.providerWizard.step)
+	}
+}
+
+func TestExistingAimlapiConfigurationUsesEnvWithoutCapturingLiteral(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "aimlapi-env-secret")
+	m := model{savedProviders: []config.ProviderProfile{{
+		Name: "aimlapi", CatalogID: "aimlapi", APIKeyEnv: "AIMLAPI_API_KEY",
+		// ResolvedConfig materializes the env value here before the TUI sees it.
+		APIKey: "aimlapi-env-secret",
+	}}}
+
+	profile, runtimeKey, ok := m.existingAimlapiConfiguration()
+	if !ok {
+		t.Fatal("expected AIMLAPI_API_KEY to be detected")
+	}
+	if runtimeKey != "aimlapi-env-secret" {
+		t.Fatalf("runtime key = %q", runtimeKey)
+	}
+	if profile.APIKeyEnv != "AIMLAPI_API_KEY" || profile.APIKey != "" || profile.APIKeyStored {
+		t.Fatalf("env credential source was not preserved: %+v", profile)
+	}
+}
+
+func TestExistingAimlapiConfigurationResolvesStoredKey(t *testing.T) {
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("work", "aimlapi-stored-secret"); err != nil {
+		t.Fatal(err)
+	}
+	m := model{
+		userConfigPath: configPath,
+		savedProviders: []config.ProviderProfile{{Name: "work", CatalogID: "aimlapi", APIKeyStored: true}},
+	}
+
+	profile, runtimeKey, ok := m.existingAimlapiConfiguration()
+	if !ok || runtimeKey != "aimlapi-stored-secret" {
+		t.Fatalf("stored configuration = (%+v, %q, %v)", profile, runtimeKey, ok)
+	}
+	if !profile.APIKeyStored || profile.APIKey != "" || profile.APIKeyEnv != "" {
+		t.Fatalf("stored credential source was not preserved: %+v", profile)
+	}
+}
+
+func TestAdvanceAimlapiWithExistingCredentialShowsConfiguredPreflight(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "aimlapi-env-secret")
+	m := model{providerWizard: &providerWizardState{
+		step: providerWizardStepProvider,
+		providers: []providercatalog.Descriptor{{
+			ID: "aimlapi", Name: "aimlapi.com", Transport: providercatalog.TransportOpenAICompatible,
+		}},
+	}}
+
+	next, _ := m.advanceProviderWizard()
+	if next.providerWizard.step != providerWizardStepAimlapiConfigured {
+		t.Fatalf("step = %v, want configured preflight", next.providerWizard.step)
+	}
+	if next.providerWizard.aimlapiExistingProfile.APIKeyEnv != "AIMLAPI_API_KEY" {
+		t.Fatalf("profile = %+v", next.providerWizard.aimlapiExistingProfile)
+	}
+}
+
+func TestAimlapiConfigureAgainUsesTwoPathOnboarding(t *testing.T) {
+	wizard := &providerWizardState{
+		step:                    providerWizardStepAimlapiConfigured,
+		aimlapiConfiguredCursor: 1,
+		aimlapiExistingProfile:  config.ProviderProfile{Name: "aimlapi", CatalogID: "aimlapi", APIKeyEnv: "AIMLAPI_API_KEY"},
+		aimlapiRuntimeKey:       "secret",
+	}
+	m := model{providerWizard: wizard}
+
+	next, _ := m.handleProviderWizardKey(testKey(tea.KeyEnter))
+	if next.providerWizard.step != providerWizardStepAimlapi || next.providerWizard.aimlapi == nil {
+		t.Fatalf("configure again did not enter onboarding: %+v", next.providerWizard)
+	}
+	if next.providerWizard.aimlapiExistingProfile.Name != "" || next.providerWizard.aimlapiRuntimeKey != "" {
+		t.Fatal("configure again must discard the old credential context")
+	}
+	next.providerWizard.aimlapi.pathCursor = 1
+	_, outcome := next.providerWizard.aimlapi.handlePickPathKey(testKey(tea.KeyDown))
+	if outcome != aimlapiContinue || next.providerWizard.aimlapi.pathCursor != 0 {
+		t.Fatal("onboarding picker must wrap across exactly new-user and API-key paths")
+	}
+}
+
+func TestExistingAimlapiLowBalanceReusesByKeyTopUp(t *testing.T) {
+	wizard := &providerWizardState{
+		step:                   providerWizardStepAimlapiConfigured,
+		aimlapiExistingProfile: config.ProviderProfile{Name: "aimlapi", CatalogID: "aimlapi", APIKeyEnv: "AIMLAPI_API_KEY"},
+		aimlapiRuntimeKey:      "secret",
+		aimlapiExistingBusy:    true,
+		aimlapiExistingGen:     4,
+	}
+	m := model{providerWizard: wizard}
+	next, _ := m.applyExistingAimlapiBalance(aimlapiExistingBalanceMsg{
+		wizard: wizard,
+		gen:    4,
+		balance: aimlapi.BalanceResult{
+			LowBalance: true,
+		},
+	})
+	if next.providerWizard.step != providerWizardStepAimlapi || next.providerWizard.aimlapi == nil {
+		t.Fatalf("low balance did not enter aimlapi top-up: %+v", next.providerWizard)
+	}
+	if !next.providerWizard.aimlapi.byKey || next.providerWizard.aimlapi.step != aimlapiStepLowBalance || next.providerWizard.aimlapi.apiKey != "secret" {
+		t.Fatalf("top-up state = %+v", next.providerWizard.aimlapi)
+	}
+}
+
+func TestApplyExistingAimlapiPreservesEnvCredentialSource(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "runtime-secret")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	provider := providercatalog.Descriptor{
+		ID: "aimlapi", Name: "aimlapi.com", Transport: providercatalog.TransportOpenAICompatible,
+	}
+	m := model{
+		userConfigPath: configPath,
+		providerWizard: &providerWizardState{
+			step:          providerWizardStepDone,
+			providers:     []providercatalog.Descriptor{provider},
+			models:        []providerWizardModel{{ID: "model/new"}},
+			selectedModel: 0,
+			modelSource:   "live",
+			aimlapiExistingProfile: config.ProviderProfile{
+				Name: "aimlapi", CatalogID: "aimlapi", APIKeyEnv: "AIMLAPI_API_KEY", Model: "model/old",
+			},
+			aimlapiRuntimeKey: "runtime-secret",
+		},
+	}
+
+	next, _ := m.applyProviderWizard()
+	if next.providerWizard != nil {
+		t.Fatal("successful apply should close the wizard")
+	}
+	cfg := readProviderWizardConfigFixture(t, configPath)
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("providers = %+v", cfg.Providers)
+	}
+	got := cfg.Providers[0]
+	if got.APIKeyEnv != "AIMLAPI_API_KEY" || got.APIKey != "" || got.APIKeyStored {
+		t.Fatalf("credential source changed: %+v", got)
+	}
+	if got.Model != "model/new" {
+		t.Fatalf("model = %q, want model/new", got.Model)
 	}
 }
 

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1314,6 +1314,21 @@ func TestExistingAimlapiConfigurationResolvesStoredKey(t *testing.T) {
 	}
 }
 
+func TestExistingAimlapiConfigurationSkipsCustomEndpointCredential(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "")
+	m := model{savedProviders: []config.ProviderProfile{{
+		Name:      "aimlapi-staging",
+		CatalogID: "aimlapi",
+		BaseURL:   "https://staging.example.test/v1",
+		APIKey:    "staging-secret",
+	}}}
+
+	profile, runtimeKey, ok := m.existingAimlapiConfiguration()
+	if ok || profile.Name != "" || runtimeKey != "" {
+		t.Fatalf("custom endpoint credential entered production preflight: (%+v, %q, %v)", profile, runtimeKey, ok)
+	}
+}
+
 func TestAdvanceAimlapiWithExistingCredentialShowsConfiguredPreflight(t *testing.T) {
 	t.Setenv("AIMLAPI_API_KEY", "aimlapi-env-secret")
 	provider, err := providercatalog.Require("aimlapi")

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1457,7 +1457,8 @@ func TestAimlapiConfigureAgainUsesTwoPathOnboarding(t *testing.T) {
 func TestExistingAimlapiLowBalanceReusesByKeyTopUp(t *testing.T) {
 	wizard := &providerWizardState{
 		step:                   providerWizardStepAimlapiConfigured,
-		aimlapiExistingProfile: config.ProviderProfile{Name: "aimlapi", CatalogID: "aimlapi", APIKeyEnv: "AIMLAPI_API_KEY"},
+		baseURL:                "https://validated.example.test/v1",
+		aimlapiExistingProfile: config.ProviderProfile{Name: "aimlapi", CatalogID: "aimlapi", BaseURL: "https://validated.example.test/v1", APIKeyEnv: "AIMLAPI_API_KEY"},
 		aimlapiRuntimeKey:      "secret",
 		aimlapiExistingBusy:    true,
 		aimlapiExistingGen:     4,
@@ -1475,6 +1476,9 @@ func TestExistingAimlapiLowBalanceReusesByKeyTopUp(t *testing.T) {
 	}
 	if !next.providerWizard.aimlapi.byKey || next.providerWizard.aimlapi.step != aimlapiStepLowBalance || next.providerWizard.aimlapi.apiKey != "secret" {
 		t.Fatalf("top-up state = %+v", next.providerWizard.aimlapi)
+	}
+	if next.providerWizard.aimlapi.baseURL != "https://validated.example.test/v1" {
+		t.Fatalf("top-up endpoint = %q, want validated endpoint", next.providerWizard.aimlapi.baseURL)
 	}
 }
 

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -1284,6 +1287,87 @@ func TestExistingAimlapiConfigurationUsesEnvWithoutCapturingLiteral(t *testing.T
 	}
 	if profile.APIKeyEnv != "AIMLAPI_API_KEY" || profile.APIKey != "" || profile.APIKeyStored {
 		t.Fatalf("env credential source was not preserved: %+v", profile)
+	}
+}
+
+func TestExistingAimlapiEnvironmentFallbackUsesResolvedEndpoint(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "aimlapi-env-secret")
+	t.Setenv("AIMLAPI_INFERENCE_URL", "https://staging.example.test/v1")
+
+	profile, runtimeKey, ok := (model{}).existingAimlapiConfiguration()
+	if !ok || runtimeKey != "aimlapi-env-secret" {
+		t.Fatalf("configuration = (%+v, %q, %v)", profile, runtimeKey, ok)
+	}
+	if profile.BaseURL != "https://staging.example.test/v1" {
+		t.Fatalf("BaseURL = %q, want resolved override", profile.BaseURL)
+	}
+	if profile.APIKeyEnv != "AIMLAPI_API_KEY" || profile.APIKey != "" {
+		t.Fatalf("credential source changed: %+v", profile)
+	}
+	if len(profile.CustomHeaders) != 0 {
+		t.Fatalf("catalog headers leaked to custom endpoint: %#v", profile.CustomHeaders)
+	}
+}
+
+func TestExistingAimlapiBalanceUsesProfileEndpointAndCancelsOnAbandon(t *testing.T) {
+	started := make(chan struct{})
+	done := make(chan struct{})
+	canonical := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(done)
+	}))
+	defer canonical.Close()
+	override := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("production profile key was sent to process override: %s", r.URL)
+	}))
+	defer override.Close()
+	t.Setenv("AIMLAPI_INFERENCE_URL", override.URL)
+
+	wizard := &providerWizardState{
+		step: providerWizardStepAimlapiConfigured,
+		aimlapiExistingProfile: config.ProviderProfile{
+			Name: "aimlapi", CatalogID: "aimlapi", BaseURL: canonical.URL,
+		},
+		aimlapiRuntimeKey: "production-secret",
+	}
+	m := model{ctx: context.Background(), providerWizard: wizard}
+	_, cmd := m.checkExistingAimlapiBalance()
+	result := make(chan tea.Msg, 1)
+	go func() { result <- execCmd(cmd) }()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("profile endpoint did not receive the balance request")
+	}
+	wizard.clearAimlapiExisting()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("abandoning the preflight did not cancel the balance request")
+	}
+	select {
+	case <-result:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled balance command did not return")
+	}
+}
+
+func TestProviderWizardAimlapiPartnerOverrideOnlyOnCanonicalEndpoint(t *testing.T) {
+	provider, err := providercatalog.Require("aimlapi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AIMLAPI_PARTNER_ID", "part_override")
+
+	canonical := providerWizardProfile(provider, provider.DefaultModel, "", provider.DefaultBaseURL, "")
+	if got := canonical.CustomHeaders[aimlapi.PartnerHeaderName]; got != "part_override" {
+		t.Fatalf("canonical partner header = %q, want part_override", got)
+	}
+	custom := providerWizardProfile(provider, provider.DefaultModel, "", "https://staging.example.test/v1", "")
+	if len(custom.CustomHeaders) != 0 {
+		t.Fatalf("partner headers leaked to custom endpoint: %#v", custom.CustomHeaders)
 	}
 }
 

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1315,11 +1316,13 @@ func TestExistingAimlapiConfigurationResolvesStoredKey(t *testing.T) {
 
 func TestAdvanceAimlapiWithExistingCredentialShowsConfiguredPreflight(t *testing.T) {
 	t.Setenv("AIMLAPI_API_KEY", "aimlapi-env-secret")
+	provider, err := providercatalog.Require("aimlapi")
+	if err != nil {
+		t.Fatal(err)
+	}
 	m := model{providerWizard: &providerWizardState{
-		step: providerWizardStepProvider,
-		providers: []providercatalog.Descriptor{{
-			ID: "aimlapi", Name: "aimlapi.com", Transport: providercatalog.TransportOpenAICompatible,
-		}},
+		step:      providerWizardStepProvider,
+		providers: []providercatalog.Descriptor{provider},
 	}}
 
 	next, _ := m.advanceProviderWizard()
@@ -1328,6 +1331,9 @@ func TestAdvanceAimlapiWithExistingCredentialShowsConfiguredPreflight(t *testing
 	}
 	if next.providerWizard.aimlapiExistingProfile.APIKeyEnv != "AIMLAPI_API_KEY" {
 		t.Fatalf("profile = %+v", next.providerWizard.aimlapiExistingProfile)
+	}
+	if !maps.Equal(next.providerWizard.aimlapiExistingProfile.CustomHeaders, provider.CustomHeaders) {
+		t.Fatalf("catalog headers were not preserved: %#v", next.providerWizard.aimlapiExistingProfile.CustomHeaders)
 	}
 }
 
@@ -1381,6 +1387,7 @@ func TestApplyExistingAimlapiPreservesEnvCredentialSource(t *testing.T) {
 	}
 	provider := providercatalog.Descriptor{
 		ID: "aimlapi", Name: "aimlapi.com", Transport: providercatalog.TransportOpenAICompatible,
+		CustomHeaders: map[string]string{"X-AIMLAPI-Partner-ID": "partner"},
 	}
 	m := model{
 		userConfigPath: configPath,
@@ -1392,6 +1399,7 @@ func TestApplyExistingAimlapiPreservesEnvCredentialSource(t *testing.T) {
 			modelSource:   "live",
 			aimlapiExistingProfile: config.ProviderProfile{
 				Name: "aimlapi", CatalogID: "aimlapi", APIKeyEnv: "AIMLAPI_API_KEY", Model: "model/old",
+				CustomHeaders: maps.Clone(provider.CustomHeaders),
 			},
 			aimlapiRuntimeKey: "runtime-secret",
 		},
@@ -1411,6 +1419,9 @@ func TestApplyExistingAimlapiPreservesEnvCredentialSource(t *testing.T) {
 	}
 	if got.Model != "model/new" {
 		t.Fatalf("model = %q, want model/new", got.Model)
+	}
+	if !maps.Equal(got.CustomHeaders, provider.CustomHeaders) {
+		t.Fatalf("custom headers changed: %#v", got.CustomHeaders)
 	}
 }
 

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -53,7 +53,7 @@ func TestProviderCommandOpensOnboardingWizard(t *testing.T) {
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 	listView := plainRender(t, next.View())
-	for _, want := range []string{"Choose provider", "GitLawb OpenGateway", "OpenAI", "Anthropic", "Google", "OpenRouter", "Ollama"} {
+	for _, want := range []string{"Choose provider", "aimlapi.com", "GitLawb OpenGateway", "OpenAI", "Anthropic", "Google", "OpenRouter", "Ollama"} {
 		assertContains(t, listView, want)
 	}
 }


### PR DESCRIPTION
## AI/ML API guided onboarding

Adds [AI/ML API](https://aimlapi.com) (aimlapi.com) as a built-in provider with a guided TUI onboarding sub-flow. Instead of leaving the CLI to register, top up, and paste a key by hand, the user goes from "no provider" to a working, funded key without leaving Zero.

Reached from both the first-run setup and the `/provider` wizard by picking **aimlapi.com** from the provider list.

Fixes #651

### Onboarding paths
- **Have a key** — paste it; the key is validated against `/v1/billing/balance` and saved. A low balance offers an optional top-up.
- **New / email** — sign in by email code (or passwordless sign-up), then top up via the hosted partner-checkout page. The browser opens the checkout, the CLI polls the session, and the issued key is written into the provider profile on success.

### Changes
- `internal/aimlapi` — OpenAI-compatible client, partner-checkout top-up with streamed progress, email/key validation, and endpoint config.
- `providercatalog` / `providermodelcatalog` — register the aimlapi provider (badged recommended) with default headers and a curated model list.
- `tui` — the shared `aimlapiOnboardState` sub-flow, wired into the provider wizard and first-run onboarding; the spinner tick stays alive during the async waits.
- `cli` / `config` — merge the provider's custom headers into `providers add aimlapi` and catalog-resolved profiles.

### Implementation notes
- Took the working OpenClaude integration as a reference and reworked it for a smoother onboarding experience in Zero.
- The sub-flow owns all of its own state and transitions behind a pointer; the two host surfaces only route keys + async messages into it and read the terminal result.
- No new runtime dependencies; endpoints and partner id are overridable via env.

### Testing
- `gofmt`, `go vet ./...`, `go build ./...`, and `go test ./...` pass locally (all packages).
- `go run ./cmd/zero-release build` + `smoke`, `zero-perf-bench --ci`, and `govulncheck ./...` pass — the blocking gates of the three CI jobs.
- New tests cover `internal/aimlapi` (client, config, onboarding) and the `internal/tui` onboarding flow.
- `-race` was not run locally (no cgo toolchain on the dev box); CI's `go test ./...` covers the suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AIMLAPI as a recommended provider with an expanded model preset catalog.
  * Introduced a guided AIMLAPI onboarding flow (API key or passwordless email verification) with automated API key provisioning.
  * Added session-based partner checkout with payment progress, browser checkout links, balance checking, optional auto top-up, and by-key top-ups (with resume support).
  * Added environment-driven endpoint and return-URL configuration.
  * Extended the provider wizard to reuse existing AIMLAPI credentials and show a “configured” preflight step.
* **Bug Fixes**
  * Improved header merging/overrides and refined AIMLAPI TUI link rendering, spinner/progress transitions, and back-navigation.
* **Tests**
  * Added/expanded AIMLAPI client, config, onboarding, provider wizard, and streaming top-up test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->