### PR TITLE
feat(providers): refresh MiniMax model and endpoint coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,41 @@ export OPENAI_API_KEY=sk-...
 export ANTHROPIC_API_KEY=...
 export GEMINI_API_KEY=...
 export LONGCAT_API_KEY=...
+export MINIMAX_API_KEY=...
+export MINIMAXI_API_KEY=...
 ```
 
 To configure Meituan LongCat (LongCat-2.0) directly, run:
 
 ```bash
 zero providers setup longcat --set-active
+```
+
+MiniMax presets use the Anthropic-compatible endpoints for the global and China
+regions:
+
+```bash
+zero providers add minimax --set-active
+zero providers add minimaxi-cn --set-active
+```
+
+To use the OpenAI-compatible endpoints instead, add a custom compatible profile
+for the required region:
+
+```bash
+zero providers add custom-openai-compatible \
+  --name minimax-openai \
+  --model MiniMax-M3 \
+  --base-url https://api.minimax.io/v1 \
+  --api-key-env MINIMAX_API_KEY \
+  --set-active
+
+zero providers add custom-openai-compatible \
+  --name minimax-cn-openai \
+  --model MiniMax-M3 \
+  --base-url https://api.minimaxi.com/v1 \
+  --api-key-env MINIMAXI_API_KEY \
+  --set-active
 ```
 
 For local models, run Ollama or LM Studio and then use `zero setup` or

--- a/internal/modelregistry/vision.go
+++ b/internal/modelregistry/vision.go
@@ -58,7 +58,7 @@ func VisionCapableByName(modelID string) bool {
 		strings.Contains(id, "qwen-vl"), strings.Contains(id, "qwenvl"):
 		return true // Qwen VL series are multimodal
 	case strings.Contains(id, "minimax-m3"):
-		return false // MiniMax M3 is text-only (the user confirmed this)
+		return true // MiniMax M3 accepts image input
 	case strings.Contains(id, "llava"), strings.Contains(id, "pixtral"),
 		strings.Contains(id, "internvl"), strings.Contains(id, "minicpm-v"),
 		strings.Contains(id, "moondream"), strings.Contains(id, "bakllava"),

--- a/internal/modelregistry/vision_name_test.go
+++ b/internal/modelregistry/vision_name_test.go
@@ -8,6 +8,7 @@ func TestVisionCapableByName(t *testing.T) {
 		"grok-4.3", "grok-4-fast", "grok-2-vision",
 		"gpt-4o", "gpt-4.1-mini", "gpt-4-turbo", "gpt-5", "o3-mini", "o1",
 		"claude-sonnet-4.5", "claude-3-haiku",
+		"MiniMax-M3",
 		"llava:13b", "qwen2.5-vl-7b", "llama3.2-vision", "pixtral-12b", "moondream",
 	}
 	textOnly := []string{
@@ -38,7 +39,7 @@ func TestSupportsVisionFallbackForUnknownModels(t *testing.T) {
 		t.Error("gpt-4o should be vision (catalog)")
 	}
 	// Unknown-to-catalog but real vision models now pass via the name fallback.
-	for _, m := range []string{"gemini-3-flash-preview", "grok-4.3"} {
+	for _, m := range []string{"gemini-3-flash-preview", "grok-4.3", "MiniMax-M3"} {
 		if !SupportsVision(reg, m) {
 			t.Errorf("%q should be vision via name fallback", m)
 		}

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -21,10 +21,33 @@ type Model struct {
 	Source           string
 }
 
+const minimaxModelSource = "https://platform.minimax.io/docs/api-reference/api-overview"
+
 // Shared by both "minimax" and "minimaxi-cn"; Models() rebuilds a fresh slice
 // per call, so the shared backing slice cannot be mutated by callers.
+// Flat cost fields stay unset because MiniMax-M3 pricing is tiered and this
+// catalog model shape cannot represent those tiers without losing information.
 var minimaxCuratedModels = []Model{
-	{ID: "MiniMax-M3", Description: "catalog default"},
+	{
+		ID:               "MiniMax-M3",
+		Description:      "catalog default",
+		ContextWindow:    1_000_000,
+		ToolCall:         true,
+		Reasoning:        true,
+		InputModalities:  []string{"text", "image", "video"},
+		OutputModalities: []string{"text"},
+		Source:           minimaxModelSource,
+	},
+	{
+		ID:               "MiniMax-M2.7",
+		Description:      "agentic coding model",
+		ContextWindow:    204_800,
+		ToolCall:         true,
+		Reasoning:        true,
+		InputModalities:  []string{"text"},
+		OutputModalities: []string{"text"},
+		Source:           minimaxModelSource,
+	},
 	{ID: "MiniMax-M2.1", Description: "agentic coding model"},
 }
 
@@ -222,10 +245,21 @@ func dedupeModels(defaultModel string, models []Model) []Model {
 		if model.Description == "" {
 			model.Description = "catalog model"
 		}
+		model.InputModalities = append([]string{}, model.InputModalities...)
+		model.OutputModalities = append([]string{}, model.OutputModalities...)
+		model.Tags = append([]string{}, model.Tags...)
 		seen[model.ID] = true
 		result = append(result, model)
 	}
-	add(Model{ID: defaultModel, Description: "catalog default"})
+	defaultEntry := Model{ID: defaultModel, Description: "catalog default"}
+	for _, model := range models {
+		if strings.TrimSpace(model.ID) == strings.TrimSpace(defaultModel) {
+			defaultEntry = model
+			defaultEntry.Description = "catalog default"
+			break
+		}
+	}
+	add(defaultEntry)
 	for _, model := range models {
 		add(model)
 	}

--- a/internal/providermodelcatalog/catalog_test.go
+++ b/internal/providermodelcatalog/catalog_test.go
@@ -1,6 +1,7 @@
 package providermodelcatalog
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/providercatalog"
@@ -39,7 +40,7 @@ func TestModelsAreProviderScoped(t *testing.T) {
 		},
 		{
 			provider: "minimaxi-cn",
-			want:     []string{"MiniMax-M3", "MiniMax-M2.1"},
+			want:     []string{"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.1"},
 			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5"},
 		},
 		{
@@ -89,18 +90,19 @@ func TestModelsAreProviderScoped(t *testing.T) {
 }
 
 func TestModelsDoNotAliasMutableCatalogState(t *testing.T) {
-	descriptor, ok := providercatalog.Get("groq")
+	descriptor, ok := providercatalog.Get("minimax")
 	if !ok {
-		t.Fatal("provider groq missing from catalog")
+		t.Fatal("provider minimax missing from catalog")
 	}
 	first := Models(descriptor)
-	if len(first) == 0 {
-		t.Fatal("expected groq models")
+	if len(first) == 0 || len(first[0].InputModalities) == 0 {
+		t.Fatal("expected MiniMax models with input modalities")
 	}
 	first[0].ID = "mutated"
+	first[0].InputModalities[0] = "mutated"
 
 	second := Models(descriptor)
-	if second[0].ID == "mutated" {
+	if second[0].ID == "mutated" || second[0].InputModalities[0] == "mutated" {
 		t.Fatal("Models returned aliased mutable catalog state")
 	}
 }
@@ -111,6 +113,35 @@ func modelIDs(models []Model) []string {
 		ids = append(ids, model.ID)
 	}
 	return ids
+}
+
+func TestMiniMaxModelsExposeCurrentCapabilities(t *testing.T) {
+	descriptor, ok := providercatalog.Get("minimax")
+	if !ok {
+		t.Fatal("provider minimax missing from catalog")
+	}
+	models := Models(descriptor)
+	if len(models) < 2 || models[0].ID != "MiniMax-M3" || models[1].ID != "MiniMax-M2.7" {
+		t.Fatalf("MiniMax current models = %#v, want MiniMax-M3 followed by MiniMax-M2.7", modelIDs(models))
+	}
+
+	m3 := models[0]
+	if m3.ContextWindow != 1_000_000 || !m3.ToolCall || !m3.Reasoning {
+		t.Fatalf("MiniMax-M3 capabilities = %#v, want 1M context with tools and reasoning", m3)
+	}
+	if !reflect.DeepEqual(m3.InputModalities, []string{"text", "image", "video"}) ||
+		!reflect.DeepEqual(m3.OutputModalities, []string{"text"}) {
+		t.Fatalf("MiniMax-M3 modalities = input:%#v output:%#v", m3.InputModalities, m3.OutputModalities)
+	}
+
+	m27 := models[1]
+	if m27.ContextWindow != 204_800 || !m27.ToolCall || !m27.Reasoning {
+		t.Fatalf("MiniMax-M2.7 capabilities = %#v, want 204.8K context with tools and reasoning", m27)
+	}
+	if !reflect.DeepEqual(m27.InputModalities, []string{"text"}) ||
+		!reflect.DeepEqual(m27.OutputModalities, []string{"text"}) {
+		t.Fatalf("MiniMax-M2.7 modalities = input:%#v output:%#v", m27.InputModalities, m27.OutputModalities)
+	}
 }
 
 // Pins the contract that MiniMax CN exposes exactly the same model IDs as the

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -127,6 +127,7 @@ func modelMayEmitThinkTags(model string) bool {
 		"glm-z1",
 		"kimi-k2-thinking",
 		"magistral",
+		"minimax-m2",
 		"minimax-m3",
 		"nemotron",
 		"qwen3",

--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -56,6 +56,81 @@ func TestNewCreatesOpenAIProviderWithFactoryOptions(t *testing.T) {
 	}
 }
 
+func TestNewUsesMiniMaxCompatibleEndpoints(t *testing.T) {
+	tests := []struct {
+		name         string
+		catalogID    string
+		providerKind config.ProviderKind
+		baseURL      string
+		responseBody string
+		wantURL      string
+	}{
+		{
+			name:         "global Anthropic",
+			catalogID:    "minimax",
+			providerKind: config.ProviderKindAnthropicCompat,
+			responseBody: "data: {\"type\":\"message_stop\"}\n\n",
+			wantURL:      "https://api.minimax.io/anthropic/v1/messages",
+		},
+		{
+			name:         "China Anthropic",
+			catalogID:    "minimaxi-cn",
+			providerKind: config.ProviderKindAnthropicCompat,
+			responseBody: "data: {\"type\":\"message_stop\"}\n\n",
+			wantURL:      "https://api.minimaxi.com/anthropic/v1/messages",
+		},
+		{
+			name:         "global OpenAI",
+			catalogID:    "custom-openai-compatible",
+			providerKind: config.ProviderKindOpenAICompatible,
+			baseURL:      "https://api.minimax.io/v1",
+			responseBody: "data: [DONE]\n\n",
+			wantURL:      "https://api.minimax.io/v1/chat/completions",
+		},
+		{
+			name:         "China OpenAI",
+			catalogID:    "custom-openai-compatible",
+			providerKind: config.ProviderKindOpenAICompatible,
+			baseURL:      "https://api.minimaxi.com/v1",
+			responseBody: "data: [DONE]\n\n",
+			wantURL:      "https://api.minimaxi.com/v1/chat/completions",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &captureTransport{responseBody: test.responseBody}
+			provider, err := New(config.ProviderProfile{
+				Name:         test.name,
+				CatalogID:    test.catalogID,
+				ProviderKind: test.providerKind,
+				BaseURL:      test.baseURL,
+				APIKey:       "sk-minimax",
+				Model:        "MiniMax-M3",
+			}, Options{HTTPClient: &http.Client{Transport: transport}})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+				Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hello"}},
+			})
+			if err != nil {
+				t.Fatalf("StreamCompletion() error = %v", err)
+			}
+			for range stream {
+			}
+
+			if transport.request == nil {
+				t.Fatal("HTTP client was not used")
+			}
+			if got := transport.request.URL.String(); got != test.wantURL {
+				t.Fatalf("request URL = %q, want %q", got, test.wantURL)
+			}
+		})
+	}
+}
+
 func TestNewPassesOpenGatewayHY3ModelThrough(t *testing.T) {
 	transport := &captureTransport{
 		responseBody: "data: [DONE]\n\n",
@@ -215,6 +290,10 @@ func TestParseThinkTagsForProfileUsesConservativeDefaultsAndOverride(t *testing.
 	openAICompatible := resolvedProfile{providerKind: config.ProviderKindOpenAICompatible, apiModel: "qwen3-coder:480b"}
 	if !parseThinkTagsForProfile(config.ProviderProfile{}, openAICompatible) {
 		t.Fatal("qwen3 OpenAI-compatible model should parse inline think tags by default")
+	}
+	minimaxM27 := resolvedProfile{providerKind: config.ProviderKindOpenAICompatible, apiModel: "MiniMax-M2.7"}
+	if !parseThinkTagsForProfile(config.ProviderProfile{}, minimaxM27) {
+		t.Fatal("MiniMax-M2.7 OpenAI-compatible model should parse inline think tags by default")
 	}
 
 	generic := resolvedProfile{providerKind: config.ProviderKindOpenAICompatible, apiModel: "factory-model"}


### PR DESCRIPTION
Supersedes #611 with a clean history based on the latest `main` branch.

## Summary

- Add `MiniMax-M2.7` to the global and China provider model catalogs.
- Record the current context, reasoning, tool-use, and input modality metadata for `MiniMax-M3` and `MiniMax-M2.7`.
- Enable image input for `MiniMax-M3` and inline thinking parsing for M2.x models on OpenAI-compatible profiles.
- Document the global and China Anthropic-compatible presets and OpenAI-compatible profile configuration.
- Verify the final request URLs for both regions and both compatible protocols.

## Verification

- `go fmt ./...`
- `go test -p 1 ./...`
- `make build-all`
- `go vet ./...`
- `make lint`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --enable-only unused,ineffassign,staticcheck --new-from-rev=origin/main ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for MiniMax M3 image input.
  - Expanded MiniMax model listings with current capabilities, including context limits, reasoning, tool calling, and supported modalities.
  - Added support for MiniMax M2 and M2.7 thinking output and compatible streaming endpoints.
  - Improved handling for global and China-region MiniMax configurations.

- **Documentation**
  - Added setup instructions for MiniMax API keys, presets, and OpenAI-compatible custom profiles.
  - Documented region-specific base URLs and API key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->