### PR TITLE
fix(tools): classify silent wrapped Windows command failures as sandbox denials

### DIFF
--- a/internal/tools/sandbox_denial.go
+++ b/internal/tools/sandbox_denial.go
@@ -66,7 +66,34 @@ func sandboxDenialKind(plan zeroSandbox.CommandPlan, exitCode int, sections ...s
 	if plan.TargetBackend == zeroSandbox.BackendLinuxBwrap && exitCode == 128+31 {
 		return SandboxDenialKindSandbox, "seccomp"
 	}
+	// Windows restricted-token failures are often SILENT: a spawn the token
+	// cannot satisfy (executable or DLL unreadable under the restricted-SID
+	// check, MSYS runtime init death, loader status 0xC0000135/0xC0000142)
+	// produces a nonzero exit with no output at all, so none of the keyword
+	// heuristics above can ever fire. Treat "wrapped Windows command failed
+	// without writing a single byte" as a likely sandbox denial so the caller
+	// offers the unsandboxed-retry prompt instead of surfacing a bare
+	// "command completed with no output". A command that legitimately fails
+	// silently (findstr with no match, for one) costs one extra approval
+	// prompt; the inverse misclassification silently strands the whole
+	// session, so the trade goes to prompting.
+	if windowsWrappedBackend(plan.TargetBackend) && sectionsEmpty(sections...) {
+		return SandboxDenialKindSandbox, "no output from sandboxed command"
+	}
 	return "", ""
+}
+
+func windowsWrappedBackend(backend zeroSandbox.BackendName) bool {
+	return backend == zeroSandbox.BackendWindowsRestrictedToken || backend == zeroSandbox.BackendWindowsElevated
+}
+
+func sectionsEmpty(sections ...string) bool {
+	for _, section := range sections {
+		if strings.TrimSpace(section) != "" {
+			return false
+		}
+	}
+	return true
 }
 
 func networkDeniedBySandbox(plan zeroSandbox.CommandPlan) bool {

--- a/internal/tools/sandbox_denial_test.go
+++ b/internal/tools/sandbox_denial_test.go
@@ -42,3 +42,48 @@ func TestLikelySandboxDeniedIgnoresUnsandboxedFailure(t *testing.T) {
 		t.Fatal("unsandboxed command output must not be classified as a sandbox denial")
 	}
 }
+
+func TestLikelySandboxDeniedDetectsSilentWindowsWrappedFailure(t *testing.T) {
+	plan := zeroSandbox.CommandPlan{
+		Wrapped:       true,
+		TargetBackend: zeroSandbox.BackendWindowsRestrictedToken,
+	}
+	if !likelySandboxDenied(plan, 1, "", "  \n") {
+		t.Fatal("wrapped Windows command failing with empty output must be classified as sandbox denied")
+	}
+	meta := map[string]string{}
+	markLikelySandboxDenial(meta, plan, 1, "")
+	if meta[SandboxLikelyDeniedMeta] != "true" || meta[SandboxDenialKindMeta] != SandboxDenialKindSandbox {
+		t.Fatalf("silent windows denial meta = %#v", meta)
+	}
+}
+
+func TestLikelySandboxDeniedIgnoresSilentWindowsWrappedSuccess(t *testing.T) {
+	plan := zeroSandbox.CommandPlan{
+		Wrapped:       true,
+		TargetBackend: zeroSandbox.BackendWindowsRestrictedToken,
+	}
+	if likelySandboxDenied(plan, 0, "") {
+		t.Fatal("wrapped Windows command exiting 0 with empty output must not be classified as sandbox denied")
+	}
+}
+
+func TestLikelySandboxDeniedIgnoresSilentFailureOnOtherBackends(t *testing.T) {
+	plan := zeroSandbox.CommandPlan{
+		Wrapped:       true,
+		TargetBackend: zeroSandbox.BackendLinuxBwrap,
+	}
+	if likelySandboxDenied(plan, 1, "") {
+		t.Fatal("silent nonzero exit on non-Windows backends must not be classified as sandbox denied")
+	}
+}
+
+func TestLikelySandboxDeniedIgnoresSilentWindowsFailureWithOutput(t *testing.T) {
+	plan := zeroSandbox.CommandPlan{
+		Wrapped:       true,
+		TargetBackend: zeroSandbox.BackendWindowsRestrictedToken,
+	}
+	if likelySandboxDenied(plan, 1, "fatal: not a git repository") {
+		t.Fatal("a wrapped Windows command that produced unrelated output must not be classified as sandbox denied")
+	}
+}

