### PR TITLE
fix(swarm): wait for job.Runs directly in scheduler skip test

### DIFF
--- a/internal/swarm/scheduler_test.go
+++ b/internal/swarm/scheduler_test.go
@@ -85,6 +85,14 @@ func TestSchedulerSkipsWhilePreviousRuns(t *testing.T) {
 	waitFor(t, "first done", func() bool { return sw.Coordinator().Summarize().Done == 1 })
 	ticks <- time.Time{}
 	waitFor(t, "second spawn", func() bool { return len(l.recorded()) == 2 })
+	// fireIfIdle's spawn (what "second spawn" observes via the launcher) and
+	// run's subsequent job.incRuns() are sequential but distinct steps in the
+	// scheduler's goroutine; wait for Runs itself rather than assuming the
+	// launcher recording it means the job's counter is updated too.
+	waitFor(t, "second run recorded", func() bool {
+		j, ok := findJob(sched.List(), id)
+		return ok && j.Runs == 2
+	})
 
 	j, ok := findJob(sched.List(), id)
 	if !ok {


### PR DESCRIPTION
### Problem
TestSchedulerSkipsWhilePreviousRuns intermittently failed on CI (observed on macOS) with `job runs=1 skipped=1, want 2/1`.

fireIfIdle's Spawn call (which the launcher's recorded() count observes) and run's subsequent job.incRuns() are sequential but distinct steps in the same scheduler goroutine. The test polled only the launcher's recorded count via waitFor, then asserted job.Runs immediately afterward with no wait of its own. Under contention, the scheduler goroutine could be preempted between those two steps, so the test's very next read caught a stale Runs value.

### Solution
Wait for job.Runs to actually reach 2 before asserting on it, instead of relying on the launcher's recorded count as a proxy for it.

Verified with `go test ./internal/swarm/... -run TestSchedulerSkipsWhilePreviousRuns -count=50 -race`, all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved scheduler test reliability by waiting for job execution counts to update before making assertions.
  * Added clarification around the sequence of scheduler events during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->