### PR TITLE
feat(tui): press up to edit queued messages

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1749,6 +1749,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if next, ok := m.moveComposerVisualCursor(-1); ok {
 				return next, nil
 			}
+			// A queued message takes ↑ priority over history recall: pop it back
+			// into the composer for editing before it sends on the next turn.
+			if m.hasQueuedMessage() && m.pendingSpecReview == nil {
+				return m.popQueuedMessageForEdit(), nil
+			}
 			if m.historyRecallActive() {
 				return m.recallHistory(-1), nil
 			}
@@ -3448,6 +3453,9 @@ func (m model) appendStreamingCursor(lines []string, width int) []string {
 // composerLine renders the borderless composer.
 func (m model) composerLine(width int) string {
 	input := m.input
+	if m.hasQueuedMessage() {
+		input.Placeholder = queuedEditHint
+	}
 	hideInputForSuggestions := m.suggestionsActive() && (!m.suggestionsAreFiles || fileSuggestionOnlyInput(m.input.Value()))
 	if hideInputForSuggestions {
 		input.SetValue("")

--- a/internal/tui/queued_message.go
+++ b/internal/tui/queued_message.go
@@ -2,15 +2,43 @@ package tui
 
 import "strings"
 
+// queuedEditHint replaces the composer placeholder while a message is queued,
+// in the style of openclaude's "Press up to edit queued messages".
+const queuedEditHint = "Press up to edit queued messages"
+
 func (m model) queueMessage(text string) model {
 	text = strings.TrimSpace(text)
 	if text == "" {
 		return m
 	}
+	// A second prompt queued during the same run stacks under the first
+	// rather than silently replacing it; both send as one message.
+	if m.hasQueuedMessage() {
+		text = m.queuedMessage + "\n" + text
+	}
 	m.queuedMessage = text
 	m.rememberInput(text)
 	m.clearComposer()
 	m.clearSuggestions()
+	return m
+}
+
+// popQueuedMessageForEdit moves the queued message back into the composer so
+// it can be edited before the next turn. Queued text lands above whatever is
+// already being typed, mirroring openclaude's press-up flow.
+func (m model) popQueuedMessageForEdit() model {
+	if !m.hasQueuedMessage() {
+		return m
+	}
+	text := m.queuedMessage
+	m.queuedMessage = ""
+	if draft := m.composerValue(); strings.TrimSpace(draft) != "" {
+		text += "\n" + draft
+	}
+	// Multiline text must go through the composer state: m.input only holds a
+	// flattened display copy (see syncInputFromComposer).
+	m.setComposerState(composerState{text: text, cursor: len([]rune(text))})
+	m.recomputeSuggestions()
 	return m
 }
 

--- a/internal/tui/queued_message.go
+++ b/internal/tui/queued_message.go
@@ -2,8 +2,8 @@ package tui
 
 import "strings"
 
-// queuedEditHint replaces the composer placeholder while a message is queued,
-// in the style of openclaude's "Press up to edit queued messages".
+// queuedEditHint replaces the composer placeholder while a message is queued
+// and informs the user they can press up to edit it.
 const queuedEditHint = "Press up to edit queued messages"
 
 func (m model) queueMessage(text string) model {
@@ -25,7 +25,7 @@ func (m model) queueMessage(text string) model {
 
 // popQueuedMessageForEdit moves the queued message back into the composer so
 // it can be edited before the next turn. Queued text lands above whatever is
-// already being typed, mirroring openclaude's press-up flow.
+// already being typed.
 func (m model) popQueuedMessageForEdit() model {
 	if !m.hasQueuedMessage() {
 		return m

--- a/internal/tui/queued_message_test.go
+++ b/internal/tui/queued_message_test.go
@@ -203,6 +203,94 @@ func TestAgentResponseLaunchesQueuedPromptAfterError(t *testing.T) {
 	}
 }
 
+func TestUpArrowPopsQueuedMessageIntoComposer(t *testing.T) {
+	m := newQueuedMessageTestModel(t)
+	m.pending = true
+	m.activeRunID = 1
+	m.runID = 1
+	m.width = 96
+	m.input.SetValue("queued followup")
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	updated, _ = next.Update(testKey(tea.KeyUp))
+	next = updated.(model)
+
+	if next.hasQueuedMessage() {
+		t.Fatalf("expected ↑ to pop the queued message, still queued: %q", next.queuedMessage)
+	}
+	if got := next.composerValue(); got != "queued followup" {
+		t.Fatalf("expected queued message back in the composer, got %q", got)
+	}
+}
+
+func TestUpArrowPutsQueuedMessageAboveDraft(t *testing.T) {
+	m := newQueuedMessageTestModel(t)
+	m.pending = true
+	m.activeRunID = 1
+	m.runID = 1
+	m.width = 96
+	m.input.SetValue("first queued")
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	next.input.SetValue("in-progress draft")
+
+	updated, _ = next.Update(testKey(tea.KeyUp))
+	next = updated.(model)
+
+	if next.hasQueuedMessage() {
+		t.Fatalf("expected ↑ to pop the queued message, still queued: %q", next.queuedMessage)
+	}
+	if got := next.composerValue(); got != "first queued\nin-progress draft" {
+		t.Fatalf("expected queued text above the draft, got %q", got)
+	}
+}
+
+func TestQueuedMessageShowsUpEditHint(t *testing.T) {
+	m := newQueuedMessageTestModel(t)
+	m.pending = true
+	m.activeRunID = 1
+	m.runID = 1
+	m.width = 96
+	m.input.SetValue("queued followup")
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	view := viewString(next.View())
+	if !strings.Contains(view, queuedEditHint) {
+		t.Fatalf("expected composer placeholder %q while a message is queued, got:\n%s", queuedEditHint, view)
+	}
+
+	updated, _ = next.Update(testKey(tea.KeyUp))
+	next = updated.(model)
+	view = viewString(next.View())
+	if strings.Contains(view, queuedEditHint) {
+		t.Fatalf("expected hint to clear once the queued message is popped, got:\n%s", view)
+	}
+}
+
+func TestSecondQueuedMessageStacksUnderFirst(t *testing.T) {
+	m := newQueuedMessageTestModel(t)
+	m.pending = true
+	m.activeRunID = 1
+	m.runID = 1
+	m.input.SetValue("first queued")
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	next.input.SetValue("second queued")
+
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+
+	if got := next.queuedMessage; got != "first queued\nsecond queued" {
+		t.Fatalf("expected second prompt to stack under the first, got %q", got)
+	}
+}
+
 func newQueuedMessageTestModel(t *testing.T) model {
 	t.Helper()
 


### PR DESCRIPTION
## What

Pressing the up arrow while a message is queued pops it back into the composer for editing, instead of navigating input history. While a message is queued, the empty composer shows a placeholder hint: "Press up to edit queued messages".

## Why

Once a prompt was queued during an active run there was no way to take it back for editing; the only options were letting it send or discarding it with Esc. This mirrors the flow in other agent TUIs where up recalls the queued message.

## Changes

- Up arrow pops the queued message into the composer, taking priority over history recall. A draft already being typed is preserved below the queued text.
- Empty composer shows the edit hint as its placeholder while a message is queued, and reverts once popped.
- Bug fix: queueing a second prompt during the same run used to silently replace the first. It now stacks under it, so both send as one message.

## Testing

Four new tests in queued_message_test.go cover the pop, queued-above-draft ordering, hint visibility, and stacking. Full internal/tui suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled editing queued follow-ups with the **Up arrow** by moving them into the composer.
  - When composing is in progress, queued text is placed above the existing draft.
  - Added a visual hint while a queued message is available, and it disappears after popping it into the editor.
  - If multiple follow-ups are queued in a row, new queued text is appended to the existing queued message.
- **Tests**
  - Added unit tests for queued-message edit, stacking, cursor placement, and hint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->