--- a/internal/tools/sandbox_denial_test.go
+++ b/internal/tools/sandbox_denial_test.go
@@ -44,17 +44,22 @@ func TestLikelySandboxDeniedIgnoresUnsandboxedFailure(t *testing.T) {
 }
 
 func TestLikelySandboxDeniedDetectsSilentWindowsWrappedFailure(t *testing.T) {
-	plan := zeroSandbox.CommandPlan{
-		Wrapped:       true,
-		TargetBackend: zeroSandbox.BackendWindowsRestrictedToken,
-	}
-	if !likelySandboxDenied(plan, 1, "", "  \n") {
-		t.Fatal("wrapped Windows command failing with empty output must be classified as sandbox denied")
-	}
-	meta := map[string]string{}
-	markLikelySandboxDenial(meta, plan, 1, "")
-	if meta[SandboxLikelyDeniedMeta] != "true" || meta[SandboxDenialKindMeta] != SandboxDenialKindSandbox {
-		t.Fatalf("silent windows denial meta = %#v", meta)
+	for _, backend := range []zeroSandbox.BackendName{
+		zeroSandbox.BackendWindowsRestrictedToken,
+		zeroSandbox.BackendWindowsElevated,
+	} {
+		plan := zeroSandbox.CommandPlan{
+			Wrapped:       true,
+			TargetBackend: backend,
+		}
+		if !likelySandboxDenied(plan, 1, "", "  \n") {
+			t.Fatalf("wrapped Windows command failing with empty output must be classified as sandbox denied (backend %s)", backend)
+		}
+		meta := map[string]string{}
+		markLikelySandboxDenial(meta, plan, 1, "")
+		if meta[SandboxLikelyDeniedMeta] != "true" || meta[SandboxDenialKindMeta] != SandboxDenialKindSandbox {
+			t.Fatalf("silent windows denial meta = %#v (backend %s)", meta, backend)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

A Windows restricted-token sandbox failure is often completely silent. When the token cannot open the target executable or one of its DLLs (see #658), or an MSYS runtime dies during init, the wrapped command exits nonzero having written zero bytes to stdout and stderr. The denial detection in internal/tools/sandbox_denial.go is keyword-based, so these failures are never marked as sandbox denials. The agent loop then never offers the unsandboxed-retry prompt, and the model is left retrying "Command completed with no output" until it gives up. This is exactly the failure mode that stranded a real session: six consecutive gh/git calls returned exit 1 with empty output and no diagnostic.

## Fix

Treat a wrapped command on the Windows restricted-token or elevated backend that exits nonzero with completely empty combined output as a likely sandbox denial (kind: sandbox). This routes the result into the existing escalation path, so the user gets the retry-unsandboxed prompt instead of a bare failure.

Trade-off: a command that legitimately fails silently (findstr with no match, for example) now costs one extra approval prompt. The inverse misclassification silently strands the whole session, so the trade goes to prompting. Other backends are unaffected: bwrap and seatbelt failures are not silent in this way, and the existing keyword and seccomp checks are unchanged.

## Verification

New unit tests cover the silent-failure classification, the exit-0 and non-Windows non-cases, and a failure that produced output. `go build ./...` and `go test ./internal/tools ./internal/agent ./internal/sandbox` pass.

Complementary to #658: that PR fixes the most common cause of these silent failures, this one makes any remaining ones (MSYS init deaths, Schannel-style limitations, DenyRead-configured profiles that keep the fully restricted token) recoverable instead of dead ends.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of sandbox-denied commands on wrapped Windows backends when commands fail without producing output.
  * Ensured silent failures are only classified as sandbox denials in the correct wrapped Windows scenarios; prevented false positives for successful runs, non-Windows backends, and commands with unrelated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->