### PR TITLE
fix(sandbox): use WRITE_RESTRICTED token when no DenyRead paths are configured

### DIFF
--- a/internal/sandbox/windows_command_runner_windows.go
+++ b/internal/sandbox/windows_command_runner_windows.go
@@ -69,7 +69,13 @@ func runWindowsSandboxCommand(config WindowsSandboxCommandConfig, stderr io.Writ
 	// this has no in-token fix; preflight blocking and output hints live in
 	// internal/tools/shell_runtime.go.
 	tokenSIDs := windowsRuntimeTokenSIDs(capabilitySIDs, offlineSID, config.PermissionProfile.Network.Mode)
-	token, err := createWindowsRestrictedTokenForCapabilitySIDs(tokenSIDs)
+	// A WRITE_RESTRICTED token keeps reads unrestricted so sandboxed commands
+	// can actually launch executables; it is only unsafe when DenyRead paths
+	// are configured, because the kernel skips restricted-SID deny ACEs for
+	// reads under that flag (#612). Profiles with DenyRead keep the fully
+	// restricted token, trading spawn capability for read-deny enforcement.
+	writeRestricted := len(config.PermissionProfile.FileSystem.DenyRead) == 0
+	token, err := createWindowsRestrictedTokenForCapabilitySIDs(tokenSIDs, writeRestricted)
 	if err != nil {
 		fmt.Fprintln(stderr, WindowsSandboxCommandRunnerName+": "+err.Error())
 		return 1

--- a/internal/sandbox/windows_token_windows.go
+++ b/internal/sandbox/windows_token_windows.go
@@ -48,7 +48,7 @@ func (sid windowsLocalSID) close() {
 	}
 }
 
-func createWindowsRestrictedTokenForCapabilitySIDs(capabilitySIDStrings []string) (windows.Token, error) {
+func createWindowsRestrictedTokenForCapabilitySIDs(capabilitySIDStrings []string, writeRestricted bool) (windows.Token, error) {
 	if len(capabilitySIDStrings) == 0 {
 		return 0, errors.New("windows restricted token requires at least one capability SID")
 	}
@@ -80,10 +80,10 @@ func createWindowsRestrictedTokenForCapabilitySIDs(capabilitySIDStrings []string
 		return 0, fmt.Errorf("open process token: %w", err)
 	}
 	defer base.Close()
-	return createWindowsRestrictedTokenFromBase(base, capabilitySIDs)
+	return createWindowsRestrictedTokenFromBase(base, capabilitySIDs, writeRestricted)
 }
 
-func createWindowsRestrictedTokenFromBase(base windows.Token, capabilitySIDs []windowsLocalSID) (windows.Token, error) {
+func createWindowsRestrictedTokenFromBase(base windows.Token, capabilitySIDs []windowsLocalSID, writeRestricted bool) (windows.Token, error) {
 	logonSID, err := copyWindowsLogonSID(base)
 	if err != nil {
 		return 0, err
@@ -102,10 +102,28 @@ func createWindowsRestrictedTokenFromBase(base windows.Token, capabilitySIDs []w
 		windows.SIDAndAttributes{Sid: worldSID},
 	)
 
+	// WRITE_RESTRICTED scopes the restricted-SID check to write-type accesses:
+	// reads use only the normal token identity, so the sandboxed process can
+	// open executables, DLLs, and per-user config the user can read, while
+	// writes still require a restricted-SID match (the workspace write-jail).
+	// Without it the restricted-SID check applies to READS too, and because
+	// default Windows DACLs grant BUILTIN\Users rather than any SID in the
+	// restricted list, the token cannot open ANY executable outside the
+	// ACL-granted write roots — every spawned command dies silently.
+	//
+	// The flag also makes the kernel skip restricted-SID deny ACEs for reads,
+	// which is the DenyRead bypass fixed in #612 — so it is only safe when the
+	// profile has no DenyRead paths. The caller passes writeRestricted=false
+	// whenever DenyRead is configured, keeping #612's enforcement for exactly
+	// the profiles that need it.
+	flags := uint32(windowsDisableMaxPrivilege | windowsLUAToken)
+	if writeRestricted {
+		flags |= windowsWriteRestricted
+	}
 	var restricted windows.Token
 	result, _, callErr := procCreateRestrictedToken.Call(
 		uintptr(base),
-		uintptr(windowsDisableMaxPrivilege|windowsLUAToken),
+		uintptr(flags),
 		0,
 		0,
 		0,


### PR DESCRIPTION
## Problem

Since #612 removed the WRITE_RESTRICTED flag, the Windows sandbox token applies the restricted-SID check to reads as well as writes. Default Windows DACLs grant BUILTIN\Users, not any SID in the token's restricted list (the random capability SIDs, the logon SID, and Everyone). The result is that a wrapped command cannot open any executable or non-KnownDlls DLL anywhere on the system:

- The wrapped cmd.exe starts (its imports come from KnownDlls, and the unrestricted runner opens cmd.exe itself), but every child it spawns fails: gh, git, where.exe, even a nested cmd.exe, all exit 1 with zero bytes of output.
- A directly wrapped where.exe dies with STATUS_DLL_NOT_FOUND (0xC0000135).
- Because the failures are completely silent, the sandbox-denial keyword heuristics never fire, so no unsandboxed-retry prompt is offered and agent sessions strand on "Command completed with no output".

The env-gated smoke test TestWindowsRestrictedTokenNestedPipeCapture (spawns whoami.exe from inside the sandbox) reproduces this on current main.

## Fix

Restore WRITE_RESTRICTED, but only when the permission profile has no DenyRead paths. The flag makes the kernel skip restricted-SID deny ACEs for reads, which is exactly the DenyRead bypass #612 fixed, so profiles that configure DenyRead keep the fully restricted token and trade spawn capability for read-deny enforcement. DenyRead is empty by default, so the common case gets a working sandbox back while the #612 guarantee holds for the profiles that rely on it.

## Verification (Windows 11, real smoke tests)

With ZERO_SANDBOX_REAL_SMOKE=1 and the runner built from this branch:

- TestWindowsRestrictedTokenNestedPipeCapture passes (fails against a runner built from main).
- TestWindowsUnelevatedRealSandboxSmoke passes, including the DenyRead assertion added in #612 (that profile configures DenyRead, so it exercises the fully restricted branch).
- Manual check through the runner: `cmd /d /c "git --version & gh --version"` under an unelevated restricted-token profile prints both versions and exits 0; on main it exits 1 with no output.

`go build ./...` and `go test ./internal/sandbox ./internal/tools ./internal/agent` pass.

## Relation to #640

#640 attacks the same regression by adding Users and Authenticated Users to the restricted-SID list. That restores executable reads, but it also widens the write jail to every location where those groups hold write access, and it still blocks reads of per-user files (profile directories grant the individual user, not the Users group), so gh can spawn but cannot read its own config. This PR keeps the write jail scoped to the capability SIDs and restores all reads the user can normally perform. Happy to close one in favor of the other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows sandbox filesystem access enforcement based on configured read restrictions.
  - Read-denied paths now receive more consistent protection while preserving appropriate write restrictions.
  - Enhanced handling of restricted permissions for improved sandbox security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->