### PR TITLE
fix(oauth): store keyring tokens as one entry per provider

### DIFF
--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -869,7 +869,7 @@ func (source *storeTokenSource) Refresh(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := source.store.SaveForServer(source.server, refreshed); err != nil {
+	if err := source.store.saveRefreshedForServer(source.server, refreshed); err != nil {
 		return "", err
 	}
 	return refreshed.AccessToken, nil

--- a/internal/mcp/oauth_store.go
+++ b/internal/mcp/oauth_store.go
@@ -163,6 +163,17 @@ func (store *TokenStore) SaveForServer(server Server, token StoredToken) error {
 	return store.store.Save(key, storedToOAuth(token))
 }
 
+// saveRefreshedForServer persists a token obtained by refreshing an existing
+// MCP credential. It is not a login: mixed-version origin markers stay put
+// and a concurrent logout cannot be overwritten.
+func (store *TokenStore) saveRefreshedForServer(server Server, token StoredToken) error {
+	key, err := mcpIdentityKey(server)
+	if err != nil {
+		return err
+	}
+	return store.store.SaveRefreshed(key, storedToOAuth(token))
+}
+
 // Load returns the stored token for a server. The second return value is false
 // when no token has been stored for the server.
 func (store *TokenStore) Load(serverName string) (StoredToken, bool, error) {

--- a/internal/mcp/oauth_store_test.go
+++ b/internal/mcp/oauth_store_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Gitlawb/zero/internal/oauth"
 )
 
 func TestTokenStoreRoundTrip(t *testing.T) {
@@ -489,6 +493,129 @@ func TestStoreTokenSourceRefreshUsesSaveRefreshed(t *testing.T) {
 	if err != nil || !ok || loaded.AccessToken != "mcp-refreshed" {
 		t.Fatalf("LoadForServer after refresh = %#v ok=%v err=%v", loaded, ok, err)
 	}
+}
+
+func TestStoreTokenSourceRefreshHonorsLegacyBinaryLogout(t *testing.T) {
+	// Production graph: MCP 401 refresh must keep legacyOrigin so an old
+	// binary's rewrite of oauth-tokens still hides the credential.
+	kr := &memoryKeyring{data: map[string]string{}}
+	unified, err := oauth.NewStore(oauth.StoreOptions{
+		Storage: "keyring",
+		Keyring: kr,
+		Env:     map[string]string{"XDG_CONFIG_HOME": t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	store := &TokenStore{store: unified}
+	server := testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)
+	key, err := mcpIdentityKey(server)
+	if err != nil {
+		t.Fatalf("mcpIdentityKey: %v", err)
+	}
+
+	t.Run("origin marked then refresh", func(t *testing.T) {
+		writeLegacyOAuthTokens(t, kr, map[string]oauth.Token{
+			key: {AccessToken: "mcp-legacy", RefreshToken: "rt"},
+		})
+		other := testOAuthServer("other", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", false)
+		if err := store.SaveForServer(other, StoredToken{AccessToken: "unrelated"}); err != nil {
+			t.Fatalf("SaveForServer(other) to seed origin: %v", err)
+		}
+		loaded, ok, err := store.LoadForServer(server)
+		if err != nil || !ok || loaded.AccessToken != "mcp-legacy" {
+			t.Fatalf("LoadForServer after origin seed = %#v ok=%v err=%v", loaded, ok, err)
+		}
+
+		refreshMCPServer(t, store, &server)
+		loaded, ok, err = store.LoadForServer(server)
+		if err != nil || !ok || loaded.AccessToken != "mcp-refreshed" {
+			t.Fatalf("LoadForServer after refresh = %#v ok=%v err=%v", loaded, ok, err)
+		}
+
+		writeLegacyOAuthTokens(t, kr, map[string]oauth.Token{})
+		if _, ok, err := store.LoadForServer(server); err != nil || ok {
+			t.Fatalf("LoadForServer after legacy logout = ok %v err %v; want hidden", ok, err)
+		}
+	})
+
+	t.Run("first persist is refresh", func(t *testing.T) {
+		kr.data = map[string]string{}
+		writeLegacyOAuthTokens(t, kr, map[string]oauth.Token{
+			key: {AccessToken: "mcp-legacy-only", RefreshToken: "rt"},
+		})
+		fresh := testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)
+		refreshMCPServer(t, store, &fresh)
+		loaded, ok, err := store.LoadForServer(fresh)
+		if err != nil || !ok || loaded.AccessToken != "mcp-refreshed" {
+			t.Fatalf("LoadForServer after first refresh persist = %#v ok=%v err=%v", loaded, ok, err)
+		}
+		writeLegacyOAuthTokens(t, kr, map[string]oauth.Token{})
+		if _, ok, err := store.LoadForServer(fresh); err != nil || ok {
+			t.Fatalf("LoadForServer after legacy logout = ok %v err %v; want hidden", ok, err)
+		}
+	})
+}
+
+func refreshMCPServer(t *testing.T, store *TokenStore, server *Server) {
+	t.Helper()
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.Form.Get("grant_type") != "refresh_token" {
+			t.Errorf("grant_type = %q", r.Form.Get("grant_type"))
+		}
+		_, _ = w.Write([]byte(`{"access_token":"mcp-refreshed","expires_in":3600}`))
+	}))
+	t.Cleanup(tokenServer.Close)
+	if server.OAuth == nil {
+		server.OAuth = &OAuthConfig{ClientID: "client"}
+	}
+	server.OAuth.TokenEndpoint = tokenServer.URL
+	source := &storeTokenSource{server: *server, store: store, httpClient: tokenServer.Client(), now: time.Now}
+	got, err := source.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got != "mcp-refreshed" {
+		t.Fatalf("Refresh = %q, want mcp-refreshed", got)
+	}
+}
+
+func writeLegacyOAuthTokens(t *testing.T, kr *memoryKeyring, tokens map[string]oauth.Token) {
+	t.Helper()
+	raw, err := json.Marshal(struct {
+		SchemaVersion int                    `json:"schemaVersion"`
+		Tokens        map[string]oauth.Token `json:"tokens"`
+	}{SchemaVersion: 1, Tokens: tokens})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := kr.Set("zero", "oauth-tokens", base64.StdEncoding.EncodeToString(raw)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type memoryKeyring struct {
+	data map[string]string
+}
+
+func (k *memoryKeyring) slot(service, account string) string { return service + "/" + account }
+
+func (k *memoryKeyring) Get(service, account string) (string, bool, error) {
+	v, ok := k.data[k.slot(service, account)]
+	return v, ok, nil
+}
+
+func (k *memoryKeyring) Set(service, account, secret string) error {
+	k.data[k.slot(service, account)] = secret
+	return nil
+}
+
+func (k *memoryKeyring) Delete(service, account string) (bool, error) {
+	key := k.slot(service, account)
+	_, ok := k.data[key]
+	delete(k.data, key)
+	return ok, nil
 }
 
 func TestSaveRefreshedForServerAbortsWhenTokenGone(t *testing.T) {

--- a/internal/mcp/oauth_store_test.go
+++ b/internal/mcp/oauth_store_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -452,6 +454,61 @@ func TestResolveTokenStorePathUsesXDG(t *testing.T) {
 	want := filepath.Join(configHome, "zero", "mcp-oauth-tokens.json")
 	if path != want {
 		t.Fatalf("path = %q, want %q", path, want)
+	}
+}
+
+func TestStoreTokenSourceRefreshUsesSaveRefreshed(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	server := testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)
+	server.OAuth = &OAuthConfig{ClientID: "client"}
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.Form.Get("grant_type") != "refresh_token" {
+			t.Errorf("grant_type = %q", r.Form.Get("grant_type"))
+		}
+		_, _ = w.Write([]byte(`{"access_token":"mcp-refreshed","expires_in":3600}`))
+	}))
+	t.Cleanup(tokenServer.Close)
+	server.OAuth.TokenEndpoint = tokenServer.URL
+
+	if err := store.SaveForServer(server, StoredToken{AccessToken: "stale", RefreshToken: "rt"}); err != nil {
+		t.Fatalf("SaveForServer() error = %v", err)
+	}
+	source := &storeTokenSource{server: server, store: store, httpClient: tokenServer.Client(), now: time.Now}
+	got, err := source.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if got != "mcp-refreshed" {
+		t.Fatalf("Refresh() = %q, want mcp-refreshed", got)
+	}
+	loaded, ok, err := store.LoadForServer(server)
+	if err != nil || !ok || loaded.AccessToken != "mcp-refreshed" {
+		t.Fatalf("LoadForServer after refresh = %#v ok=%v err=%v", loaded, ok, err)
+	}
+}
+
+func TestSaveRefreshedForServerAbortsWhenTokenGone(t *testing.T) {
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "oauth-tokens.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	server := testOAuthServer("demo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)
+	if err := store.SaveForServer(server, StoredToken{AccessToken: "live", RefreshToken: "rt"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.DeleteForServerName("demo"); err != nil {
+		t.Fatal(err)
+	}
+	err = store.saveRefreshedForServer(server, StoredToken{AccessToken: "resurrected", RefreshToken: "rt"})
+	if err == nil {
+		t.Fatal("saveRefreshedForServer after delete succeeded")
+	}
+	if _, ok, err := store.LoadForServer(server); err != nil || ok {
+		t.Fatalf("LoadForServer after aborted refresh = ok %v err %v; token resurrected", ok, err)
 	}
 }
 

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -177,10 +177,11 @@ func Refresh(ctx context.Context, client *http.Client, cfg Config, current Token
 	if len(cfg.Scopes) > 0 {
 		form.Set("scope", strings.Join(cfg.Scopes, " "))
 	}
-	// Carry the existing token_type forward: a refresh response commonly omits it,
-	// and PostToken only overwrites TokenType when the response supplies one, so
-	// without seeding it here the type would be silently lost across refreshes (L15).
-	base := Token{Scopes: current.Scopes, RefreshToken: refresh, Account: current.Account, IDToken: current.IDToken, TokenType: current.TokenType}
+	scopes := current.Scopes
+	if len(scopes) == 0 {
+		scopes = cfg.Scopes
+	}
+	base := Token{Scopes: scopes, RefreshToken: refresh, Account: current.Account, IDToken: current.IDToken, TokenType: current.TokenType}
 	return PostToken(ctx, client, cfg.TokenEndpoint, form, base, now)
 }
 

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -167,6 +167,14 @@ func Refresh(ctx context.Context, client *http.Client, cfg Config, current Token
 	if trimmed(cfg.TokenEndpoint) == "" {
 		return Token{}, errors.New("oauth: no token endpoint configured for refresh")
 	}
+	// Prefer the scopes the current token was issued with; fall back to the
+	// configured defaults only when the stored token has none. The same set is
+	// sent on the wire and kept as the base so a response that omits scope
+	// cannot report a different grant than the provider just processed.
+	scopes := current.Scopes
+	if len(scopes) == 0 {
+		scopes = cfg.Scopes
+	}
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refresh)
@@ -174,12 +182,8 @@ func Refresh(ctx context.Context, client *http.Client, cfg Config, current Token
 	if secret := trimmed(cfg.ClientSecret); secret != "" {
 		form.Set("client_secret", secret)
 	}
-	if len(cfg.Scopes) > 0 {
-		form.Set("scope", strings.Join(cfg.Scopes, " "))
-	}
-	scopes := current.Scopes
-	if len(scopes) == 0 {
-		scopes = cfg.Scopes
+	if len(scopes) > 0 {
+		form.Set("scope", strings.Join(scopes, " "))
 	}
 	base := Token{Scopes: scopes, RefreshToken: refresh, Account: current.Account, IDToken: current.IDToken, TokenType: current.TokenType}
 	return PostToken(ctx, client, cfg.TokenEndpoint, form, base, now)

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -299,3 +299,18 @@ func TestRefreshPreservesTokenTypeWhenOmitted(t *testing.T) {
 		t.Fatalf("refresh should carry the existing token_type forward, got %q", tok.TokenType)
 	}
 }
+
+func TestRefreshPreservesScopesWhenOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"new-at","expires_in":3600}`)) // no scope in response
+	}))
+	defer server.Close()
+	cfg := Config{ClientID: "c", TokenEndpoint: server.URL, Scopes: []string{"fallback-scope"}}
+	tok, err := Refresh(context.Background(), server.Client(), cfg, Token{RefreshToken: "keep-me", Scopes: []string{"custom-scope"}}, nil)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if len(tok.Scopes) != 1 || tok.Scopes[0] != "custom-scope" {
+		t.Fatalf("refresh should carry existing scopes forward, got %v", tok.Scopes)
+	}
+}

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -301,7 +301,10 @@ func TestRefreshPreservesTokenTypeWhenOmitted(t *testing.T) {
 }
 
 func TestRefreshPreservesScopesWhenOmitted(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var gotScope string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotScope = r.FormValue("scope")
 		_, _ = w.Write([]byte(`{"access_token":"new-at","expires_in":3600}`)) // no scope in response
 	}))
 	defer server.Close()
@@ -310,7 +313,31 @@ func TestRefreshPreservesScopesWhenOmitted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Refresh: %v", err)
 	}
+	if gotScope != "custom-scope" {
+		t.Fatalf("refresh form scope = %q, want current token scopes", gotScope)
+	}
 	if len(tok.Scopes) != 1 || tok.Scopes[0] != "custom-scope" {
 		t.Fatalf("refresh should carry existing scopes forward, got %v", tok.Scopes)
+	}
+}
+
+func TestRefreshUsesConfigScopesWhenTokenHasNone(t *testing.T) {
+	var gotScope string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotScope = r.FormValue("scope")
+		_, _ = w.Write([]byte(`{"access_token":"new-at","expires_in":3600}`))
+	}))
+	defer server.Close()
+	cfg := Config{ClientID: "c", TokenEndpoint: server.URL, Scopes: []string{"fallback-scope"}}
+	tok, err := Refresh(context.Background(), server.Client(), cfg, Token{RefreshToken: "keep-me"}, nil)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if gotScope != "fallback-scope" {
+		t.Fatalf("refresh form scope = %q, want cfg.Scopes fallback", gotScope)
+	}
+	if len(tok.Scopes) != 1 || tok.Scopes[0] != "fallback-scope" {
+		t.Fatalf("refresh should use cfg scopes when token has none, got %v", tok.Scopes)
 	}
 }

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -342,6 +342,25 @@ func TestRefreshUsesConfigScopesWhenTokenHasNone(t *testing.T) {
 	}
 }
 
+func TestRefreshSendsSelectedScopeOnTokenEndpointError(t *testing.T) {
+	var gotScope string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotScope = r.FormValue("scope")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"token expired"}`))
+	}))
+	defer server.Close()
+	cfg := Config{ClientID: "c", TokenEndpoint: server.URL, Scopes: []string{"fallback-scope"}}
+	_, err := Refresh(context.Background(), server.Client(), cfg, Token{RefreshToken: "expired-rt", Scopes: []string{"custom-scope"}}, nil)
+	if err == nil {
+		t.Fatal("expected refresh failure on HTTP 400")
+	}
+	if gotScope != "custom-scope" {
+		t.Fatalf("refresh form scope = %q, want current token scopes on the failure path", gotScope)
+	}
+}
+
 func TestRefreshFailsOnHTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -341,3 +341,24 @@ func TestRefreshUsesConfigScopesWhenTokenHasNone(t *testing.T) {
 		t.Fatalf("refresh should use cfg scopes when token has none, got %v", tok.Scopes)
 	}
 }
+
+func TestRefreshFailsOnHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"token expired"}`))
+	}))
+	defer server.Close()
+	cfg := Config{ClientID: "c", TokenEndpoint: server.URL}
+	_, err := Refresh(context.Background(), server.Client(), cfg, Token{RefreshToken: "expired-rt"}, nil)
+	if err == nil {
+		t.Fatal("expected refresh failure on HTTP 400")
+	}
+}
+
+func TestRefreshRequiresRefreshToken(t *testing.T) {
+	cfg := Config{ClientID: "c", TokenEndpoint: "https://example.com/token"}
+	_, err := Refresh(context.Background(), nil, cfg, Token{AccessToken: "only-access-token"}, nil)
+	if err == nil {
+		t.Fatal("expected error when token has no refresh token")
+	}
+}

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -23,6 +23,12 @@ var lockSeq atomic.Uint64
 // file is older than fileLockStaleAfter (so a crashed holder cannot deadlock the
 // store). Release is ownership-aware: it removes the lock only if it still holds
 // our token, so a stale-broken holder cannot delete a newer holder's lock.
+//
+// The acquisition deadline is always measured against the real wall clock, never
+// the now parameter: now is StoreOptions.Now, which callers may legitimately fix
+// (e.g. a test or an embedded clock), and deadline := now().Add(fileLockTimeout)
+// followed by now().After(deadline) would then never become true, turning lock
+// contention into an infinite retry loop instead of a timeout error.
 func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 	if now == nil {
 		now = time.Now
@@ -31,7 +37,7 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 		return nil, err
 	}
 	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), now().UnixNano(), lockSeq.Add(1))
-	deadline := now().Add(fileLockTimeout)
+	deadline := time.Now().Add(fileLockTimeout)
 	for {
 		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
@@ -88,7 +94,7 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 			// Lost the reclaim race (or it was actually fresh) — fall through to the
 			// bounded wait rather than hot-spinning on a reclaim that never wins.
 		}
-		if now().After(deadline) {
+		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("oauth: timed out acquiring token lock %s", filepath.Base(lockPath))
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -11,28 +11,39 @@ import (
 	"github.com/Gitlawb/zero/internal/lockutil"
 )
 
-const (
-	// fileLockTimeout is the deadline for acquiring the cross-process lock.
-	// Critical sections held under this lock consist of file operations or a
-	// small number of OS keyring subprocess calls (typically < 100ms total),
-	// so 5 seconds provides a comfortable upper bound under normal operation.
-	fileLockTimeout    = 5 * time.Second
+// Lock timing knobs (vars so tests can shorten absolute ceilings without
+// changing production defaults).
+var (
+	// fileLockTimeout is how long acquisition waits after the last sign of a
+	// healthy holder (or when the lock path cannot be stated). A multi-entry
+	// keyring pass can legitimately run several 10s OS commands while refreshing
+	// the lease; contenders must not give up while that lease stays healthy.
+	// While the holder's mtime stays within fileLockStaleAfter, this idle
+	// deadline is extended so a fixed 5s window cannot fail a healthy peer.
+	fileLockTimeout = 5 * time.Second
+	// fileLockMaxWait is a hard ceiling on total acquisition time so a wedged
+	// peer that somehow keeps refreshing forever cannot pin waiters indefinitely.
+	// Healthy multi-entry writes stay well under this; raise only with evidence.
+	fileLockMaxWait = 2 * time.Minute
+	// fileLockStaleAfter is how old a lock file's mtime must be before a waiter
+	// may reclaim it as abandoned. Must stay above one keyring command timeout
+	// plus lease refresh slack (holders refresh every fileLockRefreshInterval).
 	fileLockStaleAfter = 30 * time.Second
 )
 
 var lockSeq atomic.Uint64
 
 // acquireFileLock takes a cross-process exclusive lock by creating lockPath with
-// O_EXCL. It retries with a short backoff until a timeout, breaking a lock whose
-// file is older than fileLockStaleAfter (so a crashed holder cannot deadlock the
-// store). Release is ownership-aware: it removes the lock only if it still holds
-// our token, so a stale-broken holder cannot delete a newer holder's lock.
+// O_EXCL. It retries with a short backoff while a live holder's lease remains
+// healthy (mtime refreshed within fileLockStaleAfter), reclaiming only a lock
+// older than that threshold so a crashed holder cannot deadlock the store.
+// Release is ownership-aware: it removes the lock only if it still holds our
+// token, so a stale-broken holder cannot delete a newer holder's lock.
 //
-// The acquisition deadline is always measured against the real wall clock, never
-// the now parameter: now is StoreOptions.Now, which callers may legitimately fix
-// (e.g. a test or an embedded clock), and deadline := now().Add(fileLockTimeout)
-// followed by now().After(deadline) would then never become true, turning lock
-// contention into an infinite retry loop instead of a timeout error.
+// Timing always uses the real wall clock, never the now parameter: now is
+// StoreOptions.Now, which callers may legitimately fix (e.g. a test or an
+// embedded clock). Measuring the deadline with that clock would either never
+// fire (fixed clock) or diverge from the mtime lease stamps (wall-clock).
 func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 	if now == nil {
 		now = time.Now
@@ -41,7 +52,8 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 		return nil, err
 	}
 	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), now().UnixNano(), lockSeq.Add(1))
-	deadline := time.Now().Add(fileLockTimeout)
+	start := time.Now()
+	idleDeadline := start.Add(fileLockTimeout)
 	for {
 		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
@@ -80,25 +92,31 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 		// Remove lets two racers both reclaim + recreate and so both hold the lock;
 		// reclaimStaleLock renames the file aside (only one rename wins) and restores
 		// it if it turns out fresh, so a live lock is never deleted out from under it.
-		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > fileLockStaleAfter {
-			cleared, rerr := lockutil.ReclaimStaleLock(lockPath, token, func(reclaimedPath string) bool {
-				info, err := os.Stat(reclaimedPath)
-				return err == nil && time.Since(info.ModTime()) <= fileLockStaleAfter
-			})
-			if rerr != nil {
-				// Reclaim hit a hard failure: the rename aside failed outright, or a
-				// live holder's lock could not be put back (the lock path may be
-				// missing, so re-acquiring would break mutual exclusion). Fail closed
-				// instead of spinning to the deadline.
-				return nil, fmt.Errorf("oauth: reclaim stale token lock: %w", rerr)
+		if info, statErr := os.Stat(lockPath); statErr == nil {
+			if time.Since(info.ModTime()) > fileLockStaleAfter {
+				cleared, rerr := lockutil.ReclaimStaleLock(lockPath, token, func(reclaimedPath string) bool {
+					info, err := os.Stat(reclaimedPath)
+					return err == nil && time.Since(info.ModTime()) <= fileLockStaleAfter
+				})
+				if rerr != nil {
+					// Reclaim hit a hard failure: the rename aside failed outright, or a
+					// live holder's lock could not be put back (the lock path may be
+					// missing, so re-acquiring would break mutual exclusion). Fail closed
+					// instead of spinning to the deadline.
+					return nil, fmt.Errorf("oauth: reclaim stale token lock: %w", rerr)
+				}
+				if cleared {
+					continue
+				}
+				// Lost the reclaim race (or it was actually fresh) — fall through.
+			} else {
+				// Holder looks healthy (lease refreshed recently). Keep waiting for
+				// the critical section to finish rather than timing out after a fixed
+				// window shorter than a legitimate multi-entry keyring pass.
+				idleDeadline = time.Now().Add(fileLockTimeout)
 			}
-			if cleared {
-				continue
-			}
-			// Lost the reclaim race (or it was actually fresh) — fall through to the
-			// bounded wait rather than hot-spinning on a reclaim that never wins.
 		}
-		if time.Now().After(deadline) {
+		if time.Now().After(idleDeadline) || time.Since(start) > fileLockMaxWait {
 			return nil, fmt.Errorf("oauth: timed out acquiring token lock %s", filepath.Base(lockPath))
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -35,19 +35,22 @@ var lockSeq atomic.Uint64
 // older than that threshold so a crashed holder cannot deadlock the store.
 // Release is ownership-aware: it removes the lock only if it still holds our
 // token, so a stale-broken holder cannot delete a newer holder's lock.
+// The returned token is the contents written into the lock file; lease refresh
+// must re-check it before touching mtime so a replaced holder cannot keep a
+// thief's lock alive.
 //
 // Timing always uses the real wall clock, never the now parameter: now is
 // StoreOptions.Now, which callers may legitimately fix (e.g. a test or an
 // embedded clock). Measuring the deadline with that clock would either never
 // fire (fixed clock) or diverge from the mtime lease stamps (wall-clock).
-func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
+func acquireFileLock(lockPath string, now func() time.Time) (unlock func(), token string, err error) {
 	if now == nil {
 		now = time.Now
 	}
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), now().UnixNano(), lockSeq.Add(1))
+	token = fmt.Sprintf("%d-%d-%d", os.Getpid(), now().UnixNano(), lockSeq.Add(1))
 	idleDeadline := time.Now().Add(fileLockTimeout)
 	for {
 		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
@@ -58,11 +61,11 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 			if _, werr := f.WriteString(token); werr != nil {
 				_ = f.Close()
 				_ = lockutil.RemoveLockFile(lockPath)
-				return nil, fmt.Errorf("oauth: write token lock: %w", werr)
+				return nil, "", fmt.Errorf("oauth: write token lock: %w", werr)
 			}
 			if cerr := f.Close(); cerr != nil {
 				_ = lockutil.RemoveLockFile(lockPath)
-				return nil, fmt.Errorf("oauth: close token lock: %w", cerr)
+				return nil, "", fmt.Errorf("oauth: close token lock: %w", cerr)
 			}
 			var released bool
 			return func() {
@@ -73,7 +76,7 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 				if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == token {
 					_ = lockutil.RemoveLockFile(lockPath)
 				}
-			}, nil
+			}, token, nil
 		}
 		// On Windows a concurrent holder's os.Remove leaves the lock file in a
 		// "delete pending" state, so an O_EXCL create races it with
@@ -81,39 +84,61 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 		// as contention and retry, exactly like ErrExist — otherwise the lock
 		// spuriously fails under concurrency on Windows.
 		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
-			return nil, fmt.Errorf("oauth: acquire token lock: %w", err)
+			return nil, "", fmt.Errorf("oauth: acquire token lock: %w", err)
 		}
 		// Reclaim a stale lock left by a crashed holder — atomically (H3). A blind
 		// Remove lets two racers both reclaim + recreate and so both hold the lock;
 		// reclaimStaleLock renames the file aside (only one rename wins) and restores
 		// it if it turns out fresh, so a live lock is never deleted out from under it.
 		if info, statErr := os.Stat(lockPath); statErr == nil {
-			if time.Since(info.ModTime()) > fileLockStaleAfter {
+			age := time.Since(info.ModTime())
+			// Future mtimes (clock skew, hostile Chtimes) are not healthy leases:
+			// age is negative, so neither the reclaim branch nor the deadline
+			// extension below treats them as live. Contenders time out instead of
+			// waiting forever on a never-stale lock.
+			if age > fileLockStaleAfter {
 				cleared, rerr := lockutil.ReclaimStaleLock(lockPath, token, func(reclaimedPath string) bool {
 					info, err := os.Stat(reclaimedPath)
-					return err == nil && time.Since(info.ModTime()) <= fileLockStaleAfter
+					if err != nil {
+						return false
+					}
+					reclaimedAge := time.Since(info.ModTime())
+					return reclaimedAge >= 0 && reclaimedAge <= fileLockStaleAfter
 				})
 				if rerr != nil {
 					// Reclaim hit a hard failure: the rename aside failed outright, or a
 					// live holder's lock could not be put back (the lock path may be
 					// missing, so re-acquiring would break mutual exclusion). Fail closed
 					// instead of spinning to the deadline.
-					return nil, fmt.Errorf("oauth: reclaim stale token lock: %w", rerr)
+					return nil, "", fmt.Errorf("oauth: reclaim stale token lock: %w", rerr)
 				}
 				if cleared {
 					continue
 				}
-				// Lost the reclaim race (or it was actually fresh) — fall through.
-			} else {
-				// Holder looks healthy (lease refreshed recently). Keep waiting for
-				// the critical section to finish rather than timing out after a fixed
-				// window shorter than a legitimate multi-entry keyring pass.
+				// Lost the reclaim race, or isLive reported a still-fresh holder
+				// (callback true → ReclaimStaleLock restores and returns false).
+				// Refresh the idle deadline so reclaim work that overran the prior
+				// window does not immediately time out a healthy peer.
+				idleDeadline = time.Now().Add(fileLockTimeout)
+			} else if age >= 0 {
+				// Holder looks healthy (lease refreshed recently, mtime not in the
+				// future). Keep waiting for the critical section to finish rather
+				// than timing out after a fixed window shorter than a legitimate
+				// multi-entry keyring pass.
 				idleDeadline = time.Now().Add(fileLockTimeout)
 			}
 		}
 		if time.Now().After(idleDeadline) {
-			return nil, fmt.Errorf("oauth: timed out acquiring token lock %s", filepath.Base(lockPath))
+			return nil, "", fmt.Errorf("oauth: timed out acquiring token lock %s", filepath.Base(lockPath))
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+// ownLockFile reports whether path still holds token. Used by lease refresh so
+// a holder that was reclaimed after a long pause cannot Chtimes a replacement
+// lock and keep two critical sections alive.
+func ownLockFile(path, token string) bool {
+	data, err := os.ReadFile(path)
+	return err == nil && string(data) == token
 }

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -21,10 +21,6 @@ var (
 	// While the holder's mtime stays within fileLockStaleAfter, this idle
 	// deadline is extended so a fixed 5s window cannot fail a healthy peer.
 	fileLockTimeout = 5 * time.Second
-	// fileLockMaxWait is a hard ceiling on total acquisition time so a wedged
-	// peer that somehow keeps refreshing forever cannot pin waiters indefinitely.
-	// Healthy multi-entry writes stay well under this; raise only with evidence.
-	fileLockMaxWait = 2 * time.Minute
 	// fileLockStaleAfter is how old a lock file's mtime must be before a waiter
 	// may reclaim it as abandoned. Must stay above one keyring command timeout
 	// plus lease refresh slack (holders refresh every fileLockRefreshInterval).
@@ -52,8 +48,7 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 		return nil, err
 	}
 	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), now().UnixNano(), lockSeq.Add(1))
-	start := time.Now()
-	idleDeadline := start.Add(fileLockTimeout)
+	idleDeadline := time.Now().Add(fileLockTimeout)
 	for {
 		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
@@ -116,7 +111,7 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 				idleDeadline = time.Now().Add(fileLockTimeout)
 			}
 		}
-		if time.Now().After(idleDeadline) || time.Since(start) > fileLockMaxWait {
+		if time.Now().After(idleDeadline) {
 			return nil, fmt.Errorf("oauth: timed out acquiring token lock %s", filepath.Base(lockPath))
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -12,6 +12,10 @@ import (
 )
 
 const (
+	// fileLockTimeout is the deadline for acquiring the cross-process lock.
+	// Critical sections held under this lock consist of file operations or a
+	// small number of OS keyring subprocess calls (typically < 100ms total),
+	// so 5 seconds provides a comfortable upper bound under normal operation.
 	fileLockTimeout    = 5 * time.Second
 	fileLockStaleAfter = 30 * time.Second
 )

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -42,7 +42,7 @@ var lockSeq atomic.Uint64
 // StoreOptions.Now, which callers may legitimately fix (e.g. a test or an
 // embedded clock). Measuring the deadline with that clock would either never
 // fire (fixed clock) or diverge from the mtime lease stamps (wall-clock).
-func acquireFileLock(lockPath string, now func() time.Time) (unlock func(), token string, err error) {
+func acquireFileLock(lockPath string, now func() time.Time) (unlock func() error, token string, err error) {
 	if now == nil {
 		now = time.Now
 	}
@@ -59,22 +59,29 @@ func acquireFileLock(lockPath string, now func() time.Time) (unlock func(), toke
 			// other processes. Fail closed: remove the file and surface the error.
 			if _, werr := f.WriteString(token); werr != nil {
 				_ = f.Close()
-				_ = lockutil.RemoveLockFile(lockPath)
+				if rerr := lockutil.RemoveLockFile(lockPath); rerr != nil {
+					return nil, "", fmt.Errorf("oauth: write token lock: %w; cleanup: %v", werr, rerr)
+				}
 				return nil, "", fmt.Errorf("oauth: write token lock: %w", werr)
 			}
 			if cerr := f.Close(); cerr != nil {
-				_ = lockutil.RemoveLockFile(lockPath)
+				if rerr := lockutil.RemoveLockFile(lockPath); rerr != nil {
+					return nil, "", fmt.Errorf("oauth: close token lock: %w; cleanup: %v", cerr, rerr)
+				}
 				return nil, "", fmt.Errorf("oauth: close token lock: %w", cerr)
 			}
 			var released bool
-			return func() {
+			return func() error {
 				if released {
-					return
+					return nil
 				}
 				released = true
 				if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == token {
-					_ = lockutil.RemoveLockFile(lockPath)
+					if err := lockutil.RemoveLockFile(lockPath); err != nil {
+						return fmt.Errorf("oauth: release token lock %s: %w", filepath.Base(lockPath), err)
+					}
 				}
+				return nil
 			}, token, nil
 		}
 		// On Windows a concurrent holder's os.Remove leaves the lock file in a

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -1,7 +1,6 @@
 package oauth
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -80,10 +79,11 @@ func acquireFileLock(lockPath string, now func() time.Time) (unlock func(), toke
 		}
 		// On Windows a concurrent holder's os.Remove leaves the lock file in a
 		// "delete pending" state, so an O_EXCL create races it with
-		// ERROR_ACCESS_DENIED (os.ErrPermission) rather than ErrExist. Treat that
-		// as contention and retry, exactly like ErrExist — otherwise the lock
-		// spuriously fails under concurrency on Windows.
-		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
+		// ERROR_ACCESS_DENIED (os.ErrPermission) rather than ErrExist. The
+		// platform predicate recognizes that as contention (and returns
+		// unrelated permission errors immediately) instead of failing the lock
+		// spuriously under concurrency.
+		if !isLockCreateContention(err) {
 			return nil, "", fmt.Errorf("oauth: acquire token lock: %w", err)
 		}
 		// Reclaim a stale lock left by a crashed holder — atomically (H3). A blind

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -76,17 +77,7 @@ func acquireFileLock(lockPath string, now func() time.Time) (unlock func() error
 					return nil
 				}
 				released = true
-				data, rerr := os.ReadFile(lockPath)
-				if rerr != nil {
-					return fmt.Errorf("oauth: verify token lock on release %s: %w", filepath.Base(lockPath), rerr)
-				}
-				if string(data) != token {
-					return fmt.Errorf("oauth: lost token lock ownership on release %s", filepath.Base(lockPath))
-				}
-				if err := lockutil.RemoveLockFile(lockPath); err != nil {
-					return fmt.Errorf("oauth: release token lock %s: %w", filepath.Base(lockPath), err)
-				}
-				return nil
+				return releaseOwnedLock(lockPath, token)
 			}, token, nil
 		}
 		// On Windows a concurrent holder's os.Remove leaves the lock file in a
@@ -153,4 +144,38 @@ func acquireFileLock(lockPath string, now func() time.Time) (unlock func() error
 func ownLockFile(path, token string) bool {
 	data, err := os.ReadFile(path)
 	return err == nil && string(data) == token
+}
+
+// releaseOwnedLock removes lockPath only if it still contains token.
+// Validation and removal are bound to one rename-aside of the same inode
+// so a replacement lock cannot be deleted after a stale read.
+func releaseOwnedLock(lockPath, token string) error {
+	aside := lockPath + ".release." + token
+	if err := os.Rename(lockPath, aside); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("oauth: verify token lock on release %s: %w", filepath.Base(lockPath), err)
+		}
+		return fmt.Errorf("oauth: release token lock %s: %w", filepath.Base(lockPath), err)
+	}
+	data, err := os.ReadFile(aside)
+	if err != nil {
+		if rerr := lockutil.RestoreLockFile(aside, lockPath); rerr != nil && !errors.Is(rerr, os.ErrExist) {
+			_ = lockutil.RemoveLockFile(aside)
+			return fmt.Errorf("oauth: verify token lock on release %s: %w (restore: %v)", filepath.Base(lockPath), err, rerr)
+		}
+		return fmt.Errorf("oauth: verify token lock on release %s: %w", filepath.Base(lockPath), err)
+	}
+	if string(data) != token {
+		if rerr := lockutil.RestoreLockFile(aside, lockPath); rerr != nil {
+			_ = lockutil.RemoveLockFile(aside)
+			if !errors.Is(rerr, os.ErrExist) {
+				return fmt.Errorf("oauth: lost token lock ownership on release %s: restore: %v", filepath.Base(lockPath), rerr)
+			}
+		}
+		return fmt.Errorf("oauth: lost token lock ownership on release %s", filepath.Base(lockPath))
+	}
+	if err := lockutil.RemoveLockFile(aside); err != nil {
+		return fmt.Errorf("oauth: release token lock %s: %w", filepath.Base(lockPath), err)
+	}
+	return nil
 }

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -76,10 +76,15 @@ func acquireFileLock(lockPath string, now func() time.Time) (unlock func() error
 					return nil
 				}
 				released = true
-				if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == token {
-					if err := lockutil.RemoveLockFile(lockPath); err != nil {
-						return fmt.Errorf("oauth: release token lock %s: %w", filepath.Base(lockPath), err)
-					}
+				data, rerr := os.ReadFile(lockPath)
+				if rerr != nil {
+					return fmt.Errorf("oauth: verify token lock on release %s: %w", filepath.Base(lockPath), rerr)
+				}
+				if string(data) != token {
+					return fmt.Errorf("oauth: lost token lock ownership on release %s", filepath.Base(lockPath))
+				}
+				if err := lockutil.RemoveLockFile(lockPath); err != nil {
+					return fmt.Errorf("oauth: release token lock %s: %w", filepath.Base(lockPath), err)
 				}
 				return nil
 			}, token, nil

--- a/internal/oauth/lock_owner_unix.go
+++ b/internal/oauth/lock_owner_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package oauth
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// checkOAuthLockDirOwner rejects a fallback lock directory not owned by the
+// current user: on a shared temp root another user could have pre-created the
+// path and would then control its lifetime (deletion/renaming), permanently
+// denying OAuth keyring operations.
+func checkOAuthLockDirOwner(info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	if int(stat.Uid) != os.Geteuid() {
+		return fmt.Errorf("oauth lock fallback directory is owned by uid %d, not the current user", stat.Uid)
+	}
+	return nil
+}

--- a/internal/oauth/lock_owner_unix.go
+++ b/internal/oauth/lock_owner_unix.go
@@ -25,7 +25,7 @@ func isLockCreateContention(err error) bool {
 func checkOAuthLockDirOwner(info os.FileInfo) error {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		return nil
+		return errors.New("oauth lock fallback directory ownership metadata unavailable")
 	}
 	if int(stat.Uid) != os.Geteuid() {
 		return fmt.Errorf("oauth lock fallback directory is owned by uid %d, not the current user", stat.Uid)

--- a/internal/oauth/lock_owner_unix.go
+++ b/internal/oauth/lock_owner_unix.go
@@ -3,10 +3,20 @@
 package oauth
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
 )
+
+// isLockCreateContention reports whether a failed O_EXCL lock create should be
+// treated as contention (another holder's lock exists) rather than a hard
+// error. On non-Windows platforms the only contention errno is EEXIST
+// (os.ErrExist); EACCES (os.ErrPermission) is a genuine permission failure and
+// must surface immediately rather than spin to the lock timeout.
+func isLockCreateContention(err error) bool {
+	return errors.Is(err, os.ErrExist)
+}
 
 // checkOAuthLockDirOwner rejects a fallback lock directory not owned by the
 // current user: on a shared temp root another user could have pre-created the

--- a/internal/oauth/lock_owner_unix.go
+++ b/internal/oauth/lock_owner_unix.go
@@ -22,3 +22,10 @@ func checkOAuthLockDirOwner(info os.FileInfo) error {
 	}
 	return nil
 }
+
+// identityLockRoot is never called on non-Windows: keyringFallbackLockDir
+// resolves the uid-anchored home and the fixed /tmp root directly. It exists so
+// the shared fallback can name one helper without a build-tagged call site.
+func identityLockRoot() (string, error) {
+	return "", fmt.Errorf("oauth: identityLockRoot is windows-only")
+}

--- a/internal/oauth/lock_owner_windows.go
+++ b/internal/oauth/lock_owner_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package oauth
+
+import "os"
+
+// checkOAuthLockDirOwner is a no-op on Windows: the process temp directory is
+// per-user by default, and keyringFallbackLockDir returns it directly.
+func checkOAuthLockDirOwner(os.FileInfo) error {
+	return nil
+}

--- a/internal/oauth/lock_owner_windows.go
+++ b/internal/oauth/lock_owner_windows.go
@@ -2,10 +2,42 @@
 
 package oauth
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
 
-// checkOAuthLockDirOwner is a no-op on Windows: the process temp directory is
-// per-user by default, and keyringFallbackLockDir returns it directly.
+	"golang.org/x/sys/windows"
+)
+
+// checkOAuthLockDirOwner is a no-op on Windows: identityLockRoot resolves a
+// per-user location from the process token rather than a shared root, so there
+// is no co-tenant directory to validate ownership of.
 func checkOAuthLockDirOwner(os.FileInfo) error {
 	return nil
+}
+
+// identityLockRoot resolves the last-resort keyring lock directory from the
+// caller's own identity instead of the environment. os.TempDir() is not usable
+// here for the same reason the Unix branch refuses it: it resolves %TMP%, then
+// %TEMP%, then %USERPROFILE%, and the first two are launcher-controlled, so two
+// processes of one user can compute different lock paths while writing the same
+// fixed keyring account and race it. Being per-user by default is not the
+// property that matters; being stable for that user is.
+//
+// SHGetKnownFolderPath reads the user's profile location through the process
+// token, so it ignores %LOCALAPPDATA% and every other temp override. Failing
+// closed is deliberate: without a stable identity there is no lock path two
+// processes are guaranteed to agree on, and a guessed one silently reintroduces
+// the race it is meant to prevent.
+func identityLockRoot() (string, error) {
+	base, err := windows.KnownFolderPath(windows.FOLDERID_LocalAppData, 0)
+	if err != nil {
+		return "", fmt.Errorf("resolve LocalAppData for keyring lock: %w", err)
+	}
+	dir := filepath.Join(base, "zero", "oauth-locks")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
 }

--- a/internal/oauth/lock_owner_windows.go
+++ b/internal/oauth/lock_owner_windows.go
@@ -3,12 +3,23 @@
 package oauth
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"golang.org/x/sys/windows"
 )
+
+// isLockCreateContention reports whether a failed O_EXCL lock create should be
+// treated as contention (another holder's lock exists) rather than a hard
+// error. On Windows, a concurrent holder's os.Remove leaves the lock file in a
+// "delete pending" state, so the O_EXCL create races it with
+// ERROR_ACCESS_DENIED (os.ErrPermission) rather than os.ErrExist; both are
+// contention here.
+func isLockCreateContention(err error) bool {
+	return errors.Is(err, os.ErrExist) || errors.Is(err, os.ErrPermission)
+}
 
 // checkOAuthLockDirOwner is a no-op on Windows: identityLockRoot resolves a
 // per-user location from the process token rather than a shared root, so there

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -341,17 +341,23 @@ func (m *Manager) refreshAndSave(ctx context.Context, key string, cfg Config, cu
 	lock := m.keyLock(key)
 	lock.Lock()
 	defer lock.Unlock()
-	// Re-load inside the critical section: if a concurrent caller already refreshed
-	// (the access token changed), reuse it rather than spending the single-use
-	// refresh token a second time — the provider would reject the second use (M7).
-	if reloaded, err := m.loadToken(key); err == nil && reloaded.AccessToken != current.AccessToken {
+	// Re-load inside the critical section. A concurrent refresh that already
+	// rotated the access token is reused so we do not spend the single-use
+	// refresh token a second time. Any load error, including ErrNoToken from a
+	// concurrent logout, aborts: refresh is not login and must not recreate a
+	// credential the user just removed.
+	reloaded, err := m.loadToken(key)
+	if err != nil {
+		return "", err
+	}
+	if reloaded.AccessToken != current.AccessToken {
 		return reloaded.AccessToken, nil
 	}
 	refreshed, err := Refresh(ctx, m.client, cfg, current, m.now)
 	if err != nil {
 		return "", err
 	}
-	if err := m.store.saveRefreshed(key, refreshed); err != nil {
+	if err := m.store.SaveRefreshed(key, refreshed); err != nil {
 		return "", err
 	}
 	return refreshed.AccessToken, nil

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -351,7 +351,7 @@ func (m *Manager) refreshAndSave(ctx context.Context, key string, cfg Config, cu
 	if err != nil {
 		return "", err
 	}
-	if err := m.store.Save(key, refreshed); err != nil {
+	if err := m.store.saveRefreshed(key, refreshed); err != nil {
 		return "", err
 	}
 	return refreshed.AccessToken, nil

--- a/internal/oauth/manager_test.go
+++ b/internal/oauth/manager_test.go
@@ -282,6 +282,50 @@ func TestManagerHandle401ForcesRefresh(t *testing.T) {
 	}
 }
 
+func TestManagerRefreshAndSaveAbortsWhenLoggedOut(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		_, _ = io.WriteString(w, `{"access_token":"resurrected","expires_in":3600}`)
+	}))
+	t.Cleanup(server.Close)
+	env := map[string]string{
+		"ZERO_OAUTH_DEMO_CLIENT_ID": "client",
+		"ZERO_OAUTH_DEMO_TOKEN_URL": server.URL,
+	}
+	m := managerFor(t, env, nil)
+	key := ProviderKey("demo")
+	if err := m.store.Save(key, Token{AccessToken: "stale", RefreshToken: "rt", ExpiresAt: time.Now().Add(-time.Hour)}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.GetFresh(context.Background(), key)
+		done <- err
+	}()
+	select {
+	case <-started:
+	case err := <-done:
+		t.Fatalf("refresh finished before token endpoint: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("token endpoint was never hit")
+	}
+	if _, err := m.Logout("demo"); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	close(release)
+	err := <-done
+	if err == nil || !errors.Is(err, ErrNoToken) {
+		t.Fatalf("GetFresh after logout = %v, want ErrNoToken", err)
+	}
+	if _, ok, err := m.store.Load(key); err != nil || ok {
+		t.Fatalf("Load after concurrent logout = ok %v err %v; token resurrected", ok, err)
+	}
+}
+
 func TestManagerLogout(t *testing.T) {
 	m := managerFor(t, map[string]string{"ZERO_OAUTH_DEMO_CLIENT_ID": "c"}, nil)
 	_ = m.store.Save(ProviderKey("demo"), Token{AccessToken: "a"})

--- a/internal/oauth/persist_intent_test.go
+++ b/internal/oauth/persist_intent_test.go
@@ -11,37 +11,47 @@ import (
 func TestProductionRefreshPersistsWithRefreshIntent(t *testing.T) {
 	checks := []struct {
 		file   string
+		recv   string
 		fn     string
 		want   string
 		forbid []string
 	}{
 		{
 			file:   "manager.go",
+			recv:   "Manager",
 			fn:     "refreshAndSave",
 			want:   "SaveRefreshed",
 			forbid: []string{"Save"},
 		},
 		{
 			file:   filepath.Join("..", "mcp", "network_client.go"),
+			recv:   "storeTokenSource",
 			fn:     "Refresh",
 			want:   "saveRefreshedForServer",
 			forbid: []string{"SaveForServer", "Save"},
 		},
+		{
+			file:   filepath.Join("..", "mcp", "oauth_store.go"),
+			recv:   "TokenStore",
+			fn:     "saveRefreshedForServer",
+			want:   "SaveRefreshed",
+			forbid: []string{"Save"},
+		},
 	}
 	for _, check := range checks {
-		calls := functionSelectorCalls(t, check.file, check.fn)
+		calls := functionSelectorCalls(t, check.file, check.recv, check.fn)
 		if !containsString(calls, check.want) {
-			t.Errorf("%s %s does not call %s; got %v", check.file, check.fn, check.want, calls)
+			t.Errorf("%s %s.%s does not call %s; got %v", check.file, check.recv, check.fn, check.want, calls)
 		}
 		for _, name := range check.forbid {
 			if containsString(calls, name) {
-				t.Errorf("%s %s must not persist via %s; got %v", check.file, check.fn, name, calls)
+				t.Errorf("%s %s.%s must not persist via %s; got %v", check.file, check.recv, check.fn, name, calls)
 			}
 		}
 	}
 }
 
-func functionSelectorCalls(t *testing.T, path, funcName string) []string {
+func functionSelectorCalls(t *testing.T, path, recv, funcName string) []string {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, 0)
@@ -53,6 +63,9 @@ func functionSelectorCalls(t *testing.T, path, funcName string) []string {
 	ast.Inspect(file, func(n ast.Node) bool {
 		fn, ok := n.(*ast.FuncDecl)
 		if !ok || fn.Name.Name != funcName || fn.Body == nil {
+			return true
+		}
+		if recv != "" && recvTypeName(fn) != recv {
 			return true
 		}
 		found = true
@@ -71,9 +84,24 @@ func functionSelectorCalls(t *testing.T, path, funcName string) []string {
 		return false
 	})
 	if !found {
-		t.Fatalf("function %s not found in %s", funcName, path)
+		t.Fatalf("function %s.%s not found in %s", recv, funcName, path)
 	}
 	return calls
+}
+
+func recvTypeName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	typ := fn.Recv.List[0].Type
+	if star, ok := typ.(*ast.StarExpr); ok {
+		typ = star.X
+	}
+	ident, ok := typ.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return ident.Name
 }
 
 func containsString(values []string, want string) bool {

--- a/internal/oauth/persist_intent_test.go
+++ b/internal/oauth/persist_intent_test.go
@@ -1,0 +1,86 @@
+package oauth
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+func TestProductionRefreshPersistsWithRefreshIntent(t *testing.T) {
+	checks := []struct {
+		file   string
+		fn     string
+		want   string
+		forbid []string
+	}{
+		{
+			file:   "manager.go",
+			fn:     "refreshAndSave",
+			want:   "SaveRefreshed",
+			forbid: []string{"Save"},
+		},
+		{
+			file:   filepath.Join("..", "mcp", "network_client.go"),
+			fn:     "Refresh",
+			want:   "saveRefreshedForServer",
+			forbid: []string{"SaveForServer", "Save"},
+		},
+	}
+	for _, check := range checks {
+		calls := functionSelectorCalls(t, check.file, check.fn)
+		if !containsString(calls, check.want) {
+			t.Errorf("%s %s does not call %s; got %v", check.file, check.fn, check.want, calls)
+		}
+		for _, name := range check.forbid {
+			if containsString(calls, name) {
+				t.Errorf("%s %s must not persist via %s; got %v", check.file, check.fn, name, calls)
+			}
+		}
+	}
+}
+
+func functionSelectorCalls(t *testing.T, path, funcName string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	var calls []string
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != funcName || fn.Body == nil {
+			return true
+		}
+		found = true
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			calls = append(calls, sel.Sel.Name)
+			return true
+		})
+		return false
+	})
+	if !found {
+		t.Fatalf("function %s not found in %s", funcName, path)
+	}
+	return calls
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -213,9 +213,9 @@ func NewStore(options StoreOptions) (*Store, error) {
 		// file beside where the file backend would live. Cross-process exclusion
 		// must not silently disappear when no config location resolves (withLock
 		// would be a no-op and a concurrent save could delete another process's
-		// newly written entry), so fall back to the OS temp directory, which
-		// always exists, rather than to in-process serialization only.
-		lockPath := filepath.Join(os.TempDir(), "zero-oauth-keyring.lockfile")
+		// newly written entry), so fall back to a per-user location that always
+		// exists, rather than to in-process serialization only.
+		lockPath := keyringFallbackLockPath()
 		if storePath, perr := ResolveStorePath(options.Env); perr == nil {
 			lockPath = filepath.Join(filepath.Dir(storePath), "oauth-keyring.lockfile")
 		}
@@ -242,6 +242,30 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 		}
 	}
 	return filepath.Clean(filePath), nil
+}
+
+// keyringFallbackLockPath returns a per-user location for the keyring lock when
+// no config location resolves. A single shared ${TMPDIR}/zero-oauth-keyring.lockfile
+// let any other account on a multi-user host pre-create or keep refreshing the
+// victim's lock and time out their Load/Status/Save/Delete, even though each user
+// has a separate OS keychain. Prefer the per-user OS cache directory (created
+// 0700 by acquireFileLock); only if that cannot be resolved fall back to a temp
+// file scoped by uid so two different users never collide on one path.
+func keyringFallbackLockPath() string {
+	if dir, err := os.UserCacheDir(); err == nil && strings.TrimSpace(dir) != "" {
+		return filepath.Join(dir, "zero", "oauth-keyring.lockfile")
+	}
+	return filepath.Join(os.TempDir(), keyringTempLockName())
+}
+
+// keyringTempLockName names the last-resort temp lock file, scoping it by uid so
+// concurrently running different users do not share one path. os.Getuid returns
+// -1 where uids do not apply (Windows), where os.TempDir is already per-user.
+func keyringTempLockName() string {
+	if uid := os.Getuid(); uid >= 0 {
+		return fmt.Sprintf("zero-oauth-keyring-%d.lockfile", uid)
+	}
+	return "zero-oauth-keyring.lockfile"
 }
 
 // FilePath returns the resolved token store location (a path for the file

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -210,15 +210,14 @@ func NewStore(options StoreOptions) (*Store, error) {
 			kr = osKeyring
 		}
 		// Serialize the keyring's read-modify-write across processes with a lock
-		// file beside where the file backend would live. Cross-process exclusion
-		// must not silently disappear when no config location resolves (withLock
-		// would be a no-op and a concurrent save could delete another process's
-		// newly written entry), so fall back to a per-user location that always
-		// exists, rather than to in-process serialization only.
-		lockPath := keyringFallbackLockPath()
-		if storePath, perr := ResolveStorePath(options.Env); perr == nil {
-			lockPath = filepath.Join(filepath.Dir(storePath), "oauth-keyring.lockfile")
-		}
+		// file keyed off the keyring identity itself (service + index account),
+		// never off the file-backend's path config: two processes with different
+		// ZERO_OAUTH_TOKENS_PATH / XDG_CONFIG_HOME roots but pointed at the SAME
+		// OS keyring entry (the service/account is fixed per binary, not per
+		// config root) must still serialize against each other, or they can race
+		// a read-modify-write on the shared keyring index and silently drop one
+		// process's token write.
+		lockPath := keyringLockPath(keyringService, keyringIndexAccount)
 		return &Store{blob: keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount, lockPath: lockPath}, now: now}, nil
 	default:
 		return nil, fmt.Errorf("oauth: unknown storage %q (want \"file\", \"encrypted-file\", or \"keyring\")", storage)
@@ -244,28 +243,55 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 	return filepath.Clean(filePath), nil
 }
 
-// keyringFallbackLockPath returns a per-user location for the keyring lock when
-// no config location resolves. A single shared ${TMPDIR}/zero-oauth-keyring.lockfile
-// let any other account on a multi-user host pre-create or keep refreshing the
-// victim's lock and time out their Load/Status/Save/Delete, even though each user
-// has a separate OS keychain. Prefer the per-user OS cache directory (created
-// 0700 by acquireFileLock); only if that cannot be resolved fall back to a temp
-// file scoped by uid so two different users never collide on one path.
-func keyringFallbackLockPath() string {
+// keyringLockPath returns the cross-process lock file location for the
+// keyring backend's read-modify-write, derived from the keyring identity
+// itself (the service/account the index is stored under) rather than from
+// the unrelated file-backend path config (ZERO_OAUTH_TOKENS_PATH /
+// XDG_CONFIG_HOME): the file backend's location has nothing to do with which
+// OS keyring entry a process is about to read-modify-write, so a lock keyed
+// off it let two processes with different config roots but the SAME keyring
+// entry race the shared index and silently drop one process's token write.
+// A single shared ${TMPDIR}/zero-oauth-keyring.lockfile would also let any
+// other account on a multi-user host pre-create or keep refreshing the
+// victim's lock and time out their Load/Status/Save/Delete, even though each
+// user has a separate OS keychain, so this prefers the per-user OS cache
+// directory (created 0700 by acquireFileLock); only if that cannot be
+// resolved does it fall back to a temp file scoped by uid so two different
+// users never collide on one path.
+func keyringLockPath(service, account string) string {
+	name := keyringLockFileName(service, account)
 	if dir, err := os.UserCacheDir(); err == nil && strings.TrimSpace(dir) != "" {
-		return filepath.Join(dir, "zero", "oauth-keyring.lockfile")
+		return filepath.Join(dir, "zero", name)
 	}
-	return filepath.Join(os.TempDir(), keyringTempLockName())
+	return filepath.Join(os.TempDir(), keyringTempLockName(service, account))
+}
+
+// keyringLockFileName names the lock file after the keyring identity it
+// guards, so distinct (service, account) pairs never share a lock and the
+// same pair always resolves to the same lock regardless of caller config.
+func keyringLockFileName(service, account string) string {
+	return fmt.Sprintf("oauth-keyring-%s-%s.lockfile", sanitizeLockComponent(service), sanitizeLockComponent(account))
+}
+
+// lockComponentSafe keeps a service/account string safe as one path segment:
+// alphanumerics, dot, underscore, and hyphen pass through; anything else
+// (a path separator, especially) is replaced so a crafted identity can never
+// escape the lock directory.
+var lockComponentSafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+func sanitizeLockComponent(s string) string {
+	return lockComponentSafe.ReplaceAllString(s, "_")
 }
 
 // keyringTempLockName names the last-resort temp lock file, scoping it by uid so
 // concurrently running different users do not share one path. os.Getuid returns
 // -1 where uids do not apply (Windows), where os.TempDir is already per-user.
-func keyringTempLockName() string {
+func keyringTempLockName(service, account string) string {
+	name := keyringLockFileName(service, account)
 	if uid := os.Getuid(); uid >= 0 {
-		return fmt.Sprintf("zero-oauth-keyring-%d.lockfile", uid)
+		return fmt.Sprintf("zero-%d-%s", uid, name)
 	}
-	return "zero-oauth-keyring.lockfile"
+	return "zero-" + name
 }
 
 // FilePath returns the resolved token store location (a path for the file

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -307,7 +308,7 @@ func legacyKeyringLockPath(env map[string]string) string {
 // guards, so distinct (service, account) pairs never share a lock and the
 // same pair always resolves to the same lock regardless of caller config.
 func keyringLockFileName(service, account string) string {
-	return fmt.Sprintf("oauth-keyring-%s-%s.lockfile", sanitizeLockComponent(service), sanitizeLockComponent(account))
+	return fmt.Sprintf("oauth-keyring-%s-%s.lockfile", sanitizeLockComponent(url.QueryEscape(service)), sanitizeLockComponent(url.QueryEscape(account)))
 }
 
 // lockComponentSafe keeps a service/account string safe as one path segment:

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -269,7 +269,18 @@ func (s *Store) Load(key string) (Token, bool, error) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	state, err := s.readState()
+	// Through blob.withLock, like Save/Delete: the keyring backend's read is
+	// several separate Get calls (index, then each entry), not one atomic
+	// snapshot, so an unlocked Load can run concurrently with another
+	// process's Save/Delete mid write and observe a torn state (e.g. an index
+	// already updated but an entry not yet written). The lock keeps this read
+	// from overlapping any other process's read-modify-write cycle.
+	var state storeFile
+	err := s.blob.withLock(s.now, func() error {
+		var readErr error
+		state, readErr = s.readState()
+		return readErr
+	})
 	if err != nil {
 		return Token{}, false, err
 	}
@@ -305,7 +316,14 @@ func (s *Store) Delete(key string) (bool, error) {
 func (s *Store) Status(prefix string) ([]Status, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	state, err := s.readState()
+	// Same reasoning as Load: run the read under blob.withLock so it can't
+	// observe another process's Save/Delete mid write.
+	var state storeFile
+	err := s.blob.withLock(s.now, func() error {
+		var readErr error
+		state, readErr = s.readState()
+		return readErr
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -898,17 +898,18 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 	// from an entry it was never written to in the first place. Applied here
 	// transiently (not persisted): the durable version happens in write(),
 	// consistent with every other best-effort check in this function.
-	if legacyTokens != nil {
-		legacyOrigin, lerr := b.readLegacyOrigin()
-		if lerr == nil {
-			for key := range tokens {
-				if !legacyOrigin[key] {
+	legacyOrigin, lerr := b.readLegacyOrigin()
+	if lerr == nil && len(legacyOrigin) > 0 {
+		for key := range tokens {
+			if !legacyOrigin[key] {
+				continue
+			}
+			if legacyTokens != nil {
+				if _, stillInLegacy := legacyTokens[key]; stillInLegacy {
 					continue
 				}
-				if _, stillInLegacy := legacyTokens[key]; !stillInLegacy {
-					delete(tokens, key)
-				}
 			}
+			delete(tokens, key)
 		}
 	}
 
@@ -1053,12 +1054,6 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 	}
 	legacyOriginChanged := false
 	if legacyTokens != nil {
-		for key := range mutations {
-			if legacyOrigin[key] {
-				delete(legacyOrigin, key)
-				legacyOriginChanged = true
-			}
-		}
 		for key := range legacyTokens {
 			if ValidateKey(key) != nil {
 				continue
@@ -1070,16 +1065,22 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 				}
 			}
 		}
-		// Only once the legacy entry has actually been read (legacyTokens != nil)
-		// can its absence mean anything. mutations[key] is this same call's own
-		// explicit Save/Delete for key: that always wins over the heuristic, so
-		// a fresh Save is never immediately undone by a stale legacy reading.
+	}
+	for key := range mutations {
+		if legacyOrigin[key] {
+			delete(legacyOrigin, key)
+			legacyOriginChanged = true
+		}
+	}
+	if len(legacyOrigin) > 0 {
 		for key := range state.Tokens {
 			if _, mutated := mutations[key]; mutated || !legacyOrigin[key] {
 				continue
 			}
-			if _, stillInLegacy := legacyTokens[key]; stillInLegacy {
-				continue
+			if legacyTokens != nil {
+				if _, stillInLegacy := legacyTokens[key]; stillInLegacy {
+					continue
+				}
 			}
 			delete(state.Tokens, key)
 			if !tombstones[key] {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -152,13 +152,9 @@ func ResolveStorePath(env map[string]string) (string, error) {
 	}
 	configHome := strings.TrimSpace(envValue(env, "XDG_CONFIG_HOME"))
 	if configHome == "" {
-		home := strings.TrimSpace(firstNonEmpty(envValue(env, "HOME"), envValue(env, "USERPROFILE")))
-		if home == "" {
-			var err error
-			home, err = os.UserHomeDir()
-			if err != nil {
-				return "", fmt.Errorf("oauth: resolve user home: %w", err)
-			}
+		home, err := resolveHomeDir(env)
+		if err != nil {
+			return "", err
 		}
 		configHome = filepath.Join(home, ".config")
 	} else if !filepath.IsAbs(configHome) {
@@ -169,6 +165,24 @@ func ResolveStorePath(env map[string]string) (string, error) {
 		configHome = resolved
 	}
 	return filepath.Join(configHome, "zero", "oauth-tokens.json"), nil
+}
+
+// resolveHomeDir returns the user's home directory, honoring HOME/USERPROFILE
+// hermetically (via env) before falling back to os.UserHomeDir(). Shared by
+// ResolveStorePath's config-root fallback and by keyringLockPath, which
+// anchors on this same identity so the keyring lock never varies with a
+// per-process override like XDG_CACHE_HOME/XDG_CONFIG_HOME/TMPDIR that two
+// processes of the same real user commonly set differently (sandboxes, CI,
+// per-shell env).
+func resolveHomeDir(env map[string]string) (string, error) {
+	if home := strings.TrimSpace(firstNonEmpty(envValue(env, "HOME"), envValue(env, "USERPROFILE"))); home != "" {
+		return home, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("oauth: resolve user home: %w", err)
+	}
+	return home, nil
 }
 
 // NewStore builds a token store with the configured backend (file by default,
@@ -209,16 +223,20 @@ func NewStore(options StoreOptions) (*Store, error) {
 			}
 			kr = osKeyring
 		}
-		// Serialize the keyring's read-modify-write across processes with a lock
-		// file keyed off the keyring identity itself (service + index account),
-		// never off the file-backend's path config: two processes with different
-		// ZERO_OAUTH_TOKENS_PATH / XDG_CONFIG_HOME roots but pointed at the SAME
-		// OS keyring entry (the service/account is fixed per binary, not per
-		// config root) must still serialize against each other, or they can race
-		// a read-modify-write on the shared keyring index and silently drop one
-		// process's token write.
-		lockPath := keyringLockPath(keyringService, keyringIndexAccount)
-		return &Store{blob: keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount, lockPath: lockPath}, now: now}, nil
+		// lockPath serializes this binary's own keyring read-modify-write across
+		// processes, keyed off the keyring identity itself (service + index
+		// account) and anchored on the user's home directory (see
+		// keyringLockPath), never off a per-process cache/temp/config override:
+		// two processes with different roots but pointed at the SAME OS keyring
+		// entry (the service/account is fixed per binary, not per config root)
+		// must still serialize against each other, or they can race a
+		// read-modify-write on the shared keyring index and silently drop one
+		// process's token write. legacyLockPath additionally coordinates with a
+		// still-running pre-PR binary during the supported mixed-version window
+		// (see legacyKeyringLockPath).
+		lockPath := keyringLockPath(options.Env, keyringService, keyringIndexAccount)
+		legacyLockPath := legacyKeyringLockPath(options.Env)
+		return &Store{blob: keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount, lockPath: lockPath, legacyLockPath: legacyLockPath}, now: now}, nil
 	default:
 		return nil, fmt.Errorf("oauth: unknown storage %q (want \"file\", \"encrypted-file\", or \"keyring\")", storage)
 	}
@@ -245,25 +263,44 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 
 // keyringLockPath returns the cross-process lock file location for the
 // keyring backend's read-modify-write, derived from the keyring identity
-// itself (the service/account the index is stored under) rather than from
-// the unrelated file-backend path config (ZERO_OAUTH_TOKENS_PATH /
-// XDG_CONFIG_HOME): the file backend's location has nothing to do with which
-// OS keyring entry a process is about to read-modify-write, so a lock keyed
-// off it let two processes with different config roots but the SAME keyring
-// entry race the shared index and silently drop one process's token write.
-// A single shared ${TMPDIR}/zero-oauth-keyring.lockfile would also let any
-// other account on a multi-user host pre-create or keep refreshing the
-// victim's lock and time out their Load/Status/Save/Delete, even though each
-// user has a separate OS keychain, so this prefers the per-user OS cache
-// directory (created 0700 by acquireFileLock); only if that cannot be
-// resolved does it fall back to a temp file scoped by uid so two different
-// users never collide on one path.
-func keyringLockPath(service, account string) string {
+// itself (the service/account the index is stored under) and anchored on the
+// user's home directory (see resolveHomeDir) rather than os.UserCacheDir() or
+// os.TempDir(): those pick XDG_CACHE_HOME/TMPDIR per PROCESS, so two
+// processes of the SAME real user with different cache/temp roots (a common
+// case: sandboxes, CI, per-shell overrides) computed different lock files,
+// both read the same fixed keyring index, and could publish competing
+// updates that silently hid one process's token. HOME does not vary this way
+// for a given real user. A single shared ${TMPDIR}/zero-oauth-keyring.lockfile
+// would also let any other account on a multi-user host pre-create or keep
+// refreshing the victim's lock and time out their Load/Status/Save/Delete,
+// even though each user has a separate OS keychain, so only when even the
+// home directory can't be resolved does this fall back to a temp file scoped
+// by uid so two different users never collide on one path.
+func keyringLockPath(env map[string]string, service, account string) string {
 	name := keyringLockFileName(service, account)
-	if dir, err := os.UserCacheDir(); err == nil && strings.TrimSpace(dir) != "" {
-		return filepath.Join(dir, "zero", name)
+	if home, err := resolveHomeDir(env); err == nil && strings.TrimSpace(home) != "" {
+		return filepath.Join(home, ".cache", "zero", name)
 	}
 	return filepath.Join(os.TempDir(), keyringTempLockName(service, account))
+}
+
+// legacyKeyringLockPath returns the lock file a pre-PR binary acquires around
+// its own read-modify-write of the single combined keyring entry, beside
+// wherever ResolveStorePath resolves the file-backend location for that
+// process's env. A new binary must take this SAME lock (not just its own
+// keyringLockPath) around any write that reconciles or deletes the legacy
+// entry: an old binary observes no other lock, so only sharing its exact
+// lock file stops it from writing a fresh legacy login/refresh in the window
+// between this binary's reconciliation read and its legacy-blob delete,
+// which would otherwise discard that write permanently. Best-effort: ""
+// when the file-backend location can't be resolved at all, matching the
+// legacy code's own best-effort fallback (no cross-process lock at all).
+func legacyKeyringLockPath(env map[string]string) string {
+	storePath, err := ResolveStorePath(env)
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(storePath), "oauth-keyring.lockfile")
 }
 
 // keyringLockFileName names the lock file after the keyring identity it
@@ -586,6 +623,12 @@ type keyringBlob struct {
 	// lockPath, when set, is a cross-process lock file serializing the keyring's
 	// read-modify-write so concurrent processes don't clobber each other's tokens.
 	lockPath string
+	// legacyLockPath, when set, is the lock file a pre-PR binary acquires around
+	// its own read-modify-write of the legacy combined entry (see
+	// legacyKeyringLockPath). write() holds it too, so a live old binary can't
+	// write a fresh legacy credential in the window between this write's legacy
+	// reconciliation and its legacy-blob delete.
+	legacyLockPath string
 }
 
 func (b keyringBlob) read() ([]byte, bool, error) {
@@ -1039,20 +1082,30 @@ func chunkIndexKeys(keys []string) [][]string {
 // exists to prevent. A var so tests can shorten it.
 var fileLockRefreshInterval = 10 * time.Second
 
-// withLock serializes the keyring's read-modify-write. Store.mu covers the
-// in-process case; lockPath (when set) adds cross-process exclusion so two
-// processes can't both read the blob, modify, and write — dropping a token.
-// While fn runs, the lock file's mtime is refreshed so the stale-reclaim
-// threshold only ever expires for a genuinely crashed holder.
-func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
-	if b.lockPath == "" {
+// withLeasedLocks acquires every non-empty path in order, refreshes all of
+// their mtimes on a ticker while fn runs (so a legitimately slow multi-entry
+// keyring pass never looks like a crashed holder to another process), and
+// releases them in reverse order once fn returns.
+func withLeasedLocks(paths []string, now func() time.Time, fn func() error) error {
+	var unlocks []func()
+	var held []string
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		unlock, err := acquireFileLock(p, now)
+		if err != nil {
+			for i := len(unlocks) - 1; i >= 0; i-- {
+				unlocks[i]()
+			}
+			return err
+		}
+		unlocks = append(unlocks, unlock)
+		held = append(held, p)
+	}
+	if len(held) == 0 {
 		return fn()
 	}
-	unlock, err := acquireFileLock(b.lockPath, now)
-	if err != nil {
-		return err
-	}
-	defer unlock()
 	stop := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
@@ -1066,22 +1119,42 @@ func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
 			case <-ticker.C:
 				// Lease with wall-clock time, never the injectable now: acquireFileLock
 				// judges staleness with real time.Since(mtime), so a fixed or stale
-				// StoreOptions.Now would stamp the live lock with an old mtime that
+				// StoreOptions.Now would stamp a live lock with an old mtime that
 				// another process would immediately reclaim, reviving the token-loss
-				// race this lease prevents.
+				// race these locks prevent.
 				at := time.Now()
-				_ = os.Chtimes(b.lockPath, at, at)
+				for _, p := range held {
+					_ = os.Chtimes(p, at, at)
+				}
 			}
 		}
 	}()
-	err = fn()
+	err := fn()
 	close(stop)
 	<-done
+	for i := len(unlocks) - 1; i >= 0; i-- {
+		unlocks[i]()
+	}
 	return err
 }
 
+// withLock serializes the keyring's read-modify-write. Store.mu covers the
+// in-process case; lockPath adds cross-process exclusion between this
+// binary's own instances so two of them can't both read the blob, modify,
+// and write — dropping a token. legacyLockPath is held for the same
+// duration so a live pre-PR binary, which only ever locks there (see
+// legacyKeyringLockPath), can't write a fresh legacy credential in the
+// window between this write's legacy reconciliation and its legacy-blob
+// delete.
+func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
+	return withLeasedLocks([]string{b.lockPath, b.legacyLockPath}, now, fn)
+}
+
+// withReadLock only takes lockPath: a pre-PR binary never locks for a read
+// (see legacyKeyringLockPath), so a read here has nothing to coordinate with
+// on the legacy side.
 func (b keyringBlob) withReadLock(now func() time.Time, fn func() error) error {
-	return b.withLock(now, fn)
+	return withLeasedLocks([]string{b.lockPath}, now, fn)
 }
 
 func (b keyringBlob) location() string { return "keyring:" + b.service + "/" + b.indexAccount }

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -308,7 +308,10 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 func keyringLockPath(service, account string) (string, error) {
 	name := keyringLockFileName(service, account)
 	if u, err := currentOSUser(); err == nil && strings.TrimSpace(u.HomeDir) != "" {
-		return filepath.Join(u.HomeDir, ".cache", "zero", name), nil
+		dir := filepath.Join(u.HomeDir, ".cache", "zero")
+		if err := validateOAuthLockDir(dir); err == nil {
+			return filepath.Join(dir, name), nil
+		}
 	}
 	// Do not fall back to os.UserHomeDir: it reads ambient HOME/USERPROFILE, so
 	// two same-user processes can choose different locks for one keyring.
@@ -317,6 +320,31 @@ func keyringLockPath(service, account string) (string, error) {
 		return "", fmt.Errorf("oauth: keyring lock fallback dir: %w", err)
 	}
 	return filepath.Join(dir, keyringLockFileName(service, account)), nil
+}
+
+// validateOAuthLockDir creates dir with 0700 permissions if needed, rejects
+// symlinks and non-directories, tightens permissions to 0700, and validates
+// ownership by the current user.
+func validateOAuthLockDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("oauth lock fallback %s is not a plain directory", dir)
+	}
+	if info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return fmt.Errorf("tighten oauth lock fallback permissions: %w", err)
+		}
+	}
+	if err := checkOAuthLockDirOwner(info); err != nil {
+		return err
+	}
+	return nil
 }
 
 // keyringFallbackLockDir returns a private directory for last-resort keyring
@@ -339,15 +367,8 @@ func keyringFallbackLockDir() (string, error) {
 	if uid := os.Getuid(); uid >= 0 {
 		if u, err := lookupUserID(strconv.Itoa(uid)); err == nil && strings.TrimSpace(u.HomeDir) != "" {
 			dir := filepath.Join(u.HomeDir, ".cache", "zero")
-			if err := os.MkdirAll(dir, 0o700); err == nil {
-				if info, lerr := os.Lstat(dir); lerr == nil && info.Mode()&os.ModeSymlink == 0 && info.IsDir() {
-					if info.Mode().Perm() != 0o700 {
-						_ = os.Chmod(dir, 0o700)
-					}
-					if checkOAuthLockDirOwner(info) == nil {
-						return dir, nil
-					}
-				}
+			if err := validateOAuthLockDir(dir); err == nil {
+				return dir, nil
 			}
 		}
 	}
@@ -356,22 +377,7 @@ func keyringFallbackLockDir() (string, error) {
 		name = fmt.Sprintf("zero-oauth-locks-%d", uid)
 	}
 	dir := filepath.Join("/tmp", name)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", err
-	}
-	info, err := os.Lstat(dir)
-	if err != nil {
-		return "", err
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-		return "", fmt.Errorf("oauth lock fallback %s is not a plain directory", dir)
-	}
-	if info.Mode().Perm() != 0o700 {
-		if err := os.Chmod(dir, 0o700); err != nil {
-			return "", fmt.Errorf("tighten oauth lock fallback permissions: %w", err)
-		}
-	}
-	if err := checkOAuthLockDirOwner(info); err != nil {
+	if err := validateOAuthLockDir(dir); err != nil {
 		return "", err
 	}
 	return dir, nil
@@ -917,15 +923,10 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // permanently consume capacity) or entries that a later read/write can still
 // see and reconcile, never an invisible credential stranded in the OS keychain.
 //
-// The legacy combined entry is never written or deleted by this path. New
-// code cannot share a lock with old writers on other config roots, so any
-// snapshot-then-Set of that account can clobber an unobserved login or
-// truncate a valid oversized Linux keyring map. Legacy stays a read-only
-// discovery source; indexed entries are the sole writable representation.
-// omitFromLegacy lists keys the caller just deleted; they are recorded as
-// durable tombstones and must not be re-merged from the legacy blob even
-// when they were never indexed (a legacy-only old-binary login that the
-// user logged out of).
+// The legacy combined entry is preserved as a discovery source for unindexed
+// old-binary logins. When Delete explicitly logs out of a provider, that key
+// is removed from the legacy blob (or the legacy account deleted if empty)
+// so a downgraded binary cannot continue to use the revoked credential.
 func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease leaseCheck) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
@@ -1196,11 +1197,16 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 			return err
 		}
 		if len(legacyTokens) == 0 {
-			_, _ = b.kr.Delete(b.service, b.legacyAccount)
+			if _, err := b.kr.Delete(b.service, b.legacyAccount); err != nil {
+				return fmt.Errorf("oauth: delete empty legacy keyring blob: %w", err)
+			}
 		} else {
 			legacyData, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: legacyTokens})
-			if err == nil {
-				_ = b.kr.Set(b.service, b.legacyAccount, base64.StdEncoding.EncodeToString(legacyData))
+			if err != nil {
+				return fmt.Errorf("oauth: encode updated legacy keyring blob: %w", err)
+			}
+			if err := b.kr.Set(b.service, b.legacyAccount, base64.StdEncoding.EncodeToString(legacyData)); err != nil {
+				return fmt.Errorf("oauth: update legacy keyring blob: %w", err)
 			}
 		}
 	}
@@ -1244,6 +1250,12 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leas
 	}
 	if len(tombstones) == 0 {
 		if !existed {
+			return nil
+		}
+		if len(missingChunks) > 0 {
+			if _, _, err := tb.writeKeyIndex(nil, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
+				return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
+			}
 			return nil
 		}
 		if err := checkLease(); err != nil {
@@ -1315,6 +1327,12 @@ func (b keyringBlob) writeLegacyOrigin(origin map[string]bool, checkLease leaseC
 	}
 	if len(origin) == 0 {
 		if !existed {
+			return nil
+		}
+		if len(missingChunks) > 0 {
+			if _, _, err := lb.writeKeyIndex(nil, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
+				return fmt.Errorf("oauth: write keyring legacy-origin markers: %w", err)
+			}
 			return nil
 		}
 		if err := checkLease(); err != nil {
@@ -1524,8 +1542,8 @@ func (b keyringBlob) readKeyIndex() (keys []string, ok bool, chunks int, generat
 	if header.Chunks < 1 || header.Chunks > maxKeyringIndexChunks {
 		return nil, false, 0, 0, nil, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
 	}
-	if header.Generation < 0 {
-		return nil, false, 0, 0, nil, fmt.Errorf("oauth: keyring token index advertises a negative generation %d", header.Generation)
+	if header.Generation < 0 || header.Generation >= math.MaxInt {
+		return nil, false, 0, 0, nil, fmt.Errorf("oauth: keyring token index advertises invalid generation %d", header.Generation)
 	}
 	rawKeys := header.Keys
 	if len(rawKeys) > maxRawKeyringIndexKeys {
@@ -1613,6 +1631,9 @@ func dedupeValidKeys(keys []string) []string {
 // unconditionally; it is now scoped to only the case where advancing the
 // generation is not safe to begin with.
 func (b keyringBlob) writeKeyIndex(keys []string, priorChunks, priorGeneration int, missingChunks []int, checkLease leaseCheck) (chunks int, generation int, err error) {
+	if priorGeneration < 0 || priorGeneration >= math.MaxInt {
+		return 0, 0, fmt.Errorf("oauth: keyring key index generation overflow: %d", priorGeneration)
+	}
 	// Refuse to publish an index the reader would reject: readKeyIndex caps both
 	// total keys and chunk count, and a header beyond either would make every
 	// later Load/Status/Save/Delete fail before it could recover. Check the key
@@ -1638,7 +1659,7 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks, priorGeneration i
 // currently reads; the header Set is the only step any concurrent or crashed
 // reader can observe as a change at all.
 func (b keyringBlob) writeKeyIndexNewGeneration(chunkList [][]string, priorChunks, priorGeneration int, checkLease leaseCheck) (chunks int, generation int, err error) {
-	if priorGeneration >= math.MaxInt {
+	if priorGeneration < 0 || priorGeneration >= math.MaxInt {
 		return 0, 0, fmt.Errorf("oauth: keyring key index generation overflow: %d", priorGeneration)
 	}
 	newGeneration := priorGeneration + 1
@@ -1694,6 +1715,9 @@ func (b keyringBlob) writeKeyIndexNewGeneration(chunkList [][]string, priorChunk
 // is not protected is still overwritten in place, since there is no
 // generation boundary available to defer that behind here.
 func (b keyringBlob) writeKeyIndexInPlace(chunkList [][]string, priorChunks, priorGeneration int, missingChunks []int, checkLease leaseCheck) (chunks int, generation int, err error) {
+	if priorGeneration < 0 || priorGeneration >= math.MaxInt {
+		return 0, 0, fmt.Errorf("oauth: keyring key index generation overflow: %d", priorGeneration)
+	}
 	protected := make(map[int]bool, len(missingChunks))
 	maxProtected := 0
 	for _, c := range missingChunks {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -106,10 +106,23 @@ type KeyringClient interface {
 	Delete(service, account string) (bool, error)
 }
 
-// Keyring storage stores the whole token blob under one fixed entry.
+// Keyring storage splits the token blob into one keyring entry per token key,
+// plus a small index entry listing which keys exist. A single combined entry
+// (the original design) grows with every additional provider/MCP login and,
+// on macOS, add-generic-password now goes through `security -i`'s line-based
+// command parser (see internal/keyring), which caps a single write at 4095
+// bytes; three or more logged-in providers routinely exceeds that. Splitting
+// by key bounds each write to one token, which stays well under the cap
+// regardless of how many providers are logged in.
 const (
 	keyringService = "zero"
-	keyringAccount = "oauth-tokens"
+	// keyringLegacyAccount held the whole blob as one entry in the original
+	// design. New writes never use it; it is only read once, to migrate
+	// existing installs into the per-key format.
+	keyringLegacyAccount = "oauth-tokens"
+	// keyringIndexAccount holds a JSON array of the token keys that currently
+	// have their own keyring entry, since KeyringClient has no "list" operation.
+	keyringIndexAccount = "oauth-tokens-index"
 )
 
 // Store persists OAuth tokens (provider + MCP namespaces) as one JSON blob,
@@ -203,7 +216,7 @@ func NewStore(options StoreOptions) (*Store, error) {
 		if storePath, perr := ResolveStorePath(options.Env); perr == nil {
 			lockPath = filepath.Join(filepath.Dir(storePath), "oauth-keyring.lockfile")
 		}
-		return &Store{blob: keyringBlob{kr: kr, service: keyringService, account: keyringAccount, lockPath: lockPath}, now: now}, nil
+		return &Store{blob: keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount, lockPath: lockPath}, now: now}, nil
 	default:
 		return nil, fmt.Errorf("oauth: unknown storage %q (want \"file\", \"encrypted-file\", or \"keyring\")", storage)
 	}
@@ -469,19 +482,70 @@ func (b fileBlob) withLock(now func() time.Time, fn func() error) error {
 
 func (b fileBlob) location() string { return b.path }
 
-// keyringBlob persists the blob in the OS keyring as a single base64 entry
-// (base64 keeps the multi-line JSON a single, control-character-free value).
+// keyringBlob persists tokens in the OS keyring as one base64 entry per token
+// key (account = key), plus an index entry listing which keys exist (base64
+// keeps every value a single, control-character-free string; see keyringService
+// for why a single combined entry doesn't work). read/write still present the
+// same whole-blob shape (a marshaled storeFile) that Store expects, fanning it
+// out to/in from the individual entries internally.
 type keyringBlob struct {
 	kr      KeyringClient
 	service string
-	account string
+	// legacyAccount is the pre-migration whole-blob entry; read only, to pick up
+	// tokens saved by older versions the first time this runs.
+	legacyAccount string
+	indexAccount  string
 	// lockPath, when set, is a cross-process lock file serializing the keyring's
 	// read-modify-write so concurrent processes don't clobber each other's tokens.
 	lockPath string
 }
 
 func (b keyringBlob) read() ([]byte, bool, error) {
-	enc, ok, err := b.kr.Get(b.service, b.account)
+	indexEnc, ok, err := b.kr.Get(b.service, b.indexAccount)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return b.readLegacy()
+	}
+	keys, err := decodeKeyIndex(indexEnc)
+	if err != nil {
+		return nil, false, fmt.Errorf("oauth: decode keyring token index: %w", err)
+	}
+	tokens := make(map[string]Token, len(keys))
+	for _, key := range keys {
+		enc, ok, err := b.kr.Get(b.service, key)
+		if err != nil {
+			return nil, false, err
+		}
+		if !ok {
+			// Index and entries fell out of sync (e.g. a killed process between
+			// writing an entry and updating the index); skip rather than fail the
+			// whole read, since the next Save/Delete will reconcile the index.
+			continue
+		}
+		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
+		if err != nil {
+			return nil, false, fmt.Errorf("oauth: decode keyring token entry %q: %w", key, err)
+		}
+		var token Token
+		if err := json.Unmarshal(raw, &token); err != nil {
+			return nil, false, fmt.Errorf("oauth: invalid keyring token entry %q: %w", key, err)
+		}
+		tokens[key] = token
+	}
+	data, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens})
+	if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+// readLegacy reads the pre-migration whole-blob entry, for installs that
+// haven't written since upgrading. The next write() migrates them: it writes
+// per-key entries and an index, then deletes this entry.
+func (b keyringBlob) readLegacy() ([]byte, bool, error) {
+	enc, ok, err := b.kr.Get(b.service, b.legacyAccount)
 	if err != nil || !ok {
 		return nil, ok, err
 	}
@@ -493,7 +557,70 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 }
 
 func (b keyringBlob) write(data []byte) error {
-	return b.kr.Set(b.service, b.account, base64.StdEncoding.EncodeToString(data))
+	var state storeFile
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
+	}
+	priorKeys, err := b.indexedKeys()
+	if err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(state.Tokens))
+	for key, token := range state.Tokens {
+		raw, err := json.Marshal(token)
+		if err != nil {
+			return err
+		}
+		if err := b.kr.Set(b.service, key, base64.StdEncoding.EncodeToString(raw)); err != nil {
+			return err
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	indexData, err := json.Marshal(keys)
+	if err != nil {
+		return err
+	}
+	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(indexData)); err != nil {
+		return err
+	}
+	for _, key := range priorKeys {
+		if _, ok := state.Tokens[key]; !ok {
+			if _, err := b.kr.Delete(b.service, key); err != nil {
+				return err
+			}
+		}
+	}
+	// The index now exists and is authoritative; drop the legacy entry so a
+	// future read never falls back to it.
+	_, _ = b.kr.Delete(b.service, b.legacyAccount)
+	return nil
+}
+
+// indexedKeys returns the keys currently listed in the index, or nil if there
+// is no index yet (first write, or still on the legacy format).
+func (b keyringBlob) indexedKeys() ([]string, error) {
+	enc, ok, err := b.kr.Get(b.service, b.indexAccount)
+	if err != nil || !ok {
+		return nil, err
+	}
+	keys, err := decodeKeyIndex(enc)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: decode keyring token index: %w", err)
+	}
+	return keys, nil
+}
+
+func decodeKeyIndex(enc string) ([]string, error) {
+	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
+	if err != nil {
+		return nil, err
+	}
+	var keys []string
+	if err := json.Unmarshal(data, &keys); err != nil {
+		return nil, err
+	}
+	return keys, nil
 }
 
 // withLock serializes the keyring's read-modify-write. Store.mu covers the
@@ -511,7 +638,7 @@ func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
 	return fn()
 }
 
-func (b keyringBlob) location() string { return "keyring:" + b.service + "/" + b.account }
+func (b keyringBlob) location() string { return "keyring:" + b.service + "/" + b.indexAccount }
 
 // FormatStatuses renders a human-readable status table without leaking token
 // material.

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -280,7 +280,13 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 // by uid so two different users never collide on one path.
 func keyringLockPath(env map[string]string, service, account string) string {
 	name := keyringLockFileName(service, account)
-	if home, err := resolveHomeDir(env); err == nil && strings.TrimSpace(home) != "" {
+	// Use OS.UserHomeDir (not resolveHomeDir) for a stable per-OS-user
+	// identity. resolveHomeDir honors ZERO_OAUTH_TOKENS_PATH and
+	// XDG_CONFIG_HOME overrides; using those for the lock path means
+	// two processes for the same keychain user with different HOME
+	// values take different locks, both read-modify-write the shared
+	// keyring index, and one saved token can be left unindexed.
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
 		return filepath.Join(home, ".cache", "zero", name)
 	}
 	return filepath.Join(os.TempDir(), keyringTempLockName(service, account))
@@ -298,11 +304,14 @@ func keyringLockPath(env map[string]string, service, account string) string {
 // when the file-backend location can't be resolved at all, matching the
 // legacy code's own best-effort fallback (no cross-process lock at all).
 func legacyKeyringLockPath(env map[string]string) string {
-	home, err := resolveHomeDir(nil)
+	// Use ResolveStorePath so the legacy lock lives beside whatever the
+	// legacy binary actually stores to (honoring ZERO_OAUTH_TOKENS_PATH
+	// and XDG_CONFIG_HOME), matching the old binary's own lock path.
+	storePath, err := ResolveStorePath(env)
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, ".config", "zero", "oauth-keyring.lockfile")
+	return filepath.Join(filepath.Dir(storePath), "oauth-keyring.lockfile")
 }
 
 // keyringLockFileName names the lock file after the keyring identity it
@@ -958,14 +967,15 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 	}
 	trimmed := strings.TrimSpace(string(raw))
 	if strings.HasPrefix(trimmed, "[") {
-		var keys []string
-		if err := json.Unmarshal(raw, &keys); err != nil {
+		var rawKeys []string
+		if err := json.Unmarshal(raw, &rawKeys); err != nil {
 			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
 		}
+		keys := dedupeValidKeys(rawKeys)
 		if len(keys) > maxKeyringIndexKeys {
 			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys))
 		}
-		return dedupeValidKeys(keys), true, 1, nil
+		return keys, true, 1, nil
 	}
 	var header keyIndexHeader
 	if err := json.Unmarshal(raw, &header); err != nil {
@@ -981,10 +991,7 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 	if header.Chunks < 1 || header.Chunks > maxKeyringIndexChunks {
 		return nil, false, 0, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
 	}
-	if len(header.Keys) > maxKeyringIndexKeys {
-		return nil, false, 0, errKeyringIndexTooManyKeys(len(header.Keys))
-	}
-	keys := header.Keys
+	rawKeys := header.Keys
 	for i := 1; i < header.Chunks; i++ {
 		chunkEnc, ok, err := b.kr.Get(b.service, b.chunkAccount(i))
 		if err != nil {
@@ -1001,12 +1008,13 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		if err := json.Unmarshal(chunkRaw, &more); err != nil {
 			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
 		}
-		if len(keys)+len(more) > maxKeyringIndexKeys {
-			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys) + len(more))
-		}
-		keys = append(keys, more...)
+		rawKeys = append(rawKeys, more...)
 	}
-	return dedupeValidKeys(keys), true, header.Chunks, nil
+	keys := dedupeValidKeys(rawKeys)
+	if len(keys) > maxKeyringIndexKeys {
+		return nil, false, 0, errKeyringIndexTooManyKeys(len(keys))
+	}
+	return keys, true, header.Chunks, nil
 }
 
 // dedupeValidKeys drops duplicates and malformed entries from a decoded

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -35,6 +36,10 @@ const (
 var keyPattern = regexp.MustCompile(`^(provider|mcp):[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 
 var currentOSUser = user.Current
+
+// lookupUserID resolves an OS account by uid; a var so the keyring-lock
+// fallback can be tested hermetically without touching the real user database.
+var lookupUserID = user.LookupId
 
 // ValidateKey reports whether key is a well-formed namespaced token key.
 func ValidateKey(key string) error {
@@ -305,23 +310,34 @@ func keyringLockPath(env map[string]string, service, account string) (string, er
 	if err != nil {
 		return "", fmt.Errorf("oauth: keyring lock fallback dir: %w", err)
 	}
-	return filepath.Join(dir, keyringTempLockName(service, account)), nil
+	return filepath.Join(dir, keyringLockFileName(service, account)), nil
 }
 
 // keyringFallbackLockDir returns a private directory for last-resort keyring
-// locks when the OS user home cannot be resolved. On Windows the process temp
-// dir is already per-user. Elsewhere a UID-scoped 0700 directory under the
-// process temp root is created and validated so a co-tenant cannot pre-create
-// the lock file (or a world-writable parent) and permanently deny OAuth.
+// locks when user.Current cannot resolve a home. It first tries the OS user
+// database by uid (identity-stable, independent of HOME/XDG/TMPDIR env) so the
+// fallback lands on the SAME home-anchored cache dir as the primary branch,
+// giving every process of the user one lock file. If even that lookup fails,
+// it falls back to a uid-scoped 0700 directory under the FIXED /tmp root —
+// never os.TempDir(), which honors the per-process TMPDIR override: two
+// same-user processes with different TMPDIR values would otherwise compute
+// different lock directories while writing the same keyring index and race it.
+// Ownership and mode of the /tmp directory are validated so a co-tenant cannot
+// pre-create it and deny OAuth. Windows temp is already per-user.
 func keyringFallbackLockDir() (string, error) {
 	if runtime.GOOS == "windows" {
 		return os.TempDir(), nil
+	}
+	if uid := os.Getuid(); uid >= 0 {
+		if u, err := lookupUserID(strconv.Itoa(uid)); err == nil && strings.TrimSpace(u.HomeDir) != "" {
+			return filepath.Join(u.HomeDir, ".cache", "zero"), nil
+		}
 	}
 	name := "zero-oauth-locks"
 	if uid := os.Getuid(); uid >= 0 {
 		name = fmt.Sprintf("zero-oauth-locks-%d", uid)
 	}
-	dir := filepath.Join(os.TempDir(), name)
+	dir := filepath.Join("/tmp", name)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
@@ -378,17 +394,6 @@ var lockComponentSafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 
 func sanitizeLockComponent(s string) string {
 	return lockComponentSafe.ReplaceAllString(s, "_")
-}
-
-// keyringTempLockName names the last-resort temp lock file, scoping it by uid so
-// concurrently running different users do not share one path. os.Getuid returns
-// -1 where uids do not apply (Windows), where os.TempDir is already per-user.
-func keyringTempLockName(service, account string) string {
-	name := keyringLockFileName(service, account)
-	if uid := os.Getuid(); uid >= 0 {
-		return fmt.Sprintf("zero-%d-%s", uid, name)
-	}
-	return "zero-" + name
 }
 
 // FilePath returns the resolved token store location (a path for the file
@@ -877,10 +882,11 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
 	}
-	priorKeys, indexExisted, priorChunks, indexIncomplete, err := b.readKeyIndex()
+	priorKeys, indexExisted, priorChunks, missingChunks, err := b.readKeyIndex()
 	if err != nil {
 		return err
 	}
+	indexIncomplete := len(missingChunks) > 0
 	prior := make(map[string]bool, len(priorKeys))
 	for _, key := range priorKeys {
 		prior[key] = true
@@ -1000,7 +1006,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 		}
 		sort.Strings(union)
 	}
-	unionChunks, err := b.writeKeyIndex(union, priorChunks, indexIncomplete)
+	unionChunks, err := b.writeKeyIndex(union, priorChunks, missingChunks)
 	if err != nil {
 		return err
 	}
@@ -1025,7 +1031,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 	// Skip shrink when the prior index was incomplete: a shrink to `keys` would
 	// drop the preserved chunk advertisements and strand unlisted entries.
 	if !indexIncomplete {
-		if _, err := b.writeKeyIndex(keys, unionChunks, false); err != nil {
+		if _, err := b.writeKeyIndex(keys, unionChunks, nil); err != nil {
 			return err
 		}
 	}
@@ -1097,7 +1103,7 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
 		return nil
 	}
 	if len(tombstones) > maxKeyringTombstoneKeys {
-		return errKeyringIndexTooManyKeys(len(tombstones), maxKeyringTombstoneKeys)
+		return fmt.Errorf("oauth: keyring token tombstones list %d logged-out keys, over the %d-key writable bound; re-login to a retired provider to free a marker slot", len(tombstones), maxKeyringTombstoneKeys)
 	}
 	keys := make([]string, 0, len(tombstones))
 	for key := range tombstones {
@@ -1107,7 +1113,7 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if _, err := tb.writeKeyIndex(keys, priorChunks, false); err != nil {
+	if _, err := tb.writeKeyIndex(keys, priorChunks, nil); err != nil {
 		return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
 	}
 	return nil
@@ -1155,9 +1161,22 @@ const maxKeyringIndexChunks = 128
 // maxKeyringIndexChunks) while still rejecting a damaged index promptly.
 const maxKeyringIndexKeys = 512
 
-// Tombstones do not fan out into per-key keyring reads, so they can use the
-// codec's bounded raw capacity without imposing the live credential cap.
-const maxKeyringTombstoneKeys = maxRawKeyringIndexKeys
+// maxKeyringKeyBytes is the longest ValidateKey-shaped key: "provider:" (or
+// "mcp:") plus a leading alphanumeric plus up to 127 safe characters.
+const maxKeyringKeyBytes = 137
+
+// maxKeyringTombstoneKeys bounds the durable logout-marker set to what the
+// chunked index writer can ALWAYS serialize, even with maximum-length keys:
+// each key costs len+8 = 145 bytes of a 2700-byte chunk, so one chunk holds 18
+// and the 128-chunk reader cap holds 2304. The previous bound of 16,384 was
+// only reachable with tiny keys; a tombstone set using long provider keys
+// exhausted the chunk budget first, and once writeKeyIndex rejected it every
+// later Save/Delete failed (including the re-login that could otherwise clear
+// the marker), permanently disabling keyring-backed persistence. With the
+// writable bound, the logout that would overflow the set fails with a clear
+// error instead of bricking the store, and re-login retires a marker to free
+// a slot.
+const maxKeyringTombstoneKeys = maxKeyringIndexChunks * (maxKeyringIndexChunkBytes / (maxKeyringKeyBytes + 8))
 
 // maxRawKeyringIndexKeys bounds the raw decoded element count before
 // deduplication or map preallocation, guarding against DoS from duplicate keys.
@@ -1211,86 +1230,87 @@ func decodeKeyringIndexPayload(enc string, what string) ([]byte, error) {
 }
 
 // readKeyIndex returns the indexed keys, whether an index exists at all,
-// how many chunk entries it currently occupies, and whether a referenced
-// continuation chunk was missing. A missing chunk (external keychain damage
-// or a torn write outside this code's write order) is skipped so reads stay
-// available, but incomplete is true so write() can refuse to shrink the
-// index and strand the unlisted entries as undeletable orphans.
-func (b keyringBlob) readKeyIndex() (keys []string, ok bool, chunks int, incomplete bool, err error) {
+// how many chunk entries it currently occupies, and the indexes of any
+// advertised continuation chunks that are missing. A missing chunk (external
+// keychain damage or a torn write outside this code's write order) is skipped
+// so reads stay available, but its index is remembered so write() can refuse
+// to shrink the index (stranding the unlisted entries as undeletable orphans)
+// and can refuse to overwrite that account with unrelated new chunk data.
+func (b keyringBlob) readKeyIndex() (keys []string, ok bool, chunks int, missing []int, err error) {
 	enc, ok, err := b.kr.Get(b.service, b.indexAccount)
 	if err != nil {
-		return nil, false, 0, false, err
+		return nil, false, 0, nil, err
 	}
 	if !ok {
-		return nil, false, 0, false, nil
+		return nil, false, 0, nil, nil
 	}
 	raw, err := decodeKeyringIndexPayload(enc, "keyring token index")
 	if err != nil {
-		return nil, false, 0, false, err
+		return nil, false, 0, nil, err
 	}
 	trimmed := strings.TrimSpace(string(raw))
 	if strings.HasPrefix(trimmed, "[") {
 		var rawKeys []string
 		if err := json.Unmarshal(raw, &rawKeys); err != nil {
-			return nil, false, 0, false, fmt.Errorf("oauth: decode keyring token index: %w", err)
+			return nil, false, 0, nil, fmt.Errorf("oauth: decode keyring token index: %w", err)
 		}
 		if len(rawKeys) > maxRawKeyringIndexKeys {
-			return nil, false, 0, false, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
+			return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
 		}
 		keys := dedupeValidKeys(rawKeys)
 		if len(keys) > b.indexKeyLimit() {
-			return nil, false, 0, false, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
+			return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 		}
-		return keys, true, 1, false, nil
+		return keys, true, 1, nil, nil
 	}
 	var header keyIndexHeader
 	if err := json.Unmarshal(raw, &header); err != nil {
-		return nil, false, 0, false, fmt.Errorf("oauth: decode keyring token index: %w", err)
+		return nil, false, 0, nil, fmt.Errorf("oauth: decode keyring token index: %w", err)
 	}
 	// Reject an unsupported or corrupt header before looping: an out-of-range
 	// Chunks would otherwise drive up to that many blocking keyring lookups
 	// (each up to the 10s command timeout) while the store lock is held, wedging
 	// every Load/Status/Save/Delete instead of failing promptly.
 	if header.Version != 1 {
-		return nil, false, 0, false, fmt.Errorf("oauth: unsupported keyring token index version %d", header.Version)
+		return nil, false, 0, nil, fmt.Errorf("oauth: unsupported keyring token index version %d", header.Version)
 	}
 	if header.Chunks < 1 || header.Chunks > maxKeyringIndexChunks {
-		return nil, false, 0, false, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
+		return nil, false, 0, nil, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
 	}
 	rawKeys := header.Keys
 	if len(rawKeys) > maxRawKeyringIndexKeys {
-		return nil, false, 0, false, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
+		return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
 	}
-	incomplete = false
 	for i := 1; i < header.Chunks; i++ {
 		chunkEnc, chunkOK, err := b.kr.Get(b.service, b.chunkAccount(i))
 		if err != nil {
-			return nil, false, 0, false, err
+			return nil, false, 0, nil, err
 		}
 		if !chunkOK {
-			// Skip so Load/Status stay available, but remember the damage so
-			// write() does not shrink away the unlisted keys' entries.
-			incomplete = true
+			// Skip so Load/Status stay available, but remember which account is
+			// damaged so write() neither shrinks away the unlisted keys' entries
+			// nor overwrites this account with unrelated new chunk data.
+			missing = append(missing, i)
 			continue
 		}
 		chunkRaw, err := decodeKeyringIndexPayload(chunkEnc, fmt.Sprintf("keyring token index chunk %d", i))
 		if err != nil {
-			return nil, false, 0, false, err
+			return nil, false, 0, nil, err
 		}
 		var more []string
 		if err := json.Unmarshal(chunkRaw, &more); err != nil {
-			return nil, false, 0, false, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
+			return nil, false, 0, nil, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
 		}
 		if len(rawKeys)+len(more) > maxRawKeyringIndexKeys {
-			return nil, false, 0, false, errKeyringIndexTooManyKeys(len(rawKeys)+len(more), maxRawKeyringIndexKeys)
+			return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys)+len(more), maxRawKeyringIndexKeys)
 		}
 		rawKeys = append(rawKeys, more...)
 	}
 	keys = dedupeValidKeys(rawKeys)
 	if len(keys) > b.indexKeyLimit() {
-		return nil, false, 0, false, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
+		return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 	}
-	return keys, true, header.Chunks, incomplete, nil
+	return keys, true, header.Chunks, missing, nil
 }
 
 // dedupeValidKeys drops duplicates and malformed entries from a decoded
@@ -1327,12 +1347,14 @@ func dedupeValidKeys(keys []string) []string {
 // previously larger index are removed only after the header stops referencing
 // them (best-effort: an unreferenced chunk is never read).
 //
-// keepMissingChunks is set when readKeyIndex reported a missing continuation
-// chunk. In that mode the header keeps advertising at least priorChunks so a
-// later-restored chunk remains reachable, and chunk accounts in that range are
-// not deleted (overwriting or removing them would turn recoverable damage into
-// permanent orphans).
-func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, keepMissingChunks bool) (int, error) {
+// missingChunks lists the continuation-chunk accounts readKeyIndex reported as
+// missing. Those slots are protected: the credentials they listed may still
+// exist in the keyring, so overwriting the account with unrelated new chunk
+// data would permanently orphan them even if the original chunk is later
+// restored. New continuation chunks are therefore remapped around protected
+// slots, the header keeps advertising at least priorChunks so a later-restored
+// chunk remains reachable, and protected accounts are never deleted.
+func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks []int) (int, error) {
 	// Refuse to publish an index the reader would reject: readKeyIndex caps both
 	// total keys and chunk count, and a header beyond either would make every
 	// later Load/Status/Save/Delete fail before it could recover. Check the key
@@ -1345,19 +1367,40 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, keepMissingCh
 	if len(chunks) > maxKeyringIndexChunks {
 		return 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", len(chunks), maxKeyringIndexChunks)
 	}
-	// Only write content chunks we produced. When preserving a damaged prior
-	// index, higher-numbered accounts may still hold recoverable key lists.
+	protected := make(map[int]bool, len(missingChunks))
+	maxProtected := 0
+	for _, c := range missingChunks {
+		protected[c] = true
+		if c > maxProtected {
+			maxProtected = c
+		}
+	}
+	// Write each new continuation chunk into the next account that is not a
+	// protected (missing) slot, so recoverable chunk data is never overwritten.
+	slot := 1
+	advertised := len(chunks)
 	for i := 1; i < len(chunks); i++ {
+		for protected[slot] {
+			slot++
+		}
 		chunkData, err := json.Marshal(chunks[i])
 		if err != nil {
 			return 0, err
 		}
-		if err := b.kr.Set(b.service, b.chunkAccount(i), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
+		if err := b.kr.Set(b.service, b.chunkAccount(slot), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
 			return 0, err
 		}
+		if slot+1 > advertised {
+			advertised = slot + 1
+		}
+		slot++
 	}
-	advertised := len(chunks)
-	if keepMissingChunks && priorChunks > advertised {
+	// Keep advertising protected slots (a restored chunk is read by walking
+	// every account below the advertised count) and the prior chunk count.
+	if len(missingChunks) > 0 && maxProtected+1 > advertised {
+		advertised = maxProtected + 1
+	}
+	if len(missingChunks) > 0 && priorChunks > advertised {
 		advertised = priorChunks
 	}
 	if advertised > maxKeyringIndexChunks {
@@ -1370,7 +1413,9 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, keepMissingCh
 	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
 		return 0, err
 	}
-	if !keepMissingChunks {
+	// Remove stale chunks only when nothing is protected: deleting a protected
+	// account would destroy the last chance to recover the keys it listed.
+	if len(missingChunks) == 0 {
 		for i := len(chunks); i < priorChunks; i++ {
 			_, _ = b.kr.Delete(b.service, b.chunkAccount(i))
 		}
@@ -1405,6 +1450,12 @@ func chunkIndexKeys(keys []string) [][]string {
 // could reclaim the live lock and resume the token-loss race the lock
 // exists to prevent. A var so tests can shorten it.
 var fileLockRefreshInterval = 10 * time.Second
+
+// chtimesLockFile stamps a lock file's mtime for lease refresh. A var so tests
+// can inject renewal failures (fencing regression): a failed Chtimes leaves
+// the lock token intact but stops its mtime advancing, so a peer can reclaim
+// it as stale and start a conflicting critical section.
+var chtimesLockFile = os.Chtimes
 
 // leasedPath is one acquired lock whose mtime is refreshed until stop is
 // closed. Lease ownership starts at acquisition, not after every path is
@@ -1454,7 +1505,15 @@ func startLease(path, token string, unlock func()) *leasedPath {
 					return
 				}
 				at := time.Now()
-				_ = os.Chtimes(path, at, at)
+				if err := chtimesLockFile(path, at, at); err != nil {
+					// A failed renewal stops advancing the lock's mtime, so the
+					// lock will look stale and a peer can reclaim it
+					// mid-critical-section. Treat it as an immediate fencing
+					// failure: stop refreshing so withLeasedLocks aborts before
+					// (or surfaces the error after) the keyring mutation.
+					l.lost.Store(true)
+					return
+				}
 				if !ownLockFile(path, token) {
 					l.lost.Store(true)
 					return
@@ -1508,6 +1567,17 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func() error) erro
 		return fn()
 	}
 	defer releaseAll()
+	// Fencing: if any lease was already lost while later locks were still
+	// being acquired (e.g. the first, global index lock reclaimed as stale
+	// while the caller blocks on legacyLockPath), do not enter the critical
+	// section at all. A mutation under a lost lock would run concurrently with
+	// the peer that reclaimed it, reviving the token-loss race the locks exist
+	// to prevent.
+	for _, l := range leases {
+		if l.lost.Load() {
+			return fmt.Errorf("oauth: lost token lock lease on %s", filepath.Base(l.path))
+		}
+	}
 	err := fn()
 	for _, l := range leases {
 		if l.lost.Load() {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -199,12 +199,11 @@ func ResolveStorePath(env map[string]string) (string, error) {
 }
 
 // resolveHomeDir returns the user's home directory, honoring HOME/USERPROFILE
-// hermetically (via env) before falling back to os.UserHomeDir(). Shared by
-// ResolveStorePath's config-root fallback and by keyringLockPath, which
-// anchors on this same identity so the keyring lock never varies with a
-// per-process override like XDG_CACHE_HOME/XDG_CONFIG_HOME/TMPDIR that two
-// processes of the same real user commonly set differently (sandboxes, CI,
-// per-shell env).
+// hermetically (via env) before falling back to os.UserHomeDir(). Used by
+// ResolveStorePath's config-root fallback. Unlike ResolveStorePath,
+// keyringLockPath anchors directly on OS identity (currentOSUser /
+// keyringFallbackLockDir) so the keyring lock never varies with per-process
+// environment overrides.
 func resolveHomeDir(env map[string]string) (string, error) {
 	if home := strings.TrimSpace(firstNonEmpty(envValue(env, "HOME"), envValue(env, "USERPROFILE"))); home != "" {
 		return home, nil
@@ -1053,16 +1052,14 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 		return err
 	}
 	legacyOriginChanged := false
-	if legacyTokens != nil {
-		for key := range legacyTokens {
-			if ValidateKey(key) != nil {
-				continue
-			}
-			if !legacyOrigin[key] {
-				if _, mutated := mutations[key]; !mutated {
-					legacyOrigin[key] = true
-					legacyOriginChanged = true
-				}
+	for key := range legacyTokens {
+		if ValidateKey(key) != nil {
+			continue
+		}
+		if !legacyOrigin[key] {
+			if _, mutated := mutations[key]; !mutated {
+				legacyOrigin[key] = true
+				legacyOriginChanged = true
 			}
 		}
 	}
@@ -1253,12 +1250,10 @@ func (b keyringBlob) tombstoneBlob() keyringBlob {
 	return keyringBlob{kr: b.kr, service: b.service, indexAccount: keyringTombstoneAccount, maxIndexKeys: maxKeyringTombstoneKeys}
 }
 
-// readTombstones returns the durable set of keys deleted by a new binary.
-// Missing account => empty set. Corrupt payloads fail closed.
-func (b keyringBlob) readTombstones() (map[string]bool, error) {
-	keys, ok, _, _, _, err := b.tombstoneBlob().readKeyIndex()
+func (b keyringBlob) readMarkerSet(mb keyringBlob, label string) (map[string]bool, error) {
+	keys, ok, _, _, _, err := mb.readKeyIndex()
 	if err != nil {
-		return nil, fmt.Errorf("oauth: read keyring token tombstones: %w", err)
+		return nil, fmt.Errorf("oauth: read keyring %s: %w", label, err)
 	}
 	if !ok {
 		return map[string]bool{}, nil
@@ -1270,57 +1265,70 @@ func (b keyringBlob) readTombstones() (map[string]bool, error) {
 	return out, nil
 }
 
-// writeTombstones persists the durable deletion set. An empty set removes every
-// tombstone account/chunk so a fully clean store does not leave leftover
-// markers. Errors from that cleanup are surfaced so interruption tests and
-// real keyring failures cannot be swallowed.
-func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leaseCheck) error {
-	tb := b.tombstoneBlob()
-	_, existed, priorChunks, priorGeneration, missingChunks, err := tb.readKeyIndex()
+func (b keyringBlob) writeMarkerSet(mb keyringBlob, set map[string]bool, label string, limit int, overflowMsg string, checkLease leaseCheck) error {
+	_, existed, priorChunks, priorGeneration, missingChunks, err := mb.readKeyIndex()
 	if err != nil {
-		return fmt.Errorf("oauth: read keyring token tombstones: %w", err)
+		return fmt.Errorf("oauth: read keyring %s: %w", label, err)
 	}
-	if len(tombstones) == 0 {
+	if len(set) == 0 {
 		if !existed {
 			return nil
 		}
 		if len(missingChunks) > 0 {
-			if _, _, err := tb.writeKeyIndex(nil, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
-				return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
+			if _, _, err := mb.writeKeyIndex(nil, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
+				return fmt.Errorf("oauth: write keyring %s: %w", label, err)
 			}
 			return nil
 		}
 		if err := checkLease(); err != nil {
 			return err
 		}
-		if _, err := tb.kr.Delete(tb.service, tb.indexAccount); err != nil {
+		if _, err := mb.kr.Delete(mb.service, mb.indexAccount); err != nil {
 			return err
 		}
 		for i := 1; i < priorChunks; i++ {
 			if err := checkLease(); err != nil {
 				return err
 			}
-			if _, err := tb.kr.Delete(tb.service, tb.chunkAccount(priorGeneration, i)); err != nil {
+			if _, err := mb.kr.Delete(mb.service, mb.chunkAccount(priorGeneration, i)); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
-	if len(tombstones) > maxKeyringTombstoneKeys {
-		return fmt.Errorf("oauth: keyring token tombstones list %d logged-out keys, over the %d-key writable bound; re-login to a retired provider to free a marker slot", len(tombstones), maxKeyringTombstoneKeys)
+	if len(set) > limit {
+		if overflowMsg != "" {
+			return fmt.Errorf("oauth: keyring %s list %d %s", label, len(set), overflowMsg)
+		}
+		return fmt.Errorf("oauth: keyring %s list %d keys, over the %d-key writable bound", label, len(set), limit)
 	}
-	keys := make([]string, 0, len(tombstones))
-	for key := range tombstones {
+	keys := make([]string, 0, len(set))
+	for key := range set {
 		if ValidateKey(key) != nil {
 			continue
 		}
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if _, _, err := tb.writeKeyIndex(keys, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
-		return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
+	if _, _, err := mb.writeKeyIndex(keys, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
+		return fmt.Errorf("oauth: write keyring %s: %w", label, err)
 	}
 	return nil
+}
+
+// readTombstones returns the durable set of keys deleted by a new binary.
+// Missing account => empty set. Corrupt payloads fail closed.
+func (b keyringBlob) readTombstones() (map[string]bool, error) {
+	return b.readMarkerSet(b.tombstoneBlob(), "token tombstones")
+}
+
+// writeTombstones persists the durable deletion set. An empty set removes every
+// tombstone account/chunk so a fully clean store does not leave leftover
+// markers. Errors from that cleanup are surfaced so interruption tests and
+// real keyring failures cannot be swallowed.
+func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leaseCheck) error {
+	overflow := fmt.Sprintf("logged-out keys, over the %d-key writable bound; re-login to a retired provider to free a marker slot", maxKeyringTombstoneKeys)
+	return b.writeMarkerSet(b.tombstoneBlob(), tombstones, "token tombstones", maxKeyringTombstoneKeys, overflow, checkLease)
 }
 
 func (b keyringBlob) legacyOriginBlob() keyringBlob {
@@ -1334,70 +1342,14 @@ func (b keyringBlob) legacyOriginBlob() keyringBlob {
 // un-track every key it recorded and let the very absences it exists to
 // interpret look like fresh, ordinary keys again.
 func (b keyringBlob) readLegacyOrigin() (map[string]bool, error) {
-	keys, ok, _, _, _, err := b.legacyOriginBlob().readKeyIndex()
-	if err != nil {
-		return nil, fmt.Errorf("oauth: read keyring legacy-origin markers: %w", err)
-	}
-	if !ok {
-		return map[string]bool{}, nil
-	}
-	out := make(map[string]bool, len(keys))
-	for _, key := range keys {
-		out[key] = true
-	}
-	return out, nil
+	return b.readMarkerSet(b.legacyOriginBlob(), "legacy-origin markers")
 }
 
 // writeLegacyOrigin persists the legacy-origin set, mirroring writeTombstones:
 // an empty set removes the account/chunks entirely rather than leaving a
 // zero-key index behind.
 func (b keyringBlob) writeLegacyOrigin(origin map[string]bool, checkLease leaseCheck) error {
-	lb := b.legacyOriginBlob()
-	_, existed, priorChunks, priorGeneration, missingChunks, err := lb.readKeyIndex()
-	if err != nil {
-		return fmt.Errorf("oauth: read keyring legacy-origin markers: %w", err)
-	}
-	if len(origin) == 0 {
-		if !existed {
-			return nil
-		}
-		if len(missingChunks) > 0 {
-			if _, _, err := lb.writeKeyIndex(nil, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
-				return fmt.Errorf("oauth: write keyring legacy-origin markers: %w", err)
-			}
-			return nil
-		}
-		if err := checkLease(); err != nil {
-			return err
-		}
-		if _, err := lb.kr.Delete(lb.service, lb.indexAccount); err != nil {
-			return err
-		}
-		for i := 1; i < priorChunks; i++ {
-			if err := checkLease(); err != nil {
-				return err
-			}
-			if _, err := lb.kr.Delete(lb.service, lb.chunkAccount(priorGeneration, i)); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-	if len(origin) > maxKeyringTombstoneKeys {
-		return fmt.Errorf("oauth: keyring legacy-origin markers list %d keys, over the %d-key writable bound", len(origin), maxKeyringTombstoneKeys)
-	}
-	keys := make([]string, 0, len(origin))
-	for key := range origin {
-		if ValidateKey(key) != nil {
-			continue
-		}
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	if _, _, err := lb.writeKeyIndex(keys, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
-		return fmt.Errorf("oauth: write keyring legacy-origin markers: %w", err)
-	}
-	return nil
+	return b.writeMarkerSet(b.legacyOriginBlob(), origin, "legacy-origin markers", maxKeyringTombstoneKeys, "", checkLease)
 }
 
 // maxKeyringSingleEntryBytes bounds a single base64-encoded token secret so
@@ -1816,6 +1768,25 @@ func (b keyringBlob) writeKeyIndexInPlace(chunkList [][]string, priorChunks, pri
 			return 0, 0, err
 		}
 		if err := b.kr.Set(b.service, b.chunkAccount(priorGeneration, p.slot), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
+			return 0, 0, err
+		}
+	}
+	plannedSlots := make(map[int]bool, len(planned))
+	for _, p := range planned {
+		plannedSlots[p.slot] = true
+	}
+	for s := 1; s < advertised; s++ {
+		if protected[s] || plannedSlots[s] {
+			continue
+		}
+		emptyData, err := json.Marshal([]string{})
+		if err != nil {
+			return 0, 0, err
+		}
+		if err := checkLease(); err != nil {
+			return 0, 0, err
+		}
+		if err := b.kr.Set(b.service, b.chunkAccount(priorGeneration, s), base64.StdEncoding.EncodeToString(emptyData)); err != nil {
 			return 0, 0, err
 		}
 	}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -265,27 +266,16 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 
 // keyringLockPath returns the cross-process lock file location for the
 // keyring backend's read-modify-write, derived from the keyring identity
-// itself (the service/account the index is stored under) and anchored on the
-// user's home directory (see resolveHomeDir) rather than os.UserCacheDir() or
-// os.TempDir(): those pick XDG_CACHE_HOME/TMPDIR per PROCESS, so two
-// processes of the SAME real user with different cache/temp roots (a common
-// case: sandboxes, CI, per-shell overrides) computed different lock files,
-// both read the same fixed keyring index, and could publish competing
-// updates that silently hid one process's token. HOME does not vary this way
-// for a given real user. A single shared ${TMPDIR}/zero-oauth-keyring.lockfile
-// would also let any other account on a multi-user host pre-create or keep
-// refreshing the victim's lock and time out their Load/Status/Save/Delete,
-// even though each user has a separate OS keychain, so only when even the
-// home directory can't be resolved does this fall back to a temp file scoped
-// by uid so two different users never collide on one path.
+// itself (service + index account) and anchored on the user's OS home directory
+// (via user.Current()) rather than caller-controlled environment overrides
+// like HOME, XDG_CACHE_HOME, or TMPDIR: those pick different paths per process
+// (sandboxes, CI harnesses, launcher profiles), so two processes for the same
+// OS user would take different lock files while writing to the same OS keychain.
 func keyringLockPath(env map[string]string, service, account string) string {
 	name := keyringLockFileName(service, account)
-	// Use OS.UserHomeDir (not resolveHomeDir) for a stable per-OS-user
-	// identity. resolveHomeDir honors ZERO_OAUTH_TOKENS_PATH and
-	// XDG_CONFIG_HOME overrides; using those for the lock path means
-	// two processes for the same keychain user with different HOME
-	// values take different locks, both read-modify-write the shared
-	// keyring index, and one saved token can be left unindexed.
+	if u, err := user.Current(); err == nil && strings.TrimSpace(u.HomeDir) != "" {
+		return filepath.Join(u.HomeDir, ".cache", "zero", name)
+	}
 	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
 		return filepath.Join(home, ".cache", "zero", name)
 	}
@@ -695,21 +685,21 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 		if err := json.Unmarshal(raw, &token); err != nil {
 			return nil, false, fmt.Errorf("oauth: invalid keyring token entry %q: %w", key, err)
 		}
-		tokens[key] = token
-	}
 
-	if !legacyLoaded {
-		if lt, lerr := b.readLegacyTokens(); lerr == nil {
-			legacyTokens = lt
+		// Check if legacy blob holds a fresher token for this indexed key
+		// (e.g. refreshed by an old binary running concurrently).
+		if !legacyLoaded {
+			if lt, lerr := b.readLegacyTokens(); lerr == nil {
+				legacyTokens = lt
+			}
+			legacyLoaded = true
 		}
-	}
-	for key, legacyToken := range legacyTokens {
-		if ValidateKey(key) != nil {
-			continue
+		if legacyToken, has := legacyTokens[key]; has {
+			if legacyIsFresher(legacyToken, token) {
+				token = legacyToken
+			}
 		}
-		if _, exists := tokens[key]; !exists {
-			tokens[key] = legacyToken
-		}
+		tokens[key] = token
 	}
 
 	data, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens})
@@ -761,14 +751,21 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // legacyIsFresher reports whether the legacy copy of an already-indexed key
 // should win over the indexed copy. An old binary running alongside the new one
 // refreshes tokens only in the legacy combined entry, and a refresh pushes the
-// expiry later, so a strictly later expiry on the legacy side is the
+// expiry later (or updates token material when expires_in is omitted), so a
+// strictly later expiry or updated token material on the legacy side is the
 // signal that it holds a newer credential. Zero (unknown) expiries are valid.
 func legacyIsFresher(legacy, current Token) bool {
-	if legacy.ExpiresAt.After(current.ExpiresAt) {
-		return true
-	}
-	if legacy.ExpiresAt.Equal(current.ExpiresAt) {
+	if !legacy.ExpiresAt.IsZero() && !current.ExpiresAt.IsZero() {
+		if legacy.ExpiresAt.After(current.ExpiresAt) {
+			return true
+		}
+		if current.ExpiresAt.After(legacy.ExpiresAt) {
+			return false
+		}
 		return legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken
+	}
+	if legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken {
+		return true
 	}
 	return false
 }
@@ -871,7 +868,11 @@ func (b keyringBlob) write(data []byte) error {
 		if err != nil {
 			return err
 		}
-		if err := b.kr.Set(b.service, key, base64.StdEncoding.EncodeToString(raw)); err != nil {
+		encoded := base64.StdEncoding.EncodeToString(raw)
+		if len(encoded) > maxKeyringSingleEntryBytes {
+			return fmt.Errorf("oauth: token payload for %q (%d bytes) exceeds single keyring entry bound (%d bytes); use file or encrypted-file storage", key, len(encoded), maxKeyringSingleEntryBytes)
+		}
+		if err := b.kr.Set(b.service, key, encoded); err != nil {
 			return err
 		}
 	}
@@ -899,6 +900,11 @@ func (b keyringBlob) write(data []byte) error {
 	}
 	return nil
 }
+
+// maxKeyringSingleEntryBytes bounds a single base64-encoded token secret so
+// that the line passed to macOS `security -i` stays comfortably under the
+// 4095-byte command line cap (see internal/keyring).
+const maxKeyringSingleEntryBytes = 3800
 
 // maxKeyringIndexChunkBytes bounds one index chunk's raw JSON payload so its
 // base64 encoding plus command framing stays well under the macOS

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -431,12 +431,18 @@ func sanitizeLockComponent(s string) string {
 // backend, or a "keyring:..." identifier for the keyring backend).
 func (s *Store) FilePath() string { return s.blob.location() }
 
-// mutationIntent is why a key appears in a write's mutation set. Save and
-// Delete replace or remove a credential and must retire legacy-origin
-// precedence for that key. A token refresh is not a login or logout, so it
-// must keep the origin marker: otherwise an old-binary logout that happened
-// after this process last read the legacy blob is lost, and a later
-// absence-heuristic pass cannot delete the leftover indexed copy.
+// Mixed-version key lifecycle (keyring backend). File backends ignore intent.
+//
+//	State                         Load/Status              After refresh persist              After explicit Save                 After old binary drops the key from oauth-tokens
+//	----------------------------  -----------------------  ---------------------------------  ---------------------------------  ------------------------------------------------
+//	Legacy-only, not yet indexed  serve from legacy        index + set legacyOrigin           index + set origin                 hide + tombstone once origin is known
+//	Indexed, legacyOrigin set     serve indexed            update material, keep origin       update + retire origin             hide via origin absence (tombstone on write)
+//	Pure new-format (never legacy) serve indexed           update only                        update only                        N/A (origin never set)
+//	User logged out (tombstone)   hidden                   abort: do not refresh or persist   clear tombstone after durable write already hidden
+//
+// Refresh is not login. mutationRefresh seeds origin, never retires it, never
+// clears a tombstone, and never creates a credential that Load no longer sees.
+// Rules must key off intent, not "is this key in the mutation map?".
 type mutationIntent int
 
 const (
@@ -450,7 +456,11 @@ func (s *Store) Save(key string, token Token) error {
 	return s.save(key, token, mutationReplace)
 }
 
-func (s *Store) saveRefreshed(key string, token Token) error {
+// SaveRefreshed persists a token obtained by refreshing an existing
+// credential. Unlike Save this is not a login: it keeps mixed-version
+// origin markers, refuses to create a missing credential, and does not
+// clear a logout tombstone.
+func (s *Store) SaveRefreshed(key string, token Token) error {
 	return s.save(key, token, mutationRefresh)
 }
 
@@ -464,6 +474,11 @@ func (s *Store) save(key string, token Token, intent mutationIntent) error {
 		state, err := s.readState()
 		if err != nil {
 			return err
+		}
+		if intent == mutationRefresh {
+			if _, ok := state.Tokens[key]; !ok {
+				return fmt.Errorf("%w for %q", ErrNoToken, key)
+			}
 		}
 		state.Tokens[key] = token
 		return s.writeState(state, map[string]mutationIntent{key: intent}, check)
@@ -736,6 +751,11 @@ func createPublicationFile(path string) (*os.File, string, error) {
 // is no ownership loss for fn to observe mid-critical-section.
 func noLeaseLoss() error { return nil }
 
+// testAfterCriticalSection, if set, runs after the backend critical section
+// returns and before lock release / post-fn lease check. Tests use it to
+// simulate a peer reclaiming the lock after a successful persist.
+var testAfterCriticalSection func()
+
 func (b fileBlob) withLock(now func() time.Time, fn func(check leaseCheck) error) error {
 	unlock, _, err := acquireFileLock(b.path+".lockfile", now)
 	if err != nil {
@@ -743,10 +763,16 @@ func (b fileBlob) withLock(now func() time.Time, fn func(check leaseCheck) error
 	}
 	defer func() { _ = unlock() }()
 	fnErr := fn(noLeaseLoss)
-	if uerr := unlock(); uerr != nil && fnErr == nil {
-		return uerr
+	if hook := testAfterCriticalSection; hook != nil {
+		hook()
 	}
-	return fnErr
+	if fnErr != nil {
+		return fnErr
+	}
+	// Persist is the atomic rename inside fn. A later ownership loss on
+	// unlock is mutex cleanup and must not invert a successful write.
+	_ = unlock()
+	return nil
 }
 
 // withReadLock is deliberately lock-free: write() replaces the file with an
@@ -946,8 +972,9 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 }
 
 // readLegacy reads the pre-migration whole-blob entry, for installs that
-// haven't written since upgrading. The next write() migrates them: it writes
-// per-key entries and an index, then deletes this entry.
+// haven't written since upgrading. The next write() indexes per-key entries
+// from it and leaves oauth-tokens untouched. Tombstones and legacy-origin
+// handle logout and mixed-version detection.
 func (b keyringBlob) readLegacy() ([]byte, bool, error) {
 	enc, ok, err := b.kr.Get(b.service, b.legacyAccount)
 	if err != nil || !ok {
@@ -1078,17 +1105,23 @@ func (b keyringBlob) write(data []byte, mutations map[string]mutationIntent, che
 		return err
 	}
 	legacyOriginChanged := false
+	// Seed origin for every live legacy key except an in-flight delete.
+	// Refresh is often the first indexed write and must record origin so a
+	// later old-binary logout is distinguishable from "never in legacy".
 	for key := range legacyTokens {
 		if ValidateKey(key) != nil {
 			continue
 		}
-		if !legacyOrigin[key] {
-			if _, mutated := mutations[key]; !mutated {
-				legacyOrigin[key] = true
-				legacyOriginChanged = true
-			}
+		if legacyOrigin[key] {
+			continue
 		}
+		if intent, mutated := mutations[key]; mutated && intent == mutationDelete {
+			continue
+		}
+		legacyOrigin[key] = true
+		legacyOriginChanged = true
 	}
+	// Retire origin only on explicit login or logout, never on refresh.
 	for key, intent := range mutations {
 		if intent == mutationRefresh {
 			continue
@@ -1100,7 +1133,12 @@ func (b keyringBlob) write(data []byte, mutations map[string]mutationIntent, che
 	}
 	if len(legacyOrigin) > 0 {
 		for key := range state.Tokens {
-			if _, mutated := mutations[key]; mutated || !legacyOrigin[key] {
+			// Skip only the key being refreshed. Other origin-marked keys
+			// absent from legacy are still a logout, including on this pass.
+			if intent, mutated := mutations[key]; mutated && intent == mutationRefresh {
+				continue
+			}
+			if !legacyOrigin[key] {
 				continue
 			}
 			if legacyTokens != nil {
@@ -1251,11 +1289,13 @@ func (b keyringBlob) write(data []byte, mutations map[string]mutationIntent, che
 		}
 	}
 	// A re-login clears its tombstone only after the replacement entry and exact
-	// index are durable. If any earlier step fails, legacy fallback remains
+	// index are durable. Refresh is not re-login: if a concurrent logout
+	// published a tombstone, keep it so the persist cannot resurrect the
+	// credential. If any earlier step fails, legacy fallback remains
 	// suppressed instead of restoring the revoked credential.
 	tombstonesChanged := false
 	for key, intent := range mutations {
-		if intent != mutationDelete && tombstones[key] {
+		if intent == mutationReplace && tombstones[key] {
 			delete(tombstones, key)
 			tombstonesChanged = true
 		}
@@ -1957,9 +1997,11 @@ func (l *leasedPath) release() error {
 // cannot leave an earlier lock looking abandoned. Locks are released in
 // reverse order once fn returns — including when fn panics — so a recovered
 // panic cannot leave a forever-refreshed lock that wedges every later waiter.
-// If a lease is replaced under us mid-critical-section, the operation fails
-// closed after fn returns (or with fn's error) rather than treating a dual-
-// entry window as success.
+// Mid-fn lease loss is fail-closed: fn must consult checkLease before each
+// mutation, and a non-nil fn error is returned as-is. After fn returns nil,
+// every mutation it intended has already passed that fence, so a later lease
+// loss is mutex cleanup and must not invert success (a retry can burn a
+// single-use refresh token).
 // leaseCheck reports whether every lock backing the current critical section
 // is still owned, at the instant it is called. fn must call it immediately
 // before each externally visible mutation (a keyring Set/Delete, not a read),
@@ -2024,12 +2066,15 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func(check leaseCh
 		return err
 	}
 	err := fn(check)
+	if hook := testAfterCriticalSection; hook != nil {
+		hook()
+	}
 	if lostErr := check(); lostErr != nil {
 		_ = releaseAll()
 		if err != nil {
 			return err
 		}
-		return lostErr
+		return nil
 	}
 	if relErr := releaseAll(); relErr != nil {
 		if err != nil {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -481,15 +481,15 @@ func (s *Store) Delete(key string) (bool, error) {
 		if err != nil {
 			return err
 		}
-		if _, ok := state.Tokens[key]; !ok {
-			return nil
+		if _, ok := state.Tokens[key]; ok {
+			delete(state.Tokens, key)
+			removed = true
+			return s.writeState(state, map[string]bool{key: true}, check)
 		}
-		delete(state.Tokens, key)
-		removed = true
-		// Exclude the deleted key from legacy reconciliation so a credential
-		// that was only present in the legacy blob (never indexed) is not
-		// reclassified as a fresh old-binary login and written back.
-		return s.writeState(state, map[string]bool{key: true}, check)
+		if kb, ok := s.blob.(keyringBlob); ok && kb.hasResidentEntry(key) {
+			return s.writeState(state, map[string]bool{key: true}, check)
+		}
+		return nil
 	})
 	return removed, err
 }
@@ -741,6 +741,23 @@ type keyringBlob struct {
 	maxIndexKeys int
 }
 
+// hasResidentEntry reports whether key is still named in the key index or
+// has an individual entry in the OS keyring. Used during Store.Delete to
+// finish reconciling interrupted deletes whose tombstones already hide the key
+// from readState().
+func (b keyringBlob) hasResidentEntry(key string) bool {
+	keys, ok, _, _, _, _ := b.readKeyIndex()
+	if ok {
+		for _, k := range keys {
+			if k == key {
+				return true
+			}
+		}
+	}
+	_, exists, _ := b.kr.Get(b.service, key)
+	return exists
+}
+
 func (b keyringBlob) read() ([]byte, bool, error) {
 	keys, ok, _, _, _, err := b.readKeyIndex()
 	if err != nil {
@@ -795,6 +812,9 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 	}
 	tokens := make(map[string]Token, len(keys))
 	for _, key := range keys {
+		if tombstones[key] {
+			continue
+		}
 		enc, ok, err := b.kr.Get(b.service, key)
 		if err != nil {
 			return nil, false, err
@@ -804,11 +824,6 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 			// from the legacy blob when present and not tombstoned; otherwise
 			// skip rather than fail the whole read (the next Save/Delete prunes
 			// the phantom index key so it cannot permanently consume capacity).
-			// Tombstones do not hide a still-present indexed entry (in-flight
-			// delete): they only block resurrection from the legacy account.
-			if tombstones[key] {
-				continue
-			}
 			loadLegacy()
 			if token, has := legacyTokens[key]; has {
 				tokens[key] = token
@@ -1002,14 +1017,11 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 		return err
 	}
 	legacyOriginChanged := false
-	legacyTokensChanged := false
 	if legacyTokens != nil {
-		for key, deleted := range mutations {
-			if deleted {
-				if _, ok := legacyTokens[key]; ok {
-					delete(legacyTokens, key)
-					legacyTokensChanged = true
-				}
+		for key := range mutations {
+			if legacyOrigin[key] {
+				delete(legacyOrigin, key)
+				legacyOriginChanged = true
 			}
 		}
 		for key := range legacyTokens {
@@ -1017,8 +1029,10 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 				continue
 			}
 			if !legacyOrigin[key] {
-				legacyOrigin[key] = true
-				legacyOriginChanged = true
+				if _, mutated := mutations[key]; !mutated {
+					legacyOrigin[key] = true
+					legacyOriginChanged = true
+				}
 			}
 		}
 		// Only once the legacy entry has actually been read (legacyTokens != nil)
@@ -1192,22 +1206,9 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 			return err
 		}
 	}
-	if legacyTokensChanged {
-		if err := checkLease(); err != nil {
-			return err
-		}
-		if len(legacyTokens) == 0 {
-			if _, err := b.kr.Delete(b.service, b.legacyAccount); err != nil {
-				return fmt.Errorf("oauth: delete empty legacy keyring blob: %w", err)
-			}
-		} else {
-			legacyData, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: legacyTokens})
-			if err != nil {
-				return fmt.Errorf("oauth: encode updated legacy keyring blob: %w", err)
-			}
-			if err := b.kr.Set(b.service, b.legacyAccount, base64.StdEncoding.EncodeToString(legacyData)); err != nil {
-				return fmt.Errorf("oauth: update legacy keyring blob: %w", err)
-			}
+	if len(state.Tokens) == 0 && len(legacyTokens) > 0 {
+		if err := checkLease(); err == nil {
+			_, _ = b.kr.Delete(b.service, b.legacyAccount)
 		}
 	}
 	return nil
@@ -1686,6 +1687,12 @@ func (b keyringBlob) writeKeyIndexNewGeneration(chunkList [][]string, priorChunk
 	if err := checkLease(); err != nil {
 		return 0, 0, err
 	}
+	if priorGeneration > 0 {
+		_, ok, _, curGen, _, err := b.readKeyIndex()
+		if err == nil && ok && curGen != priorGeneration {
+			return 0, 0, fmt.Errorf("oauth: keyring key index generation conflict: expected %d, found %d", priorGeneration, curGen)
+		}
+	}
 	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
 		return 0, 0, err
 	}
@@ -1772,6 +1779,12 @@ func (b keyringBlob) writeKeyIndexInPlace(chunkList [][]string, priorChunks, pri
 	}
 	if err := checkLease(); err != nil {
 		return 0, 0, err
+	}
+	if priorGeneration > 0 {
+		_, ok, _, curGen, _, err := b.readKeyIndex()
+		if err == nil && ok && curGen != priorGeneration {
+			return 0, 0, fmt.Errorf("oauth: keyring key index generation conflict: expected %d, found %d", priorGeneration, curGen)
+		}
 	}
 	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
 		return 0, 0, err

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -617,7 +617,15 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 			// gone) skip rather than fail the whole read, since the next
 			// Save/Delete will reconcile the index.
 			if !legacyLoaded {
-				legacyTokens = b.readLegacyTokens()
+				// A best-effort recovery source for a read: a transient failure
+				// here must not fail the whole Load/Status, only skip recovering
+				// this particular desynced key. The next Save/Delete will
+				// reconcile it once the legacy blob is legible again (and,
+				// unlike here, will refuse to delete the legacy blob until it
+				// can actually read it — see write()).
+				if lt, lerr := b.readLegacyTokens(); lerr == nil {
+					legacyTokens = lt
+				}
 				legacyLoaded = true
 			}
 			if token, has := legacyTokens[key]; has {
@@ -657,20 +665,28 @@ func (b keyringBlob) readLegacy() ([]byte, bool, error) {
 	return data, true, nil
 }
 
-// readLegacyTokens returns the tokens held in the legacy combined entry, or an
-// empty map when there is no readable legacy blob. It is a best-effort recovery
-// source (read() falls back to it, write() reconciles against it), so a missing
-// or malformed legacy entry is reported as "no tokens" rather than a hard error.
-func (b keyringBlob) readLegacyTokens() map[string]Token {
+// readLegacyTokens returns the tokens held in the legacy combined entry. A
+// nil map with a nil error means the entry genuinely does not exist (readLegacy
+// returned ok=false, err=nil) — the one case callers may treat as "no tokens"
+// and proceed. Any other failure (a transient keyring read error, undecodable
+// base64, invalid JSON) is returned as err and must NOT be collapsed into "no
+// tokens": write() deletes the legacy blob once it believes reconciliation is
+// complete, so mistaking a transient read failure for an empty blob would
+// delete a still-unread, still-live credential that belongs to an older,
+// still-installed zero binary.
+func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 	data, ok, err := b.readLegacy()
-	if err != nil || !ok {
-		return nil
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
 	}
 	var legacyState storeFile
-	if json.Unmarshal(data, &legacyState) != nil {
-		return nil
+	if err := json.Unmarshal(data, &legacyState); err != nil {
+		return nil, fmt.Errorf("oauth: invalid legacy keyring token blob: %w", err)
 	}
-	return legacyState.Tokens
+	return legacyState.Tokens, nil
 }
 
 // legacyIsFresher reports whether the legacy copy of an already-indexed key
@@ -724,7 +740,17 @@ func (b keyringBlob) write(data []byte) error {
 	//   - a key that was in the prior index but is absent from this write was
 	//     deliberately removed (a logout); it is left removed, not resurrected.
 	if indexExisted {
-		for key, legacyToken := range b.readLegacyTokens() {
+		// Unlike read()'s best-effort fallback, a failure here must abort the
+		// whole write rather than proceed as though the legacy blob were empty:
+		// step 4 below deletes it, and a transient read error (the legacy blob
+		// genuinely exists but couldn't be read right now) must never be
+		// mistaken for "nothing to reconcile," or a still-live credential from
+		// an older, still-installed zero binary is destroyed irrecoverably.
+		legacyTokens, err := b.readLegacyTokens()
+		if err != nil {
+			return fmt.Errorf("oauth: read legacy keyring token blob for reconciliation: %w", err)
+		}
+		for key, legacyToken := range legacyTokens {
 			if ValidateKey(key) != nil {
 				continue
 			}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -319,7 +319,7 @@ func keyringLockPath(service, account string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("oauth: keyring lock fallback dir: %w", err)
 	}
-	return filepath.Join(dir, keyringLockFileName(service, account)), nil
+	return filepath.Join(dir, name), nil
 }
 
 // validateOAuthLockDir creates dir with 0700 permissions if needed, rejects
@@ -364,12 +364,17 @@ func keyringFallbackLockDir() (string, error) {
 		// anchor a lock two processes of the same user must agree on.
 		return identityLockRoot()
 	}
+	var homeErr error
 	if uid := os.Getuid(); uid >= 0 {
 		if u, err := lookupUserID(strconv.Itoa(uid)); err == nil && strings.TrimSpace(u.HomeDir) != "" {
 			dir := filepath.Join(u.HomeDir, ".cache", "zero")
 			if err := validateOAuthLockDir(dir); err == nil {
 				return dir, nil
+			} else {
+				homeErr = err
 			}
+		} else if err != nil {
+			homeErr = err
 		}
 	}
 	name := "zero-oauth-locks"
@@ -378,6 +383,9 @@ func keyringFallbackLockDir() (string, error) {
 	}
 	dir := filepath.Join("/tmp", name)
 	if err := validateOAuthLockDir(dir); err != nil {
+		if homeErr != nil {
+			return "", fmt.Errorf("oauth lock fallback /tmp: %w; prior home lookup error: %v", err, homeErr)
+		}
 		return "", err
 	}
 	return dir, nil
@@ -492,9 +500,15 @@ func (s *Store) Delete(key string) (bool, error) {
 		// credential-bearing entry, so report it as removed: `zero auth logout`
 		// surfaces this boolean directly and "nothing removed" would be wrong
 		// while per-key deletes and an index shrink are running.
-		if kb, ok := s.blob.(keyringBlob); ok && kb.hasResidentEntry(key) {
-			removed = true
-			return s.writeState(state, map[string]bool{key: true}, check)
+		if kb, ok := s.blob.(keyringBlob); ok {
+			resident, rerr := kb.hasResidentEntry(key)
+			if rerr != nil {
+				return rerr
+			}
+			if resident {
+				removed = true
+				return s.writeState(state, map[string]bool{key: true}, check)
+			}
 		}
 		return nil
 	})
@@ -611,8 +625,8 @@ type blobStore interface {
 	// each externally visible mutation write() performs; see leaseCheck.
 	write(data []byte, mutations map[string]bool, checkLease leaseCheck) error
 	// withLock runs fn under whatever cross-process exclusion the backend offers
-	// (a lock file for the file backend; none for the keyring, which is the
-	// authoritative store and is serialized within the process by Store.mu).
+	// (a lock file for the file backend; leased lock files for the keyring backend;
+	// Store.mu provides in-process serialization).
 	// fn receives a leaseCheck to consult before mutating; see its doc comment.
 	withLock(now func() time.Time, fn func(check leaseCheck) error) error
 	// withReadLock guards a read-only pass. The file backend's writes are
@@ -704,8 +718,12 @@ func (b fileBlob) withLock(now func() time.Time, fn func(check leaseCheck) error
 	if err != nil {
 		return err
 	}
-	defer unlock()
-	return fn(noLeaseLoss)
+	defer func() { _ = unlock() }()
+	fnErr := fn(noLeaseLoss)
+	if uerr := unlock(); uerr != nil && fnErr == nil {
+		return uerr
+	}
+	return fnErr
 }
 
 // withReadLock is deliberately lock-free: write() replaces the file with an
@@ -752,17 +770,23 @@ type keyringBlob struct {
 // has an individual entry in the OS keyring. Used during Store.Delete to
 // finish reconciling interrupted deletes whose tombstones already hide the key
 // from readState().
-func (b keyringBlob) hasResidentEntry(key string) bool {
-	keys, ok, _, _, _, _ := b.readKeyIndex()
+func (b keyringBlob) hasResidentEntry(key string) (bool, error) {
+	keys, ok, _, _, _, err := b.readKeyIndex()
+	if err != nil {
+		return false, err
+	}
 	if ok {
 		for _, k := range keys {
 			if k == key {
-				return true
+				return true, nil
 			}
 		}
 	}
-	_, exists, _ := b.kr.Get(b.service, key)
-	return exists
+	_, exists, gerr := b.kr.Get(b.service, key)
+	if gerr != nil {
+		return false, gerr
+	}
+	return exists, nil
 }
 
 func (b keyringBlob) read() ([]byte, bool, error) {
@@ -1051,7 +1075,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 		// explicit Save/Delete for key: that always wins over the heuristic, so
 		// a fresh Save is never immediately undone by a stale legacy reading.
 		for key := range state.Tokens {
-			if !legacyOrigin[key] || mutations[key] {
+			if _, mutated := mutations[key]; mutated || !legacyOrigin[key] {
 				continue
 			}
 			if _, stillInLegacy := legacyTokens[key]; stillInLegacy {
@@ -1659,6 +1683,12 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks, priorGeneration i
 	return b.writeKeyIndexInPlace(chunkList, priorChunks, priorGeneration, missingChunks, checkLease)
 }
 
+func (b keyringBlob) discardStagedChunks(generation, count int) {
+	for i := 1; i < count; i++ {
+		_, _ = b.kr.Delete(b.service, b.chunkAccount(generation, i))
+	}
+}
+
 // writeKeyIndexNewGeneration is writeKeyIndex's normal-case path: prior state
 // is fully known (missingChunks is empty), so it is safe to stage the entire
 // new layout under a never-before-used generation and adopt it with a single
@@ -1674,32 +1704,41 @@ func (b keyringBlob) writeKeyIndexNewGeneration(chunkList [][]string, priorChunk
 	if advertised > maxKeyringIndexChunks {
 		return 0, 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", advertised, maxKeyringIndexChunks)
 	}
+	staged := 0
 	for i := 1; i < len(chunkList); i++ {
 		chunkData, err := json.Marshal(chunkList[i])
 		if err != nil {
+			b.discardStagedChunks(newGeneration, staged+1)
 			return 0, 0, err
 		}
 		if err := checkLease(); err != nil {
+			b.discardStagedChunks(newGeneration, staged+1)
 			return 0, 0, err
 		}
 		if err := b.kr.Set(b.service, b.chunkAccount(newGeneration, i), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
+			b.discardStagedChunks(newGeneration, staged+1)
 			return 0, 0, err
 		}
+		staged = i
 	}
 	headerData, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: advertised, Generation: newGeneration, Keys: chunkList[0]})
 	if err != nil {
+		b.discardStagedChunks(newGeneration, len(chunkList))
 		return 0, 0, err
 	}
 	if err := checkLease(); err != nil {
+		b.discardStagedChunks(newGeneration, len(chunkList))
 		return 0, 0, err
 	}
 	if priorGeneration > 0 {
 		_, ok, _, curGen, _, err := b.readKeyIndex()
 		if err == nil && ok && curGen != priorGeneration {
+			b.discardStagedChunks(newGeneration, len(chunkList))
 			return 0, 0, fmt.Errorf("oauth: keyring key index generation conflict: expected %d, found %d", priorGeneration, curGen)
 		}
 	}
 	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
+		b.discardStagedChunks(newGeneration, len(chunkList))
 		return 0, 0, err
 	}
 	// The new generation is durable and exclusively authoritative from this
@@ -1845,13 +1884,13 @@ var chtimesLockFile = os.Chtimes
 type leasedPath struct {
 	path   string
 	token  string
-	unlock func()
+	unlock func() error
 	stop   chan struct{}
 	done   chan struct{}
 	lost   atomic.Bool
 }
 
-func startLease(path, token string, unlock func()) *leasedPath {
+func startLease(path, token string, unlock func() error) *leasedPath {
 	l := &leasedPath{
 		path:   path,
 		token:  token,
@@ -1902,10 +1941,13 @@ func startLease(path, token string, unlock func()) *leasedPath {
 	return l
 }
 
-func (l *leasedPath) release() {
+func (l *leasedPath) release() error {
 	close(l.stop)
 	<-l.done
-	l.unlock()
+	if l.unlock != nil {
+		return l.unlock()
+	}
+	return nil
 }
 
 // withLeasedLocks acquires every non-empty path in order. Each lock's mtime
@@ -1932,14 +1974,18 @@ type leaseCheck func() error
 func withLeasedLocks(paths []string, now func() time.Time, fn func(check leaseCheck) error) error {
 	var leases []*leasedPath
 	released := false
-	releaseAll := func() {
+	releaseAll := func() error {
 		if released {
-			return
+			return nil
 		}
 		released = true
+		var firstErr error
 		for i := len(leases) - 1; i >= 0; i-- {
-			leases[i].release()
+			if err := leases[i].release(); err != nil && firstErr == nil {
+				firstErr = err
+			}
 		}
+		return firstErr
 	}
 	for _, p := range paths {
 		if p == "" {
@@ -1947,7 +1993,7 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func(check leaseCh
 		}
 		unlock, token, err := acquireFileLock(p, now)
 		if err != nil {
-			releaseAll()
+			_ = releaseAll()
 			return err
 		}
 		// Start refreshing this lock before blocking on the next path.
@@ -1968,7 +2014,7 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func(check leaseCh
 	if len(leases) == 0 {
 		return fn(check)
 	}
-	defer releaseAll()
+	defer func() { _ = releaseAll() }()
 	// Fencing: if any lease was already lost while later locks were still
 	// being acquired (e.g. the first, global index lock reclaimed as stale
 	// while the caller blocks on legacyLockPath), do not enter the critical
@@ -1978,10 +2024,17 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func(check leaseCh
 	}
 	err := fn(check)
 	if lostErr := check(); lostErr != nil {
+		_ = releaseAll()
 		if err != nil {
 			return err
 		}
 		return lostErr
+	}
+	if relErr := releaseAll(); relErr != nil {
+		if err != nil {
+			return err
+		}
+		return relErr
 	}
 	return err
 }

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -119,9 +119,13 @@ type KeyringClient interface {
 // regardless of how many providers are logged in.
 const (
 	keyringService = "zero"
-	// keyringLegacyAccount held the whole blob as one entry in the original
-	// design. New writes never use it; it is only read once, to migrate
-	// existing installs into the per-key format.
+	// keyringLegacyAccount is the combined-blob entry used by pre-per-key
+	// binaries. New code dual-writes the reconciled token map here on every
+	// save so an old binary on another config root (which cannot share this
+	// process's legacy lock) still sees current credentials, and so a
+	// concurrent old-writer update is never permanently deleted just because
+	// this process could not observe it. The per-key index remains
+	// authoritative for new binaries.
 	keyringLegacyAccount = "oauth-tokens"
 	// keyringIndexAccount holds a JSON array of the token keys that currently
 	// have their own keyring entry, since KeyringClient has no "list" operation.
@@ -286,13 +290,11 @@ func keyringLockPath(env map[string]string, service, account string) string {
 // its own read-modify-write of the single combined keyring entry, beside
 // wherever ResolveStorePath resolves the file-backend location for that
 // process's env. A new binary must take this SAME lock (not just its own
-// keyringLockPath) around any write that reconciles or deletes the legacy
-// entry: an old binary observes no other lock, so only sharing its exact
-// lock file stops it from writing a fresh legacy login/refresh in the window
-// between this binary's reconciliation read and its legacy-blob delete,
-// which would otherwise discard that write permanently. Best-effort: ""
-// when the file-backend location can't be resolved at all, matching the
-// legacy code's own best-effort fallback (no cross-process lock at all).
+// keyringLockPath) around any write that reconciles or dual-writes the legacy
+// entry when the old binary shares this config root. Old binaries on other
+// roots cannot share this lock; dual-write-without-delete is the safety net
+// for that case. Best-effort: "" when the file-backend location can't be
+// resolved at all, matching the legacy code's own best-effort fallback.
 func legacyKeyringLockPath(env map[string]string) string {
 	// Use ResolveStorePath so the legacy lock lives beside whatever the
 	// legacy binary actually stores to (honoring ZERO_OAUTH_TOKENS_PATH
@@ -634,9 +636,10 @@ type keyringBlob struct {
 	lockPath string
 	// legacyLockPath, when set, is the lock file a pre-PR binary acquires around
 	// its own read-modify-write of the legacy combined entry (see
-	// legacyKeyringLockPath). write() holds it too, so a live old binary can't
-	// write a fresh legacy credential in the window between this write's legacy
-	// reconciliation and its legacy-blob delete.
+	// legacyKeyringLockPath). write() holds it too so, when the old binary shares
+	// this config root, it cannot race our dual-write. Binaries on other roots
+	// still cannot share this lock; dual-write (never delete) is what keeps their
+	// updates from being permanently destroyed.
 	legacyLockPath string
 }
 
@@ -648,14 +651,26 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 	if !ok {
 		return b.readLegacy()
 	}
-	// The legacy combined entry is consulted lazily (below) only when an indexed
-	// key's own entry is missing. write() publishes the index before the per-key
-	// entries and deletes the legacy blob only after every entry is written, so a
-	// crash partway through the initial legacy->indexed migration can leave a
-	// pre-existing credential readable solely in the still-present legacy blob.
-	// In steady state (all entries present) the legacy blob is never read.
+	// The legacy combined entry is consulted when an indexed key's own entry is
+	// missing (torn write / migration) and for keys only present there (an old
+	// binary logged into a provider this process has never indexed). Indexed
+	// entries always win over legacy for the same key: expiry and token material
+	// are not a causal version vector, so preferring "fresher-looking" legacy
+	// can overwrite an explicit new-binary Save with an older account's token.
 	var legacyTokens map[string]Token
 	legacyLoaded := false
+	loadLegacy := func() {
+		if legacyLoaded {
+			return
+		}
+		// Best-effort on read: a transient failure must not fail Load/Status,
+		// only skip legacy recovery for this pass. write() still refuses to
+		// dual-write over a legacy blob it cannot read (see write()).
+		if lt, lerr := b.readLegacyTokens(); lerr == nil {
+			legacyTokens = lt
+		}
+		legacyLoaded = true
+	}
 	tokens := make(map[string]Token, len(keys))
 	for _, key := range keys {
 		enc, ok, err := b.kr.Get(b.service, key)
@@ -664,22 +679,10 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 		}
 		if !ok {
 			// The index lists this key but its own entry is missing. Recover it
-			// from the legacy blob when a migration is still in flight; otherwise
-			// (a steady-state index/entry desync whose legacy blob is already
-			// gone) skip rather than fail the whole read, since the next
-			// Save/Delete will reconcile the index.
-			if !legacyLoaded {
-				// A best-effort recovery source for a read: a transient failure
-				// here must not fail the whole Load/Status, only skip recovering
-				// this particular desynced key. The next Save/Delete will
-				// reconcile it once the legacy blob is legible again (and,
-				// unlike here, will refuse to delete the legacy blob until it
-				// can actually read it — see write()).
-				if lt, lerr := b.readLegacyTokens(); lerr == nil {
-					legacyTokens = lt
-				}
-				legacyLoaded = true
-			}
+			// from the dual-written legacy blob when present; otherwise skip
+			// rather than fail the whole read (the next Save/Delete prunes the
+			// phantom index key so it cannot permanently consume capacity).
+			loadLegacy()
 			if token, has := legacyTokens[key]; has {
 				tokens[key] = token
 			}
@@ -693,31 +696,12 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 		if err := json.Unmarshal(raw, &token); err != nil {
 			return nil, false, fmt.Errorf("oauth: invalid keyring token entry %q: %w", key, err)
 		}
-
-		// Check if legacy blob holds a fresher token for this indexed key
-		// (e.g. refreshed by an old binary running concurrently).
-		if !legacyLoaded {
-			if lt, lerr := b.readLegacyTokens(); lerr == nil {
-				legacyTokens = lt
-			}
-			legacyLoaded = true
-		}
-		if legacyToken, has := legacyTokens[key]; has {
-			if legacyIsFresher(legacyToken, token) {
-				token = legacyToken
-			}
-		}
 		tokens[key] = token
 	}
 
 	// Keep legacy-only keys visible through the compatibility window:
 	// an old binary may have logged into a provider after the index was created.
-	if !legacyLoaded {
-		if lt, lerr := b.readLegacyTokens(); lerr == nil {
-			legacyTokens = lt
-		}
-		legacyLoaded = true
-	}
+	loadLegacy()
 	for key, legacyToken := range legacyTokens {
 		if ValidateKey(key) != nil {
 			continue
@@ -754,10 +738,10 @@ func (b keyringBlob) readLegacy() ([]byte, bool, error) {
 // returned ok=false, err=nil) — the one case callers may treat as "no tokens"
 // and proceed. Any other failure (a transient keyring read error, undecodable
 // base64, invalid JSON) is returned as err and must NOT be collapsed into "no
-// tokens": write() deletes the legacy blob once it believes reconciliation is
-// complete, so mistaking a transient read failure for an empty blob would
-// delete a still-unread, still-live credential that belongs to an older,
-// still-installed zero binary.
+// tokens": write() dual-writes the reconciled map over the legacy blob, so
+// mistaking a transient read failure for an empty blob would overwrite a
+// still-unread, still-live credential that belongs to an older, still-installed
+// zero binary.
 func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 	data, ok, err := b.readLegacy()
 	if err != nil {
@@ -773,29 +757,6 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 	return legacyState.Tokens, nil
 }
 
-// legacyIsFresher reports whether the legacy copy of an already-indexed key
-// should win over the indexed copy. An old binary running alongside the new one
-// refreshes tokens only in the legacy combined entry. When both sides carry a
-// nonzero expiry, the later expiry wins (a refresh normally pushes it forward).
-// When either side omits expiry (OAuth responses may omit expires_in, and
-// Refresh does not always carry the previous ExpiresAt), fall back to token
-// material: a changed access or refresh token on the legacy side is treated as
-// a concurrent old-binary refresh that must not be discarded.
-func legacyIsFresher(legacy, current Token) bool {
-	if !legacy.ExpiresAt.IsZero() && !current.ExpiresAt.IsZero() {
-		if legacy.ExpiresAt.After(current.ExpiresAt) {
-			return true
-		}
-		if current.ExpiresAt.After(legacy.ExpiresAt) {
-			return false
-		}
-		// Equal expiries: prefer legacy when material differs (concurrent refresh
-		// that happened to keep the same lifetime).
-		return legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken
-	}
-	return legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken
-}
-
 // write replaces the keyring's token entries with state, ordered so that
 // every interruption boundary leaves a recoverable store. The invariant is
 // that any token entry existing in the keyring at any instant is listed in
@@ -803,13 +764,17 @@ func legacyIsFresher(legacy, current Token) bool {
 // written, entries are deleted before the index shrinks, and the index
 // header is only updated after the chunks it references exist. A crash at
 // any step therefore leaves either an index over-listing keys whose entries
-// are missing (read() recovers those from the legacy blob during a migration,
-// or skips them once it is gone) or entries that a later read/write can still
+// are missing (read() recovers those from the dual-written legacy blob, or
+// skips them; the next write prunes phantom index keys so they cannot
+// permanently consume capacity) or entries that a later read/write can still
 // see and reconcile, never an invisible credential stranded in the OS keychain.
-// The legacy combined entry is the durable fallback for the initial migration
-// and is deleted only after every per-key entry is written, while the union
-// index still lists removed keys; a failure of that delete is returned so a
-// logout is never reported successful with the stale blob still resident.
+//
+// The legacy combined entry is dual-written with the reconciled map after
+// per-key entries succeed, never deleted: a pre-PR binary using another
+// config root cannot share this process's compatibility lock, so deleting
+// the blob would permanently drop an update that process wrote between our
+// reconcile read and a delete. Dual-write keeps old readers current and
+// leaves concurrent old-writer keys for the next reconcile pass.
 // omitFromLegacy lists keys the caller just deleted; they must not be
 // re-merged from the legacy blob even when they were never indexed (a
 // legacy-only old-binary login that the user logged out of).
@@ -828,29 +793,23 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 	}
 
 	// An older binary running alongside this one still reads and writes only the
-	// legacy combined entry. If that entry exists even though the index has
-	// already been published, an old binary wrote it after migration, so
-	// reconcile it into state before it is deleted below rather than blindly
-	// overwriting it:
-	//   - a key the indexed schema has never seen is a fresh old-binary login;
-	//     merge it so it is not lost, unless the caller just deleted it
-	//     (omitFromLegacy) or it was already indexed and deliberately removed;
-	//   - a key already present in state that the legacy blob refreshed takes
-	//     the legacy value when legacyIsFresher says so, so a concurrent
-	//     old-binary refresh is not discarded in favor of the stale indexed one;
-	//   - a key that was in the prior index but is absent from this write was
-	//     deliberately removed (a logout); it is left removed, not resurrected.
+	// legacy combined entry. Merge keys that entry holds which the indexed
+	// schema has never seen (fresh old-binary logins). Never overwrite a key
+	// already present in state: expiry and token strings are not causal order,
+	// so a "later" legacy expiry can replace an explicit new-binary Save with
+	// the wrong account. Keys in the prior index but absent from this write
+	// were deliberately removed (logout) and must not be resurrected.
+	//
+	// Unlike read()'s best-effort fallback, a failure here must abort the whole
+	// write rather than proceed as though the legacy blob were empty: step 4
+	// dual-writes over it, and a transient read error must never be mistaken
+	// for "nothing to reconcile," or a still-live credential from an older,
+	// still-installed zero binary is destroyed irrecoverably.
+	legacyTokens, err := b.readLegacyTokens()
+	if err != nil {
+		return fmt.Errorf("oauth: read legacy keyring token blob for reconciliation: %w", err)
+	}
 	if indexExisted {
-		// Unlike read()'s best-effort fallback, a failure here must abort the
-		// whole write rather than proceed as though the legacy blob were empty:
-		// step 4 below deletes it, and a transient read error (the legacy blob
-		// genuinely exists but couldn't be read right now) must never be
-		// mistaken for "nothing to reconcile," or a still-live credential from
-		// an older, still-installed zero binary is destroyed irrecoverably.
-		legacyTokens, err := b.readLegacyTokens()
-		if err != nil {
-			return fmt.Errorf("oauth: read legacy keyring token blob for reconciliation: %w", err)
-		}
 		for key, legacyToken := range legacyTokens {
 			if ValidateKey(key) != nil {
 				continue
@@ -858,10 +817,7 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 			if omitFromLegacy[key] {
 				continue
 			}
-			if current, exists := state.Tokens[key]; exists {
-				if legacyIsFresher(legacyToken, current) {
-					state.Tokens[key] = legacyToken
-				}
+			if _, exists := state.Tokens[key]; exists {
 				continue
 			}
 			if prior[key] {
@@ -877,12 +833,47 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 	}
 	sort.Strings(keys)
 
-	// 1. Publish the union of the prior and new key sets first, so every
+	// Preflight: marshal and size-check every desired token BEFORE publishing
+	// any index key. Publishing first left rejected oversized Saves as permanent
+	// index phantoms that could exhaust maxKeyringIndexKeys and brick the store.
+	encoded := make(map[string]string, len(keys))
+	for _, key := range keys {
+		raw, err := json.Marshal(state.Tokens[key])
+		if err != nil {
+			return err
+		}
+		enc := base64.StdEncoding.EncodeToString(raw)
+		if len(enc) > maxKeyringSingleEntryBytes {
+			return fmt.Errorf("oauth: token payload for %q (%d bytes) exceeds single keyring entry bound (%d bytes); use file or encrypted-file storage", key, len(enc), maxKeyringSingleEntryBytes)
+		}
+		encoded[key] = enc
+	}
+
+	// Drop prior index keys that have neither a live entry nor a place in the
+	// desired set (phantoms from an interrupted Set after a previous union
+	// publish). Including them in the next union would permanently consume
+	// index capacity after enough failed writes.
+	livePrior := make([]string, 0, len(priorKeys))
+	for _, key := range priorKeys {
+		if _, ok := state.Tokens[key]; ok {
+			livePrior = append(livePrior, key)
+			continue
+		}
+		_, exists, err := b.kr.Get(b.service, key)
+		if err != nil {
+			return err
+		}
+		if exists {
+			livePrior = append(livePrior, key)
+		}
+	}
+
+	// 1. Publish the union of the live prior and new key sets first, so every
 	// entry that exists at any point during this update is indexed.
 	union := keys
-	if len(priorKeys) > 0 {
-		merged := make(map[string]bool, len(keys)+len(priorKeys))
-		for _, key := range append(append([]string{}, keys...), priorKeys...) {
+	if len(livePrior) > 0 {
+		merged := make(map[string]bool, len(keys)+len(livePrior))
+		for _, key := range append(append([]string{}, keys...), livePrior...) {
 			merged[key] = true
 		}
 		union = make([]string, 0, len(merged))
@@ -895,36 +886,29 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 	if err != nil {
 		return err
 	}
-	// 2. Write each token entry.
+	// 2. Write each token entry (encodings preflighted above).
 	for _, key := range keys {
-		raw, err := json.Marshal(state.Tokens[key])
-		if err != nil {
-			return err
-		}
-		encoded := base64.StdEncoding.EncodeToString(raw)
-		if len(encoded) > maxKeyringSingleEntryBytes {
-			return fmt.Errorf("oauth: token payload for %q (%d bytes) exceeds single keyring entry bound (%d bytes); use file or encrypted-file storage", key, len(encoded), maxKeyringSingleEntryBytes)
-		}
-		if err := b.kr.Set(b.service, key, encoded); err != nil {
+		if err := b.kr.Set(b.service, key, encoded[key]); err != nil {
 			return err
 		}
 	}
 	// 3. Delete removed entries while the union index still lists them, so a
 	// failed Delete leaves a visible (re-deletable) entry, never an orphan.
-	for _, key := range priorKeys {
+	for _, key := range livePrior {
 		if _, ok := state.Tokens[key]; !ok {
 			if _, err := b.kr.Delete(b.service, key); err != nil {
 				return err
 			}
 		}
 	}
-	// 4. Drop the legacy entry: the index now exists and is authoritative,
-	// and its fresh writes were merged above. This must happen while the
-	// union index still lists any removed keys and its failure must surface:
-	// if a stale legacy blob survived a logout whose index shrink already
-	// completed, the next save would classify its keys as fresh old-binary
-	// logins and silently resurrect the logged-out credential.
-	if _, err := b.kr.Delete(b.service, b.legacyAccount); err != nil {
+	// 4. Dual-write the reconciled map to the legacy combined entry (never
+	// delete it). Old binaries on other config roots keep reading this account;
+	// logout correctness comes from updating the map, not from removing the
+	// entry. The combined entry is still subject to the single-keyring-item
+	// size cap that forced per-key storage, so full dual-write only happens
+	// when it fits; otherwise we patch the existing legacy map (drop logouts)
+	// without re-aggregating every provider token.
+	if err := b.dualWriteLegacy(state, omitFromLegacy, prior, legacyTokens); err != nil {
 		return err
 	}
 	// 5. Shrink the index to the exact new key set.
@@ -932,6 +916,72 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 		return err
 	}
 	return nil
+}
+
+// dualWriteLegacy updates the combined legacy keyring entry without ever
+// deleting it. Full dual-write of state is preferred when it fits under
+// maxKeyringSingleEntryBytes (so old readers see current tokens). When state
+// is too large (the multi-provider case that forced the per-key split), the
+// existing legacy map is patched to drop logged-out keys so they cannot be
+// resurrected, but is not expanded with every indexed token.
+func (b keyringBlob) dualWriteLegacy(state storeFile, omitFromLegacy, prior map[string]bool, legacyTokens map[string]Token) error {
+	full, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: state.Tokens})
+	if err != nil {
+		return err
+	}
+	fullEnc := base64.StdEncoding.EncodeToString(full)
+	if len(fullEnc) <= maxKeyringSingleEntryBytes {
+		return b.kr.Set(b.service, b.legacyAccount, fullEnc)
+	}
+
+	// Oversize full map: never delete the legacy entry, and never write an
+	// oversized value the OS keyring / security -i would reject. Patch the
+	// previous legacy contents so explicit logouts stick.
+	next := make(map[string]Token, len(legacyTokens))
+	for key, token := range legacyTokens {
+		if omitFromLegacy[key] {
+			continue
+		}
+		if prior[key] {
+			if _, ok := state.Tokens[key]; !ok {
+				continue
+			}
+		}
+		next[key] = token
+	}
+	// Prefer indexed material for keys still present in both, when that keeps
+	// the patch under the single-entry bound (best-effort; skip keys that push
+	// it over rather than failing the whole Save).
+	patchTokens := make(map[string]Token, len(next))
+	for key, token := range next {
+		if current, ok := state.Tokens[key]; ok {
+			token = current
+		}
+		candidate := make(map[string]Token, len(patchTokens)+1)
+		for k, v := range patchTokens {
+			candidate[k] = v
+		}
+		candidate[key] = token
+		raw, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: candidate})
+		if err != nil {
+			return err
+		}
+		if len(base64.StdEncoding.EncodeToString(raw)) > maxKeyringSingleEntryBytes {
+			continue
+		}
+		patchTokens[key] = token
+	}
+	raw, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: patchTokens})
+	if err != nil {
+		return err
+	}
+	enc := base64.StdEncoding.EncodeToString(raw)
+	if len(enc) > maxKeyringSingleEntryBytes {
+		// Pre-existing oversized legacy blob: leave it untouched rather than
+		// fail an otherwise successful indexed write.
+		return nil
+	}
+	return b.kr.Set(b.service, b.legacyAccount, enc)
 }
 
 // maxKeyringSingleEntryBytes bounds a single base64-encoded token secret so
@@ -946,6 +996,14 @@ const maxKeyringSingleEntryBytes = 3800
 // syntax, service, and account. The old single-entry index hit that cap at
 // roughly 22 maximum-length keys even when every token was tiny.
 const maxKeyringIndexChunkBytes = 2700
+
+// maxKeyringIndexEncodedBytes bounds one index header/chunk's base64 string
+// before DecodeString or json.Unmarshal. Writers never emit more than
+// maxKeyringIndexChunkBytes of raw JSON per chunk (header wraps one chunk of
+// keys plus a few metadata fields), so anything larger is damaged or hostile
+// and must be rejected without allocating unbounded decode buffers on the
+// hot path that holds the store lock.
+const maxKeyringIndexEncodedBytes = 4096
 
 // maxKeyringIndexChunks caps how many chunk entries a stored index header may
 // claim before readKeyIndex issues one OS-keyring lookup per chunk. Each chunk
@@ -992,6 +1050,26 @@ func (b keyringBlob) chunkAccount(index int) string {
 	return fmt.Sprintf("%s-%d", b.indexAccount, index)
 }
 
+// decodeKeyringIndexPayload bounds and decodes one index header/chunk value
+// before json.Unmarshal. The element-count cap alone does not bound the size of
+// a single JSON string inside a damaged payload.
+func decodeKeyringIndexPayload(enc string, what string) ([]byte, error) {
+	enc = strings.TrimSpace(enc)
+	if len(enc) > maxKeyringIndexEncodedBytes {
+		return nil, fmt.Errorf("oauth: %s is %d bytes encoded, over the %d-byte bound", what, len(enc), maxKeyringIndexEncodedBytes)
+	}
+	raw, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: decode %s: %w", what, err)
+	}
+	// Header wraps one chunk of keys plus a few metadata fields; reject anything
+	// well beyond the writer-side raw chunk budget before Unmarshal.
+	if len(raw) > maxKeyringIndexChunkBytes+256 {
+		return nil, fmt.Errorf("oauth: %s decodes to %d bytes, over the %d-byte raw bound", what, len(raw), maxKeyringIndexChunkBytes+256)
+	}
+	return raw, nil
+}
+
 // readKeyIndex returns the indexed keys, whether an index exists at all, and
 // how many chunk entries it currently occupies. A chunk listed by the header
 // but missing from the keyring (a torn write) is skipped, mirroring how
@@ -1004,9 +1082,9 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 	if !ok {
 		return nil, false, 0, nil
 	}
-	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
+	raw, err := decodeKeyringIndexPayload(enc, "keyring token index")
 	if err != nil {
-		return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
+		return nil, false, 0, err
 	}
 	trimmed := strings.TrimSpace(string(raw))
 	if strings.HasPrefix(trimmed, "[") {
@@ -1049,9 +1127,9 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		if !ok {
 			continue
 		}
-		chunkRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(chunkEnc))
+		chunkRaw, err := decodeKeyringIndexPayload(chunkEnc, fmt.Sprintf("keyring token index chunk %d", i))
 		if err != nil {
-			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
+			return nil, false, 0, err
 		}
 		var more []string
 		if err := json.Unmarshal(chunkRaw, &more); err != nil {
@@ -1224,11 +1302,11 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func() error) erro
 // withLock serializes the keyring's read-modify-write. Store.mu covers the
 // in-process case; lockPath adds cross-process exclusion between this
 // binary's own instances so two of them can't both read the blob, modify,
-// and write — dropping a token. legacyLockPath is held for the same
-// duration so a live pre-PR binary, which only ever locks there (see
-// legacyKeyringLockPath), can't write a fresh legacy credential in the
-// window between this write's legacy reconciliation and its legacy-blob
-// delete.
+// and write — dropping a token. legacyLockPath is held for the same duration
+// so a live pre-PR binary that shares this config root (see
+// legacyKeyringLockPath) can't race our dual-write of the legacy combined
+// entry. Cross-root old writers cannot share that lock; dual-write without
+// delete is the remaining safety net for them.
 func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
 	return withLeasedLocks([]string{b.lockPath, b.legacyLockPath}, now, fn)
 }

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"net/url"
 	"os"
 	"os/user"
@@ -338,7 +339,17 @@ func keyringFallbackLockDir() (string, error) {
 	}
 	if uid := os.Getuid(); uid >= 0 {
 		if u, err := lookupUserID(strconv.Itoa(uid)); err == nil && strings.TrimSpace(u.HomeDir) != "" {
-			return filepath.Join(u.HomeDir, ".cache", "zero"), nil
+			dir := filepath.Join(u.HomeDir, ".cache", "zero")
+			if err := os.MkdirAll(dir, 0o700); err == nil {
+				if info, lerr := os.Lstat(dir); lerr == nil && info.Mode()&os.ModeSymlink == 0 && info.IsDir() {
+					if info.Mode().Perm() != 0o700 {
+						_ = os.Chmod(dir, 0o700)
+					}
+					if checkOAuthLockDirOwner(info) == nil {
+						return dir, nil
+					}
+				}
+			}
 		}
 	}
 	name := "zero-oauth-locks"
@@ -991,7 +1002,16 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 		return err
 	}
 	legacyOriginChanged := false
+	legacyTokensChanged := false
 	if legacyTokens != nil {
+		for key, deleted := range mutations {
+			if deleted {
+				if _, ok := legacyTokens[key]; ok {
+					delete(legacyTokens, key)
+					legacyTokensChanged = true
+				}
+			}
+		}
 		for key := range legacyTokens {
 			if ValidateKey(key) != nil {
 				continue
@@ -1172,6 +1192,19 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 			return err
 		}
 	}
+	if legacyTokensChanged {
+		if err := checkLease(); err != nil {
+			return err
+		}
+		if len(legacyTokens) == 0 {
+			_, _ = b.kr.Delete(b.service, b.legacyAccount)
+		} else {
+			legacyData, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: legacyTokens})
+			if err == nil {
+				_ = b.kr.Set(b.service, b.legacyAccount, base64.StdEncoding.EncodeToString(legacyData))
+			}
+		}
+	}
 	return nil
 }
 
@@ -1206,7 +1239,7 @@ func (b keyringBlob) readTombstones() (map[string]bool, error) {
 // real keyring failures cannot be swallowed.
 func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leaseCheck) error {
 	tb := b.tombstoneBlob()
-	_, existed, priorChunks, priorGeneration, _, err := tb.readKeyIndex()
+	_, existed, priorChunks, priorGeneration, missingChunks, err := tb.readKeyIndex()
 	if err != nil {
 		return fmt.Errorf("oauth: read keyring token tombstones: %w", err)
 	}
@@ -1241,7 +1274,7 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leas
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if _, _, err := tb.writeKeyIndex(keys, priorChunks, priorGeneration, nil, checkLease); err != nil {
+	if _, _, err := tb.writeKeyIndex(keys, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
 		return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
 	}
 	return nil
@@ -1277,7 +1310,7 @@ func (b keyringBlob) readLegacyOrigin() (map[string]bool, error) {
 // zero-key index behind.
 func (b keyringBlob) writeLegacyOrigin(origin map[string]bool, checkLease leaseCheck) error {
 	lb := b.legacyOriginBlob()
-	_, existed, priorChunks, priorGeneration, _, err := lb.readKeyIndex()
+	_, existed, priorChunks, priorGeneration, missingChunks, err := lb.readKeyIndex()
 	if err != nil {
 		return fmt.Errorf("oauth: read keyring legacy-origin markers: %w", err)
 	}
@@ -1312,7 +1345,7 @@ func (b keyringBlob) writeLegacyOrigin(origin map[string]bool, checkLease leaseC
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if _, _, err := lb.writeKeyIndex(keys, priorChunks, priorGeneration, nil, checkLease); err != nil {
+	if _, _, err := lb.writeKeyIndex(keys, priorChunks, priorGeneration, missingChunks, checkLease); err != nil {
 		return fmt.Errorf("oauth: write keyring legacy-origin markers: %w", err)
 	}
 	return nil
@@ -1607,6 +1640,9 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks, priorGeneration i
 // currently reads; the header Set is the only step any concurrent or crashed
 // reader can observe as a change at all.
 func (b keyringBlob) writeKeyIndexNewGeneration(chunkList [][]string, priorChunks, priorGeneration int, checkLease leaseCheck) (chunks int, generation int, err error) {
+	if priorGeneration >= math.MaxInt {
+		return 0, 0, fmt.Errorf("oauth: keyring key index generation overflow: %d", priorGeneration)
+	}
 	newGeneration := priorGeneration + 1
 	advertised := len(chunkList)
 	if advertised > maxKeyringIndexChunks {
@@ -1879,6 +1915,10 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func(check leaseCh
 	check := func() error {
 		for _, l := range leases {
 			if l.lost.Load() {
+				return fmt.Errorf("oauth: lost token lock lease on %s", filepath.Base(l.path))
+			}
+			if !ownLockFile(l.path, l.token) {
+				l.lost.Store(true)
 				return fmt.Errorf("oauth: lost token lock lease on %s", filepath.Base(l.path))
 			}
 		}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -117,19 +117,29 @@ type KeyringClient interface {
 // bytes; three or more logged-in providers routinely exceeds that. Splitting
 // by key bounds each write to one token, which stays well under the cap
 // regardless of how many providers are logged in.
+//
+// Coexistence with pre-per-key binaries: the legacy combined entry is a
+// read-only discovery source for new code. New writers never overwrite it
+// (they cannot share a lock with old writers on other config roots, so any
+// snapshot-then-Set would clobber unobserved updates or truncate oversized
+// Linux keyring maps). Indexed per-key entries are the sole writable
+// representation for new binaries. Durable deletion markers (tombstones)
+// prevent an uncoordinated old writer from resurrecting a logout via the
+// legacy blob.
 const (
 	keyringService = "zero"
 	// keyringLegacyAccount is the combined-blob entry used by pre-per-key
-	// binaries. New code dual-writes the reconciled token map here on every
-	// save so an old binary on another config root (which cannot share this
-	// process's legacy lock) still sees current credentials, and so a
-	// concurrent old-writer update is never permanently deleted just because
-	// this process could not observe it. The per-key index remains
-	// authoritative for new binaries.
+	// binaries. New code reads it for migration and for legacy-only logins,
+	// but never writes or deletes it: dual-write cannot be made safe across
+	// config roots that do not share legacyKeyringLockPath.
 	keyringLegacyAccount = "oauth-tokens"
 	// keyringIndexAccount holds a JSON array of the token keys that currently
 	// have their own keyring entry, since KeyringClient has no "list" operation.
 	keyringIndexAccount = "oauth-tokens-index"
+	// keyringTombstoneAccount holds the set of keys deliberately deleted by a
+	// new binary. Old writers cannot see this entry; new readers and writers
+	// honor it so a stale legacy rewrite cannot resurrect a logout.
+	keyringTombstoneAccount = "oauth-tokens-tombstones"
 )
 
 // Store persists OAuth tokens (provider + MCP namespaces) as one JSON blob,
@@ -484,8 +494,9 @@ func (s *Store) readState() (storeFile, error) {
 }
 
 // writeState persists state. omitFromLegacy lists keys that must not be
-// re-merged from the keyring legacy blob during reconciliation (Delete intent).
-// File and encrypted-file backends ignore omitFromLegacy.
+// re-merged from the keyring legacy blob during reconciliation (Delete intent);
+// the keyring backend also records them as durable tombstones. File and
+// encrypted-file backends ignore omitFromLegacy.
 func (s *Store) writeState(state storeFile, omitFromLegacy map[string]bool) error {
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
@@ -514,7 +525,8 @@ type blobStore interface {
 	read() (data []byte, ok bool, err error)
 	// write replaces the stored blob. omitFromLegacy is keyring-only: keys the
 	// caller deliberately removed that must not be re-merged from the legacy
-	// combined entry during mixed-version reconciliation. File backends ignore it.
+	// combined entry and that should be recorded as durable tombstones. File
+	// backends ignore it.
 	write(data []byte, omitFromLegacy map[string]bool) error
 	// withLock runs fn under whatever cross-process exclusion the backend offers
 	// (a lock file for the file backend; none for the keyring, which is the
@@ -628,7 +640,8 @@ type keyringBlob struct {
 	kr      KeyringClient
 	service string
 	// legacyAccount is the pre-migration whole-blob entry; read only, to pick up
-	// tokens saved by older versions the first time this runs.
+	// tokens saved by older versions and legacy-only logins from old binaries.
+	// New code never writes this account (see package comment on coexistence).
 	legacyAccount string
 	indexAccount  string
 	// lockPath, when set, is a cross-process lock file serializing the keyring's
@@ -636,10 +649,11 @@ type keyringBlob struct {
 	lockPath string
 	// legacyLockPath, when set, is the lock file a pre-PR binary acquires around
 	// its own read-modify-write of the legacy combined entry (see
-	// legacyKeyringLockPath). write() holds it too so, when the old binary shares
-	// this config root, it cannot race our dual-write. Binaries on other roots
-	// still cannot share this lock; dual-write (never delete) is what keeps their
-	// updates from being permanently destroyed.
+	// legacyKeyringLockPath). write() still holds it when the old binary shares
+	// this config root so concurrent legacy mutations serialize with our
+	// reconcile-and-index pass. Cross-root old writers cannot share that lock;
+	// safety there comes from never overwriting the legacy blob and from
+	// durable tombstones, not from dual-write.
 	legacyLockPath string
 }
 
@@ -650,6 +664,14 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 	}
 	if !ok {
 		return b.readLegacy()
+	}
+	// Tombstones block resurrection of deliberately deleted keys from the
+	// legacy combined entry (an old binary may rewrite a stale snapshot into
+	// that account after logout). Fail closed on a corrupt tombstone set so a
+	// damaged marker cannot silently re-expose logged-out credentials.
+	tombstones, err := b.readTombstones()
+	if err != nil {
+		return nil, false, err
 	}
 	// The legacy combined entry is consulted when an indexed key's own entry is
 	// missing (torn write / migration) and for keys only present there (an old
@@ -664,8 +686,9 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 			return
 		}
 		// Best-effort on read: a transient failure must not fail Load/Status,
-		// only skip legacy recovery for this pass. write() still refuses to
-		// dual-write over a legacy blob it cannot read (see write()).
+		// only skip legacy recovery for this pass. write() still requires a
+		// successful legacy read before reconciling so it never mistakes a
+		// transient error for an empty blob.
 		if lt, lerr := b.readLegacyTokens(); lerr == nil {
 			legacyTokens = lt
 		}
@@ -679,9 +702,14 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 		}
 		if !ok {
 			// The index lists this key but its own entry is missing. Recover it
-			// from the dual-written legacy blob when present; otherwise skip
-			// rather than fail the whole read (the next Save/Delete prunes the
-			// phantom index key so it cannot permanently consume capacity).
+			// from the legacy blob when present and not tombstoned; otherwise
+			// skip rather than fail the whole read (the next Save/Delete prunes
+			// the phantom index key so it cannot permanently consume capacity).
+			// Tombstones do not hide a still-present indexed entry (in-flight
+			// delete): they only block resurrection from the legacy account.
+			if tombstones[key] {
+				continue
+			}
 			loadLegacy()
 			if token, has := legacyTokens[key]; has {
 				tokens[key] = token
@@ -701,9 +729,13 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 
 	// Keep legacy-only keys visible through the compatibility window:
 	// an old binary may have logged into a provider after the index was created.
+	// Tombstones suppress keys the user already logged out of.
 	loadLegacy()
 	for key, legacyToken := range legacyTokens {
 		if ValidateKey(key) != nil {
+			continue
+		}
+		if tombstones[key] {
 			continue
 		}
 		if _, has := tokens[key]; !has {
@@ -738,10 +770,9 @@ func (b keyringBlob) readLegacy() ([]byte, bool, error) {
 // returned ok=false, err=nil) — the one case callers may treat as "no tokens"
 // and proceed. Any other failure (a transient keyring read error, undecodable
 // base64, invalid JSON) is returned as err and must NOT be collapsed into "no
-// tokens": write() dual-writes the reconciled map over the legacy blob, so
-// mistaking a transient read failure for an empty blob would overwrite a
-// still-unread, still-live credential that belongs to an older, still-installed
-// zero binary.
+// tokens": write() merges legacy-only keys into the indexed representation,
+// and mistaking a transient read failure for an empty blob would skip
+// credentials that still live only in that account.
 func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 	data, ok, err := b.readLegacy()
 	if err != nil {
@@ -764,20 +795,20 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // written, entries are deleted before the index shrinks, and the index
 // header is only updated after the chunks it references exist. A crash at
 // any step therefore leaves either an index over-listing keys whose entries
-// are missing (read() recovers those from the dual-written legacy blob, or
-// skips them; the next write prunes phantom index keys so they cannot
+// are missing (read() recovers those from the legacy blob unless tombstoned,
+// or skips them; the next write prunes phantom index keys so they cannot
 // permanently consume capacity) or entries that a later read/write can still
 // see and reconcile, never an invisible credential stranded in the OS keychain.
 //
-// The legacy combined entry is dual-written with the reconciled map after
-// per-key entries succeed, never deleted: a pre-PR binary using another
-// config root cannot share this process's compatibility lock, so deleting
-// the blob would permanently drop an update that process wrote between our
-// reconcile read and a delete. Dual-write keeps old readers current and
-// leaves concurrent old-writer keys for the next reconcile pass.
-// omitFromLegacy lists keys the caller just deleted; they must not be
-// re-merged from the legacy blob even when they were never indexed (a
-// legacy-only old-binary login that the user logged out of).
+// The legacy combined entry is never written or deleted by this path. New
+// code cannot share a lock with old writers on other config roots, so any
+// snapshot-then-Set of that account can clobber an unobserved login or
+// truncate a valid oversized Linux keyring map. Legacy stays a read-only
+// discovery source; indexed entries are the sole writable representation.
+// omitFromLegacy lists keys the caller just deleted; they are recorded as
+// durable tombstones and must not be re-merged from the legacy blob even
+// when they were never indexed (a legacy-only old-binary login that the
+// user logged out of).
 func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
@@ -792,19 +823,33 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 		prior[key] = true
 	}
 
+	tombstones, err := b.readTombstones()
+	if err != nil {
+		return err
+	}
+	// Record durable deletion markers before mutating entries so a crash
+	// mid-write cannot leave a logged-out key importable from legacy alone.
+	for key := range omitFromLegacy {
+		tombstones[key] = true
+	}
+	// A re-login after logout clears the tombstone for that key.
+	for key := range state.Tokens {
+		delete(tombstones, key)
+	}
+
 	// An older binary running alongside this one still reads and writes only the
 	// legacy combined entry. Merge keys that entry holds which the indexed
-	// schema has never seen (fresh old-binary logins). Never overwrite a key
-	// already present in state: expiry and token strings are not causal order,
-	// so a "later" legacy expiry can replace an explicit new-binary Save with
-	// the wrong account. Keys in the prior index but absent from this write
-	// were deliberately removed (logout) and must not be resurrected.
+	// schema has never seen (fresh old-binary logins), unless tombstoned or
+	// omitted by this operation. Never overwrite a key already present in
+	// state: expiry and token strings are not causal order. Keys in the prior
+	// index but absent from this write were deliberately removed (logout) and
+	// must not be resurrected.
 	//
 	// Unlike read()'s best-effort fallback, a failure here must abort the whole
-	// write rather than proceed as though the legacy blob were empty: step 4
-	// dual-writes over it, and a transient read error must never be mistaken
-	// for "nothing to reconcile," or a still-live credential from an older,
-	// still-installed zero binary is destroyed irrecoverably.
+	// write rather than proceed as though the legacy blob were empty: skipping
+	// a still-live legacy-only credential would leave it unindexed until the
+	// next successful reconcile, and a concurrent old-writer update is only
+	// discoverable through this read.
 	legacyTokens, err := b.readLegacyTokens()
 	if err != nil {
 		return fmt.Errorf("oauth: read legacy keyring token blob for reconciliation: %w", err)
@@ -814,7 +859,7 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 			if ValidateKey(key) != nil {
 				continue
 			}
-			if omitFromLegacy[key] {
+			if omitFromLegacy[key] || tombstones[key] {
 				continue
 			}
 			if _, exists := state.Tokens[key]; exists {
@@ -868,7 +913,13 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 		}
 	}
 
-	// 1. Publish the union of the live prior and new key sets first, so every
+	// 1. Persist tombstones before removing entries so logout survives a crash
+	// between entry delete and a later reconcile (and survives an old binary
+	// rewriting the legacy blob with the deleted key still present).
+	if err := b.writeTombstones(tombstones); err != nil {
+		return err
+	}
+	// 2. Publish the union of the live prior and new key sets first, so every
 	// entry that exists at any point during this update is indexed.
 	union := keys
 	if len(livePrior) > 0 {
@@ -886,13 +937,13 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 	if err != nil {
 		return err
 	}
-	// 2. Write each token entry (encodings preflighted above).
+	// 3. Write each token entry (encodings preflighted above).
 	for _, key := range keys {
 		if err := b.kr.Set(b.service, key, encoded[key]); err != nil {
 			return err
 		}
 	}
-	// 3. Delete removed entries while the union index still lists them, so a
+	// 4. Delete removed entries while the union index still lists them, so a
 	// failed Delete leaves a visible (re-deletable) entry, never an orphan.
 	for _, key := range livePrior {
 		if _, ok := state.Tokens[key]; !ok {
@@ -901,87 +952,77 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 			}
 		}
 	}
-	// 4. Dual-write the reconciled map to the legacy combined entry (never
-	// delete it). Old binaries on other config roots keep reading this account;
-	// logout correctness comes from updating the map, not from removing the
-	// entry. The combined entry is still subject to the single-keyring-item
-	// size cap that forced per-key storage, so full dual-write only happens
-	// when it fits; otherwise we patch the existing legacy map (drop logouts)
-	// without re-aggregating every provider token.
-	if err := b.dualWriteLegacy(state, omitFromLegacy, prior, legacyTokens); err != nil {
-		return err
-	}
-	// 5. Shrink the index to the exact new key set.
+	// 5. Shrink the index to the exact new key set. Legacy is left untouched.
 	if _, err := b.writeKeyIndex(keys, unionChunks); err != nil {
 		return err
 	}
 	return nil
 }
 
-// dualWriteLegacy updates the combined legacy keyring entry without ever
-// deleting it. Full dual-write of state is preferred when it fits under
-// maxKeyringSingleEntryBytes (so old readers see current tokens). When state
-// is too large (the multi-provider case that forced the per-key split), the
-// existing legacy map is patched to drop logged-out keys so they cannot be
-// resurrected, but is not expanded with every indexed token.
-func (b keyringBlob) dualWriteLegacy(state storeFile, omitFromLegacy, prior map[string]bool, legacyTokens map[string]Token) error {
-	full, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: state.Tokens})
-	if err != nil {
-		return err
-	}
-	fullEnc := base64.StdEncoding.EncodeToString(full)
-	if len(fullEnc) <= maxKeyringSingleEntryBytes {
-		return b.kr.Set(b.service, b.legacyAccount, fullEnc)
-	}
+// tombstoneBlob returns a keyringBlob that reuses the chunked index codec for
+// the durable deletion set. Tombstones can grow to the same key/chunk caps as
+// the live index (max-length keys after many logouts), so a single entry is
+// not enough under the macOS line bound.
+func (b keyringBlob) tombstoneBlob() keyringBlob {
+	return keyringBlob{kr: b.kr, service: b.service, indexAccount: keyringTombstoneAccount}
+}
 
-	// Oversize full map: never delete the legacy entry, and never write an
-	// oversized value the OS keyring / security -i would reject. Patch the
-	// previous legacy contents so explicit logouts stick.
-	next := make(map[string]Token, len(legacyTokens))
-	for key, token := range legacyTokens {
-		if omitFromLegacy[key] {
-			continue
-		}
-		if prior[key] {
-			if _, ok := state.Tokens[key]; !ok {
-				continue
-			}
-		}
-		next[key] = token
+// readTombstones returns the durable set of keys deleted by a new binary.
+// Missing account => empty set. Corrupt payloads fail closed.
+func (b keyringBlob) readTombstones() (map[string]bool, error) {
+	keys, ok, _, err := b.tombstoneBlob().readKeyIndex()
+	if err != nil {
+		return nil, fmt.Errorf("oauth: read keyring token tombstones: %w", err)
 	}
-	// Prefer indexed material for keys still present in both, when that keeps
-	// the patch under the single-entry bound (best-effort; skip keys that push
-	// it over rather than failing the whole Save).
-	patchTokens := make(map[string]Token, len(next))
-	for key, token := range next {
-		if current, ok := state.Tokens[key]; ok {
-			token = current
+	if !ok {
+		return map[string]bool{}, nil
+	}
+	out := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		out[key] = true
+	}
+	return out, nil
+}
+
+// writeTombstones persists the durable deletion set. An empty set removes every
+// tombstone account/chunk so a fully clean store does not leave leftover
+// markers. Errors from that cleanup are surfaced so interruption tests and
+// real keyring failures cannot be swallowed.
+func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
+	tb := b.tombstoneBlob()
+	_, existed, priorChunks, err := tb.readKeyIndex()
+	if err != nil {
+		return fmt.Errorf("oauth: read keyring token tombstones: %w", err)
+	}
+	if len(tombstones) == 0 {
+		if !existed {
+			return nil
 		}
-		candidate := make(map[string]Token, len(patchTokens)+1)
-		for k, v := range patchTokens {
-			candidate[k] = v
-		}
-		candidate[key] = token
-		raw, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: candidate})
-		if err != nil {
+		if _, err := tb.kr.Delete(tb.service, tb.indexAccount); err != nil {
 			return err
 		}
-		if len(base64.StdEncoding.EncodeToString(raw)) > maxKeyringSingleEntryBytes {
-			continue
+		for i := 1; i < priorChunks; i++ {
+			if _, err := tb.kr.Delete(tb.service, tb.chunkAccount(i)); err != nil {
+				return err
+			}
 		}
-		patchTokens[key] = token
-	}
-	raw, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: patchTokens})
-	if err != nil {
-		return err
-	}
-	enc := base64.StdEncoding.EncodeToString(raw)
-	if len(enc) > maxKeyringSingleEntryBytes {
-		// Pre-existing oversized legacy blob: leave it untouched rather than
-		// fail an otherwise successful indexed write.
 		return nil
 	}
-	return b.kr.Set(b.service, b.legacyAccount, enc)
+	if len(tombstones) > maxKeyringIndexKeys {
+		return errKeyringIndexTooManyKeys(len(tombstones))
+	}
+	keys := make([]string, 0, len(tombstones))
+	for key := range tombstones {
+		if ValidateKey(key) != nil {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if _, err := tb.writeKeyIndex(keys, priorChunks); err != nil {
+		return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
+	}
+	return nil
 }
 
 // maxKeyringSingleEntryBytes bounds a single base64-encoded token secret so
@@ -1243,39 +1284,31 @@ func chunkIndexKeys(keys []string) [][]string {
 // exists to prevent. A var so tests can shorten it.
 var fileLockRefreshInterval = 10 * time.Second
 
-// withLeasedLocks acquires every non-empty path in order, refreshes all of
-// their mtimes on a ticker while fn runs (so a legitimately slow multi-entry
-// keyring pass never looks like a crashed holder to another process), and
-// releases them in reverse order once fn returns.
-func withLeasedLocks(paths []string, now func() time.Time, fn func() error) error {
-	var unlocks []func()
-	var held []string
-	for _, p := range paths {
-		if p == "" {
-			continue
-		}
-		unlock, err := acquireFileLock(p, now)
-		if err != nil {
-			for i := len(unlocks) - 1; i >= 0; i-- {
-				unlocks[i]()
-			}
-			return err
-		}
-		unlocks = append(unlocks, unlock)
-		held = append(held, p)
+// leasedPath is one acquired lock whose mtime is refreshed until stop is
+// closed. Lease ownership starts at acquisition, not after every path is
+// held: withLock acquires lockPath then may block on legacyLockPath, and a
+// peer must not be able to reclaim the first lock as stale during that wait.
+type leasedPath struct {
+	path   string
+	unlock func()
+	stop   chan struct{}
+	done   chan struct{}
+}
+
+func startLease(path string, unlock func()) *leasedPath {
+	l := &leasedPath{
+		path:   path,
+		unlock: unlock,
+		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
 	}
-	if len(held) == 0 {
-		return fn()
-	}
-	stop := make(chan struct{})
-	done := make(chan struct{})
 	go func() {
-		defer close(done)
+		defer close(l.done)
 		ticker := time.NewTicker(fileLockRefreshInterval)
 		defer ticker.Stop()
 		for {
 			select {
-			case <-stop:
+			case <-l.stop:
 				return
 			case <-ticker.C:
 				// Lease with wall-clock time, never the injectable now: acquireFileLock
@@ -1284,18 +1317,48 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func() error) erro
 				// another process would immediately reclaim, reviving the token-loss
 				// race these locks prevent.
 				at := time.Now()
-				for _, p := range held {
-					_ = os.Chtimes(p, at, at)
-				}
+				_ = os.Chtimes(path, at, at)
 			}
 		}
 	}()
-	err := fn()
-	close(stop)
-	<-done
-	for i := len(unlocks) - 1; i >= 0; i-- {
-		unlocks[i]()
+	return l
+}
+
+func (l *leasedPath) release() {
+	close(l.stop)
+	<-l.done
+	l.unlock()
+}
+
+// withLeasedLocks acquires every non-empty path in order. Each lock's mtime
+// lease starts immediately on acquisition (and keeps refreshing while later
+// paths are still being acquired and while fn runs), so a multi-lock wait
+// cannot leave an earlier lock looking abandoned. Locks are released in
+// reverse order once fn returns.
+func withLeasedLocks(paths []string, now func() time.Time, fn func() error) error {
+	var leases []*leasedPath
+	releaseAll := func() {
+		for i := len(leases) - 1; i >= 0; i-- {
+			leases[i].release()
+		}
 	}
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		unlock, err := acquireFileLock(p, now)
+		if err != nil {
+			releaseAll()
+			return err
+		}
+		// Start refreshing this lock before blocking on the next path.
+		leases = append(leases, startLease(p, unlock))
+	}
+	if len(leases) == 0 {
+		return fn()
+	}
+	err := fn()
+	releaseAll()
 	return err
 }
 
@@ -1304,9 +1367,9 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func() error) erro
 // binary's own instances so two of them can't both read the blob, modify,
 // and write — dropping a token. legacyLockPath is held for the same duration
 // so a live pre-PR binary that shares this config root (see
-// legacyKeyringLockPath) can't race our dual-write of the legacy combined
-// entry. Cross-root old writers cannot share that lock; dual-write without
-// delete is the remaining safety net for them.
+// legacyKeyringLockPath) serializes with our reconcile-and-index pass.
+// Cross-root old writers cannot share that lock; never overwriting the
+// legacy blob and durable tombstones are the remaining safety net for them.
 func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
 	return withLeasedLocks([]string{b.lockPath, b.legacyLockPath}, now, fn)
 }

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -668,7 +668,9 @@ func legacyIsFresher(legacy, current Token) bool {
 // or skips them once it is gone) or entries that a later read/write can still
 // see and reconcile, never an invisible credential stranded in the OS keychain.
 // The legacy combined entry is the durable fallback for the initial migration
-// and is deleted only as the final step, after every per-key entry is written.
+// and is deleted only after every per-key entry is written, while the union
+// index still lists removed keys; a failure of that delete is returned so a
+// logout is never reported successful with the stale blob still resident.
 func (b keyringBlob) write(data []byte) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
@@ -756,13 +758,19 @@ func (b keyringBlob) write(data []byte) error {
 			}
 		}
 	}
-	// 4. Shrink the index to the exact new key set.
+	// 4. Drop the legacy entry: the index now exists and is authoritative,
+	// and its fresh writes were merged above. This must happen while the
+	// union index still lists any removed keys and its failure must surface:
+	// if a stale legacy blob survived a logout whose index shrink already
+	// completed, the next save would classify its keys as fresh old-binary
+	// logins and silently resurrect the logged-out credential.
+	if _, err := b.kr.Delete(b.service, b.legacyAccount); err != nil {
+		return err
+	}
+	// 5. Shrink the index to the exact new key set.
 	if _, err := b.writeKeyIndex(keys, unionChunks); err != nil {
 		return err
 	}
-	// The index now exists and is authoritative; drop the legacy entry so a
-	// future read never falls back to it (its fresh writes were merged above).
-	_, _ = b.kr.Delete(b.service, b.legacyAccount)
 	return nil
 }
 
@@ -863,6 +871,12 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 // chunk is never read).
 func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int) (int, error) {
 	chunks := chunkIndexKeys(keys)
+	// Refuse to publish an index the reader would reject: readKeyIndex caps
+	// headers at maxKeyringIndexChunks, and a header beyond it would make
+	// every later Load/Status/Save/Delete fail before it could recover.
+	if len(chunks) > maxKeyringIndexChunks {
+		return 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", len(chunks), maxKeyringIndexChunks)
+	}
 	for i := 1; i < len(chunks); i++ {
 		chunkData, err := json.Marshal(chunks[i])
 		if err != nil {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -982,6 +982,12 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 	}
 	// 2. Publish the union of the live prior and new key sets first, so every
 	// entry that exists at any point during this update is indexed.
+	//
+	// When a referenced continuation chunk was missing, livePrior is truncated
+	// and cannot name the unlisted keys. Keep advertising the prior chunk count
+	// (and never delete those chunk accounts) so a later-restored chunk can
+	// still be reconciled; a complete rewrite to only the known keys would
+	// permanently orphan their OS keychain entries.
 	union := keys
 	if len(livePrior) > 0 {
 		merged := make(map[string]bool, len(keys)+len(livePrior))
@@ -994,7 +1000,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 		}
 		sort.Strings(union)
 	}
-	unionChunks, err := b.writeKeyIndex(union, priorChunks)
+	unionChunks, err := b.writeKeyIndex(union, priorChunks, indexIncomplete)
 	if err != nil {
 		return err
 	}
@@ -1006,6 +1012,8 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 	}
 	// 4. Delete removed entries while the union index still lists them, so a
 	// failed Delete leaves a visible (re-deletable) entry, never an orphan.
+	// Only walk livePrior (keys we could see): entries named only in a missing
+	// chunk stay put so a restored chunk can still find them.
 	for _, key := range livePrior {
 		if _, ok := state.Tokens[key]; !ok {
 			if _, err := b.kr.Delete(b.service, key); err != nil {
@@ -1014,13 +1022,10 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 		}
 	}
 	// 5. Shrink the index to the exact new key set. Legacy is left untouched.
-	// Skip shrink when a referenced index chunk was missing: livePrior was
-	// computed from a truncated key list, so shrinking would drop those keys
-	// from the published index while leaving their OS keychain entries
-	// stranded and unreachable by Load/Status/Delete. Leaving the union index
-	// in place keeps them listed until an intact read can reconcile them.
+	// Skip shrink when the prior index was incomplete: a shrink to `keys` would
+	// drop the preserved chunk advertisements and strand unlisted entries.
 	if !indexIncomplete {
-		if _, err := b.writeKeyIndex(keys, unionChunks); err != nil {
+		if _, err := b.writeKeyIndex(keys, unionChunks, false); err != nil {
 			return err
 		}
 	}
@@ -1102,7 +1107,7 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if _, err := tb.writeKeyIndex(keys, priorChunks); err != nil {
+	if _, err := tb.writeKeyIndex(keys, priorChunks, false); err != nil {
 		return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
 	}
 	return nil
@@ -1316,12 +1321,18 @@ func dedupeValidKeys(keys []string) []string {
 }
 
 // writeKeyIndex persists keys as a chunked index and reports how many chunk
-// entries it used. Continuation chunks are written before the header that
-// references them, so the authoritative chunk 0 never advertises a chunk that
-// does not exist yet; stale chunks from a previously larger index are removed
-// only after the header stops referencing them (best-effort: an unreferenced
-// chunk is never read).
-func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int) (int, error) {
+// entries the published header advertises. Continuation chunks are written
+// before the header that references them, so the authoritative chunk 0 never
+// advertises a content chunk that does not exist yet; stale chunks from a
+// previously larger index are removed only after the header stops referencing
+// them (best-effort: an unreferenced chunk is never read).
+//
+// keepMissingChunks is set when readKeyIndex reported a missing continuation
+// chunk. In that mode the header keeps advertising at least priorChunks so a
+// later-restored chunk remains reachable, and chunk accounts in that range are
+// not deleted (overwriting or removing them would turn recoverable damage into
+// permanent orphans).
+func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, keepMissingChunks bool) (int, error) {
 	// Refuse to publish an index the reader would reject: readKeyIndex caps both
 	// total keys and chunk count, and a header beyond either would make every
 	// later Load/Status/Save/Delete fail before it could recover. Check the key
@@ -1334,6 +1345,8 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int) (int, error) 
 	if len(chunks) > maxKeyringIndexChunks {
 		return 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", len(chunks), maxKeyringIndexChunks)
 	}
+	// Only write content chunks we produced. When preserving a damaged prior
+	// index, higher-numbered accounts may still hold recoverable key lists.
 	for i := 1; i < len(chunks); i++ {
 		chunkData, err := json.Marshal(chunks[i])
 		if err != nil {
@@ -1343,17 +1356,26 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int) (int, error) 
 			return 0, err
 		}
 	}
-	headerData, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: len(chunks), Keys: chunks[0]})
+	advertised := len(chunks)
+	if keepMissingChunks && priorChunks > advertised {
+		advertised = priorChunks
+	}
+	if advertised > maxKeyringIndexChunks {
+		return 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", advertised, maxKeyringIndexChunks)
+	}
+	headerData, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: advertised, Keys: chunks[0]})
 	if err != nil {
 		return 0, err
 	}
 	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
 		return 0, err
 	}
-	for i := len(chunks); i < priorChunks; i++ {
-		_, _ = b.kr.Delete(b.service, b.chunkAccount(i))
+	if !keepMissingChunks {
+		for i := len(chunks); i < priorChunks; i++ {
+			_, _ = b.kr.Delete(b.service, b.chunkAccount(i))
+		}
 	}
-	return len(chunks), nil
+	return advertised, nil
 }
 
 // chunkIndexKeys packs keys into chunks whose marshaled JSON stays under
@@ -1424,12 +1446,16 @@ func startLease(path, token string, unlock func()) *leasedPath {
 				// race these locks prevent. Only refresh while we still own the
 				// token: a post-stale reclaim can replace the file, and Chtimes on
 				// the replacement would keep both holders inside the critical section.
+				// Re-check ownership after Chtimes as well: between the pre-check and
+				// the stamp a peer can swap the file, and a successful Chtimes on the
+				// thief's lock would keep both critical sections alive.
 				if !ownLockFile(path, token) {
 					l.lost.Store(true)
 					return
 				}
 				at := time.Now()
-				if err := os.Chtimes(path, at, at); err != nil && !ownLockFile(path, token) {
+				_ = os.Chtimes(path, at, at)
+				if !ownLockFile(path, token) {
 					l.lost.Store(true)
 					return
 				}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -898,10 +898,15 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 // only after the header stops referencing them (best-effort: an unreferenced
 // chunk is never read).
 func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int) (int, error) {
+	// Refuse to publish an index the reader would reject: readKeyIndex caps both
+	// total keys and chunk count, and a header beyond either would make every
+	// later Load/Status/Save/Delete fail before it could recover. Check the key
+	// count before chunking so a large set of short keys that still fit under
+	// maxKeyringIndexChunks cannot strand the store unreadable.
+	if len(keys) > maxKeyringIndexKeys {
+		return 0, errKeyringIndexTooManyKeys(len(keys))
+	}
 	chunks := chunkIndexKeys(keys)
-	// Refuse to publish an index the reader would reject: readKeyIndex caps
-	// headers at maxKeyringIndexChunks, and a header beyond it would make
-	// every later Load/Status/Save/Delete fail before it could recover.
 	if len(chunks) > maxKeyringIndexChunks {
 		return 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", len(chunks), maxKeyringIndexChunks)
 	}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -148,6 +148,12 @@ const (
 	// new binary. Old writers cannot see this entry; new readers and writers
 	// honor it so a stale legacy rewrite cannot resurrect a logout.
 	keyringTombstoneAccount = "oauth-tokens-tombstones"
+	// keyringLegacyOriginAccount holds the set of keys ever observed in the
+	// legacy combined entry. It lets write() tell "a pre-migration binary
+	// removed this key" apart from "this key was never in the legacy blob to
+	// begin with" — both look identical as a single absence, but only the
+	// first is a logout that must propagate as one.
+	keyringLegacyOriginAccount = "oauth-tokens-legacy-origin"
 )
 
 // Store persists OAuth tokens (provider + MCP namespaces) as one JSON blob,
@@ -819,6 +825,30 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 			tokens[key] = legacyToken
 		}
 	}
+	// A running pre-migration binary can only log out through the legacy
+	// entry, and that logout is invisible here as anything but the key's
+	// absence from legacyTokens — indistinguishable, on its own, from a key
+	// this process's index just happens to also hold that legacy never knew
+	// about. legacyOrigin (populated by write(), the only place with a
+	// durable record to consult) disambiguates the two: only a key ever
+	// actually observed in legacy is subject to this exclusion, so a
+	// purely-new-format credential is never hidden the moment it is absent
+	// from an entry it was never written to in the first place. Applied here
+	// transiently (not persisted): the durable version happens in write(),
+	// consistent with every other best-effort check in this function.
+	if legacyTokens != nil {
+		legacyOrigin, lerr := b.readLegacyOrigin()
+		if lerr == nil {
+			for key := range tokens {
+				if !legacyOrigin[key] {
+					continue
+				}
+				if _, stillInLegacy := legacyTokens[key]; !stillInLegacy {
+					delete(tokens, key)
+				}
+			}
+		}
+	}
 
 	data, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens})
 	if err != nil {
@@ -948,6 +978,49 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 		}
 	}
 
+	// A running pre-migration binary only ever rewrites the legacy combined
+	// entry: it has no concept of the index or tombstones, so its own logout
+	// is indistinguishable, in isolation, from a key this process simply never
+	// indexed. legacyOrigin remembers which keys were ever actually observed in
+	// that entry, so a later absence can be read as "removed" rather than
+	// "never was there" — the distinction the merge above cannot make on its
+	// own, since a key created purely through this binary's Save also never
+	// appears in legacyTokens.
+	legacyOrigin, err := b.readLegacyOrigin()
+	if err != nil {
+		return err
+	}
+	legacyOriginChanged := false
+	if legacyTokens != nil {
+		for key := range legacyTokens {
+			if ValidateKey(key) != nil {
+				continue
+			}
+			if !legacyOrigin[key] {
+				legacyOrigin[key] = true
+				legacyOriginChanged = true
+			}
+		}
+		// Only once the legacy entry has actually been read (legacyTokens != nil)
+		// can its absence mean anything. mutations[key] is this same call's own
+		// explicit Save/Delete for key: that always wins over the heuristic, so
+		// a fresh Save is never immediately undone by a stale legacy reading.
+		for key := range state.Tokens {
+			if !legacyOrigin[key] || mutations[key] {
+				continue
+			}
+			if _, stillInLegacy := legacyTokens[key]; stillInLegacy {
+				continue
+			}
+			delete(state.Tokens, key)
+			if !tombstones[key] {
+				tombstones[key] = true
+			}
+			delete(legacyOrigin, key)
+			legacyOriginChanged = true
+		}
+	}
+
 	keys := make([]string, 0, len(state.Tokens))
 	for key := range state.Tokens {
 		keys = append(keys, key)
@@ -1005,6 +1078,20 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 	}
 	if err := b.writeTombstones(tombstones, checkLease); err != nil {
 		return err
+	}
+	// Persist legacyOrigin membership changes alongside the tombstones they
+	// justify: a key observed here for the first time, or one just tombstoned
+	// for having disappeared from legacy, must survive a crash the same way
+	// the tombstone itself does, or a retried write would repeat the same
+	// detection from a colder cache and could reorder relative to a concurrent
+	// old-binary rewrite.
+	if legacyOriginChanged {
+		if err := checkLease(); err != nil {
+			return err
+		}
+		if err := b.writeLegacyOrigin(legacyOrigin, checkLease); err != nil {
+			return err
+		}
 	}
 	// 2. Publish the union of the live prior and new key sets first, so every
 	// entry that exists at any point during this update is indexed.
@@ -1156,6 +1243,77 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leas
 	sort.Strings(keys)
 	if _, err := tb.writeKeyIndex(keys, priorChunks, nil, checkLease); err != nil {
 		return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
+	}
+	return nil
+}
+
+func (b keyringBlob) legacyOriginBlob() keyringBlob {
+	return keyringBlob{kr: b.kr, service: b.service, indexAccount: keyringLegacyOriginAccount, maxIndexKeys: maxKeyringTombstoneKeys}
+}
+
+// readLegacyOrigin returns the durable set of keys ever observed in the
+// legacy combined entry. Missing account => empty set (no old binary has
+// ever touched this store). Corrupt payloads fail closed, the same as
+// readTombstones: silently treating a damaged marker set as empty would
+// un-track every key it recorded and let the very absences it exists to
+// interpret look like fresh, ordinary keys again.
+func (b keyringBlob) readLegacyOrigin() (map[string]bool, error) {
+	keys, ok, _, _, err := b.legacyOriginBlob().readKeyIndex()
+	if err != nil {
+		return nil, fmt.Errorf("oauth: read keyring legacy-origin markers: %w", err)
+	}
+	if !ok {
+		return map[string]bool{}, nil
+	}
+	out := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		out[key] = true
+	}
+	return out, nil
+}
+
+// writeLegacyOrigin persists the legacy-origin set, mirroring writeTombstones:
+// an empty set removes the account/chunks entirely rather than leaving a
+// zero-key index behind.
+func (b keyringBlob) writeLegacyOrigin(origin map[string]bool, checkLease leaseCheck) error {
+	lb := b.legacyOriginBlob()
+	_, existed, priorChunks, _, err := lb.readKeyIndex()
+	if err != nil {
+		return fmt.Errorf("oauth: read keyring legacy-origin markers: %w", err)
+	}
+	if len(origin) == 0 {
+		if !existed {
+			return nil
+		}
+		if err := checkLease(); err != nil {
+			return err
+		}
+		if _, err := lb.kr.Delete(lb.service, lb.indexAccount); err != nil {
+			return err
+		}
+		for i := 1; i < priorChunks; i++ {
+			if err := checkLease(); err != nil {
+				return err
+			}
+			if _, err := lb.kr.Delete(lb.service, lb.chunkAccount(i)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if len(origin) > maxKeyringTombstoneKeys {
+		return fmt.Errorf("oauth: keyring legacy-origin markers list %d keys, over the %d-key writable bound", len(origin), maxKeyringTombstoneKeys)
+	}
+	keys := make([]string, 0, len(origin))
+	for key := range origin {
+		if ValidateKey(key) != nil {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if _, err := lb.writeKeyIndex(keys, priorChunks, nil, checkLease); err != nil {
+		return fmt.Errorf("oauth: write keyring legacy-origin markers: %w", err)
 	}
 	return nil
 }

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -409,13 +409,13 @@ func (s *Store) Save(key string, token Token) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.blob.withLock(s.now, func() error {
+	return s.blob.withLock(s.now, func(check leaseCheck) error {
 		state, err := s.readState()
 		if err != nil {
 			return err
 		}
 		state.Tokens[key] = token
-		return s.writeState(state, map[string]bool{key: false})
+		return s.writeState(state, map[string]bool{key: false}, check)
 	})
 }
 
@@ -434,7 +434,7 @@ func (s *Store) Load(key string) (Token, bool, error) {
 	// reads keep their crash tolerance (a crashed writer's fresh lock file
 	// must not block reads of the last complete file).
 	var state storeFile
-	err := s.blob.withReadLock(s.now, func() error {
+	err := s.blob.withReadLock(s.now, func(check leaseCheck) error {
 		var readErr error
 		state, readErr = s.readState()
 		return readErr
@@ -454,7 +454,7 @@ func (s *Store) Delete(key string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var removed bool
-	err := s.blob.withLock(s.now, func() error {
+	err := s.blob.withLock(s.now, func(check leaseCheck) error {
 		state, err := s.readState()
 		if err != nil {
 			return err
@@ -467,7 +467,7 @@ func (s *Store) Delete(key string) (bool, error) {
 		// Exclude the deleted key from legacy reconciliation so a credential
 		// that was only present in the legacy blob (never indexed) is not
 		// reclassified as a fresh old-binary login and written back.
-		return s.writeState(state, map[string]bool{key: true})
+		return s.writeState(state, map[string]bool{key: true}, check)
 	})
 	return removed, err
 }
@@ -481,7 +481,7 @@ func (s *Store) Status(prefix string) ([]Status, error) {
 	// keyring's multi-entry read can't observe another process's Save/Delete
 	// mid write, while file-backend reads stay lock-free.
 	var state storeFile
-	err := s.blob.withReadLock(s.now, func() error {
+	err := s.blob.withReadLock(s.now, func(check leaseCheck) error {
 		var readErr error
 		state, readErr = s.readState()
 		return readErr
@@ -550,7 +550,7 @@ func (s *Store) readState() (storeFile, error) {
 // writeState persists state. mutations identifies explicitly saved (false) and
 // deleted (true) keys. The keyring backend uses it to order durable tombstone
 // transitions; file and encrypted-file backends ignore it.
-func (s *Store) writeState(state storeFile, mutations map[string]bool) error {
+func (s *Store) writeState(state storeFile, mutations map[string]bool, checkLease leaseCheck) error {
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
@@ -564,7 +564,7 @@ func (s *Store) writeState(state storeFile, mutations map[string]bool) error {
 			return err
 		}
 	}
-	return s.blob.write(payload, mutations)
+	return s.blob.write(payload, mutations, checkLease)
 }
 
 func emptyStoreFile() storeFile {
@@ -578,19 +578,21 @@ type blobStore interface {
 	read() (data []byte, ok bool, err error)
 	// write replaces the stored blob. mutations is keyring-only and identifies
 	// explicit saves (false) and deletes (true) for durable tombstone ordering.
-	// File backends ignore it.
-	write(data []byte, mutations map[string]bool) error
+	// File backends ignore it. checkLease must be consulted immediately before
+	// each externally visible mutation write() performs; see leaseCheck.
+	write(data []byte, mutations map[string]bool, checkLease leaseCheck) error
 	// withLock runs fn under whatever cross-process exclusion the backend offers
 	// (a lock file for the file backend; none for the keyring, which is the
 	// authoritative store and is serialized within the process by Store.mu).
-	withLock(now func() time.Time, fn func() error) error
+	// fn receives a leaseCheck to consult before mutating; see its doc comment.
+	withLock(now func() time.Time, fn func(check leaseCheck) error) error
 	// withReadLock guards a read-only pass. The file backend's writes are
 	// atomic renames, so its reads stay lock-free: a crashed writer's fresh
 	// lock file must not turn into ~30s of read failures when the last
 	// complete file is perfectly readable. The keyring backend's read is
 	// several separate Get calls (index, then each entry), not one atomic
 	// snapshot, so it takes the same cross-process lock as its writes.
-	withReadLock(now func() time.Time, fn func() error) error
+	withReadLock(now func() time.Time, fn func(check leaseCheck) error) error
 	// location is a human-readable identifier for diagnostics/errors.
 	location() string
 }
@@ -610,7 +612,7 @@ func (b fileBlob) read() ([]byte, bool, error) {
 	return data, true, nil
 }
 
-func (b fileBlob) write(data []byte, _ map[string]bool) error {
+func (b fileBlob) write(data []byte, _ map[string]bool, _ leaseCheck) error {
 	if err := os.MkdirAll(filepath.Dir(b.path), 0o700); err != nil {
 		return err
 	}
@@ -663,21 +665,26 @@ func createPublicationFile(path string) (*os.File, string, error) {
 	return temp, temp.Name(), nil
 }
 
-func (b fileBlob) withLock(now func() time.Time, fn func() error) error {
+// noLeaseLoss is the fileBlob checkLease: acquireFileLock's O_EXCL lock has no
+// reclaim path (unlike the keyring's mtime-based staleness reclaim), so there
+// is no ownership loss for fn to observe mid-critical-section.
+func noLeaseLoss() error { return nil }
+
+func (b fileBlob) withLock(now func() time.Time, fn func(check leaseCheck) error) error {
 	unlock, _, err := acquireFileLock(b.path+".lockfile", now)
 	if err != nil {
 		return err
 	}
 	defer unlock()
-	return fn()
+	return fn(noLeaseLoss)
 }
 
 // withReadLock is deliberately lock-free: write() replaces the file with an
 // atomic rename, so a reader always sees a complete file, and a crashed
 // writer's leftover lock file must not turn readable state into ~30 seconds
 // of Load/Status failures while the stale threshold runs out.
-func (b fileBlob) withReadLock(now func() time.Time, fn func() error) error {
-	return fn()
+func (b fileBlob) withReadLock(now func() time.Time, fn func(check leaseCheck) error) error {
+	return fn(noLeaseLoss)
 }
 
 func (b fileBlob) location() string { return b.path }
@@ -879,7 +886,7 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // durable tombstones and must not be re-merged from the legacy blob even
 // when they were never indexed (a legacy-only old-binary login that the
 // user logged out of).
-func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
+func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease leaseCheck) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
@@ -982,10 +989,21 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 		}
 	}
 
+	// Each numbered step below is gated on checkLease immediately before it
+	// mutates the keyring: this write can span several round-trips (a chunked
+	// index plus one Set per token), and a process that stalls partway through
+	// after another process reclaimed its lock as stale must not let the rest
+	// of the sequence land. Checking only once at entry would let every step
+	// after the stall complete, racing the reclaiming process's own
+	// read-modify-write instead of aborting before touching shared state.
+
 	// 1. Persist tombstones before removing entries so logout survives a crash
 	// between entry delete and a later reconcile (and survives an old binary
 	// rewriting the legacy blob with the deleted key still present).
-	if err := b.writeTombstones(tombstones); err != nil {
+	if err := checkLease(); err != nil {
+		return err
+	}
+	if err := b.writeTombstones(tombstones, checkLease); err != nil {
 		return err
 	}
 	// 2. Publish the union of the live prior and new key sets first, so every
@@ -1008,12 +1026,18 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 		}
 		sort.Strings(union)
 	}
-	unionChunks, err := b.writeKeyIndex(union, priorChunks, missingChunks)
+	if err := checkLease(); err != nil {
+		return err
+	}
+	unionChunks, err := b.writeKeyIndex(union, priorChunks, missingChunks, checkLease)
 	if err != nil {
 		return err
 	}
 	// 3. Write each token entry (encodings preflighted above).
 	for _, key := range keys {
+		if err := checkLease(); err != nil {
+			return err
+		}
 		if err := b.kr.Set(b.service, key, encoded[key]); err != nil {
 			return err
 		}
@@ -1024,6 +1048,9 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 	// chunk stay put so a restored chunk can still find them.
 	for _, key := range livePrior {
 		if _, ok := state.Tokens[key]; !ok {
+			if err := checkLease(); err != nil {
+				return err
+			}
 			if _, err := b.kr.Delete(b.service, key); err != nil {
 				return err
 			}
@@ -1033,7 +1060,10 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 	// Skip shrink when the prior index was incomplete: a shrink to `keys` would
 	// drop the preserved chunk advertisements and strand unlisted entries.
 	if !indexIncomplete {
-		if _, err := b.writeKeyIndex(keys, unionChunks, nil); err != nil {
+		if err := checkLease(); err != nil {
+			return err
+		}
+		if _, err := b.writeKeyIndex(keys, unionChunks, nil, checkLease); err != nil {
 			return err
 		}
 	}
@@ -1048,7 +1078,10 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 		}
 	}
 	if tombstonesChanged {
-		if err := b.writeTombstones(tombstones); err != nil {
+		if err := checkLease(); err != nil {
+			return err
+		}
+		if err := b.writeTombstones(tombstones, checkLease); err != nil {
 			return err
 		}
 	}
@@ -1084,7 +1117,7 @@ func (b keyringBlob) readTombstones() (map[string]bool, error) {
 // tombstone account/chunk so a fully clean store does not leave leftover
 // markers. Errors from that cleanup are surfaced so interruption tests and
 // real keyring failures cannot be swallowed.
-func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
+func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leaseCheck) error {
 	tb := b.tombstoneBlob()
 	_, existed, priorChunks, _, err := tb.readKeyIndex()
 	if err != nil {
@@ -1094,10 +1127,16 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
 		if !existed {
 			return nil
 		}
+		if err := checkLease(); err != nil {
+			return err
+		}
 		if _, err := tb.kr.Delete(tb.service, tb.indexAccount); err != nil {
 			return err
 		}
 		for i := 1; i < priorChunks; i++ {
+			if err := checkLease(); err != nil {
+				return err
+			}
 			if _, err := tb.kr.Delete(tb.service, tb.chunkAccount(i)); err != nil {
 				return err
 			}
@@ -1115,7 +1154,7 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if _, err := tb.writeKeyIndex(keys, priorChunks, nil); err != nil {
+	if _, err := tb.writeKeyIndex(keys, priorChunks, nil, checkLease); err != nil {
 		return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
 	}
 	return nil
@@ -1356,7 +1395,7 @@ func dedupeValidKeys(keys []string) []string {
 // restored. New continuation chunks are therefore remapped around protected
 // slots, the header keeps advertising at least priorChunks so a later-restored
 // chunk remains reachable, and protected accounts are never deleted.
-func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks []int) (int, error) {
+func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks []int, checkLease leaseCheck) (int, error) {
 	// Refuse to publish an index the reader would reject: readKeyIndex caps both
 	// total keys and chunk count, and a header beyond either would make every
 	// later Load/Status/Save/Delete fail before it could recover. Check the key
@@ -1389,6 +1428,9 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks
 		if err != nil {
 			return 0, err
 		}
+		if err := checkLease(); err != nil {
+			return 0, err
+		}
 		if err := b.kr.Set(b.service, b.chunkAccount(slot), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
 			return 0, err
 		}
@@ -1412,6 +1454,9 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks
 	if err != nil {
 		return 0, err
 	}
+	if err := checkLease(); err != nil {
+		return 0, err
+	}
 	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
 		return 0, err
 	}
@@ -1419,6 +1464,14 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks
 	// account would destroy the last chance to recover the keys it listed.
 	if len(missingChunks) == 0 {
 		for i := len(chunks); i < priorChunks; i++ {
+			if checkLease() != nil {
+				// Best-effort cleanup: a lost lease here must not turn into an
+				// error return, since the index header above is already
+				// durable and correct. Leaving an orphaned chunk account is
+				// the same shape of harmless leftover a failed Delete already
+				// tolerates below.
+				break
+			}
 			_, _ = b.kr.Delete(b.service, b.chunkAccount(i))
 		}
 	}
@@ -1541,7 +1594,19 @@ func (l *leasedPath) release() {
 // If a lease is replaced under us mid-critical-section, the operation fails
 // closed after fn returns (or with fn's error) rather than treating a dual-
 // entry window as success.
-func withLeasedLocks(paths []string, now func() time.Time, fn func() error) error {
+// leaseCheck reports whether every lock backing the current critical section
+// is still owned, at the instant it is called. fn must call it immediately
+// before each externally visible mutation (a keyring Set/Delete, not a read),
+// not only rely on the pre/post checks around fn as a whole: a process can
+// pass the pre-check, stall past the stale interval, and have another process
+// reclaim the lock while it is paused. Checking only before and after fn lets
+// every mutation fn performs while stalled complete before the loss is
+// reported, so it races the reclaiming process's read-modify-write rather
+// than aborting before touching shared state. A mid-fn check closes that
+// window to whatever fn's own step granularity is.
+type leaseCheck func() error
+
+func withLeasedLocks(paths []string, now func() time.Time, fn func(check leaseCheck) error) error {
 	var leases []*leasedPath
 	released := false
 	releaseAll := func() {
@@ -1565,29 +1630,31 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func() error) erro
 		// Start refreshing this lock before blocking on the next path.
 		leases = append(leases, startLease(p, token, unlock))
 	}
+	check := func() error {
+		for _, l := range leases {
+			if l.lost.Load() {
+				return fmt.Errorf("oauth: lost token lock lease on %s", filepath.Base(l.path))
+			}
+		}
+		return nil
+	}
 	if len(leases) == 0 {
-		return fn()
+		return fn(check)
 	}
 	defer releaseAll()
 	// Fencing: if any lease was already lost while later locks were still
 	// being acquired (e.g. the first, global index lock reclaimed as stale
 	// while the caller blocks on legacyLockPath), do not enter the critical
-	// section at all. A mutation under a lost lock would run concurrently with
-	// the peer that reclaimed it, reviving the token-loss race the locks exist
-	// to prevent.
-	for _, l := range leases {
-		if l.lost.Load() {
-			return fmt.Errorf("oauth: lost token lock lease on %s", filepath.Base(l.path))
-		}
+	// section at all.
+	if err := check(); err != nil {
+		return err
 	}
-	err := fn()
-	for _, l := range leases {
-		if l.lost.Load() {
-			if err != nil {
-				return err
-			}
-			return fmt.Errorf("oauth: lost token lock lease on %s", filepath.Base(l.path))
+	err := fn(check)
+	if lostErr := check(); lostErr != nil {
+		if err != nil {
+			return err
 		}
+		return lostErr
 	}
 	return err
 }
@@ -1600,14 +1667,14 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func() error) erro
 // legacyKeyringLockPath) serializes with our reconcile-and-index pass.
 // Cross-root old writers cannot share that lock; never overwriting the
 // legacy blob and durable tombstones are the remaining safety net for them.
-func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
+func (b keyringBlob) withLock(now func() time.Time, fn func(check leaseCheck) error) error {
 	return withLeasedLocks([]string{b.lockPath, b.legacyLockPath}, now, fn)
 }
 
 // withReadLock only takes lockPath: a pre-PR binary never locks for a read
 // (see legacyKeyringLockPath), so a read here has nothing to coordinate with
 // on the legacy side.
-func (b keyringBlob) withReadLock(now func() time.Time, fn func() error) error {
+func (b keyringBlob) withReadLock(now func() time.Time, fn func(check leaseCheck) error) error {
 	return withLeasedLocks([]string{b.lockPath}, now, fn)
 }
 

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -432,17 +432,21 @@ func sanitizeLockComponent(s string) string {
 func (s *Store) FilePath() string { return s.blob.location() }
 
 // Mixed-version key lifecycle (keyring backend). File backends ignore intent.
+// Load/Status, refresh persist, login Save, Delete, and a pre-per-key binary
+// that removes a key from oauth-tokens must follow this table. write() applies
+// the persist columns; read() applies Load/Status.
 //
-//	State                         Load/Status              After refresh persist              After explicit Save                 After old binary drops the key from oauth-tokens
-//	----------------------------  -----------------------  ---------------------------------  ---------------------------------  ------------------------------------------------
-//	Legacy-only, not yet indexed  serve from legacy        index + set legacyOrigin           index + set origin                 hide + tombstone once origin is known
-//	Indexed, legacyOrigin set     serve indexed            update material, keep origin       update + retire origin             hide via origin absence (tombstone on write)
-//	Pure new-format (never legacy) serve indexed           update only                        update only                        N/A (origin never set)
-//	User logged out (tombstone)   hidden                   abort: do not refresh or persist   clear tombstone after durable write already hidden
+//	State                          Load/Status     After refresh persist            After explicit re-login (Save)            After old binary drops key from oauth-tokens
+//	-----------------------------  --------------  -------------------------------  ----------------------------------------  -------------------------------------------
+//	Legacy-only, not yet indexed   serve legacy    index + set legacyOrigin         index + set origin                        hide + tombstone (once origin is known)
+//	Indexed, legacyOrigin set      serve indexed   update material, keep origin     update + retire origin                    hide via origin absence
+//	Pure new-format (never legacy) serve indexed   update only                      update only                               N/A
+//	User logged out (tombstone)    hidden          abort: do not refresh/persist    clear tombstone after durable replace     already hidden
 //
-// Refresh is not login. mutationRefresh seeds origin, never retires it, never
-// clears a tombstone, and never creates a credential that Load no longer sees.
-// Rules must key off intent, not "is this key in the mutation map?".
+// Delete hides the key and writes a tombstone. Refresh is not login:
+// mutationRefresh seeds origin, never retires it, never clears a tombstone,
+// and never creates a credential Load no longer sees. Rules key off intent,
+// not "is this key in the mutation map?".
 type mutationIntent int
 
 const (
@@ -1030,6 +1034,9 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // legacy blob would require a snapshot-then-Set that cannot be locked against
 // old writers on other config roots, so it would trade a bounded downgrade
 // window for unbounded loss of concurrent old-binary logins.
+//
+// Persist intent (seed/retire legacyOrigin, absence heuristic, tombstone
+// clear) follows the mixed-version table on mutationIntent.
 func (b keyringBlob) write(data []byte, mutations map[string]mutationIntent, checkLease leaseCheck) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -431,8 +431,30 @@ func sanitizeLockComponent(s string) string {
 // backend, or a "keyring:..." identifier for the keyring backend).
 func (s *Store) FilePath() string { return s.blob.location() }
 
+// mutationIntent is why a key appears in a write's mutation set. Save and
+// Delete replace or remove a credential and must retire legacy-origin
+// precedence for that key. A token refresh is not a login or logout, so it
+// must keep the origin marker: otherwise an old-binary logout that happened
+// after this process last read the legacy blob is lost, and a later
+// absence-heuristic pass cannot delete the leftover indexed copy.
+type mutationIntent int
+
+const (
+	mutationReplace mutationIntent = iota
+	mutationDelete
+	mutationRefresh
+)
+
 // Save persists a token under key, replacing any existing entry.
 func (s *Store) Save(key string, token Token) error {
+	return s.save(key, token, mutationReplace)
+}
+
+func (s *Store) saveRefreshed(key string, token Token) error {
+	return s.save(key, token, mutationRefresh)
+}
+
+func (s *Store) save(key string, token Token, intent mutationIntent) error {
 	if err := ValidateKey(key); err != nil {
 		return err
 	}
@@ -444,7 +466,7 @@ func (s *Store) Save(key string, token Token) error {
 			return err
 		}
 		state.Tokens[key] = token
-		return s.writeState(state, map[string]bool{key: false}, check)
+		return s.writeState(state, map[string]mutationIntent{key: intent}, check)
 	})
 }
 
@@ -491,7 +513,7 @@ func (s *Store) Delete(key string) (bool, error) {
 		if _, ok := state.Tokens[key]; ok {
 			delete(state.Tokens, key)
 			removed = true
-			return s.writeState(state, map[string]bool{key: true}, check)
+			return s.writeState(state, map[string]mutationIntent{key: mutationDelete}, check)
 		}
 		// readState no longer exposes the key (a tombstone hides it, or an
 		// interrupted delete already finished the logical logout) but a keyring
@@ -506,7 +528,7 @@ func (s *Store) Delete(key string) (bool, error) {
 			}
 			if resident {
 				removed = true
-				return s.writeState(state, map[string]bool{key: true}, check)
+				return s.writeState(state, map[string]mutationIntent{key: mutationDelete}, check)
 			}
 		}
 		return nil
@@ -589,10 +611,11 @@ func (s *Store) readState() (storeFile, error) {
 	return state, nil
 }
 
-// writeState persists state. mutations identifies explicitly saved (false) and
-// deleted (true) keys. The keyring backend uses it to order durable tombstone
-// transitions; file and encrypted-file backends ignore it.
-func (s *Store) writeState(state storeFile, mutations map[string]bool, checkLease leaseCheck) error {
+// writeState persists state. mutations identifies explicit Save, Delete, and
+// refresh writes. The keyring backend uses that intent to order durable
+// tombstone transitions and to decide whether to retire legacy-origin
+// precedence; file and encrypted-file backends ignore it.
+func (s *Store) writeState(state storeFile, mutations map[string]mutationIntent, checkLease leaseCheck) error {
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
@@ -619,10 +642,11 @@ type blobStore interface {
 	// read returns the stored blob; ok is false when nothing is stored yet.
 	read() (data []byte, ok bool, err error)
 	// write replaces the stored blob. mutations is keyring-only and identifies
-	// explicit saves (false) and deletes (true) for durable tombstone ordering.
-	// File backends ignore it. checkLease must be consulted immediately before
-	// each externally visible mutation write() performs; see leaseCheck.
-	write(data []byte, mutations map[string]bool, checkLease leaseCheck) error
+	// explicit Save, Delete, and refresh writes for durable tombstone
+	// ordering. File backends ignore it. checkLease must be consulted
+	// immediately before each externally visible mutation write() performs;
+	// see leaseCheck.
+	write(data []byte, mutations map[string]mutationIntent, checkLease leaseCheck) error
 	// withLock runs fn under whatever cross-process exclusion the backend offers
 	// (a lock file for the file backend; leased lock files for the keyring backend;
 	// Store.mu provides in-process serialization).
@@ -654,7 +678,7 @@ func (b fileBlob) read() ([]byte, bool, error) {
 	return data, true, nil
 }
 
-func (b fileBlob) write(data []byte, _ map[string]bool, _ leaseCheck) error {
+func (b fileBlob) write(data []byte, _ map[string]mutationIntent, _ leaseCheck) error {
 	if err := os.MkdirAll(filepath.Dir(b.path), 0o700); err != nil {
 		return err
 	}
@@ -979,7 +1003,7 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // legacy blob would require a snapshot-then-Set that cannot be locked against
 // old writers on other config roots, so it would trade a bounded downgrade
 // window for unbounded loss of concurrent old-binary logins.
-func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease leaseCheck) error {
+func (b keyringBlob) write(data []byte, mutations map[string]mutationIntent, checkLease leaseCheck) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
@@ -1000,8 +1024,8 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 	}
 	// Record durable deletion markers before mutating entries so a crash
 	// mid-write cannot leave a logged-out key importable from legacy alone.
-	for key, deleted := range mutations {
-		if deleted {
+	for key, intent := range mutations {
+		if intent == mutationDelete {
 			tombstones[key] = true
 		}
 	}
@@ -1028,7 +1052,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 			if ValidateKey(key) != nil {
 				continue
 			}
-			if mutations[key] || tombstones[key] {
+			if _, mutated := mutations[key]; mutated || tombstones[key] {
 				continue
 			}
 			if _, exists := state.Tokens[key]; exists {
@@ -1065,7 +1089,10 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 			}
 		}
 	}
-	for key := range mutations {
+	for key, intent := range mutations {
+		if intent == mutationRefresh {
+			continue
+		}
 		if legacyOrigin[key] {
 			delete(legacyOrigin, key)
 			legacyOriginChanged = true
@@ -1227,8 +1254,8 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 	// index are durable. If any earlier step fails, legacy fallback remains
 	// suppressed instead of restoring the revoked credential.
 	tombstonesChanged := false
-	for key, deleted := range mutations {
-		if !deleted && tombstones[key] {
+	for key, intent := range mutations {
+		if intent != mutationDelete && tombstones[key] {
 			delete(tombstones, key)
 			tombstonesChanged = true
 		}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -1574,24 +1574,27 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks
 			maxProtected = c
 		}
 	}
-	// Write each new continuation chunk into the next account that is not a
-	// protected (missing) slot, so recoverable chunk data is never overwritten.
+	// Plan the complete slot assignment before writing anything. This must be
+	// a pure computation: the loop below overwrites existing, non-protected
+	// chunk accounts the old header still references, so if it started
+	// writing and only discovered a capacity overflow afterward, the old
+	// header would be left describing a layout partially clobbered by pieces
+	// of the new one, potentially stranding every key it lists. Assigning
+	// slots first and validating the result means a rejected write leaves
+	// every existing chunk account and every existing token byte-for-byte
+	// untouched.
+	type plannedChunk struct {
+		slot  int
+		index int
+	}
+	var planned []plannedChunk
 	slot := 1
 	advertised := len(chunks)
 	for i := 1; i < len(chunks); i++ {
 		for protected[slot] {
 			slot++
 		}
-		chunkData, err := json.Marshal(chunks[i])
-		if err != nil {
-			return 0, err
-		}
-		if err := checkLease(); err != nil {
-			return 0, err
-		}
-		if err := b.kr.Set(b.service, b.chunkAccount(slot), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
-			return 0, err
-		}
+		planned = append(planned, plannedChunk{slot: slot, index: i})
 		if slot+1 > advertised {
 			advertised = slot + 1
 		}
@@ -1607,6 +1610,19 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks
 	}
 	if advertised > maxKeyringIndexChunks {
 		return 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", advertised, maxKeyringIndexChunks)
+	}
+	// Planning is done and the layout fits; now perform the writes it called for.
+	for _, p := range planned {
+		chunkData, err := json.Marshal(chunks[p.index])
+		if err != nil {
+			return 0, err
+		}
+		if err := checkLease(); err != nil {
+			return 0, err
+		}
+		if err := b.kr.Set(b.service, b.chunkAccount(p.slot), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
+			return 0, err
+		}
 	}
 	headerData, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: advertised, Keys: chunks[0]})
 	if err != nil {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -899,7 +899,7 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		if len(keys) > maxKeyringIndexKeys {
 			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys))
 		}
-		return keys, true, 1, nil
+		return dedupeValidKeys(keys), true, 1, nil
 	}
 	var header keyIndexHeader
 	if err := json.Unmarshal(raw, &header); err != nil {
@@ -940,7 +940,34 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		}
 		keys = append(keys, more...)
 	}
-	return keys, true, header.Chunks, nil
+	return dedupeValidKeys(keys), true, header.Chunks, nil
+}
+
+// dedupeValidKeys drops duplicates and malformed entries from a decoded
+// index's key list before it is fanned out into one keyring lookup per key by
+// read()/write() (via Load/Status/Save/Delete). maxKeyringIndexKeys already
+// bounds the raw decode, but that bound does nothing against a corrupted or
+// adversarially crafted index that packs its budget with repeats of the same
+// key (or garbage that was never a real ValidateKey-shaped entry): every
+// duplicate or malformed key would otherwise still cost its own blocking
+// keyring lookup (up to the 10s command timeout) while the store lock is
+// held, reintroducing the fan-out DoS the index cap was meant to close.
+// Order is preserved (first occurrence wins) so callers that sort or display
+// keys see stable results.
+func dedupeValidKeys(keys []string) []string {
+	seen := make(map[string]bool, len(keys))
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if seen[key] {
+			continue
+		}
+		if ValidateKey(key) != nil {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	return out
 }
 
 // writeKeyIndex persists keys as a chunked index and reports how many chunk

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -702,6 +702,23 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 		tokens[key] = token
 	}
 
+	// Keep legacy-only keys visible through the compatibility window:
+	// an old binary may have logged into a provider after the index was created.
+	if !legacyLoaded {
+		if lt, lerr := b.readLegacyTokens(); lerr == nil {
+			legacyTokens = lt
+		}
+		legacyLoaded = true
+	}
+	for key, legacyToken := range legacyTokens {
+		if ValidateKey(key) != nil {
+			continue
+		}
+		if _, has := tokens[key]; !has {
+			tokens[key] = legacyToken
+		}
+	}
+
 	data, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens})
 	if err != nil {
 		return nil, false, err
@@ -755,19 +772,7 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // strictly later expiry or updated token material on the legacy side is the
 // signal that it holds a newer credential. Zero (unknown) expiries are valid.
 func legacyIsFresher(legacy, current Token) bool {
-	if !legacy.ExpiresAt.IsZero() && !current.ExpiresAt.IsZero() {
-		if legacy.ExpiresAt.After(current.ExpiresAt) {
-			return true
-		}
-		if current.ExpiresAt.After(legacy.ExpiresAt) {
-			return false
-		}
-		return legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken
-	}
-	if legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken {
-		return true
-	}
-	return false
+	return legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken
 }
 
 // write replaces the keyring's token entries with state, ordered so that
@@ -935,6 +940,10 @@ const maxKeyringIndexChunks = 128
 // maxKeyringIndexChunks) while still rejecting a damaged index promptly.
 const maxKeyringIndexKeys = 512
 
+// maxRawKeyringIndexKeys bounds the raw decoded element count before
+// deduplication or map preallocation, guarding against DoS from duplicate keys.
+const maxRawKeyringIndexKeys = 16384
+
 // errKeyringIndexTooManyKeys is returned when a decoded index (or one of its
 // chunks) claims more keys than maxKeyringIndexKeys.
 func errKeyringIndexTooManyKeys(count int) error {
@@ -977,6 +986,9 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		if err := json.Unmarshal(raw, &rawKeys); err != nil {
 			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
 		}
+		if len(rawKeys) > maxRawKeyringIndexKeys {
+			return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys))
+		}
 		keys := dedupeValidKeys(rawKeys)
 		if len(keys) > maxKeyringIndexKeys {
 			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys))
@@ -998,6 +1010,9 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		return nil, false, 0, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
 	}
 	rawKeys := header.Keys
+	if len(rawKeys) > maxRawKeyringIndexKeys {
+		return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys))
+	}
 	for i := 1; i < header.Chunks; i++ {
 		chunkEnc, ok, err := b.kr.Get(b.service, b.chunkAccount(i))
 		if err != nil {
@@ -1013,6 +1028,9 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		var more []string
 		if err := json.Unmarshal(chunkRaw, &more); err != nil {
 			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
+		}
+		if len(rawKeys)+len(more) > maxRawKeyringIndexKeys {
+			return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys) + len(more))
 		}
 		rawKeys = append(rawKeys, more...)
 	}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"net/url"
 	"os"
@@ -266,7 +265,7 @@ func NewStore(options StoreOptions) (*Store, error) {
 		// process's token write. legacyLockPath additionally coordinates with a
 		// still-running pre-PR binary during the supported mixed-version window
 		// (see legacyKeyringLockPath).
-		lockPath, err := keyringLockPath(options.Env, keyringService, keyringIndexAccount)
+		lockPath, err := keyringLockPath(keyringService, keyringIndexAccount)
 		if err != nil {
 			return nil, err
 		}
@@ -306,7 +305,7 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 // When the OS user lookup fails, the fallback is a private UID-scoped directory
 // under the process temp root (validated 0700, owned by us); a co-tenant DoS
 // of the shared /tmp name is rejected rather than accepted as the lock path.
-func keyringLockPath(env map[string]string, service, account string) (string, error) {
+func keyringLockPath(service, account string) (string, error) {
 	name := keyringLockFileName(service, account)
 	if u, err := currentOSUser(); err == nil && strings.TrimSpace(u.HomeDir) != "" {
 		return filepath.Join(u.HomeDir, ".cache", "zero", name), nil
@@ -1417,7 +1416,6 @@ const maxRawKeyringIndexKeys = 16384
 // errKeyringIndexTooManyKeys is returned when a decoded index (or one of its
 // chunks) claims more keys than maxKeyringIndexKeys.
 func errKeyringIndexTooManyKeys(count, limit int) error {
-	log.Printf("warning: oauth: keyring token index lists %d keys, over the %d-key cap", count, limit)
 	return fmt.Errorf("oauth: keyring token index lists %d keys, over the %d-key cap", count, limit)
 }
 

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -210,9 +210,12 @@ func NewStore(options StoreOptions) (*Store, error) {
 			kr = osKeyring
 		}
 		// Serialize the keyring's read-modify-write across processes with a lock
-		// file beside where the file backend would live. Best-effort: if no config
-		// location resolves, fall back to in-process serialization only.
-		lockPath := ""
+		// file beside where the file backend would live. Cross-process exclusion
+		// must not silently disappear when no config location resolves (withLock
+		// would be a no-op and a concurrent save could delete another process's
+		// newly written entry), so fall back to the OS temp directory, which
+		// always exists, rather than to in-process serialization only.
+		lockPath := filepath.Join(os.TempDir(), "zero-oauth-keyring.lockfile")
 		if storePath, perr := ResolveStorePath(options.Env); perr == nil {
 			lockPath = filepath.Join(filepath.Dir(storePath), "oauth-keyring.lockfile")
 		}
@@ -269,14 +272,15 @@ func (s *Store) Load(key string) (Token, bool, error) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Through blob.withLock, like Save/Delete: the keyring backend's read is
-	// several separate Get calls (index, then each entry), not one atomic
-	// snapshot, so an unlocked Load can run concurrently with another
-	// process's Save/Delete mid write and observe a torn state (e.g. an index
-	// already updated but an entry not yet written). The lock keeps this read
-	// from overlapping any other process's read-modify-write cycle.
+	// Through blob.withReadLock: the keyring backend's read is several
+	// separate Get calls (index, then each entry), not one atomic snapshot,
+	// so an unguarded Load could run concurrently with another process's
+	// Save/Delete mid write and observe a torn state. The file backend's
+	// withReadLock is a no-op: its writes are atomic renames, so lock-free
+	// reads keep their crash tolerance (a crashed writer's fresh lock file
+	// must not block reads of the last complete file).
 	var state storeFile
-	err := s.blob.withLock(s.now, func() error {
+	err := s.blob.withReadLock(s.now, func() error {
 		var readErr error
 		state, readErr = s.readState()
 		return readErr
@@ -316,10 +320,11 @@ func (s *Store) Delete(key string) (bool, error) {
 func (s *Store) Status(prefix string) ([]Status, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Same reasoning as Load: run the read under blob.withLock so it can't
-	// observe another process's Save/Delete mid write.
+	// Same reasoning as Load: run the read under blob.withReadLock so the
+	// keyring's multi-entry read can't observe another process's Save/Delete
+	// mid write, while file-backend reads stay lock-free.
 	var state storeFile
-	err := s.blob.withLock(s.now, func() error {
+	err := s.blob.withReadLock(s.now, func() error {
 		var readErr error
 		state, readErr = s.readState()
 		return readErr
@@ -417,6 +422,13 @@ type blobStore interface {
 	// (a lock file for the file backend; none for the keyring, which is the
 	// authoritative store and is serialized within the process by Store.mu).
 	withLock(now func() time.Time, fn func() error) error
+	// withReadLock guards a read-only pass. The file backend's writes are
+	// atomic renames, so its reads stay lock-free: a crashed writer's fresh
+	// lock file must not turn into ~30s of read failures when the last
+	// complete file is perfectly readable. The keyring backend's read is
+	// several separate Get calls (index, then each entry), not one atomic
+	// snapshot, so it takes the same cross-process lock as its writes.
+	withReadLock(now func() time.Time, fn func() error) error
 	// location is a human-readable identifier for diagnostics/errors.
 	location() string
 }
@@ -498,6 +510,14 @@ func (b fileBlob) withLock(now func() time.Time, fn func() error) error {
 	return fn()
 }
 
+// withReadLock is deliberately lock-free: write() replaces the file with an
+// atomic rename, so a reader always sees a complete file, and a crashed
+// writer's leftover lock file must not turn readable state into ~30 seconds
+// of Load/Status failures while the stale threshold runs out.
+func (b fileBlob) withReadLock(now func() time.Time, fn func() error) error {
+	return fn()
+}
+
 func (b fileBlob) location() string { return b.path }
 
 // keyringBlob persists tokens in the OS keyring as one base64 entry per token
@@ -519,16 +539,12 @@ type keyringBlob struct {
 }
 
 func (b keyringBlob) read() ([]byte, bool, error) {
-	indexEnc, ok, err := b.kr.Get(b.service, b.indexAccount)
+	keys, ok, _, err := b.readKeyIndex()
 	if err != nil {
 		return nil, false, err
 	}
 	if !ok {
 		return b.readLegacy()
-	}
-	keys, err := decodeKeyIndex(indexEnc)
-	if err != nil {
-		return nil, false, fmt.Errorf("oauth: decode keyring token index: %w", err)
 	}
 	tokens := make(map[string]Token, len(keys))
 	for _, key := range keys {
@@ -574,34 +590,87 @@ func (b keyringBlob) readLegacy() ([]byte, bool, error) {
 	return data, true, nil
 }
 
+// write replaces the keyring's token entries with state, ordered so that
+// every interruption boundary leaves a recoverable store. The invariant is
+// that any token entry existing in the keyring at any instant is listed in
+// the published index: the union index is published before entries are
+// written, entries are deleted before the index shrinks, and the index
+// header is only updated after the chunks it references exist. A crash at
+// any step therefore leaves either an index over-listing keys whose entries
+// are missing (read() already skips those) or entries that a later
+// read/write can still see and reconcile, never an invisible credential
+// stranded in the OS keychain.
 func (b keyringBlob) write(data []byte) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
 	}
-	priorKeys, err := b.indexedKeys()
+	priorKeys, indexExisted, priorChunks, err := b.readKeyIndex()
 	if err != nil {
 		return err
 	}
+	prior := make(map[string]bool, len(priorKeys))
+	for _, key := range priorKeys {
+		prior[key] = true
+	}
+
+	// An older binary running alongside this one still reads and writes only
+	// the legacy combined entry. If that entry exists even though the index
+	// has already been published, it was recreated by such a binary after
+	// migration: merge any key the indexed schema has never seen before the
+	// legacy entry is deleted below, or that binary's freshly saved token
+	// would be silently lost. Keys already in the prior index are not merged;
+	// their absence from state means this write deliberately removed them.
+	if indexExisted {
+		if legacyData, ok, legacyErr := b.readLegacy(); legacyErr == nil && ok {
+			var legacyState storeFile
+			if json.Unmarshal(legacyData, &legacyState) == nil {
+				for key, token := range legacyState.Tokens {
+					if _, exists := state.Tokens[key]; exists || prior[key] || ValidateKey(key) != nil {
+						continue
+					}
+					state.Tokens[key] = token
+				}
+			}
+		}
+	}
+
 	keys := make([]string, 0, len(state.Tokens))
-	for key, token := range state.Tokens {
-		raw, err := json.Marshal(token)
+	for key := range state.Tokens {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// 1. Publish the union of the prior and new key sets first, so every
+	// entry that exists at any point during this update is indexed.
+	union := keys
+	if len(priorKeys) > 0 {
+		merged := make(map[string]bool, len(keys)+len(priorKeys))
+		for _, key := range append(append([]string{}, keys...), priorKeys...) {
+			merged[key] = true
+		}
+		union = make([]string, 0, len(merged))
+		for key := range merged {
+			union = append(union, key)
+		}
+		sort.Strings(union)
+	}
+	unionChunks, err := b.writeKeyIndex(union, priorChunks)
+	if err != nil {
+		return err
+	}
+	// 2. Write each token entry.
+	for _, key := range keys {
+		raw, err := json.Marshal(state.Tokens[key])
 		if err != nil {
 			return err
 		}
 		if err := b.kr.Set(b.service, key, base64.StdEncoding.EncodeToString(raw)); err != nil {
 			return err
 		}
-		keys = append(keys, key)
 	}
-	sort.Strings(keys)
-	indexData, err := json.Marshal(keys)
-	if err != nil {
-		return err
-	}
-	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(indexData)); err != nil {
-		return err
-	}
+	// 3. Delete removed entries while the union index still lists them, so a
+	// failed Delete leaves a visible (re-deletable) entry, never an orphan.
 	for _, key := range priorKeys {
 		if _, ok := state.Tokens[key]; !ok {
 			if _, err := b.kr.Delete(b.service, key); err != nil {
@@ -609,41 +678,154 @@ func (b keyringBlob) write(data []byte) error {
 			}
 		}
 	}
+	// 4. Shrink the index to the exact new key set.
+	if _, err := b.writeKeyIndex(keys, unionChunks); err != nil {
+		return err
+	}
 	// The index now exists and is authoritative; drop the legacy entry so a
-	// future read never falls back to it.
+	// future read never falls back to it (its fresh writes were merged above).
 	_, _ = b.kr.Delete(b.service, b.legacyAccount)
 	return nil
 }
 
-// indexedKeys returns the keys currently listed in the index, or nil if there
-// is no index yet (first write, or still on the legacy format).
-func (b keyringBlob) indexedKeys() ([]string, error) {
-	enc, ok, err := b.kr.Get(b.service, b.indexAccount)
-	if err != nil || !ok {
-		return nil, err
-	}
-	keys, err := decodeKeyIndex(enc)
-	if err != nil {
-		return nil, fmt.Errorf("oauth: decode keyring token index: %w", err)
-	}
-	return keys, nil
+// maxKeyringIndexChunkBytes bounds one index chunk's raw JSON payload so its
+// base64 encoding plus command framing stays well under the macOS
+// `security -i` 4095-byte line cap (see internal/keyring): 2700 raw bytes
+// expand to 3600 base64 bytes, leaving ~490 bytes for the add-generic-password
+// syntax, service, and account. The old single-entry index hit that cap at
+// roughly 22 maximum-length keys even when every token was tiny.
+const maxKeyringIndexChunkBytes = 2700
+
+// keyIndexHeader is chunk 0 of the key index. Chunks 1..Chunks-1 live under
+// "<indexAccount>-<n>" as plain JSON string arrays. The pre-chunking format
+// (a bare JSON array at indexAccount) is still read transparently.
+type keyIndexHeader struct {
+	Version int      `json:"v"`
+	Chunks  int      `json:"chunks"`
+	Keys    []string `json:"keys"`
 }
 
-func decodeKeyIndex(enc string) ([]string, error) {
-	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
-	if err != nil {
-		return nil, err
-	}
-	var keys []string
-	if err := json.Unmarshal(data, &keys); err != nil {
-		return nil, err
-	}
-	return keys, nil
+func (b keyringBlob) chunkAccount(index int) string {
+	return fmt.Sprintf("%s-%d", b.indexAccount, index)
 }
+
+// readKeyIndex returns the indexed keys, whether an index exists at all, and
+// how many chunk entries it currently occupies. A chunk listed by the header
+// but missing from the keyring (a torn write) is skipped, mirroring how
+// read() skips an indexed key whose entry is missing.
+func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
+	enc, ok, err := b.kr.Get(b.service, b.indexAccount)
+	if err != nil {
+		return nil, false, 0, err
+	}
+	if !ok {
+		return nil, false, 0, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
+	if err != nil {
+		return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if strings.HasPrefix(trimmed, "[") {
+		var keys []string
+		if err := json.Unmarshal(raw, &keys); err != nil {
+			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
+		}
+		return keys, true, 1, nil
+	}
+	var header keyIndexHeader
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
+	}
+	keys := header.Keys
+	for i := 1; i < header.Chunks; i++ {
+		chunkEnc, ok, err := b.kr.Get(b.service, b.chunkAccount(i))
+		if err != nil {
+			return nil, false, 0, err
+		}
+		if !ok {
+			continue
+		}
+		chunkRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(chunkEnc))
+		if err != nil {
+			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
+		}
+		var more []string
+		if err := json.Unmarshal(chunkRaw, &more); err != nil {
+			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
+		}
+		keys = append(keys, more...)
+	}
+	chunks := header.Chunks
+	if chunks < 1 {
+		chunks = 1
+	}
+	return keys, true, chunks, nil
+}
+
+// writeKeyIndex persists keys as a chunked index and reports how many chunk
+// entries it used. Continuation chunks are written before the header that
+// references them, so the authoritative chunk 0 never advertises a chunk that
+// does not exist yet; stale chunks from a previously larger index are removed
+// only after the header stops referencing them (best-effort: an unreferenced
+// chunk is never read).
+func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int) (int, error) {
+	chunks := chunkIndexKeys(keys)
+	for i := 1; i < len(chunks); i++ {
+		chunkData, err := json.Marshal(chunks[i])
+		if err != nil {
+			return 0, err
+		}
+		if err := b.kr.Set(b.service, b.chunkAccount(i), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
+			return 0, err
+		}
+	}
+	headerData, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: len(chunks), Keys: chunks[0]})
+	if err != nil {
+		return 0, err
+	}
+	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
+		return 0, err
+	}
+	for i := len(chunks); i < priorChunks; i++ {
+		_, _ = b.kr.Delete(b.service, b.chunkAccount(i))
+	}
+	return len(chunks), nil
+}
+
+// chunkIndexKeys packs keys into chunks whose marshaled JSON stays under
+// maxKeyringIndexChunkBytes. Always returns at least one (possibly empty)
+// chunk.
+func chunkIndexKeys(keys []string) [][]string {
+	chunks := [][]string{{}}
+	size := 0
+	for _, key := range keys {
+		// Per-key JSON cost: quotes, comma, and headroom for escaping.
+		cost := len(key) + 8
+		if size+cost > maxKeyringIndexChunkBytes && len(chunks[len(chunks)-1]) > 0 {
+			chunks = append(chunks, []string{})
+			size = 0
+		}
+		chunks[len(chunks)-1] = append(chunks[len(chunks)-1], key)
+		size += cost
+	}
+	return chunks
+}
+
+// fileLockRefreshInterval is how often a held keyring lock's mtime is
+// refreshed while its critical section runs. It must stay comfortably under
+// fileLockStaleAfter (30s): one external keyring command may legitimately
+// take up to its 10s timeout and a multi-entry pass runs several, so without
+// refreshing, a healthy slow holder would look stale and another process
+// could reclaim the live lock and resume the token-loss race the lock
+// exists to prevent. A var so tests can shorten it.
+var fileLockRefreshInterval = 10 * time.Second
 
 // withLock serializes the keyring's read-modify-write. Store.mu covers the
 // in-process case; lockPath (when set) adds cross-process exclusion so two
 // processes can't both read the blob, modify, and write — dropping a token.
+// While fn runs, the lock file's mtime is refreshed so the stale-reclaim
+// threshold only ever expires for a genuinely crashed holder.
 func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
 	if b.lockPath == "" {
 		return fn()
@@ -653,7 +835,30 @@ func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
 		return err
 	}
 	defer unlock()
-	return fn()
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(fileLockRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				at := now()
+				_ = os.Chtimes(b.lockPath, at, at)
+			}
+		}
+	}()
+	err = fn()
+	close(stop)
+	<-done
+	return err
+}
+
+func (b keyringBlob) withReadLock(now func() time.Time, fn func() error) error {
+	return b.withLock(now, fn)
 }
 
 func (b keyringBlob) location() string { return "keyring:" + b.service + "/" + b.indexAccount }

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -33,6 +33,8 @@ const (
 // so a key can never traverse or collide with store internals.
 var keyPattern = regexp.MustCompile(`^(provider|mcp):[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 
+var currentOSUser = user.Current
+
 // ValidateKey reports whether key is a well-formed namespaced token key.
 func ValidateKey(key string) error {
 	if !keyPattern.MatchString(key) {
@@ -287,13 +289,20 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 // OS user would take different lock files while writing to the same OS keychain.
 func keyringLockPath(env map[string]string, service, account string) string {
 	name := keyringLockFileName(service, account)
-	if u, err := user.Current(); err == nil && strings.TrimSpace(u.HomeDir) != "" {
+	if u, err := currentOSUser(); err == nil && strings.TrimSpace(u.HomeDir) != "" {
 		return filepath.Join(u.HomeDir, ".cache", "zero", name)
 	}
-	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
-		return filepath.Join(home, ".cache", "zero", name)
+	// Do not fall back to os.UserHomeDir: it reads ambient HOME/USERPROFILE, so
+	// two same-user processes can choose different locks for one keyring. The
+	// temporary name is UID-scoped where UIDs exist.
+	return filepath.Join(keyringFallbackLockDir(), keyringTempLockName(service, account))
+}
+
+func keyringFallbackLockDir() string {
+	if runtime.GOOS == "windows" {
+		return os.TempDir()
 	}
-	return filepath.Join(os.TempDir(), keyringTempLockName(service, account))
+	return "/tmp"
 }
 
 // legacyKeyringLockPath returns the lock file a pre-PR binary acquires around
@@ -361,7 +370,7 @@ func (s *Store) Save(key string, token Token) error {
 			return err
 		}
 		state.Tokens[key] = token
-		return s.writeState(state, nil)
+		return s.writeState(state, map[string]bool{key: false})
 	})
 }
 
@@ -493,11 +502,10 @@ func (s *Store) readState() (storeFile, error) {
 	return state, nil
 }
 
-// writeState persists state. omitFromLegacy lists keys that must not be
-// re-merged from the keyring legacy blob during reconciliation (Delete intent);
-// the keyring backend also records them as durable tombstones. File and
-// encrypted-file backends ignore omitFromLegacy.
-func (s *Store) writeState(state storeFile, omitFromLegacy map[string]bool) error {
+// writeState persists state. mutations identifies explicitly saved (false) and
+// deleted (true) keys. The keyring backend uses it to order durable tombstone
+// transitions; file and encrypted-file backends ignore it.
+func (s *Store) writeState(state storeFile, mutations map[string]bool) error {
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
@@ -511,7 +519,7 @@ func (s *Store) writeState(state storeFile, omitFromLegacy map[string]bool) erro
 			return err
 		}
 	}
-	return s.blob.write(payload, omitFromLegacy)
+	return s.blob.write(payload, mutations)
 }
 
 func emptyStoreFile() storeFile {
@@ -523,11 +531,10 @@ func emptyStoreFile() storeFile {
 type blobStore interface {
 	// read returns the stored blob; ok is false when nothing is stored yet.
 	read() (data []byte, ok bool, err error)
-	// write replaces the stored blob. omitFromLegacy is keyring-only: keys the
-	// caller deliberately removed that must not be re-merged from the legacy
-	// combined entry and that should be recorded as durable tombstones. File
-	// backends ignore it.
-	write(data []byte, omitFromLegacy map[string]bool) error
+	// write replaces the stored blob. mutations is keyring-only and identifies
+	// explicit saves (false) and deletes (true) for durable tombstone ordering.
+	// File backends ignore it.
+	write(data []byte, mutations map[string]bool) error
 	// withLock runs fn under whatever cross-process exclusion the backend offers
 	// (a lock file for the file backend; none for the keyring, which is the
 	// authoritative store and is serialized within the process by Store.mu).
@@ -655,6 +662,9 @@ type keyringBlob struct {
 	// safety there comes from never overwriting the legacy blob and from
 	// durable tombstones, not from dual-write.
 	legacyLockPath string
+	// maxIndexKeys overrides the live credential cap for bounded metadata
+	// indexes, such as tombstones, that do not fan out into per-key reads.
+	maxIndexKeys int
 }
 
 func (b keyringBlob) read() ([]byte, bool, error) {
@@ -662,17 +672,32 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+	// Tombstones are authoritative even before the first index commits. A
+	// delete can persist its marker and then be interrupted while publishing the
+	// initial index; returning the untouched legacy blob here would resurrect it.
+	tombstones, err := b.readTombstones()
+	if err != nil {
+		return nil, false, err
+	}
 	if !ok {
-		return b.readLegacy()
+		data, legacyOK, err := b.readLegacy()
+		if err != nil || !legacyOK || len(tombstones) == 0 {
+			return data, legacyOK, err
+		}
+		var state storeFile
+		if err := json.Unmarshal(data, &state); err != nil {
+			return nil, false, fmt.Errorf("oauth: invalid legacy keyring token blob: %w", err)
+		}
+		for key := range tombstones {
+			delete(state.Tokens, key)
+		}
+		filtered, err := json.Marshal(state)
+		return filtered, true, err
 	}
 	// Tombstones block resurrection of deliberately deleted keys from the
 	// legacy combined entry (an old binary may rewrite a stale snapshot into
 	// that account after logout). Fail closed on a corrupt tombstone set so a
 	// damaged marker cannot silently re-expose logged-out credentials.
-	tombstones, err := b.readTombstones()
-	if err != nil {
-		return nil, false, err
-	}
 	// The legacy combined entry is consulted when an indexed key's own entry is
 	// missing (torn write / migration) and for keys only present there (an old
 	// binary logged into a provider this process has never indexed). Indexed
@@ -809,7 +834,7 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // durable tombstones and must not be re-merged from the legacy blob even
 // when they were never indexed (a legacy-only old-binary login that the
 // user logged out of).
-func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
+func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
@@ -829,12 +854,10 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 	}
 	// Record durable deletion markers before mutating entries so a crash
 	// mid-write cannot leave a logged-out key importable from legacy alone.
-	for key := range omitFromLegacy {
-		tombstones[key] = true
-	}
-	// A re-login after logout clears the tombstone for that key.
-	for key := range state.Tokens {
-		delete(tombstones, key)
+	for key, deleted := range mutations {
+		if deleted {
+			tombstones[key] = true
+		}
 	}
 
 	// An older binary running alongside this one still reads and writes only the
@@ -859,7 +882,7 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 			if ValidateKey(key) != nil {
 				continue
 			}
-			if omitFromLegacy[key] || tombstones[key] {
+			if mutations[key] || tombstones[key] {
 				continue
 			}
 			if _, exists := state.Tokens[key]; exists {
@@ -956,6 +979,21 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 	if _, err := b.writeKeyIndex(keys, unionChunks); err != nil {
 		return err
 	}
+	// A re-login clears its tombstone only after the replacement entry and exact
+	// index are durable. If any earlier step fails, legacy fallback remains
+	// suppressed instead of restoring the revoked credential.
+	tombstonesChanged := false
+	for key, deleted := range mutations {
+		if !deleted && tombstones[key] {
+			delete(tombstones, key)
+			tombstonesChanged = true
+		}
+	}
+	if tombstonesChanged {
+		if err := b.writeTombstones(tombstones); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -964,7 +1002,7 @@ func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 // the live index (max-length keys after many logouts), so a single entry is
 // not enough under the macOS line bound.
 func (b keyringBlob) tombstoneBlob() keyringBlob {
-	return keyringBlob{kr: b.kr, service: b.service, indexAccount: keyringTombstoneAccount}
+	return keyringBlob{kr: b.kr, service: b.service, indexAccount: keyringTombstoneAccount, maxIndexKeys: maxKeyringTombstoneKeys}
 }
 
 // readTombstones returns the durable set of keys deleted by a new binary.
@@ -1008,8 +1046,8 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
 		}
 		return nil
 	}
-	if len(tombstones) > maxKeyringIndexKeys {
-		return errKeyringIndexTooManyKeys(len(tombstones))
+	if len(tombstones) > maxKeyringTombstoneKeys {
+		return errKeyringIndexTooManyKeys(len(tombstones), maxKeyringTombstoneKeys)
 	}
 	keys := make([]string, 0, len(tombstones))
 	for key := range tombstones {
@@ -1067,15 +1105,19 @@ const maxKeyringIndexChunks = 128
 // maxKeyringIndexChunks) while still rejecting a damaged index promptly.
 const maxKeyringIndexKeys = 512
 
+// Tombstones do not fan out into per-key keyring reads, so they can use the
+// codec's bounded raw capacity without imposing the live credential cap.
+const maxKeyringTombstoneKeys = maxRawKeyringIndexKeys
+
 // maxRawKeyringIndexKeys bounds the raw decoded element count before
 // deduplication or map preallocation, guarding against DoS from duplicate keys.
 const maxRawKeyringIndexKeys = 16384
 
 // errKeyringIndexTooManyKeys is returned when a decoded index (or one of its
 // chunks) claims more keys than maxKeyringIndexKeys.
-func errKeyringIndexTooManyKeys(count int) error {
-	log.Printf("warning: oauth: keyring token index lists %d keys, over the %d-key cap", count, maxKeyringIndexKeys)
-	return fmt.Errorf("oauth: keyring token index lists %d keys, over the %d-key cap", count, maxKeyringIndexKeys)
+func errKeyringIndexTooManyKeys(count, limit int) error {
+	log.Printf("warning: oauth: keyring token index lists %d keys, over the %d-key cap", count, limit)
+	return fmt.Errorf("oauth: keyring token index lists %d keys, over the %d-key cap", count, limit)
 }
 
 // keyIndexHeader is chunk 0 of the key index. Chunks 1..Chunks-1 live under
@@ -1085,6 +1127,13 @@ type keyIndexHeader struct {
 	Version int      `json:"v"`
 	Chunks  int      `json:"chunks"`
 	Keys    []string `json:"keys"`
+}
+
+func (b keyringBlob) indexKeyLimit() int {
+	if b.maxIndexKeys > 0 {
+		return b.maxIndexKeys
+	}
+	return maxKeyringIndexKeys
 }
 
 func (b keyringBlob) chunkAccount(index int) string {
@@ -1134,11 +1183,11 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
 		}
 		if len(rawKeys) > maxRawKeyringIndexKeys {
-			return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys))
+			return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
 		}
 		keys := dedupeValidKeys(rawKeys)
-		if len(keys) > maxKeyringIndexKeys {
-			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys))
+		if len(keys) > b.indexKeyLimit() {
+			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 		}
 		return keys, true, 1, nil
 	}
@@ -1158,7 +1207,7 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 	}
 	rawKeys := header.Keys
 	if len(rawKeys) > maxRawKeyringIndexKeys {
-		return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys))
+		return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
 	}
 	for i := 1; i < header.Chunks; i++ {
 		chunkEnc, ok, err := b.kr.Get(b.service, b.chunkAccount(i))
@@ -1177,13 +1226,13 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
 		}
 		if len(rawKeys)+len(more) > maxRawKeyringIndexKeys {
-			return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys) + len(more))
+			return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys)+len(more), maxRawKeyringIndexKeys)
 		}
 		rawKeys = append(rawKeys, more...)
 	}
 	keys := dedupeValidKeys(rawKeys)
-	if len(keys) > maxKeyringIndexKeys {
-		return nil, false, 0, errKeyringIndexTooManyKeys(len(keys))
+	if len(keys) > b.indexKeyLimit() {
+		return nil, false, 0, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 	}
 	return keys, true, header.Chunks, nil
 }
@@ -1227,8 +1276,8 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int) (int, error) 
 	// later Load/Status/Save/Delete fail before it could recover. Check the key
 	// count before chunking so a large set of short keys that still fit under
 	// maxKeyringIndexChunks cannot strand the store unreadable.
-	if len(keys) > maxKeyringIndexKeys {
-		return 0, errKeyringIndexTooManyKeys(len(keys))
+	if len(keys) > b.indexKeyLimit() {
+		return 0, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 	}
 	chunks := chunkIndexKeys(keys)
 	if len(chunks) > maxKeyringIndexChunks {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -750,6 +750,14 @@ func (b keyringBlob) write(data []byte) error {
 // roughly 22 maximum-length keys even when every token was tiny.
 const maxKeyringIndexChunkBytes = 2700
 
+// maxKeyringIndexChunks caps how many chunk entries a stored index header may
+// claim before readKeyIndex issues one OS-keyring lookup per chunk. Each chunk
+// holds up to maxKeyringIndexChunkBytes of keys (dozens to ~150 keys), so this
+// bound admits far more logins than any real install while refusing to fan a
+// corrupt header (e.g. {"v":1,"chunks":1000000000}) out into a billion blocking
+// lookups that would wedge every OAuth operation under the store lock.
+const maxKeyringIndexChunks = 128
+
 // keyIndexHeader is chunk 0 of the key index. Chunks 1..Chunks-1 live under
 // "<indexAccount>-<n>" as plain JSON string arrays. The pre-chunking format
 // (a bare JSON array at indexAccount) is still read transparently.
@@ -791,6 +799,16 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 	if err := json.Unmarshal(raw, &header); err != nil {
 		return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
 	}
+	// Reject an unsupported or corrupt header before looping: an out-of-range
+	// Chunks would otherwise drive up to that many blocking keyring lookups
+	// (each up to the 10s command timeout) while the store lock is held, wedging
+	// every Load/Status/Save/Delete instead of failing promptly.
+	if header.Version != 1 {
+		return nil, false, 0, fmt.Errorf("oauth: unsupported keyring token index version %d", header.Version)
+	}
+	if header.Chunks < 1 || header.Chunks > maxKeyringIndexChunks {
+		return nil, false, 0, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
+	}
 	keys := header.Keys
 	for i := 1; i < header.Chunks; i++ {
 		chunkEnc, ok, err := b.kr.Get(b.service, b.chunkAccount(i))
@@ -810,11 +828,7 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		}
 		keys = append(keys, more...)
 	}
-	chunks := header.Chunks
-	if chunks < 1 {
-		chunks = 1
-	}
-	return keys, true, chunks, nil
+	return keys, true, header.Chunks, nil
 }
 
 // writeKeyIndex persists keys as a chunked index and reports how many chunk

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -349,7 +349,7 @@ func (s *Store) Save(key string, token Token) error {
 			return err
 		}
 		state.Tokens[key] = token
-		return s.writeState(state)
+		return s.writeState(state, nil)
 	})
 }
 
@@ -398,7 +398,10 @@ func (s *Store) Delete(key string) (bool, error) {
 		}
 		delete(state.Tokens, key)
 		removed = true
-		return s.writeState(state)
+		// Exclude the deleted key from legacy reconciliation so a credential
+		// that was only present in the legacy blob (never indexed) is not
+		// reclassified as a fresh old-binary login and written back.
+		return s.writeState(state, map[string]bool{key: true})
 	})
 	return removed, err
 }
@@ -478,7 +481,10 @@ func (s *Store) readState() (storeFile, error) {
 	return state, nil
 }
 
-func (s *Store) writeState(state storeFile) error {
+// writeState persists state. omitFromLegacy lists keys that must not be
+// re-merged from the keyring legacy blob during reconciliation (Delete intent).
+// File and encrypted-file backends ignore omitFromLegacy.
+func (s *Store) writeState(state storeFile, omitFromLegacy map[string]bool) error {
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
@@ -492,7 +498,7 @@ func (s *Store) writeState(state storeFile) error {
 			return err
 		}
 	}
-	return s.blob.write(payload)
+	return s.blob.write(payload, omitFromLegacy)
 }
 
 func emptyStoreFile() storeFile {
@@ -504,8 +510,10 @@ func emptyStoreFile() storeFile {
 type blobStore interface {
 	// read returns the stored blob; ok is false when nothing is stored yet.
 	read() (data []byte, ok bool, err error)
-	// write replaces the stored blob.
-	write(data []byte) error
+	// write replaces the stored blob. omitFromLegacy is keyring-only: keys the
+	// caller deliberately removed that must not be re-merged from the legacy
+	// combined entry during mixed-version reconciliation. File backends ignore it.
+	write(data []byte, omitFromLegacy map[string]bool) error
 	// withLock runs fn under whatever cross-process exclusion the backend offers
 	// (a lock file for the file backend; none for the keyring, which is the
 	// authoritative store and is serialized within the process by Store.mu).
@@ -536,7 +544,7 @@ func (b fileBlob) read() ([]byte, bool, error) {
 	return data, true, nil
 }
 
-func (b fileBlob) write(data []byte) error {
+func (b fileBlob) write(data []byte, _ map[string]bool) error {
 	if err := os.MkdirAll(filepath.Dir(b.path), 0o700); err != nil {
 		return err
 	}
@@ -767,11 +775,24 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 
 // legacyIsFresher reports whether the legacy copy of an already-indexed key
 // should win over the indexed copy. An old binary running alongside the new one
-// refreshes tokens only in the legacy combined entry, and a refresh pushes the
-// expiry later (or updates token material when expires_in is omitted), so a
-// strictly later expiry or updated token material on the legacy side is the
-// signal that it holds a newer credential. Zero (unknown) expiries are valid.
+// refreshes tokens only in the legacy combined entry. When both sides carry a
+// nonzero expiry, the later expiry wins (a refresh normally pushes it forward).
+// When either side omits expiry (OAuth responses may omit expires_in, and
+// Refresh does not always carry the previous ExpiresAt), fall back to token
+// material: a changed access or refresh token on the legacy side is treated as
+// a concurrent old-binary refresh that must not be discarded.
 func legacyIsFresher(legacy, current Token) bool {
+	if !legacy.ExpiresAt.IsZero() && !current.ExpiresAt.IsZero() {
+		if legacy.ExpiresAt.After(current.ExpiresAt) {
+			return true
+		}
+		if current.ExpiresAt.After(legacy.ExpiresAt) {
+			return false
+		}
+		// Equal expiries: prefer legacy when material differs (concurrent refresh
+		// that happened to keep the same lifetime).
+		return legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken
+	}
 	return legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken
 }
 
@@ -789,7 +810,10 @@ func legacyIsFresher(legacy, current Token) bool {
 // and is deleted only after every per-key entry is written, while the union
 // index still lists removed keys; a failure of that delete is returned so a
 // logout is never reported successful with the stale blob still resident.
-func (b keyringBlob) write(data []byte) error {
+// omitFromLegacy lists keys the caller just deleted; they must not be
+// re-merged from the legacy blob even when they were never indexed (a
+// legacy-only old-binary login that the user logged out of).
+func (b keyringBlob) write(data []byte, omitFromLegacy map[string]bool) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
@@ -809,9 +833,10 @@ func (b keyringBlob) write(data []byte) error {
 	// reconcile it into state before it is deleted below rather than blindly
 	// overwriting it:
 	//   - a key the indexed schema has never seen is a fresh old-binary login;
-	//     merge it so it is not lost;
-	//   - a key already present in state that the legacy blob refreshed (a
-	//     strictly later expiry) takes the legacy value, so a concurrent
+	//     merge it so it is not lost, unless the caller just deleted it
+	//     (omitFromLegacy) or it was already indexed and deliberately removed;
+	//   - a key already present in state that the legacy blob refreshed takes
+	//     the legacy value when legacyIsFresher says so, so a concurrent
 	//     old-binary refresh is not discarded in favor of the stale indexed one;
 	//   - a key that was in the prior index but is absent from this write was
 	//     deliberately removed (a logout); it is left removed, not resurrected.
@@ -828,6 +853,9 @@ func (b keyringBlob) write(data []byte) error {
 		}
 		for key, legacyToken := range legacyTokens {
 			if ValidateKey(key) != nil {
+				continue
+			}
+			if omitFromLegacy[key] {
 				continue
 			}
 			if current, exists := state.Tokens[key]; exists {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -790,6 +790,25 @@ const maxKeyringIndexChunkBytes = 2700
 // lookups that would wedge every OAuth operation under the store lock.
 const maxKeyringIndexChunks = 128
 
+// maxKeyringIndexKeys bounds how many keys readKeyIndex will ever return, across
+// the header and every chunk (and the legacy bare-array format), before read()
+// and write() fan them out into one kr.Get per key while holding the store
+// lock. maxKeyringIndexChunks only bounds the number of chunk entries fetched;
+// it does not bound how many keys a single chunk's JSON can claim, so a
+// corrupted index with an oversized keys array (or many chunks each stuffed
+// with keys) could still drive an unbounded number of blocking lookups. The
+// bound here is generous relative to what chunkIndexKeys ever legitimately
+// produces (short namespaced keys cost at least ~18 bytes each, so one
+// maxKeyringIndexChunkBytes chunk holds on the order of a hundred, times
+// maxKeyringIndexChunks) while still rejecting a damaged index promptly.
+const maxKeyringIndexKeys = maxKeyringIndexChunks * 200
+
+// errKeyringIndexTooManyKeys is returned when a decoded index (or one of its
+// chunks) claims more keys than maxKeyringIndexKeys.
+func errKeyringIndexTooManyKeys(count int) error {
+	return fmt.Errorf("oauth: keyring token index lists %d keys, over the %d-key cap", count, maxKeyringIndexKeys)
+}
+
 // keyIndexHeader is chunk 0 of the key index. Chunks 1..Chunks-1 live under
 // "<indexAccount>-<n>" as plain JSON string arrays. The pre-chunking format
 // (a bare JSON array at indexAccount) is still read transparently.
@@ -825,6 +844,9 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		if err := json.Unmarshal(raw, &keys); err != nil {
 			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
 		}
+		if len(keys) > maxKeyringIndexKeys {
+			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys))
+		}
 		return keys, true, 1, nil
 	}
 	var header keyIndexHeader
@@ -840,6 +862,9 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 	}
 	if header.Chunks < 1 || header.Chunks > maxKeyringIndexChunks {
 		return nil, false, 0, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
+	}
+	if len(header.Keys) > maxKeyringIndexKeys {
+		return nil, false, 0, errKeyringIndexTooManyKeys(len(header.Keys))
 	}
 	keys := header.Keys
 	for i := 1; i < header.Chunks; i++ {
@@ -857,6 +882,9 @@ func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
 		var more []string
 		if err := json.Unmarshal(chunkRaw, &more); err != nil {
 			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
+		}
+		if len(keys)+len(more) > maxKeyringIndexKeys {
+			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys) + len(more))
 		}
 		keys = append(keys, more...)
 	}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Gitlawb/zero/internal/keyring"
@@ -253,7 +254,10 @@ func NewStore(options StoreOptions) (*Store, error) {
 		// process's token write. legacyLockPath additionally coordinates with a
 		// still-running pre-PR binary during the supported mixed-version window
 		// (see legacyKeyringLockPath).
-		lockPath := keyringLockPath(options.Env, keyringService, keyringIndexAccount)
+		lockPath, err := keyringLockPath(options.Env, keyringService, keyringIndexAccount)
+		if err != nil {
+			return nil, err
+		}
 		legacyLockPath := legacyKeyringLockPath(options.Env)
 		return &Store{blob: keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount, lockPath: lockPath, legacyLockPath: legacyLockPath}, now: now}, nil
 	default:
@@ -287,22 +291,56 @@ func resolveStoreFilePath(options StoreOptions) (string, error) {
 // like HOME, XDG_CACHE_HOME, or TMPDIR: those pick different paths per process
 // (sandboxes, CI harnesses, launcher profiles), so two processes for the same
 // OS user would take different lock files while writing to the same OS keychain.
-func keyringLockPath(env map[string]string, service, account string) string {
+// When the OS user lookup fails, the fallback is a private UID-scoped directory
+// under the process temp root (validated 0700, owned by us); a co-tenant DoS
+// of the shared /tmp name is rejected rather than accepted as the lock path.
+func keyringLockPath(env map[string]string, service, account string) (string, error) {
 	name := keyringLockFileName(service, account)
 	if u, err := currentOSUser(); err == nil && strings.TrimSpace(u.HomeDir) != "" {
-		return filepath.Join(u.HomeDir, ".cache", "zero", name)
+		return filepath.Join(u.HomeDir, ".cache", "zero", name), nil
 	}
 	// Do not fall back to os.UserHomeDir: it reads ambient HOME/USERPROFILE, so
-	// two same-user processes can choose different locks for one keyring. The
-	// temporary name is UID-scoped where UIDs exist.
-	return filepath.Join(keyringFallbackLockDir(), keyringTempLockName(service, account))
+	// two same-user processes can choose different locks for one keyring.
+	dir, err := keyringFallbackLockDir()
+	if err != nil {
+		return "", fmt.Errorf("oauth: keyring lock fallback dir: %w", err)
+	}
+	return filepath.Join(dir, keyringTempLockName(service, account)), nil
 }
 
-func keyringFallbackLockDir() string {
+// keyringFallbackLockDir returns a private directory for last-resort keyring
+// locks when the OS user home cannot be resolved. On Windows the process temp
+// dir is already per-user. Elsewhere a UID-scoped 0700 directory under the
+// process temp root is created and validated so a co-tenant cannot pre-create
+// the lock file (or a world-writable parent) and permanently deny OAuth.
+func keyringFallbackLockDir() (string, error) {
 	if runtime.GOOS == "windows" {
-		return os.TempDir()
+		return os.TempDir(), nil
 	}
-	return "/tmp"
+	name := "zero-oauth-locks"
+	if uid := os.Getuid(); uid >= 0 {
+		name = fmt.Sprintf("zero-oauth-locks-%d", uid)
+	}
+	dir := filepath.Join(os.TempDir(), name)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", fmt.Errorf("oauth lock fallback %s is not a plain directory", dir)
+	}
+	if info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return "", fmt.Errorf("tighten oauth lock fallback permissions: %w", err)
+		}
+	}
+	if err := checkOAuthLockDirOwner(info); err != nil {
+		return "", err
+	}
+	return dir, nil
 }
 
 // legacyKeyringLockPath returns the lock file a pre-PR binary acquires around
@@ -619,7 +657,7 @@ func createPublicationFile(path string) (*os.File, string, error) {
 }
 
 func (b fileBlob) withLock(now func() time.Time, fn func() error) error {
-	unlock, err := acquireFileLock(b.path+".lockfile", now)
+	unlock, _, err := acquireFileLock(b.path+".lockfile", now)
 	if err != nil {
 		return err
 	}
@@ -668,7 +706,7 @@ type keyringBlob struct {
 }
 
 func (b keyringBlob) read() ([]byte, bool, error) {
-	keys, ok, _, err := b.readKeyIndex()
+	keys, ok, _, _, err := b.readKeyIndex()
 	if err != nil {
 		return nil, false, err
 	}
@@ -839,7 +877,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
 	}
-	priorKeys, indexExisted, priorChunks, err := b.readKeyIndex()
+	priorKeys, indexExisted, priorChunks, indexIncomplete, err := b.readKeyIndex()
 	if err != nil {
 		return err
 	}
@@ -976,8 +1014,15 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool) error {
 		}
 	}
 	// 5. Shrink the index to the exact new key set. Legacy is left untouched.
-	if _, err := b.writeKeyIndex(keys, unionChunks); err != nil {
-		return err
+	// Skip shrink when a referenced index chunk was missing: livePrior was
+	// computed from a truncated key list, so shrinking would drop those keys
+	// from the published index while leaving their OS keychain entries
+	// stranded and unreachable by Load/Status/Delete. Leaving the union index
+	// in place keeps them listed until an intact read can reconcile them.
+	if !indexIncomplete {
+		if _, err := b.writeKeyIndex(keys, unionChunks); err != nil {
+			return err
+		}
 	}
 	// A re-login clears its tombstone only after the replacement entry and exact
 	// index are durable. If any earlier step fails, legacy fallback remains
@@ -1008,7 +1053,7 @@ func (b keyringBlob) tombstoneBlob() keyringBlob {
 // readTombstones returns the durable set of keys deleted by a new binary.
 // Missing account => empty set. Corrupt payloads fail closed.
 func (b keyringBlob) readTombstones() (map[string]bool, error) {
-	keys, ok, _, err := b.tombstoneBlob().readKeyIndex()
+	keys, ok, _, _, err := b.tombstoneBlob().readKeyIndex()
 	if err != nil {
 		return nil, fmt.Errorf("oauth: read keyring token tombstones: %w", err)
 	}
@@ -1028,7 +1073,7 @@ func (b keyringBlob) readTombstones() (map[string]bool, error) {
 // real keyring failures cannot be swallowed.
 func (b keyringBlob) writeTombstones(tombstones map[string]bool) error {
 	tb := b.tombstoneBlob()
-	_, existed, priorChunks, err := tb.readKeyIndex()
+	_, existed, priorChunks, _, err := tb.readKeyIndex()
 	if err != nil {
 		return fmt.Errorf("oauth: read keyring token tombstones: %w", err)
 	}
@@ -1160,81 +1205,87 @@ func decodeKeyringIndexPayload(enc string, what string) ([]byte, error) {
 	return raw, nil
 }
 
-// readKeyIndex returns the indexed keys, whether an index exists at all, and
-// how many chunk entries it currently occupies. A chunk listed by the header
-// but missing from the keyring (a torn write) is skipped, mirroring how
-// read() skips an indexed key whose entry is missing.
-func (b keyringBlob) readKeyIndex() ([]string, bool, int, error) {
+// readKeyIndex returns the indexed keys, whether an index exists at all,
+// how many chunk entries it currently occupies, and whether a referenced
+// continuation chunk was missing. A missing chunk (external keychain damage
+// or a torn write outside this code's write order) is skipped so reads stay
+// available, but incomplete is true so write() can refuse to shrink the
+// index and strand the unlisted entries as undeletable orphans.
+func (b keyringBlob) readKeyIndex() (keys []string, ok bool, chunks int, incomplete bool, err error) {
 	enc, ok, err := b.kr.Get(b.service, b.indexAccount)
 	if err != nil {
-		return nil, false, 0, err
+		return nil, false, 0, false, err
 	}
 	if !ok {
-		return nil, false, 0, nil
+		return nil, false, 0, false, nil
 	}
 	raw, err := decodeKeyringIndexPayload(enc, "keyring token index")
 	if err != nil {
-		return nil, false, 0, err
+		return nil, false, 0, false, err
 	}
 	trimmed := strings.TrimSpace(string(raw))
 	if strings.HasPrefix(trimmed, "[") {
 		var rawKeys []string
 		if err := json.Unmarshal(raw, &rawKeys); err != nil {
-			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
+			return nil, false, 0, false, fmt.Errorf("oauth: decode keyring token index: %w", err)
 		}
 		if len(rawKeys) > maxRawKeyringIndexKeys {
-			return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
+			return nil, false, 0, false, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
 		}
 		keys := dedupeValidKeys(rawKeys)
 		if len(keys) > b.indexKeyLimit() {
-			return nil, false, 0, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
+			return nil, false, 0, false, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 		}
-		return keys, true, 1, nil
+		return keys, true, 1, false, nil
 	}
 	var header keyIndexHeader
 	if err := json.Unmarshal(raw, &header); err != nil {
-		return nil, false, 0, fmt.Errorf("oauth: decode keyring token index: %w", err)
+		return nil, false, 0, false, fmt.Errorf("oauth: decode keyring token index: %w", err)
 	}
 	// Reject an unsupported or corrupt header before looping: an out-of-range
 	// Chunks would otherwise drive up to that many blocking keyring lookups
 	// (each up to the 10s command timeout) while the store lock is held, wedging
 	// every Load/Status/Save/Delete instead of failing promptly.
 	if header.Version != 1 {
-		return nil, false, 0, fmt.Errorf("oauth: unsupported keyring token index version %d", header.Version)
+		return nil, false, 0, false, fmt.Errorf("oauth: unsupported keyring token index version %d", header.Version)
 	}
 	if header.Chunks < 1 || header.Chunks > maxKeyringIndexChunks {
-		return nil, false, 0, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
+		return nil, false, 0, false, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
 	}
 	rawKeys := header.Keys
 	if len(rawKeys) > maxRawKeyringIndexKeys {
-		return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
+		return nil, false, 0, false, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
 	}
+	incomplete = false
 	for i := 1; i < header.Chunks; i++ {
-		chunkEnc, ok, err := b.kr.Get(b.service, b.chunkAccount(i))
+		chunkEnc, chunkOK, err := b.kr.Get(b.service, b.chunkAccount(i))
 		if err != nil {
-			return nil, false, 0, err
+			return nil, false, 0, false, err
 		}
-		if !ok {
+		if !chunkOK {
+			// Skip so Load/Status stay available, but remember the damage so
+			// write() does not shrink away the unlisted keys' entries.
+			incomplete = true
 			continue
 		}
 		chunkRaw, err := decodeKeyringIndexPayload(chunkEnc, fmt.Sprintf("keyring token index chunk %d", i))
 		if err != nil {
-			return nil, false, 0, err
+			return nil, false, 0, false, err
 		}
 		var more []string
 		if err := json.Unmarshal(chunkRaw, &more); err != nil {
-			return nil, false, 0, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
+			return nil, false, 0, false, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
 		}
 		if len(rawKeys)+len(more) > maxRawKeyringIndexKeys {
-			return nil, false, 0, errKeyringIndexTooManyKeys(len(rawKeys)+len(more), maxRawKeyringIndexKeys)
+			return nil, false, 0, false, errKeyringIndexTooManyKeys(len(rawKeys)+len(more), maxRawKeyringIndexKeys)
 		}
 		rawKeys = append(rawKeys, more...)
 	}
-	keys := dedupeValidKeys(rawKeys)
+	keys = dedupeValidKeys(rawKeys)
 	if len(keys) > b.indexKeyLimit() {
-		return nil, false, 0, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
+		return nil, false, 0, false, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 	}
-	return keys, true, header.Chunks, nil
+	return keys, true, header.Chunks, incomplete, nil
 }
 
 // dedupeValidKeys drops duplicates and malformed entries from a decoded
@@ -1337,16 +1388,22 @@ var fileLockRefreshInterval = 10 * time.Second
 // closed. Lease ownership starts at acquisition, not after every path is
 // held: withLock acquires lockPath then may block on legacyLockPath, and a
 // peer must not be able to reclaim the first lock as stale during that wait.
+// Refresh is ownership-aware: if a peer reclaims and replaces the lock while
+// this holder is paused, Chtimes is skipped and lost is set so the critical
+// section can fail closed instead of keeping the thief's lock forever-fresh.
 type leasedPath struct {
 	path   string
+	token  string
 	unlock func()
 	stop   chan struct{}
 	done   chan struct{}
+	lost   atomic.Bool
 }
 
-func startLease(path string, unlock func()) *leasedPath {
+func startLease(path, token string, unlock func()) *leasedPath {
 	l := &leasedPath{
 		path:   path,
+		token:  token,
 		unlock: unlock,
 		stop:   make(chan struct{}),
 		done:   make(chan struct{}),
@@ -1364,9 +1421,18 @@ func startLease(path string, unlock func()) *leasedPath {
 				// judges staleness with real time.Since(mtime), so a fixed or stale
 				// StoreOptions.Now would stamp a live lock with an old mtime that
 				// another process would immediately reclaim, reviving the token-loss
-				// race these locks prevent.
+				// race these locks prevent. Only refresh while we still own the
+				// token: a post-stale reclaim can replace the file, and Chtimes on
+				// the replacement would keep both holders inside the critical section.
+				if !ownLockFile(path, token) {
+					l.lost.Store(true)
+					return
+				}
 				at := time.Now()
-				_ = os.Chtimes(path, at, at)
+				if err := os.Chtimes(path, at, at); err != nil && !ownLockFile(path, token) {
+					l.lost.Store(true)
+					return
+				}
 			}
 		}
 	}()
@@ -1383,10 +1449,19 @@ func (l *leasedPath) release() {
 // lease starts immediately on acquisition (and keeps refreshing while later
 // paths are still being acquired and while fn runs), so a multi-lock wait
 // cannot leave an earlier lock looking abandoned. Locks are released in
-// reverse order once fn returns.
+// reverse order once fn returns — including when fn panics — so a recovered
+// panic cannot leave a forever-refreshed lock that wedges every later waiter.
+// If a lease is replaced under us mid-critical-section, the operation fails
+// closed after fn returns (or with fn's error) rather than treating a dual-
+// entry window as success.
 func withLeasedLocks(paths []string, now func() time.Time, fn func() error) error {
 	var leases []*leasedPath
+	released := false
 	releaseAll := func() {
+		if released {
+			return
+		}
+		released = true
 		for i := len(leases) - 1; i >= 0; i-- {
 			leases[i].release()
 		}
@@ -1395,19 +1470,27 @@ func withLeasedLocks(paths []string, now func() time.Time, fn func() error) erro
 		if p == "" {
 			continue
 		}
-		unlock, err := acquireFileLock(p, now)
+		unlock, token, err := acquireFileLock(p, now)
 		if err != nil {
 			releaseAll()
 			return err
 		}
 		// Start refreshing this lock before blocking on the next path.
-		leases = append(leases, startLease(p, unlock))
+		leases = append(leases, startLease(p, token, unlock))
 	}
 	if len(leases) == 0 {
 		return fn()
 	}
+	defer releaseAll()
 	err := fn()
-	releaseAll()
+	for _, l := range leases {
+		if l.lost.Load() {
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("oauth: lost token lock lease on %s", filepath.Base(l.path))
+		}
+	}
 	return err
 }
 

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -726,7 +726,7 @@ type keyringBlob struct {
 }
 
 func (b keyringBlob) read() ([]byte, bool, error) {
-	keys, ok, _, _, err := b.readKeyIndex()
+	keys, ok, _, _, _, err := b.readKeyIndex()
 	if err != nil {
 		return nil, false, err
 	}
@@ -921,7 +921,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("oauth: encode keyring token blob: %w", err)
 	}
-	priorKeys, indexExisted, priorChunks, missingChunks, err := b.readKeyIndex()
+	priorKeys, indexExisted, priorChunks, priorGeneration, missingChunks, err := b.readKeyIndex()
 	if err != nil {
 		return err
 	}
@@ -1116,7 +1116,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 	if err := checkLease(); err != nil {
 		return err
 	}
-	unionChunks, err := b.writeKeyIndex(union, priorChunks, missingChunks, checkLease)
+	unionChunks, unionGeneration, err := b.writeKeyIndex(union, priorChunks, priorGeneration, missingChunks, checkLease)
 	if err != nil {
 		return err
 	}
@@ -1150,7 +1150,7 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 		if err := checkLease(); err != nil {
 			return err
 		}
-		if _, err := b.writeKeyIndex(keys, unionChunks, nil, checkLease); err != nil {
+		if _, _, err := b.writeKeyIndex(keys, unionChunks, unionGeneration, nil, checkLease); err != nil {
 			return err
 		}
 	}
@@ -1186,7 +1186,7 @@ func (b keyringBlob) tombstoneBlob() keyringBlob {
 // readTombstones returns the durable set of keys deleted by a new binary.
 // Missing account => empty set. Corrupt payloads fail closed.
 func (b keyringBlob) readTombstones() (map[string]bool, error) {
-	keys, ok, _, _, err := b.tombstoneBlob().readKeyIndex()
+	keys, ok, _, _, _, err := b.tombstoneBlob().readKeyIndex()
 	if err != nil {
 		return nil, fmt.Errorf("oauth: read keyring token tombstones: %w", err)
 	}
@@ -1206,7 +1206,7 @@ func (b keyringBlob) readTombstones() (map[string]bool, error) {
 // real keyring failures cannot be swallowed.
 func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leaseCheck) error {
 	tb := b.tombstoneBlob()
-	_, existed, priorChunks, _, err := tb.readKeyIndex()
+	_, existed, priorChunks, priorGeneration, _, err := tb.readKeyIndex()
 	if err != nil {
 		return fmt.Errorf("oauth: read keyring token tombstones: %w", err)
 	}
@@ -1224,7 +1224,7 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leas
 			if err := checkLease(); err != nil {
 				return err
 			}
-			if _, err := tb.kr.Delete(tb.service, tb.chunkAccount(i)); err != nil {
+			if _, err := tb.kr.Delete(tb.service, tb.chunkAccount(priorGeneration, i)); err != nil {
 				return err
 			}
 		}
@@ -1241,7 +1241,7 @@ func (b keyringBlob) writeTombstones(tombstones map[string]bool, checkLease leas
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if _, err := tb.writeKeyIndex(keys, priorChunks, nil, checkLease); err != nil {
+	if _, _, err := tb.writeKeyIndex(keys, priorChunks, priorGeneration, nil, checkLease); err != nil {
 		return fmt.Errorf("oauth: write keyring token tombstones: %w", err)
 	}
 	return nil
@@ -1258,7 +1258,7 @@ func (b keyringBlob) legacyOriginBlob() keyringBlob {
 // un-track every key it recorded and let the very absences it exists to
 // interpret look like fresh, ordinary keys again.
 func (b keyringBlob) readLegacyOrigin() (map[string]bool, error) {
-	keys, ok, _, _, err := b.legacyOriginBlob().readKeyIndex()
+	keys, ok, _, _, _, err := b.legacyOriginBlob().readKeyIndex()
 	if err != nil {
 		return nil, fmt.Errorf("oauth: read keyring legacy-origin markers: %w", err)
 	}
@@ -1277,7 +1277,7 @@ func (b keyringBlob) readLegacyOrigin() (map[string]bool, error) {
 // zero-key index behind.
 func (b keyringBlob) writeLegacyOrigin(origin map[string]bool, checkLease leaseCheck) error {
 	lb := b.legacyOriginBlob()
-	_, existed, priorChunks, _, err := lb.readKeyIndex()
+	_, existed, priorChunks, priorGeneration, _, err := lb.readKeyIndex()
 	if err != nil {
 		return fmt.Errorf("oauth: read keyring legacy-origin markers: %w", err)
 	}
@@ -1295,7 +1295,7 @@ func (b keyringBlob) writeLegacyOrigin(origin map[string]bool, checkLease leaseC
 			if err := checkLease(); err != nil {
 				return err
 			}
-			if _, err := lb.kr.Delete(lb.service, lb.chunkAccount(i)); err != nil {
+			if _, err := lb.kr.Delete(lb.service, lb.chunkAccount(priorGeneration, i)); err != nil {
 				return err
 			}
 		}
@@ -1312,7 +1312,7 @@ func (b keyringBlob) writeLegacyOrigin(origin map[string]bool, checkLease leaseC
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if _, err := lb.writeKeyIndex(keys, priorChunks, nil, checkLease); err != nil {
+	if _, _, err := lb.writeKeyIndex(keys, priorChunks, priorGeneration, nil, checkLease); err != nil {
 		return fmt.Errorf("oauth: write keyring legacy-origin markers: %w", err)
 	}
 	return nil
@@ -1395,6 +1395,12 @@ type keyIndexHeader struct {
 	Version int      `json:"v"`
 	Chunks  int      `json:"chunks"`
 	Keys    []string `json:"keys"`
+	// Generation selects which physical chunk-account namespace Chunks refers
+	// to; see chunkAccount. Omitted (0) both for an index that predates this
+	// field and for generation 0 itself, which are the same namespace by
+	// construction: chunkAccount(0, i) reproduces the original, ungenerationed
+	// naming, so an old header decodes exactly as it always did.
+	Generation int `json:"gen,omitempty"`
 }
 
 func (b keyringBlob) indexKeyLimit() int {
@@ -1404,8 +1410,19 @@ func (b keyringBlob) indexKeyLimit() int {
 	return maxKeyringIndexKeys
 }
 
-func (b keyringBlob) chunkAccount(index int) string {
-	return fmt.Sprintf("%s-%d", b.indexAccount, index)
+// chunkAccount names the continuation-chunk account for index within
+// generation. generation 0 reproduces the original naming an ungenerationed
+// index already used, so every index written before generations existed
+// keeps working with no migration step. A later generation gets its own
+// disjoint namespace, so a writer publishing generation N+1 can stage every
+// chunk it needs under names generation N's reader (or a concurrent one still
+// using the old header) will never look at, and only touch generation N's
+// accounts afterward, as cleanup.
+func (b keyringBlob) chunkAccount(generation, index int) string {
+	if generation <= 0 {
+		return fmt.Sprintf("%s-%d", b.indexAccount, index)
+	}
+	return fmt.Sprintf("%s-g%d-%d", b.indexAccount, generation, index)
 }
 
 // decodeKeyringIndexPayload bounds and decodes one index header/chunk value
@@ -1435,55 +1452,58 @@ func decodeKeyringIndexPayload(enc string, what string) ([]byte, error) {
 // so reads stay available, but its index is remembered so write() can refuse
 // to shrink the index (stranding the unlisted entries as undeletable orphans)
 // and can refuse to overwrite that account with unrelated new chunk data.
-func (b keyringBlob) readKeyIndex() (keys []string, ok bool, chunks int, missing []int, err error) {
+func (b keyringBlob) readKeyIndex() (keys []string, ok bool, chunks int, generation int, missing []int, err error) {
 	enc, ok, err := b.kr.Get(b.service, b.indexAccount)
 	if err != nil {
-		return nil, false, 0, nil, err
+		return nil, false, 0, 0, nil, err
 	}
 	if !ok {
-		return nil, false, 0, nil, nil
+		return nil, false, 0, 0, nil, nil
 	}
 	raw, err := decodeKeyringIndexPayload(enc, "keyring token index")
 	if err != nil {
-		return nil, false, 0, nil, err
+		return nil, false, 0, 0, nil, err
 	}
 	trimmed := strings.TrimSpace(string(raw))
 	if strings.HasPrefix(trimmed, "[") {
 		var rawKeys []string
 		if err := json.Unmarshal(raw, &rawKeys); err != nil {
-			return nil, false, 0, nil, fmt.Errorf("oauth: decode keyring token index: %w", err)
+			return nil, false, 0, 0, nil, fmt.Errorf("oauth: decode keyring token index: %w", err)
 		}
 		if len(rawKeys) > maxRawKeyringIndexKeys {
-			return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
+			return nil, false, 0, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
 		}
 		keys := dedupeValidKeys(rawKeys)
 		if len(keys) > b.indexKeyLimit() {
-			return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
+			return nil, false, 0, 0, nil, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 		}
-		return keys, true, 1, nil, nil
+		return keys, true, 1, 0, nil, nil
 	}
 	var header keyIndexHeader
 	if err := json.Unmarshal(raw, &header); err != nil {
-		return nil, false, 0, nil, fmt.Errorf("oauth: decode keyring token index: %w", err)
+		return nil, false, 0, 0, nil, fmt.Errorf("oauth: decode keyring token index: %w", err)
 	}
 	// Reject an unsupported or corrupt header before looping: an out-of-range
 	// Chunks would otherwise drive up to that many blocking keyring lookups
 	// (each up to the 10s command timeout) while the store lock is held, wedging
 	// every Load/Status/Save/Delete instead of failing promptly.
 	if header.Version != 1 {
-		return nil, false, 0, nil, fmt.Errorf("oauth: unsupported keyring token index version %d", header.Version)
+		return nil, false, 0, 0, nil, fmt.Errorf("oauth: unsupported keyring token index version %d", header.Version)
 	}
 	if header.Chunks < 1 || header.Chunks > maxKeyringIndexChunks {
-		return nil, false, 0, nil, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
+		return nil, false, 0, 0, nil, fmt.Errorf("oauth: keyring token index advertises %d chunks (want 1..%d)", header.Chunks, maxKeyringIndexChunks)
+	}
+	if header.Generation < 0 {
+		return nil, false, 0, 0, nil, fmt.Errorf("oauth: keyring token index advertises a negative generation %d", header.Generation)
 	}
 	rawKeys := header.Keys
 	if len(rawKeys) > maxRawKeyringIndexKeys {
-		return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
+		return nil, false, 0, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys), maxRawKeyringIndexKeys)
 	}
 	for i := 1; i < header.Chunks; i++ {
-		chunkEnc, chunkOK, err := b.kr.Get(b.service, b.chunkAccount(i))
+		chunkEnc, chunkOK, err := b.kr.Get(b.service, b.chunkAccount(header.Generation, i))
 		if err != nil {
-			return nil, false, 0, nil, err
+			return nil, false, 0, 0, nil, err
 		}
 		if !chunkOK {
 			// Skip so Load/Status stay available, but remember which account is
@@ -1494,22 +1514,22 @@ func (b keyringBlob) readKeyIndex() (keys []string, ok bool, chunks int, missing
 		}
 		chunkRaw, err := decodeKeyringIndexPayload(chunkEnc, fmt.Sprintf("keyring token index chunk %d", i))
 		if err != nil {
-			return nil, false, 0, nil, err
+			return nil, false, 0, 0, nil, err
 		}
 		var more []string
 		if err := json.Unmarshal(chunkRaw, &more); err != nil {
-			return nil, false, 0, nil, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
+			return nil, false, 0, 0, nil, fmt.Errorf("oauth: decode keyring token index chunk %d: %w", i, err)
 		}
 		if len(rawKeys)+len(more) > maxRawKeyringIndexKeys {
-			return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys)+len(more), maxRawKeyringIndexKeys)
+			return nil, false, 0, 0, nil, errKeyringIndexTooManyKeys(len(rawKeys)+len(more), maxRawKeyringIndexKeys)
 		}
 		rawKeys = append(rawKeys, more...)
 	}
 	keys = dedupeValidKeys(rawKeys)
 	if len(keys) > b.indexKeyLimit() {
-		return nil, false, 0, nil, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
+		return nil, false, 0, 0, nil, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 	}
-	return keys, true, header.Chunks, missing, nil
+	return keys, true, header.Chunks, header.Generation, missing, nil
 }
 
 // dedupeValidKeys drops duplicates and malformed entries from a decoded
@@ -1540,32 +1560,106 @@ func dedupeValidKeys(keys []string) []string {
 }
 
 // writeKeyIndex persists keys as a chunked index and reports how many chunk
-// entries the published header advertises. Continuation chunks are written
-// before the header that references them, so the authoritative chunk 0 never
-// advertises a content chunk that does not exist yet; stale chunks from a
-// previously larger index are removed only after the header stops referencing
-// them (best-effort: an unreferenced chunk is never read).
+// entries the published header advertises, and under which generation (see
+// chunkAccount) it wrote them.
 //
-// missingChunks lists the continuation-chunk accounts readKeyIndex reported as
-// missing. Those slots are protected: the credentials they listed may still
-// exist in the keyring, so overwriting the account with unrelated new chunk
-// data would permanently orphan them even if the original chunk is later
-// restored. New continuation chunks are therefore remapped around protected
-// slots, the header keeps advertising at least priorChunks so a later-restored
-// chunk remains reachable, and protected accounts are never deleted.
-func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks []int, checkLease leaseCheck) (int, error) {
+// missingChunks lists continuation-chunk accounts readKeyIndex could not read
+// from priorGeneration: their keys are unknown, so advancing past them would
+// silently orphan whatever credentials they listed, with no record of what
+// they were left to recover from. When missingChunks is empty, every key this
+// index has ever listed is accounted for in keys, so it is safe to stage the
+// complete new layout under a fresh generation, publish a header that adopts
+// it atomically, and only then clean up priorGeneration's now-unreferenced
+// chunk accounts: nothing this function does before the header Set can ever
+// leave a half-written layout reachable, because nothing reads a generation
+// the header does not name. When missingChunks is non-empty, this instead
+// falls back to the narrower in-place update the fresh-generation path exists
+// to avoid elsewhere: new continuation chunks are remapped around the
+// protected (missing) slots within priorGeneration itself, the header keeps
+// advertising at least priorChunks so a later-restored chunk stays reachable,
+// and protected accounts are never deleted. That path accepts the same
+// in-place-overwrite exposure this function's own doc used to describe
+// unconditionally; it is now scoped to only the case where advancing the
+// generation is not safe to begin with.
+func (b keyringBlob) writeKeyIndex(keys []string, priorChunks, priorGeneration int, missingChunks []int, checkLease leaseCheck) (chunks int, generation int, err error) {
 	// Refuse to publish an index the reader would reject: readKeyIndex caps both
 	// total keys and chunk count, and a header beyond either would make every
 	// later Load/Status/Save/Delete fail before it could recover. Check the key
 	// count before chunking so a large set of short keys that still fit under
 	// maxKeyringIndexChunks cannot strand the store unreadable.
 	if len(keys) > b.indexKeyLimit() {
-		return 0, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
+		return 0, 0, errKeyringIndexTooManyKeys(len(keys), b.indexKeyLimit())
 	}
-	chunks := chunkIndexKeys(keys)
-	if len(chunks) > maxKeyringIndexChunks {
-		return 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", len(chunks), maxKeyringIndexChunks)
+	chunkList := chunkIndexKeys(keys)
+	if len(chunkList) > maxKeyringIndexChunks {
+		return 0, 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", len(chunkList), maxKeyringIndexChunks)
 	}
+	if len(missingChunks) == 0 {
+		return b.writeKeyIndexNewGeneration(chunkList, priorChunks, priorGeneration, checkLease)
+	}
+	return b.writeKeyIndexInPlace(chunkList, priorChunks, priorGeneration, missingChunks, checkLease)
+}
+
+// writeKeyIndexNewGeneration is writeKeyIndex's normal-case path: prior state
+// is fully known (missingChunks is empty), so it is safe to stage the entire
+// new layout under a never-before-used generation and adopt it with a single
+// header write. Every chunk write below therefore targets an account nothing
+// currently reads; the header Set is the only step any concurrent or crashed
+// reader can observe as a change at all.
+func (b keyringBlob) writeKeyIndexNewGeneration(chunkList [][]string, priorChunks, priorGeneration int, checkLease leaseCheck) (chunks int, generation int, err error) {
+	newGeneration := priorGeneration + 1
+	advertised := len(chunkList)
+	if advertised > maxKeyringIndexChunks {
+		return 0, 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", advertised, maxKeyringIndexChunks)
+	}
+	for i := 1; i < len(chunkList); i++ {
+		chunkData, err := json.Marshal(chunkList[i])
+		if err != nil {
+			return 0, 0, err
+		}
+		if err := checkLease(); err != nil {
+			return 0, 0, err
+		}
+		if err := b.kr.Set(b.service, b.chunkAccount(newGeneration, i), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
+			return 0, 0, err
+		}
+	}
+	headerData, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: advertised, Generation: newGeneration, Keys: chunkList[0]})
+	if err != nil {
+		return 0, 0, err
+	}
+	if err := checkLease(); err != nil {
+		return 0, 0, err
+	}
+	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
+		return 0, 0, err
+	}
+	// The new generation is durable and exclusively authoritative from this
+	// point on. Reclaiming the old one is pure cleanup: best-effort, and safe
+	// to abandon partway, since nothing will ever read priorGeneration again
+	// regardless of how much of it gets deleted here.
+	if priorGeneration != newGeneration {
+		for i := 1; i < priorChunks; i++ {
+			if checkLease() != nil {
+				break
+			}
+			_, _ = b.kr.Delete(b.service, b.chunkAccount(priorGeneration, i))
+		}
+	}
+	return advertised, newGeneration, nil
+}
+
+// writeKeyIndexInPlace is writeKeyIndex's degraded-case fallback, used only
+// when missingChunks is non-empty: some prior chunk's keys are unknown, so
+// staging a fresh generation would publish a layout that silently drops them
+// with no remaining record of what they were. It stays within priorGeneration
+// and mirrors the original single-namespace protocol exactly: new
+// continuation chunks are remapped around protected (missing) slots, and
+// capacity is still planned before any chunk is written (a rejected write
+// here still leaves every existing chunk account untouched), but a slot that
+// is not protected is still overwritten in place, since there is no
+// generation boundary available to defer that behind here.
+func (b keyringBlob) writeKeyIndexInPlace(chunkList [][]string, priorChunks, priorGeneration int, missingChunks []int, checkLease leaseCheck) (chunks int, generation int, err error) {
 	protected := make(map[int]bool, len(missingChunks))
 	maxProtected := 0
 	for _, c := range missingChunks {
@@ -1574,23 +1668,14 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks
 			maxProtected = c
 		}
 	}
-	// Plan the complete slot assignment before writing anything. This must be
-	// a pure computation: the loop below overwrites existing, non-protected
-	// chunk accounts the old header still references, so if it started
-	// writing and only discovered a capacity overflow afterward, the old
-	// header would be left describing a layout partially clobbered by pieces
-	// of the new one, potentially stranding every key it lists. Assigning
-	// slots first and validating the result means a rejected write leaves
-	// every existing chunk account and every existing token byte-for-byte
-	// untouched.
 	type plannedChunk struct {
 		slot  int
 		index int
 	}
 	var planned []plannedChunk
 	slot := 1
-	advertised := len(chunks)
-	for i := 1; i < len(chunks); i++ {
+	advertised := len(chunkList)
+	for i := 1; i < len(chunkList); i++ {
 		for protected[slot] {
 			slot++
 		}
@@ -1602,54 +1687,41 @@ func (b keyringBlob) writeKeyIndex(keys []string, priorChunks int, missingChunks
 	}
 	// Keep advertising protected slots (a restored chunk is read by walking
 	// every account below the advertised count) and the prior chunk count.
-	if len(missingChunks) > 0 && maxProtected+1 > advertised {
+	if maxProtected+1 > advertised {
 		advertised = maxProtected + 1
 	}
-	if len(missingChunks) > 0 && priorChunks > advertised {
+	if priorChunks > advertised {
 		advertised = priorChunks
 	}
 	if advertised > maxKeyringIndexChunks {
-		return 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", advertised, maxKeyringIndexChunks)
+		return 0, 0, fmt.Errorf("oauth: keyring key index needs %d chunks, over the %d-chunk cap readers accept; too many stored credentials", advertised, maxKeyringIndexChunks)
 	}
-	// Planning is done and the layout fits; now perform the writes it called for.
 	for _, p := range planned {
-		chunkData, err := json.Marshal(chunks[p.index])
+		chunkData, err := json.Marshal(chunkList[p.index])
 		if err != nil {
-			return 0, err
+			return 0, 0, err
 		}
 		if err := checkLease(); err != nil {
-			return 0, err
+			return 0, 0, err
 		}
-		if err := b.kr.Set(b.service, b.chunkAccount(p.slot), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
-			return 0, err
+		if err := b.kr.Set(b.service, b.chunkAccount(priorGeneration, p.slot), base64.StdEncoding.EncodeToString(chunkData)); err != nil {
+			return 0, 0, err
 		}
 	}
-	headerData, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: advertised, Keys: chunks[0]})
+	headerData, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: advertised, Generation: priorGeneration, Keys: chunkList[0]})
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	if err := checkLease(); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	if err := b.kr.Set(b.service, b.indexAccount, base64.StdEncoding.EncodeToString(headerData)); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	// Remove stale chunks only when nothing is protected: deleting a protected
-	// account would destroy the last chance to recover the keys it listed.
-	if len(missingChunks) == 0 {
-		for i := len(chunks); i < priorChunks; i++ {
-			if checkLease() != nil {
-				// Best-effort cleanup: a lost lease here must not turn into an
-				// error return, since the index header above is already
-				// durable and correct. Leaving an orphaned chunk account is
-				// the same shape of harmless leftover a failed Delete already
-				// tolerates below.
-				break
-			}
-			_, _ = b.kr.Delete(b.service, b.chunkAccount(i))
-		}
-	}
-	return advertised, nil
+	// No shrink-cleanup here: protected slots are always present in this path
+	// (that is why it was taken), and deleting a protected account would
+	// destroy the last chance to recover the keys it listed.
+	return advertised, priorGeneration, nil
 }
 
 // chunkIndexKeys packs keys into chunks whose marshaled JSON stays under

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -827,6 +827,7 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 	// can overwrite an explicit new-binary Save with an older account's token.
 	var legacyTokens map[string]Token
 	legacyLoaded := false
+	legacyReadOK := false
 	loadLegacy := func() {
 		if legacyLoaded {
 			return
@@ -837,6 +838,7 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 		// transient error for an empty blob.
 		if lt, lerr := b.readLegacyTokens(); lerr == nil {
 			legacyTokens = lt
+			legacyReadOK = true
 		}
 		legacyLoaded = true
 	}
@@ -898,7 +900,7 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 	// transiently (not persisted): the durable version happens in write(),
 	// consistent with every other best-effort check in this function.
 	legacyOrigin, lerr := b.readLegacyOrigin()
-	if lerr == nil && len(legacyOrigin) > 0 {
+	if lerr == nil && len(legacyOrigin) > 0 && legacyReadOK {
 		for key := range tokens {
 			if !legacyOrigin[key] {
 				continue

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -326,7 +326,9 @@ func keyringLockPath(env map[string]string, service, account string) (string, er
 // pre-create it and deny OAuth. Windows temp is already per-user.
 func keyringFallbackLockDir() (string, error) {
 	if runtime.GOOS == "windows" {
-		return os.TempDir(), nil
+		// Not os.TempDir(): see identityLockRoot for why %TMP%/%TEMP% cannot
+		// anchor a lock two processes of the same user must agree on.
+		return identityLockRoot()
 	}
 	if uid := os.Getuid(); uid >= 0 {
 		if u, err := lookupUserID(strconv.Itoa(uid)); err == nil && strings.TrimSpace(u.HomeDir) != "" {

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -486,7 +486,14 @@ func (s *Store) Delete(key string) (bool, error) {
 			removed = true
 			return s.writeState(state, map[string]bool{key: true}, check)
 		}
+		// readState no longer exposes the key (a tombstone hides it, or an
+		// interrupted delete already finished the logical logout) but a keyring
+		// entry for it survives. Reconciling that residue still deletes a
+		// credential-bearing entry, so report it as removed: `zero auth logout`
+		// surfaces this boolean directly and "nothing removed" would be wrong
+		// while per-key deletes and an index shrink are running.
 		if kb, ok := s.blob.(keyringBlob); ok && kb.hasResidentEntry(key) {
+			removed = true
 			return s.writeState(state, map[string]bool{key: true}, check)
 		}
 		return nil
@@ -938,10 +945,14 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // permanently consume capacity) or entries that a later read/write can still
 // see and reconcile, never an invisible credential stranded in the OS keychain.
 //
-// The legacy combined entry is preserved as a discovery source for unindexed
-// old-binary logins. When Delete explicitly logs out of a provider, that key
-// is removed from the legacy blob (or the legacy account deleted if empty)
-// so a downgraded binary cannot continue to use the revoked credential.
+// The legacy combined entry is never written or deleted here; it stays frozen
+// as a discovery source for unindexed old-binary logins. Logout is authoritative
+// for new binaries only: a tombstone durably suppresses the legacy copy on every
+// new-binary read, but a pre-per-key binary reading `oauth-tokens` directly can
+// still use the credential until it is upgraded. Scrubbing the key out of the
+// legacy blob would require a snapshot-then-Set that cannot be locked against
+// old writers on other config roots, so it would trade a bounded downgrade
+// window for unbounded loss of concurrent old-binary logins.
 func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease leaseCheck) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
@@ -1204,11 +1215,6 @@ func (b keyringBlob) write(data []byte, mutations map[string]bool, checkLease le
 		}
 		if err := b.writeTombstones(tombstones, checkLease); err != nil {
 			return err
-		}
-	}
-	if len(state.Tokens) == 0 && len(legacyTokens) > 0 {
-		if err := checkLease(); err == nil {
-			_, _ = b.kr.Delete(b.service, b.legacyAccount)
 		}
 	}
 	return nil

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -546,6 +546,14 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 	if !ok {
 		return b.readLegacy()
 	}
+	// The legacy combined entry is consulted lazily (below) only when an indexed
+	// key's own entry is missing. write() publishes the index before the per-key
+	// entries and deletes the legacy blob only after every entry is written, so a
+	// crash partway through the initial legacy->indexed migration can leave a
+	// pre-existing credential readable solely in the still-present legacy blob.
+	// In steady state (all entries present) the legacy blob is never read.
+	var legacyTokens map[string]Token
+	legacyLoaded := false
 	tokens := make(map[string]Token, len(keys))
 	for _, key := range keys {
 		enc, ok, err := b.kr.Get(b.service, key)
@@ -553,9 +561,18 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 			return nil, false, err
 		}
 		if !ok {
-			// Index and entries fell out of sync (e.g. a killed process between
-			// writing an entry and updating the index); skip rather than fail the
-			// whole read, since the next Save/Delete will reconcile the index.
+			// The index lists this key but its own entry is missing. Recover it
+			// from the legacy blob when a migration is still in flight; otherwise
+			// (a steady-state index/entry desync whose legacy blob is already
+			// gone) skip rather than fail the whole read, since the next
+			// Save/Delete will reconcile the index.
+			if !legacyLoaded {
+				legacyTokens = b.readLegacyTokens()
+				legacyLoaded = true
+			}
+			if token, has := legacyTokens[key]; has {
+				tokens[key] = token
+			}
 			continue
 		}
 		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
@@ -590,6 +607,32 @@ func (b keyringBlob) readLegacy() ([]byte, bool, error) {
 	return data, true, nil
 }
 
+// readLegacyTokens returns the tokens held in the legacy combined entry, or an
+// empty map when there is no readable legacy blob. It is a best-effort recovery
+// source (read() falls back to it, write() reconciles against it), so a missing
+// or malformed legacy entry is reported as "no tokens" rather than a hard error.
+func (b keyringBlob) readLegacyTokens() map[string]Token {
+	data, ok, err := b.readLegacy()
+	if err != nil || !ok {
+		return nil
+	}
+	var legacyState storeFile
+	if json.Unmarshal(data, &legacyState) != nil {
+		return nil
+	}
+	return legacyState.Tokens
+}
+
+// legacyIsFresher reports whether the legacy copy of an already-indexed key
+// should win over the indexed copy. An old binary running alongside the new one
+// refreshes tokens only in the legacy combined entry, and a refresh pushes the
+// expiry later, so a strictly later, non-zero expiry on the legacy side is the
+// signal that it holds a newer credential. A zero (unknown) expiry on either
+// side is not evidence of freshness, so the indexed value is kept.
+func legacyIsFresher(legacy, current Token) bool {
+	return !legacy.ExpiresAt.IsZero() && !current.ExpiresAt.IsZero() && legacy.ExpiresAt.After(current.ExpiresAt)
+}
+
 // write replaces the keyring's token entries with state, ordered so that
 // every interruption boundary leaves a recoverable store. The invariant is
 // that any token entry existing in the keyring at any instant is listed in
@@ -597,9 +640,11 @@ func (b keyringBlob) readLegacy() ([]byte, bool, error) {
 // written, entries are deleted before the index shrinks, and the index
 // header is only updated after the chunks it references exist. A crash at
 // any step therefore leaves either an index over-listing keys whose entries
-// are missing (read() already skips those) or entries that a later
-// read/write can still see and reconcile, never an invisible credential
-// stranded in the OS keychain.
+// are missing (read() recovers those from the legacy blob during a migration,
+// or skips them once it is gone) or entries that a later read/write can still
+// see and reconcile, never an invisible credential stranded in the OS keychain.
+// The legacy combined entry is the durable fallback for the initial migration
+// and is deleted only as the final step, after every per-key entry is written.
 func (b keyringBlob) write(data []byte) error {
 	var state storeFile
 	if err := json.Unmarshal(data, &state); err != nil {
@@ -614,24 +659,33 @@ func (b keyringBlob) write(data []byte) error {
 		prior[key] = true
 	}
 
-	// An older binary running alongside this one still reads and writes only
-	// the legacy combined entry. If that entry exists even though the index
-	// has already been published, it was recreated by such a binary after
-	// migration: merge any key the indexed schema has never seen before the
-	// legacy entry is deleted below, or that binary's freshly saved token
-	// would be silently lost. Keys already in the prior index are not merged;
-	// their absence from state means this write deliberately removed them.
+	// An older binary running alongside this one still reads and writes only the
+	// legacy combined entry. If that entry exists even though the index has
+	// already been published, an old binary wrote it after migration, so
+	// reconcile it into state before it is deleted below rather than blindly
+	// overwriting it:
+	//   - a key the indexed schema has never seen is a fresh old-binary login;
+	//     merge it so it is not lost;
+	//   - a key already present in state that the legacy blob refreshed (a
+	//     strictly later expiry) takes the legacy value, so a concurrent
+	//     old-binary refresh is not discarded in favor of the stale indexed one;
+	//   - a key that was in the prior index but is absent from this write was
+	//     deliberately removed (a logout); it is left removed, not resurrected.
 	if indexExisted {
-		if legacyData, ok, legacyErr := b.readLegacy(); legacyErr == nil && ok {
-			var legacyState storeFile
-			if json.Unmarshal(legacyData, &legacyState) == nil {
-				for key, token := range legacyState.Tokens {
-					if _, exists := state.Tokens[key]; exists || prior[key] || ValidateKey(key) != nil {
-						continue
-					}
-					state.Tokens[key] = token
-				}
+		for key, legacyToken := range b.readLegacyTokens() {
+			if ValidateKey(key) != nil {
+				continue
 			}
+			if current, exists := state.Tokens[key]; exists {
+				if legacyIsFresher(legacyToken, current) {
+					state.Tokens[key] = legacyToken
+				}
+				continue
+			}
+			if prior[key] {
+				continue
+			}
+			state.Tokens[key] = legacyToken
 		}
 	}
 

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -297,11 +298,11 @@ func keyringLockPath(env map[string]string, service, account string) string {
 // when the file-backend location can't be resolved at all, matching the
 // legacy code's own best-effort fallback (no cross-process lock at all).
 func legacyKeyringLockPath(env map[string]string) string {
-	storePath, err := ResolveStorePath(env)
+	home, err := resolveHomeDir(nil)
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(filepath.Dir(storePath), "oauth-keyring.lockfile")
+	return filepath.Join(home, ".config", "zero", "oauth-keyring.lockfile")
 }
 
 // keyringLockFileName names the lock file after the keyring identity it
@@ -687,6 +688,21 @@ func (b keyringBlob) read() ([]byte, bool, error) {
 		}
 		tokens[key] = token
 	}
+
+	if !legacyLoaded {
+		if lt, lerr := b.readLegacyTokens(); lerr == nil {
+			legacyTokens = lt
+		}
+	}
+	for key, legacyToken := range legacyTokens {
+		if ValidateKey(key) != nil {
+			continue
+		}
+		if _, exists := tokens[key]; !exists {
+			tokens[key] = legacyToken
+		}
+	}
+
 	data, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens})
 	if err != nil {
 		return nil, false, err
@@ -736,11 +752,16 @@ func (b keyringBlob) readLegacyTokens() (map[string]Token, error) {
 // legacyIsFresher reports whether the legacy copy of an already-indexed key
 // should win over the indexed copy. An old binary running alongside the new one
 // refreshes tokens only in the legacy combined entry, and a refresh pushes the
-// expiry later, so a strictly later, non-zero expiry on the legacy side is the
-// signal that it holds a newer credential. A zero (unknown) expiry on either
-// side is not evidence of freshness, so the indexed value is kept.
+// expiry later, so a strictly later expiry on the legacy side is the
+// signal that it holds a newer credential. Zero (unknown) expiries are valid.
 func legacyIsFresher(legacy, current Token) bool {
-	return !legacy.ExpiresAt.IsZero() && !current.ExpiresAt.IsZero() && legacy.ExpiresAt.After(current.ExpiresAt)
+	if legacy.ExpiresAt.After(current.ExpiresAt) {
+		return true
+	}
+	if legacy.ExpiresAt.Equal(current.ExpiresAt) {
+		return legacy.AccessToken != current.AccessToken || legacy.RefreshToken != current.RefreshToken
+	}
+	return false
 }
 
 // write replaces the keyring's token entries with state, ordered so that
@@ -897,11 +918,12 @@ const maxKeyringIndexChunks = 128
 // produces (short namespaced keys cost at least ~18 bytes each, so one
 // maxKeyringIndexChunkBytes chunk holds on the order of a hundred, times
 // maxKeyringIndexChunks) while still rejecting a damaged index promptly.
-const maxKeyringIndexKeys = maxKeyringIndexChunks * 200
+const maxKeyringIndexKeys = 512
 
 // errKeyringIndexTooManyKeys is returned when a decoded index (or one of its
 // chunks) claims more keys than maxKeyringIndexKeys.
 func errKeyringIndexTooManyKeys(count int) error {
+	log.Printf("warning: oauth: keyring token index lists %d keys, over the %d-key cap", count, maxKeyringIndexKeys)
 	return fmt.Errorf("oauth: keyring token index lists %d keys, over the %d-key cap", count, maxKeyringIndexKeys)
 }
 

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -900,7 +900,12 @@ func (b keyringBlob) withLock(now func() time.Time, fn func() error) error {
 			case <-stop:
 				return
 			case <-ticker.C:
-				at := now()
+				// Lease with wall-clock time, never the injectable now: acquireFileLock
+				// judges staleness with real time.Since(mtime), so a fixed or stale
+				// StoreOptions.Now would stamp the live lock with an old mtime that
+				// another process would immediately reclaim, reviving the token-loss
+				// race this lease prevents.
+				at := time.Now()
 				_ = os.Chtimes(b.lockPath, at, at)
 			}
 		}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -1058,3 +1058,83 @@ func TestStoreKeyringWriteIndexRejectsOverCapKeys(t *testing.T) {
 		t.Fatalf("over-cap key write must publish nothing, found %d entries", len(kr.data))
 	}
 }
+
+// legacyGetFailKR fails Get for the legacy combined entry only, simulating a
+// transient keyring read error (as opposed to the entry genuinely not
+// existing, which fakeKR's normal Get reports as ok=false, err=nil).
+type legacyGetFailKR struct {
+	*fakeKR
+	fail bool
+}
+
+func (f *legacyGetFailKR) Get(service, account string) (string, bool, error) {
+	if f.fail && account == keyringLegacyAccount {
+		return "", false, errKRInjected
+	}
+	return f.fakeKR.Get(service, account)
+}
+
+// TestStoreKeyringWriteRefusesToDeleteLegacyBlobOnTransientReadError is the
+// regression test for finding #2: during mixed-version reconciliation (an old
+// zero binary's legacy blob alongside the new keyring-based index), a
+// transient error reading the legacy blob must not be treated as "the legacy
+// blob is empty." write() must refuse to reconcile-and-delete it in that case,
+// or an unread credential belonging to an older, still-installed zero binary
+// is destroyed irrecoverably.
+func TestStoreKeyringWriteRefusesToDeleteLegacyBlobOnTransientReadError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := &legacyGetFailKR{fakeKR: newFakeKR()}
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A first save publishes the index, so indexExisted is true for the next
+	// write and exercises the mixed-version reconciliation path in write()
+	// where the bug lived.
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A legacy blob still carries a credential written by an older,
+	// still-installed binary.
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("stale-binary-login"): {AccessToken: "still-live"},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	// A transient failure reading it: Get returns a real error, not
+	// ok=false/err=nil ("doesn't exist").
+	kr.fail = true
+	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err == nil {
+		t.Fatal("Save succeeded despite a transient legacy-blob read failure; it must refuse rather than silently treat the blob as empty")
+	}
+	// The legacy blob must still be present, not deleted out from under a
+	// read failure.
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
+		t.Fatal("legacy blob was deleted despite a transient read failure (data loss)")
+	}
+	// Nothing else the aborted write touched should be visible either.
+	if _, ok, _ := s.Load(ProviderKey("beta")); ok {
+		t.Fatal("beta should not be visible: the write should have aborted entirely, not partially applied")
+	}
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || !ok {
+		t.Fatalf("alpha lost after an aborted write: ok=%v err=%v", ok, err)
+	}
+
+	// Once the transient failure clears, the legacy credential is recovered
+	// and the blob is cleaned up normally.
+	kr.fail = false
+	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+		t.Fatalf("retried Save: %v", err)
+	}
+	if _, ok, err := s.Load(ProviderKey("stale-binary-login")); err != nil || !ok {
+		t.Fatalf("Load(stale-binary-login): ok=%v err=%v (legacy credential lost)", ok, err)
+	}
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
+		t.Fatal("legacy blob should be removed once it was actually read and reconciled")
+	}
+}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -702,3 +702,37 @@ func TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey(t *testing.T) {
 		t.Fatal("legacy entry should be removed once its refresh is merged")
 	}
 }
+
+// TestStoreKeyringLeaseUsesWallClockNotStoreClock guards the lock lease against
+// a fixed or stale StoreOptions.Now. acquireFileLock judges staleness with real
+// time.Since(mtime), so the lease must stamp the live lock with wall-clock time;
+// leasing with an old injectable clock would let a peer immediately reclaim the
+// held lock and re-enter the keyring read-modify-write concurrently.
+func TestStoreKeyringLeaseUsesWallClockNotStoreClock(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "oauth-keyring.lockfile")
+	blob := keyringBlob{kr: newFakeKR(), service: "zero-test", indexAccount: "idx", lockPath: lockPath}
+
+	previous := fileLockRefreshInterval
+	fileLockRefreshInterval = 20 * time.Millisecond
+	defer func() { fileLockRefreshInterval = previous }()
+
+	// A deliberately stale, fixed clock: if the lease used it, the lock mtime
+	// would land decades in the past and look stale immediately.
+	fixed := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	var mtime time.Time
+	err := blob.withLock(func() time.Time { return fixed }, func() error {
+		time.Sleep(150 * time.Millisecond)
+		info, statErr := os.Stat(lockPath)
+		if statErr != nil {
+			return statErr
+		}
+		mtime = info.ModTime()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withLock: %v", err)
+	}
+	if time.Since(mtime) > fileLockStaleAfter {
+		t.Fatalf("lease stamped the lock with the store clock (%v); a peer would reclaim the live lock", mtime)
+	}
+}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -595,3 +595,110 @@ func TestStoreKeyringStatus(t *testing.T) {
 		t.Fatalf("status = %#v", statuses)
 	}
 }
+
+// TestStoreKeyringMigrationInterruptionsPreserveLegacyTokens drives the initial
+// legacy->indexed migration through an injected failure at every mutating
+// operation and checks that no pre-existing legacy credential is ever lost.
+// write() publishes the index before the per-key entries, so a crash after the
+// index appears but before an entry is written must still leave that token
+// readable in the not-yet-deleted legacy blob; read() recovers it, and a
+// following unimpeded save completes the migration.
+func TestStoreKeyringMigrationInterruptionsPreserveLegacyTokens(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	seeded := map[string]Token{
+		ProviderKey("demo"):  {AccessToken: "demo-a", RefreshToken: "demo-r"},
+		ProviderKey("other"): {AccessToken: "other-a"},
+	}
+	for failAt := 1; ; failAt++ {
+		kr := &failingKR{fakeKR: newFakeKR()}
+		// A legacy-only install: one combined entry, no index yet.
+		legacyData, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: seeded})
+		if err != nil {
+			t.Fatal(err)
+		}
+		kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyData)
+
+		s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+		if err != nil {
+			t.Fatal(err)
+		}
+		kr.ops = 0
+		kr.failAt = failAt
+		_ = s.Save(ProviderKey("new"), Token{AccessToken: "new-c"})
+		opsUsed := kr.ops
+		kr.failAt = 0
+
+		// Regardless of where the migration was interrupted, a subsequent
+		// unimpeded save must complete it with every token intact.
+		if err := s.Save(ProviderKey("new"), Token{AccessToken: "new-c"}); err != nil {
+			t.Fatalf("failAt=%d: reconciling Save: %v", failAt, err)
+		}
+		for key, want := range seeded {
+			got, ok, err := s.Load(key)
+			if err != nil || !ok {
+				t.Fatalf("failAt=%d: Load(%s) after migration: ok=%v err=%v (legacy token lost)", failAt, key, ok, err)
+			}
+			if got.AccessToken != want.AccessToken {
+				t.Fatalf("failAt=%d: Load(%s) = %q, want %q", failAt, key, got.AccessToken, want.AccessToken)
+			}
+		}
+		if got, ok, err := s.Load(ProviderKey("new")); err != nil || !ok || got.AccessToken != "new-c" {
+			t.Fatalf("failAt=%d: Load(new): ok=%v err=%v token=%#v", failAt, ok, err, got)
+		}
+		// The completed migration drops the legacy entry.
+		if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
+			t.Fatalf("failAt=%d: legacy entry not removed after migration completed", failAt)
+		}
+		if opsUsed < failAt {
+			break
+		}
+	}
+}
+
+// TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey covers the mixed-version
+// window for a key that already exists in the index: an old binary refreshes
+// provider:alpha in the legacy combined entry (a strictly later expiry). The
+// next new-binary save must keep that fresher refresh instead of overwriting it
+// with the stale indexed value and then deleting the legacy entry.
+func TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().Add(1 * time.Hour)
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a-old", RefreshToken: "r-old", ExpiresAt: stale}); err != nil {
+		t.Fatal(err)
+	}
+
+	// An old binary refreshes alpha through the legacy combined entry, pushing
+	// the expiry later than the indexed copy.
+	fresh := stale.Add(1 * time.Hour)
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "a-new", RefreshToken: "r-new", ExpiresAt: fresh},
+	}}
+	legacyData, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyData)
+
+	// A new-binary save of an unrelated key must reconcile alpha, not clobber it.
+	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.Load(ProviderKey("alpha"))
+	if err != nil || !ok {
+		t.Fatalf("Load(alpha): ok=%v err=%v", ok, err)
+	}
+	if got.AccessToken != "a-new" || got.RefreshToken != "r-new" {
+		t.Fatalf("Load(alpha) = %#v, want the refreshed legacy value (fresh refresh discarded)", got)
+	}
+	if _, ok, _ := s.Load(ProviderKey("beta")); !ok {
+		t.Fatal("Load(beta): not stored")
+	}
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
+		t.Fatal("legacy entry should be removed once its refresh is merged")
+	}
+}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -364,6 +364,15 @@ func TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 			}
 		}
 
+		// The tokens this write didn't touch must stay readable at the
+		// interruption boundary itself, not just after a later reconciling
+		// write papers over an incorrect intermediate state.
+		for _, name := range []string{"alpha", "beta"} {
+			if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
+				t.Fatalf("failAt=%d: Load(%s) before reconcile: ok=%v err=%v", failAt, name, ok, err)
+			}
+		}
+
 		// A later unimpeded write must reconcile completely.
 		if err := s.Save(ProviderKey("gamma"), Token{AccessToken: "c"}); err != nil {
 			t.Fatalf("failAt=%d: reconciling Save: %v", failAt, err)
@@ -407,7 +416,7 @@ func TestStoreKeyringDeleteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 		}
 		kr.ops = 0
 		kr.failAt = failAt
-		_, _ = s.Delete(ProviderKey("beta"))
+		_, deleteErr := s.Delete(ProviderKey("beta"))
 		opsUsed := kr.ops
 		kr.failAt = 0
 
@@ -432,6 +441,12 @@ func TestStoreKeyringDeleteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 		}
 		if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || !ok {
 			t.Fatalf("failAt=%d: Load(alpha): ok=%v err=%v", failAt, ok, err)
+		}
+		// Every mutating boundary of the delete path must surface its failure,
+		// mirroring the Save-interruption assertion: a swallowed error here
+		// would let a caller believe a logout succeeded when it didn't.
+		if opsUsed >= failAt && deleteErr == nil {
+			t.Fatalf("failAt=%d: injected keyring failure was swallowed", failAt)
 		}
 		if opsUsed < failAt {
 			break
@@ -472,6 +487,11 @@ func TestStoreKeyringMergesFreshLegacyWriteFromOldBinary(t *testing.T) {
 		if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
 			t.Fatalf("Load(%s): ok=%v err=%v (fresh legacy write lost)", name, ok, err)
 		}
+	}
+	// Presence alone doesn't rule out the merge corrupting carol's credential
+	// material; check the actual values survived the legacy->indexed merge.
+	if got, _, err := s.Load(ProviderKey("carol")); err != nil || got.AccessToken != "c" || got.RefreshToken != "cr" {
+		t.Fatalf("Load(carol) = %#v, err=%v, want the legacy access/refresh tokens intact", got, err)
 	}
 	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
 		t.Fatal("legacy entry should be removed once its fresh writes are merged")
@@ -694,14 +714,39 @@ func TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("Load(alpha): ok=%v err=%v", ok, err)
 	}
-	if got.AccessToken != "a-new" || got.RefreshToken != "r-new" {
-		t.Fatalf("Load(alpha) = %#v, want the refreshed legacy value (fresh refresh discarded)", got)
+	if got.AccessToken != "a-new" || got.RefreshToken != "r-new" || !got.ExpiresAt.Equal(fresh) {
+		t.Fatalf("Load(alpha) = %#v, want the refreshed legacy value (tokens and expiry) with ExpiresAt=%v", got, fresh)
 	}
 	if _, ok, _ := s.Load(ProviderKey("beta")); !ok {
 		t.Fatal("Load(beta): not stored")
 	}
 	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
 		t.Fatal("legacy entry should be removed once its refresh is merged")
+	}
+}
+
+// TestAcquireFileLockDeadlineUsesWallClockNotInjectedClock guards the other
+// half of the same hazard as the lease test below: acquireFileLock's own
+// acquisition deadline must be measured against the real wall clock, not the
+// injectable now parameter. StoreOptions.Now may legitimately be a fixed
+// clock (as this test uses), and deadline := now().Add(fileLockTimeout)
+// followed by now().After(deadline) would then never become true, so a
+// contested lock would retry forever instead of returning a timeout error.
+func TestAcquireFileLockDeadlineUsesWallClockNotInjectedClock(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "test.lockfile")
+	// A fresh (non-stale) lock held by someone else: acquireFileLock must not
+	// reclaim it, only wait out fileLockTimeout and report a timeout.
+	if err := os.WriteFile(lockPath, []byte("someone-else"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixed := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	start := time.Now()
+	_, err := acquireFileLock(lockPath, func() time.Time { return fixed })
+	if err == nil {
+		t.Fatal("expected a timeout error acquiring an already-held, non-stale lock")
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("acquireFileLock took %v with a fixed clock; the deadline must use the wall clock, not now()", elapsed)
 	}
 }
 
@@ -777,8 +822,47 @@ func TestStoreKeyringReadIndexRejectsCorruptHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(unsupported)
+	ckr.gets = 0
 	if _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an unsupported index version to be rejected")
+	}
+	if ckr.gets != 1 {
+		t.Fatalf("readKeyIndex issued %d gets for an unsupported version; want header lookup only", ckr.gets)
+	}
+}
+
+// TestStoreKeyringReadIndexRejectsOversizedKeyList regresses a corrupt index
+// that claims more keys than maxKeyringIndexKeys: maxKeyringIndexChunks alone
+// bounds only how many chunk entries are fetched, not how many keys a single
+// chunk's JSON (or the legacy bare-array format) can claim, so without this
+// check readKeyIndex would hand read()/write() an oversized key list to fan
+// out into one blocking kr.Get per key while holding the store lock.
+func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
+	ckr := &countingKR{fakeKR: newFakeKR()}
+	blob := keyringBlob{kr: ckr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+
+	tooMany := make([]string, maxKeyringIndexKeys+1)
+	for i := range tooMany {
+		tooMany[i] = ProviderKey(fmt.Sprintf("p%d", i))
+	}
+
+	header, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 1, Keys: tooMany})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+	if _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("expected an oversized key list in a chunk-0 header to be rejected")
+	}
+
+	// The pre-chunking bare-array format must be capped the same way.
+	legacyArray, err := json.Marshal(tooMany)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(legacyArray)
+	if _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("expected an oversized legacy-format key array to be rejected")
 	}
 }
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -901,14 +901,14 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 // and the last-resort temp name must be scoped by uid so different users
 // never collide on one lock file.
 func TestKeyringLockPathIsPerUser(t *testing.T) {
-	got := keyringLockPath(keyringService, keyringIndexAccount)
+	got := keyringLockPath(nil, keyringService, keyringIndexAccount)
 	name := keyringLockFileName(keyringService, keyringIndexAccount)
 	if got == filepath.Join(os.TempDir(), "zero-"+name) {
 		t.Fatalf("lock path is the shared temp path %q; a co-tenant could grief it", got)
 	}
-	if cache, err := os.UserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
-		if want := filepath.Join(cache, "zero", name); got != want {
-			t.Fatalf("lock path = %q, want per-user cache path %q", got, want)
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		if want := filepath.Join(home, ".cache", "zero", name); got != want {
+			t.Fatalf("lock path = %q, want per-user home-anchored path %q", got, want)
 		}
 	}
 	tempName := keyringTempLockName(keyringService, keyringIndexAccount)
@@ -918,6 +918,119 @@ func TestKeyringLockPathIsPerUser(t *testing.T) {
 		}
 	} else if tempName == "" {
 		t.Fatal("temp lock name is empty")
+	}
+}
+
+// TestKeyringLockPathIndependentOfCacheAndTempRoots is the regression test
+// for [P1] Make the keyring lock path independent of XDG_CACHE_HOME
+// (2026-07-22): os.UserCacheDir() (and its os.TempDir() fallback) is chosen
+// per PROCESS from XDG_CACHE_HOME/TMPDIR, so two zero processes belonging to
+// the SAME real user but with different cache/temp roots (sandboxes, CI,
+// per-shell overrides) computed different lock files, both read the shared
+// keyring index, and could publish competing updates that hid one process's
+// token. The lock must resolve identically regardless of those roots, since
+// it is anchored on the user's home directory instead.
+func TestKeyringLockPathIndependentOfCacheAndTempRoots(t *testing.T) {
+	home := t.TempDir()
+	envA := map[string]string{
+		"HOME":           home,
+		"XDG_CACHE_HOME": filepath.Join(t.TempDir(), "cache-a"),
+		"TMPDIR":         filepath.Join(t.TempDir(), "tmp-a"),
+	}
+	envB := map[string]string{
+		"HOME":           home,
+		"XDG_CACHE_HOME": filepath.Join(t.TempDir(), "cache-b"),
+		"TMPDIR":         filepath.Join(t.TempDir(), "tmp-b"),
+	}
+
+	storeA, err := NewStore(StoreOptions{Storage: "keyring", Keyring: newFakeKR(), Env: envA})
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeB, err := NewStore(StoreOptions{Storage: "keyring", Keyring: newFakeKR(), Env: envB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blobA, okA := storeA.blob.(keyringBlob)
+	blobB, okB := storeB.blob.(keyringBlob)
+	if !okA || !okB {
+		t.Fatal("Store.blob is not keyringBlob")
+	}
+	if blobA.lockPath == "" || blobB.lockPath == "" {
+		t.Fatal("lockPath should never be empty for the keyring backend")
+	}
+	if blobA.lockPath != blobB.lockPath {
+		t.Fatalf("two same-user processes with different cache/temp roots got different lock paths: %q vs %q (they can race the shared keyring index)", blobA.lockPath, blobB.lockPath)
+	}
+	if strings.Contains(blobA.lockPath, "cache-a") || strings.Contains(blobA.lockPath, "cache-b") ||
+		strings.Contains(blobA.lockPath, "tmp-a") || strings.Contains(blobA.lockPath, "tmp-b") {
+		t.Fatalf("lock path %q is still derived from XDG_CACHE_HOME/TMPDIR", blobA.lockPath)
+	}
+}
+
+// TestStoreKeyringWriteWaitsForLegacyLockDuringReconciliation is the
+// regression test for [P1] Coordinate migration with the legacy lock used by
+// old binaries (2026-07-22): a pre-PR binary locks beside ResolveStorePath
+// around its own read-modify-write of the legacy combined entry, but this
+// binary's write() used to lock only under the cache-derived keyring path, so
+// the two never excluded each other. A new save could reconcile the legacy
+// blob, an old process could then save a fresh legacy credential, and the new
+// save would unconditionally delete that blob without ever having observed
+// the old write, losing it permanently.
+//
+// This simulates a live old binary by holding the exact lock file
+// legacyKeyringLockPath computes (the same one a pre-PR binary's Save takes)
+// and asserting that Store.Save — which must reconcile and then drop the
+// legacy entry here, since one is seeded below — blocks until that lock is
+// released, and that the seeded legacy token survives the reconciliation.
+func TestStoreKeyringWriteWaitsForLegacyLockDuringReconciliation(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	kr := newFakeKR()
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "legacy-alpha"},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, ok := s.blob.(keyringBlob)
+	if !ok || blob.legacyLockPath == "" {
+		t.Fatal("keyring store has no legacy-compat lock path")
+	}
+
+	// Simulate an old binary holding the legacy lock for its own in-flight Save.
+	unlock, err := acquireFileLock(blob.legacyLockPath, s.now)
+	if err != nil {
+		t.Fatalf("acquire simulated legacy lock: %v", err)
+	}
+
+	saveDone := make(chan error, 1)
+	go func() {
+		saveDone <- s.Save(ProviderKey("beta"), Token{AccessToken: "beta"})
+	}()
+
+	select {
+	case err := <-saveDone:
+		t.Fatalf("Save proceeded (err=%v) while an old binary held the legacy lock; it can race the reconcile-then-delete window and lose a concurrent legacy write", err)
+	case <-time.After(200 * time.Millisecond):
+		// Still blocked, as expected.
+	}
+
+	unlock()
+	if err := <-saveDone; err != nil {
+		t.Fatalf("Save after the legacy lock was released: %v", err)
+	}
+
+	got, ok, err := s.Load(ProviderKey("alpha"))
+	if err != nil || !ok || got.AccessToken != "legacy-alpha" {
+		t.Fatalf("legacy alpha token lost across reconciliation: ok=%v err=%v got=%#v", ok, err, got)
 	}
 }
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -895,27 +895,67 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 	}
 }
 
-// TestKeyringFallbackLockPathIsPerUser covers the fallback taken when no config
-// location resolves. It must not be the single shared temp path that any account
-// on a multi-user host could pre-create or hold, and the last-resort temp name
-// must be scoped by uid so different users never collide on one lock file.
-func TestKeyringFallbackLockPathIsPerUser(t *testing.T) {
-	got := keyringFallbackLockPath()
-	if got == filepath.Join(os.TempDir(), "zero-oauth-keyring.lockfile") {
-		t.Fatalf("fallback lock path is the shared temp path %q; a co-tenant could grief it", got)
+// TestKeyringLockPathIsPerUser covers the lock path used for every keyring
+// Store regardless of file-backend config. It must not be the single shared
+// temp path that any account on a multi-user host could pre-create or hold,
+// and the last-resort temp name must be scoped by uid so different users
+// never collide on one lock file.
+func TestKeyringLockPathIsPerUser(t *testing.T) {
+	got := keyringLockPath(keyringService, keyringIndexAccount)
+	name := keyringLockFileName(keyringService, keyringIndexAccount)
+	if got == filepath.Join(os.TempDir(), "zero-"+name) {
+		t.Fatalf("lock path is the shared temp path %q; a co-tenant could grief it", got)
 	}
 	if cache, err := os.UserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
-		if want := filepath.Join(cache, "zero", "oauth-keyring.lockfile"); got != want {
-			t.Fatalf("fallback = %q, want per-user cache path %q", got, want)
+		if want := filepath.Join(cache, "zero", name); got != want {
+			t.Fatalf("lock path = %q, want per-user cache path %q", got, want)
 		}
 	}
-	name := keyringTempLockName()
+	tempName := keyringTempLockName(keyringService, keyringIndexAccount)
 	if uid := os.Getuid(); uid >= 0 {
-		if !strings.Contains(name, fmt.Sprintf("%d", uid)) {
-			t.Fatalf("temp lock name %q is not scoped by uid %d", name, uid)
+		if !strings.Contains(tempName, fmt.Sprintf("%d", uid)) {
+			t.Fatalf("temp lock name %q is not scoped by uid %d", tempName, uid)
 		}
-	} else if name == "" {
+	} else if tempName == "" {
 		t.Fatal("temp lock name is empty")
+	}
+}
+
+// TestKeyringLockPathDerivedFromKeyringIdentityNotFileConfig is the
+// regression test for the cross-process lock racing bug: the lock guarding
+// the shared keyring index must be keyed off the keyring's own identity
+// (service + index account), never off the file-backend path config
+// (ZERO_OAUTH_TOKENS_PATH / XDG_CONFIG_HOME). Two zero processes with
+// different config roots but pointed at the SAME keyring entry (the service
+// and account are fixed per binary, not per config root) must resolve to the
+// identical lock path, or they can race a read-modify-write on the shared
+// index and silently drop one process's token write.
+func TestKeyringLockPathDerivedFromKeyringIdentityNotFileConfig(t *testing.T) {
+	dirA := filepath.Join(t.TempDir(), "config-root-a")
+	dirB := filepath.Join(t.TempDir(), "config-root-b")
+
+	storeA, err := NewStore(StoreOptions{Storage: "keyring", Keyring: newFakeKR(), Env: map[string]string{"XDG_CONFIG_HOME": dirA}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeB, err := NewStore(StoreOptions{Storage: "keyring", Keyring: newFakeKR(), Env: map[string]string{"XDG_CONFIG_HOME": dirB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blobA, okA := storeA.blob.(keyringBlob)
+	blobB, okB := storeB.blob.(keyringBlob)
+	if !okA || !okB {
+		t.Fatal("Store.blob is not keyringBlob")
+	}
+	if blobA.lockPath == "" || blobB.lockPath == "" {
+		t.Fatal("lockPath should never be empty for the keyring backend")
+	}
+	if blobA.lockPath != blobB.lockPath {
+		t.Fatalf("two processes on the SAME keyring entry got different lock paths for different config roots: %q vs %q (they can race the shared keyring index)", blobA.lockPath, blobB.lockPath)
+	}
+	// And it must not be derived from either config root's resolved store path.
+	if strings.Contains(blobA.lockPath, dirA) || strings.Contains(blobA.lockPath, dirB) {
+		t.Fatalf("lock path %q is still derived from file-backend config, not the keyring identity", blobA.lockPath)
 	}
 }
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -736,3 +736,46 @@ func TestStoreKeyringLeaseUsesWallClockNotStoreClock(t *testing.T) {
 		t.Fatalf("lease stamped the lock with the store clock (%v); a peer would reclaim the live lock", mtime)
 	}
 }
+
+// countingKR counts Get calls so a test can prove a corrupt index is rejected
+// before it fans out into a keyring lookup per advertised chunk.
+type countingKR struct {
+	*fakeKR
+	gets int
+}
+
+func (c *countingKR) Get(service, account string) (string, bool, error) {
+	c.gets++
+	return c.fakeKR.Get(service, account)
+}
+
+// TestStoreKeyringReadIndexRejectsCorruptHeader is the regression test for an
+// index header whose advertised chunk count is unbounded: readKeyIndex must
+// reject an out-of-range or unsupported header up front rather than issue up to
+// that many blocking keyring lookups while holding the store lock.
+func TestStoreKeyringReadIndexRejectsCorruptHeader(t *testing.T) {
+	ckr := &countingKR{fakeKR: newFakeKR()}
+	blob := keyringBlob{kr: ckr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+
+	oversized, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 1_000_000_000, Keys: []string{ProviderKey("demo")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(oversized)
+	ckr.gets = 0
+	if _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("expected an oversized chunk count to be rejected")
+	}
+	if ckr.gets != 1 {
+		t.Fatalf("readKeyIndex issued %d keyring gets on a corrupt header; it must reject before fanning out over chunks", ckr.gets)
+	}
+
+	unsupported, err := json.Marshal(keyIndexHeader{Version: 2, Chunks: 1, Keys: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(unsupported)
+	if _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("expected an unsupported index version to be rejected")
+	}
+}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -777,5 +778,29 @@ func TestStoreKeyringReadIndexRejectsCorruptHeader(t *testing.T) {
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(unsupported)
 	if _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an unsupported index version to be rejected")
+	}
+}
+
+// TestKeyringFallbackLockPathIsPerUser covers the fallback taken when no config
+// location resolves. It must not be the single shared temp path that any account
+// on a multi-user host could pre-create or hold, and the last-resort temp name
+// must be scoped by uid so different users never collide on one lock file.
+func TestKeyringFallbackLockPathIsPerUser(t *testing.T) {
+	got := keyringFallbackLockPath()
+	if got == filepath.Join(os.TempDir(), "zero-oauth-keyring.lockfile") {
+		t.Fatalf("fallback lock path is the shared temp path %q; a co-tenant could grief it", got)
+	}
+	if cache, err := os.UserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
+		if want := filepath.Join(cache, "zero", "oauth-keyring.lockfile"); got != want {
+			t.Fatalf("fallback = %q, want per-user cache path %q", got, want)
+		}
+	}
+	name := keyringTempLockName()
+	if uid := os.Getuid(); uid >= 0 {
+		if !strings.Contains(name, fmt.Sprintf("%d", uid)) {
+			t.Fatalf("temp lock name %q is not scoped by uid %d", name, uid)
+		}
+	} else if name == "" {
+		t.Fatal("temp lock name is empty")
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -3,8 +3,11 @@ package oauth
 import (
 	"encoding/base64"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeKR is an in-memory KeyringClient for exercising the keyring backend
@@ -221,6 +224,258 @@ func TestStoreKeyringSkipsIndexedKeyMissingItsEntry(t *testing.T) {
 	}
 }
 
+// failingKR wraps fakeKR and fails the Nth mutating operation (Set/Delete),
+// for exercising every interruption boundary of the multi-step write.
+type failingKR struct {
+	*fakeKR
+	failAt int // 1-based mutating-operation number to fail; 0 disables
+	ops    int
+}
+
+func (f *failingKR) Set(service, account, secret string) error {
+	f.ops++
+	if f.failAt != 0 && f.ops == f.failAt {
+		return errKRInjected
+	}
+	return f.fakeKR.Set(service, account, secret)
+}
+
+func (f *failingKR) Delete(service, account string) (bool, error) {
+	f.ops++
+	if f.failAt != 0 && f.ops == f.failAt {
+		return false, errKRInjected
+	}
+	return f.fakeKR.Delete(service, account)
+}
+
+var errKRInjected = errKR("injected keyring failure")
+
+type errKR string
+
+func (e errKR) Error() string { return string(e) }
+
+// indexedKeysOf parses the (possibly chunked) index in kr and returns every
+// listed key.
+func indexedKeysOf(t *testing.T, kr *fakeKR) map[string]bool {
+	t.Helper()
+	blob := keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+	keys, _, _, err := blob.readKeyIndex()
+	if err != nil {
+		t.Fatalf("readKeyIndex: %v", err)
+	}
+	out := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		out[k] = true
+	}
+	return out
+}
+
+// TestStoreKeyringIndexStaysUnderEntryLimit is the regression test for the
+// index itself hitting the same macOS `security -i` line cap the per-token
+// split fixed for token entries: with enough maximum-length keys, a single
+// index entry base64-expands past 4095 bytes even when every token is tiny.
+// The index must therefore be bounded per entry (chunked) like everything
+// else, and still round-trip.
+func TestStoreKeyringIndexStaysUnderEntryLimit(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 40 keys near ValidateKey's cap: an unchunked index of these would
+	// serialize to ~5.5KB before base64.
+	names := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		names = append(names, strings.Repeat("p", 100)+"-"+strings.Repeat("0123456789", 2)+string(rune('a'+i%26))+string(rune('a'+i/26)))
+	}
+	for _, name := range names {
+		if err := s.Save(ProviderKey(name), Token{AccessToken: "a"}); err != nil {
+			t.Fatalf("Save(%s): %v", name, err)
+		}
+	}
+	// Every keyring value, index entries included, must stay under the cap
+	// with generous framing margin.
+	const entryCeiling = 3800
+	for k, v := range kr.data {
+		if len(v) > entryCeiling {
+			t.Fatalf("keyring entry %q is %d bytes, want <= %d (index cap regression)", k, len(v), entryCeiling)
+		}
+	}
+	// The index actually chunked (otherwise the ceiling check proves nothing).
+	if _, ok := kr.data[keyringService+"/"+keyringIndexAccount+"-1"]; !ok {
+		t.Fatal("expected the index to split into continuation chunks")
+	}
+	for _, name := range names {
+		if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
+			t.Fatalf("Load(%s): ok=%v err=%v", name, ok, err)
+		}
+	}
+	// Shrinking back to one token must also shrink the index and drop the
+	// stale continuation chunks.
+	for _, name := range names[1:] {
+		if _, err := s.Delete(ProviderKey(name)); err != nil {
+			t.Fatalf("Delete(%s): %v", name, err)
+		}
+	}
+	if _, ok := kr.data[keyringService+"/"+keyringIndexAccount+"-1"]; ok {
+		t.Fatal("stale index continuation chunk left behind after shrink")
+	}
+}
+
+// TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens drives a write
+// through an injected failure at every mutating operation in turn and checks
+// the recoverable-store invariant at each boundary: every token entry present
+// in the keyring is listed in the published index (so no credential is ever
+// stranded invisibly), and a subsequent unimpeded write fully reconciles.
+func TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	for failAt := 1; ; failAt++ {
+		kr := &failingKR{fakeKR: newFakeKR()}
+		s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Seed two tokens cleanly, then fail the Nth mutating operation of a
+		// write that both adds a token and (via the later delete pass of a
+		// Delete call) removes one.
+		if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+			t.Fatal(err)
+		}
+		kr.ops = 0
+		kr.failAt = failAt
+		saveErr := s.Save(ProviderKey("gamma"), Token{AccessToken: "c"})
+		opsUsed := kr.ops
+		kr.failAt = 0
+
+		// Invariant at the interruption boundary: nothing invisible.
+		indexed := indexedKeysOf(t, kr.fakeKR)
+		for entry := range kr.data {
+			account := strings.TrimPrefix(entry, keyringService+"/")
+			if account == keyringIndexAccount || strings.HasPrefix(account, keyringIndexAccount+"-") || account == keyringLegacyAccount {
+				continue
+			}
+			if !indexed[account] {
+				t.Fatalf("failAt=%d: token entry %q exists but is not listed in the index (invisible credential)", failAt, account)
+			}
+		}
+
+		// A later unimpeded write must reconcile completely.
+		if err := s.Save(ProviderKey("gamma"), Token{AccessToken: "c"}); err != nil {
+			t.Fatalf("failAt=%d: reconciling Save: %v", failAt, err)
+		}
+		for _, name := range []string{"alpha", "beta", "gamma"} {
+			if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
+				t.Fatalf("failAt=%d: Load(%s) after reconcile: ok=%v err=%v", failAt, name, ok, err)
+			}
+		}
+		// saveErr itself is not asserted: most boundaries surface the injected
+		// failure, but the final legacy-entry delete is deliberately
+		// best-effort, so its failure is swallowed by design. The invariant
+		// and the reconcile above are the actual contract.
+		_ = saveErr
+		if opsUsed < failAt {
+			// The write used fewer mutating ops than failAt, so the injection
+			// never fired and every boundary has been covered.
+			break
+		}
+	}
+}
+
+// TestStoreKeyringDeleteInterruptionsLeaveNoInvisibleTokens is the Delete
+// counterpart: a logout interrupted at any boundary must not leave a
+// logged-out credential invisibly resident in the OS keychain (the index is
+// only shrunk after the entry deletion), and a repeated delete reconciles.
+func TestStoreKeyringDeleteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	for failAt := 1; ; failAt++ {
+		kr := &failingKR{fakeKR: newFakeKR()}
+		s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+			t.Fatal(err)
+		}
+		kr.ops = 0
+		kr.failAt = failAt
+		_, _ = s.Delete(ProviderKey("beta"))
+		opsUsed := kr.ops
+		kr.failAt = 0
+
+		indexed := indexedKeysOf(t, kr.fakeKR)
+		for entry := range kr.data {
+			account := strings.TrimPrefix(entry, keyringService+"/")
+			if account == keyringIndexAccount || strings.HasPrefix(account, keyringIndexAccount+"-") || account == keyringLegacyAccount {
+				continue
+			}
+			if !indexed[account] {
+				t.Fatalf("failAt=%d: token entry %q exists but is not listed in the index (invisible credential)", failAt, account)
+			}
+		}
+
+		// Retrying the delete must fully reconcile: beta gone from both the
+		// index and the keyring, alpha intact.
+		if _, err := s.Delete(ProviderKey("beta")); err != nil {
+			t.Fatalf("failAt=%d: reconciling Delete: %v", failAt, err)
+		}
+		if _, ok := kr.data[keyringService+"/"+ProviderKey("beta")]; ok {
+			t.Fatalf("failAt=%d: logged-out credential still resident after reconcile", failAt)
+		}
+		if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || !ok {
+			t.Fatalf("failAt=%d: Load(alpha): ok=%v err=%v", failAt, ok, err)
+		}
+		if opsUsed < failAt {
+			break
+		}
+	}
+}
+
+// TestStoreKeyringMergesFreshLegacyWriteFromOldBinary covers the mixed-version
+// window: after migration to the indexed format, an old binary still running
+// can save a token into the legacy combined entry. The next new-binary write
+// must merge that fresh token instead of deleting the legacy entry over it.
+func TestStoreKeyringMergesFreshLegacyWriteFromOldBinary(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// An old binary saves token "carol" through the legacy combined entry.
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("carol"): {AccessToken: "c", RefreshToken: "cr"},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	// The next new-binary save must keep carol, not silently lose it.
+	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"alpha", "beta", "carol"} {
+		if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
+			t.Fatalf("Load(%s): ok=%v err=%v (fresh legacy write lost)", name, ok, err)
+		}
+	}
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
+		t.Fatal("legacy entry should be removed once its fresh writes are merged")
+	}
+}
+
 func TestNewStoreStorageSelection(t *testing.T) {
 	// Unknown storage is rejected (fail closed).
 	if _, err := NewStore(StoreOptions{Storage: "bogus"}); err == nil {
@@ -244,6 +499,77 @@ func TestNewStoreStorageSelection(t *testing.T) {
 	}
 	if strings.HasPrefix(fileStore.FilePath(), "keyring:") {
 		t.Fatalf("default backend should be file, got %q", fileStore.FilePath())
+	}
+}
+
+// TestStoreKeyringWithLockRefreshesLease guards the stale-reclaim race: one
+// keyring command can take up to 10s and a multi-entry pass runs several, so
+// a lock held for a legitimately slow operation can outlive the fixed 30s
+// stale threshold. withLock must keep the lock file's mtime fresh while its
+// critical section runs, so only a genuinely crashed holder ever looks stale.
+func TestStoreKeyringWithLockRefreshesLease(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "oauth-keyring.lockfile")
+	blob := keyringBlob{kr: newFakeKR(), service: "zero-test", indexAccount: "idx", lockPath: lockPath}
+
+	previous := fileLockRefreshInterval
+	fileLockRefreshInterval = 20 * time.Millisecond
+	defer func() { fileLockRefreshInterval = previous }()
+
+	var first, second time.Time
+	err := blob.withLock(time.Now, func() error {
+		info, err := os.Stat(lockPath)
+		if err != nil {
+			return err
+		}
+		first = info.ModTime()
+		time.Sleep(150 * time.Millisecond)
+		info, err = os.Stat(lockPath)
+		if err != nil {
+			return err
+		}
+		second = info.ModTime()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withLock: %v", err)
+	}
+	if !second.After(first) {
+		t.Fatalf("lock mtime was not refreshed during the critical section: %v then %v", first, second)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock file not released: %v", err)
+	}
+}
+
+// TestStoreFileLoadToleratesCrashedWriterLock: file-backend reads must stay
+// lock-free. A writer that crashed after taking the lock leaves a fresh lock
+// file behind; the store file itself is always complete (writes are atomic
+// renames), so Load must read it rather than waiting out the lock and
+// failing for the ~30 seconds the stale threshold takes to expire.
+func TestStoreFileLoadToleratesCrashedWriterLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oauth-tokens.json")
+	s, err := NewStore(StoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("demo"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the crashed writer: a fresh, never-released lock file.
+	if err := os.WriteFile(path+".lockfile", []byte("someone-else"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	got, ok, err := s.Load(ProviderKey("demo"))
+	if err != nil || !ok || got.AccessToken != "a" {
+		t.Fatalf("Load behind a crashed writer's lock: ok=%v err=%v token=%#v", ok, err, got)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("Load waited on the write lock (%v); reads must be lock-free", elapsed)
+	}
+	statuses, err := s.Status("")
+	if err != nil || len(statuses) != 1 {
+		t.Fatalf("Status behind a crashed writer's lock: %v (%d entries)", err, len(statuses))
 	}
 }
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -171,6 +171,56 @@ func TestStoreKeyringMigratesLegacyCombinedEntry(t *testing.T) {
 	}
 }
 
+// TestStoreKeyringSkipsIndexedKeyMissingItsEntry covers read()'s recovery from
+// an index/entry desync: a key listed in the index whose own entry is
+// missing (e.g. a process killed between writing the entry and updating the
+// index, or between updating the index and deleting a removed entry). read()
+// must skip that key rather than fail the whole read, since the next
+// Save/Delete reconciles the index against what's actually there.
+func TestStoreKeyringSkipsIndexedKeyMissingItsEntry(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+
+	present := Token{AccessToken: "present-a", RefreshToken: "present-r"}
+	raw, err := json.Marshal(present)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+ProviderKey("present")] = base64.StdEncoding.EncodeToString(raw)
+
+	// The index references both keys, but "missing"'s own entry was never
+	// written (or was already deleted) — the desync this test targets.
+	index, err := json.Marshal([]string{ProviderKey("missing"), ProviderKey("present")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(index)
+
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok, err := s.Load(ProviderKey("missing")); err != nil || ok {
+		t.Fatalf("Load(missing): ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+	got, ok, err := s.Load(ProviderKey("present"))
+	if err != nil || !ok {
+		t.Fatalf("Load(present): ok=%v err=%v", ok, err)
+	}
+	if got.AccessToken != present.AccessToken {
+		t.Fatalf("Load(present) = %#v", got)
+	}
+
+	statuses, err := s.Status("")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Key != ProviderKey("present") {
+		t.Fatalf("Status = %#v, want only the present key", statuses)
+	}
+}
+
 func TestNewStoreStorageSelection(t *testing.T) {
 	// Unknown storage is rejected (fail closed).
 	if _, err := NewStore(StoreOptions{Storage: "bogus"}); err == nil {

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -373,11 +373,12 @@ func TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 				t.Fatalf("failAt=%d: Load(%s) after reconcile: ok=%v err=%v", failAt, name, ok, err)
 			}
 		}
-		// saveErr itself is not asserted: most boundaries surface the injected
-		// failure, but the final legacy-entry delete is deliberately
-		// best-effort, so its failure is swallowed by design. The invariant
-		// and the reconcile above are the actual contract.
-		_ = saveErr
+		// Every mutating boundary of the write path now surfaces its failure,
+		// including the legacy-entry delete (a swallowed failure there could
+		// let a later save resurrect logged-out credentials).
+		if opsUsed >= failAt && saveErr == nil {
+			t.Fatalf("failAt=%d: injected keyring failure was swallowed", failAt)
+		}
 		if opsUsed < failAt {
 			// The write used fewer mutating ops than failAt, so the injection
 			// never fired and every boundary has been covered.
@@ -802,5 +803,85 @@ func TestKeyringFallbackLockPathIsPerUser(t *testing.T) {
 		}
 	} else if name == "" {
 		t.Fatal("temp lock name is empty")
+	}
+}
+
+// legacyDeleteFailKR fails Delete for the legacy combined entry only, to
+// exercise the boundary where a logout has already rewritten the indexed
+// state but the stale legacy blob cannot be removed.
+type legacyDeleteFailKR struct {
+	*fakeKR
+	fail bool
+}
+
+func (f *legacyDeleteFailKR) Delete(service, account string) (bool, error) {
+	if f.fail && account == keyringLegacyAccount {
+		return false, errKRInjected
+	}
+	return f.fakeKR.Delete(service, account)
+}
+
+// TestStoreKeyringLogoutSurfacesLegacyBlobDeleteFailure: when the final
+// legacy-blob delete fails during a logout, the operation must report the
+// failure (not success with the secret still resident), and after a clean
+// retry the logged-out credential must not be resurrected by a later save.
+func TestStoreKeyringLogoutSurfacesLegacyBlobDeleteFailure(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := &legacyDeleteFailKR{fakeKR: newFakeKR()}
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	// A leftover legacy blob still carries alpha (e.g. written by an old
+	// binary during the upgrade window).
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "stale-a"},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	kr.fail = true
+	if _, err := s.Delete(ProviderKey("alpha")); err == nil {
+		t.Fatal("Delete reported success although the stale legacy blob could not be removed")
+	}
+
+	// A clean retry succeeds, and a later save must not classify the stale
+	// legacy alpha as a fresh old-binary login.
+	kr.fail = false
+	if _, err := s.Delete(ProviderKey("alpha")); err != nil {
+		t.Fatalf("retried Delete: %v", err)
+	}
+	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || ok {
+		t.Fatalf("logged-out credential resurrected: ok=%v err=%v", ok, err)
+	}
+}
+
+// TestStoreKeyringWriteIndexRejectsOverCapChunks: writeKeyIndex must refuse
+// to publish an index header that readKeyIndex would reject, instead of
+// persisting a store no later operation can open.
+func TestStoreKeyringWriteIndexRejectsOverCapChunks(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+	// Each key exceeds the per-chunk byte budget on its own, forcing one
+	// chunk per key.
+	long := strings.Repeat("k", maxKeyringIndexChunkBytes)
+	keys := make([]string, maxKeyringIndexChunks+1)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("%s-%d", long, i)
+	}
+	if _, err := b.writeKeyIndex(keys, 0); err == nil {
+		t.Fatal("writeKeyIndex published an index readKeyIndex would refuse")
+	}
+	if len(kr.data) != 0 {
+		t.Fatalf("over-cap index write must publish nothing, found %d entries", len(kr.data))
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -1059,6 +1059,106 @@ func TestStoreKeyringWriteIndexRejectsOverCapKeys(t *testing.T) {
 	}
 }
 
+// TestStoreKeyringReadIndexDedupesDuplicateKeys is the regression test for the
+// index fan-out DoS: a corrupted or adversarially crafted index that repeats
+// the same key many times must collapse to its distinct, valid keys before
+// read()/write() fan them out into one blocking keyring lookup per key.
+func TestStoreKeyringReadIndexDedupesDuplicateKeys(t *testing.T) {
+	ckr := &countingKR{fakeKR: newFakeKR()}
+	blob := keyringBlob{kr: ckr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+
+	dup := ProviderKey("demo")
+	many := make([]string, 2000)
+	for i := range many {
+		many[i] = dup
+	}
+	header, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 1, Keys: many})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+
+	keys, ok, _, err := blob.readKeyIndex()
+	if err != nil {
+		t.Fatalf("readKeyIndex: %v", err)
+	}
+	if !ok {
+		t.Fatal("readKeyIndex: expected an index to be found")
+	}
+	if len(keys) != 1 {
+		t.Fatalf("readKeyIndex returned %d keys for a 2000-duplicate index, want 1 (deduplicated)", len(keys))
+	}
+
+	// A malformed (non-ValidateKey-shaped) entry must also be dropped rather
+	// than fanned out into a lookup.
+	mixed, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 1, Keys: []string{dup, dup, "not a valid key", ProviderKey("other")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(mixed)
+	keys, _, _, err = blob.readKeyIndex()
+	if err != nil {
+		t.Fatalf("readKeyIndex: %v", err)
+	}
+	want := map[string]bool{dup: true, ProviderKey("other"): true}
+	if len(keys) != len(want) {
+		t.Fatalf("readKeyIndex = %v, want exactly %v", keys, want)
+	}
+	for _, k := range keys {
+		if !want[k] {
+			t.Fatalf("readKeyIndex returned unexpected key %q", k)
+		}
+	}
+}
+
+// TestStoreKeyringDuplicateIndexDoesNotFanOutPerEntry is the end-to-end
+// regression test for the same DoS: a duplicate-heavy index must not drive
+// one keyring Get per listed entry. Before the index is deduplicated at its
+// source, a corrupted index holding thousands of copies of the same key would
+// hold the store lock for one blocking keyring lookup (each up to the 10s
+// command timeout) per copy, even though the cap on total distinct credentials
+// this bug was meant to bound was never actually exceeded.
+func TestStoreKeyringDuplicateIndexDoesNotFanOutPerEntry(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	ckr := &countingKR{fakeKR: newFakeKR()}
+
+	dup := ProviderKey("demo")
+	raw, err := json.Marshal(Token{AccessToken: "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+dup] = base64.StdEncoding.EncodeToString(raw)
+
+	many := make([]string, 3000)
+	for i := range many {
+		many[i] = dup
+	}
+	header, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 1, Keys: many})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: ckr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ckr.gets = 0
+	statuses, err := s.Status("")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("Status returned %d entries for a 3000-duplicate index of one key, want 1", len(statuses))
+	}
+	// One Get for the index header, one Get for the single deduplicated key's
+	// own entry — not one per (duplicate) index entry.
+	if ckr.gets > 2 {
+		t.Fatalf("Status issued %d keyring gets for a 3000-entry duplicate index, want <= 2 (fan-out DoS regression)", ckr.gets)
+	}
+}
+
 // legacyGetFailKR fails Get for the legacy combined entry only, simulating a
 // transient keyring read error (as opposed to the entry genuinely not
 // existing, which fakeKR's normal Get reports as ok=false, err=nil).

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -851,8 +851,12 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 		t.Fatal(err)
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+	ckr.gets = 0
 	if _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized key list in a chunk-0 header to be rejected")
+	}
+	if ckr.gets != 1 {
+		t.Fatalf("readKeyIndex issued %d gets for an oversized header keys list; want header lookup only", ckr.gets)
 	}
 
 	// The pre-chunking bare-array format must be capped the same way.
@@ -861,8 +865,33 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 		t.Fatal(err)
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(legacyArray)
+	ckr.gets = 0
 	if _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized legacy-format key array to be rejected")
+	}
+	if ckr.gets != 1 {
+		t.Fatalf("readKeyIndex issued %d gets for an oversized legacy array; want header lookup only", ckr.gets)
+	}
+
+	// Accumulation across continuation chunks must hit the same total cap: a
+	// small header plus an oversized chunk-1 would otherwise fan out past the
+	// bound after the per-header check has already passed.
+	headerOK, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 2, Keys: []string{ProviderKey("seed")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk1, err := json.Marshal(tooMany)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(headerOK)
+	ckr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
+	ckr.gets = 0
+	if _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("expected an oversized key list accumulated across chunks to be rejected")
+	}
+	if ckr.gets != 2 {
+		t.Fatalf("readKeyIndex issued %d gets for a header+oversize-chunk; want header and chunk-1 only", ckr.gets)
 	}
 }
 
@@ -967,5 +996,25 @@ func TestStoreKeyringWriteIndexRejectsOverCapChunks(t *testing.T) {
 	}
 	if len(kr.data) != 0 {
 		t.Fatalf("over-cap index write must publish nothing, found %d entries", len(kr.data))
+	}
+}
+
+// TestStoreKeyringWriteIndexRejectsOverCapKeys: short keys can still fit under
+// the chunk-count cap while exceeding maxKeyringIndexKeys. writeKeyIndex must
+// refuse that set before publishing, matching the reader-side total key cap.
+func TestStoreKeyringWriteIndexRejectsOverCapKeys(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+	keys := make([]string, maxKeyringIndexKeys+1)
+	for i := range keys {
+		// Short keys pack densely into chunks so the chunk-count check alone
+		// would not catch this over-cap set.
+		keys[i] = fmt.Sprintf("p%d", i)
+	}
+	if _, err := b.writeKeyIndex(keys, 0); err == nil {
+		t.Fatal("writeKeyIndex published a key count readKeyIndex would refuse")
+	}
+	if len(kr.data) != 0 {
+		t.Fatalf("over-cap key write must publish nothing, found %d entries", len(kr.data))
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -49,13 +51,17 @@ func TestStoreKeyringBackendRoundTrip(t *testing.T) {
 		t.Fatalf("Load = %#v", got)
 	}
 
-	// The blob is stored base64-encoded, so the raw JSON field names never appear.
-	raw := kr.data[keyringService+"/"+keyringAccount]
+	// The token lives under its own entry (account = key), not one combined
+	// blob, and is base64-encoded so the raw JSON field names never appear.
+	raw := kr.data[keyringService+"/"+ProviderKey("demo")]
 	if raw == "" {
-		t.Fatal("nothing stored in keyring")
+		t.Fatal("nothing stored under the token's own keyring entry")
 	}
 	if strings.Contains(raw, "access_token") {
-		t.Fatalf("keyring blob is not encoded: %s", raw)
+		t.Fatalf("keyring entry is not encoded: %s", raw)
+	}
+	if raw := kr.data[keyringService+"/"+keyringLegacyAccount]; raw != "" {
+		t.Fatalf("legacy combined entry should not be written by new code: %s", raw)
 	}
 
 	removed, err := s.Delete(ProviderKey("demo"))
@@ -64,6 +70,104 @@ func TestStoreKeyringBackendRoundTrip(t *testing.T) {
 	}
 	if _, ok, _ := s.Load(ProviderKey("demo")); ok {
 		t.Fatal("token still present after delete")
+	}
+	// Delete must also drop the now-unused entry, not just remove it from the
+	// index, or a stale keyring item accumulates for every logout.
+	if _, ok := kr.data[keyringService+"/"+ProviderKey("demo")]; ok {
+		t.Fatal("deleted token's keyring entry was not removed")
+	}
+}
+
+// TestStoreKeyringManyProvidersStayUnderEntryLimit is the regression test for
+// the bug this backend originally shipped with: every provider's tokens were
+// combined into one keyring entry, and on macOS that entry is written through
+// `security -i`, whose command parser caps a single write around 4KB. Three or
+// more logged-in providers routinely exceeded it, so Set() would start failing
+// for every provider, not just the one pushing it over. Splitting into one
+// entry per key bounds each individual write to a single token regardless of
+// how many providers are logged in.
+func TestStoreKeyringManyProvidersStayUnderEntryLimit(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A realistically large single token: JWT-shaped access/ID tokens plus an
+	// opaque refresh token, comparable to what OIDC providers actually issue.
+	big := Token{
+		AccessToken:  "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("QUJDRA", 60) + ".sig",
+		RefreshToken: "rt_" + strings.Repeat("x", 80),
+		TokenType:    "Bearer",
+		Scopes:       []string{"openid", "profile", "email", "offline_access"},
+		Account:      "user@example.com",
+		IDToken:      "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("QUJDRA", 70) + ".sig",
+	}
+	providers := []string{"anthropic", "openai", "minimax", "zai", "google"}
+	for _, name := range providers {
+		if err := s.Save(ProviderKey(name), big); err != nil {
+			t.Fatalf("Save(%s): %v", name, err)
+		}
+	}
+	// Each individual keyring value must stay small even with 5 providers
+	// logged in: no entry aggregates more than one provider's tokens.
+	const singleTokenCeiling = 3000 // generous margin under the ~4095-byte line cap
+	for k, v := range kr.data {
+		if len(v) > singleTokenCeiling {
+			t.Fatalf("keyring entry %q is %d bytes, want < %d (aggregation regression)", k, len(v), singleTokenCeiling)
+		}
+	}
+	for _, name := range providers {
+		got, ok, err := s.Load(ProviderKey(name))
+		if err != nil || !ok {
+			t.Fatalf("Load(%s): ok=%v err=%v", name, ok, err)
+		}
+		if got.AccessToken != big.AccessToken {
+			t.Fatalf("Load(%s) = %#v", name, got)
+		}
+	}
+}
+
+// TestStoreKeyringMigratesLegacyCombinedEntry ensures installs upgrading from
+// the original single-blob format keep reading their existing tokens, and get
+// migrated to per-key entries (with the legacy entry removed) the next time
+// anything is saved.
+func TestStoreKeyringMigratesLegacyCombinedEntry(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("demo"): {AccessToken: "legacy-a", RefreshToken: "legacy-r"},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.Load(ProviderKey("demo"))
+	if err != nil || !ok {
+		t.Fatalf("Load legacy token: ok=%v err=%v", ok, err)
+	}
+	if got.AccessToken != "legacy-a" {
+		t.Fatalf("Load = %#v", got)
+	}
+
+	// Saving a second provider must migrate: the legacy entry is dropped, and
+	// both tokens end up as their own entries.
+	if err := s.Save(ProviderKey("other"), Token{AccessToken: "other-a"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
+		t.Fatal("legacy combined entry should be removed after migration")
+	}
+	for _, name := range []string{"demo", "other"} {
+		if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
+			t.Fatalf("Load(%s) after migration: ok=%v err=%v", name, ok, err)
+		}
 	}
 }
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -567,9 +567,13 @@ func TestStoreFileLoadToleratesCrashedWriterLock(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("Load waited on the write lock (%v); reads must be lock-free", elapsed)
 	}
+	statusStart := time.Now()
 	statuses, err := s.Status("")
 	if err != nil || len(statuses) != 1 {
 		t.Fatalf("Status behind a crashed writer's lock: %v (%d entries)", err, len(statuses))
+	}
+	if elapsed := time.Since(statusStart); elapsed > 2*time.Second {
+		t.Fatalf("Status waited on the write lock (%v); reads must be lock-free", elapsed)
 	}
 }
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -807,35 +807,6 @@ func TestStoreKeyringExplicitSaveWinsOverStaleLookingLegacy(t *testing.T) {
 	}
 }
 
-// TestAcquireFileLockDeadlineUsesWallClockNotInjectedClock guards the other
-// half of the same hazard as the lease test below: acquireFileLock's own
-// acquisition deadline must be measured against the real wall clock, not the
-// injectable now parameter. StoreOptions.Now may legitimately be a fixed
-// clock (as this test uses), and deadline := now().Add(fileLockTimeout)
-// followed by now().After(deadline) would then never become true, so a
-// contested lock would retry forever instead of returning a timeout error.
-func TestAcquireFileLockDeadlineUsesWallClockNotInjectedClock(t *testing.T) {
-	lockPath := filepath.Join(t.TempDir(), "test.lockfile")
-	// A fresh (non-stale) lock held by someone else. With wait-while-healthy,
-	// that extends the idle deadline, so cap the absolute wait for the test.
-	if err := os.WriteFile(lockPath, []byte("someone-else"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	prevMax := fileLockMaxWait
-	fileLockMaxWait = 200 * time.Millisecond
-	defer func() { fileLockMaxWait = prevMax }()
-
-	fixed := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	start := time.Now()
-	_, err := acquireFileLock(lockPath, func() time.Time { return fixed })
-	if err == nil {
-		t.Fatal("expected a timeout error acquiring an already-held, non-stale lock")
-	}
-	if elapsed := time.Since(start); elapsed > 2*time.Second {
-		t.Fatalf("acquireFileLock took %v with a fixed clock; the deadline must use the wall clock, not now()", elapsed)
-	}
-}
-
 // TestAcquireFileLockWaitsWhileLeaseHealthy covers [P2] Let lock acquisition
 // cover a healthy keyring operation: a holder that keeps the lease fresh for
 // longer than the idle timeout must not cause contenders to fail; they wait
@@ -843,12 +814,9 @@ func TestAcquireFileLockDeadlineUsesWallClockNotInjectedClock(t *testing.T) {
 func TestAcquireFileLockWaitsWhileLeaseHealthy(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "test.lockfile")
 	prevTimeout := fileLockTimeout
-	prevMax := fileLockMaxWait
 	fileLockTimeout = 80 * time.Millisecond
-	fileLockMaxWait = 3 * time.Second
 	defer func() {
 		fileLockTimeout = prevTimeout
-		fileLockMaxWait = prevMax
 	}()
 
 	unlock, err := acquireFileLock(lockPath, time.Now)
@@ -2235,5 +2203,99 @@ func TestStoreKeyringLeaseRefreshesWhileWaitingOnSecondLock(t *testing.T) {
 	holdLegacy()
 	if err := <-done; err != nil {
 		t.Fatalf("withLeasedLocks after legacy release: %v", err)
+	}
+}
+
+func TestStoreKeyringLegacyOnlyReadHonorsInterruptedDeleteTombstone(t *testing.T) {
+	kr := &failingKR{fakeKR: newFakeKR()}
+	legacy, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "revoked"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacy)
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kr.failAt = 2
+	if removed, err := s.Delete(ProviderKey("alpha")); err == nil || !removed {
+		t.Fatalf("Delete = removed %v, err %v; want removed with injected failure", removed, err)
+	}
+	kr.failAt = 0
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || ok {
+		t.Fatalf("Load after interrupted delete = ok %v, err %v; tombstone must hide legacy token", ok, err)
+	}
+}
+
+func TestStoreKeyringReloginKeepsTombstoneUntilReplacementCommits(t *testing.T) {
+	kr := &failingKR{fakeKR: newFakeKR()}
+	legacy, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "revoked"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacy)
+	b := keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+	if err := b.writeTombstones(map[string]bool{ProviderKey("alpha"): true}); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kr.ops = 0
+	kr.failAt = 2
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "replacement"}); err == nil {
+		t.Fatal("Save succeeded despite injected index failure")
+	}
+	kr.failAt = 0
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || ok {
+		t.Fatalf("Load after interrupted re-login = ok %v, err %v; revoked legacy token was restored", ok, err)
+	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "replacement"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok, err := s.Load(ProviderKey("alpha")); err != nil || !ok || got.AccessToken != "replacement" {
+		t.Fatalf("Load committed replacement = %#v, ok %v, err %v", got, ok, err)
+	}
+}
+
+func TestStoreKeyringTombstonesOutgrowLiveCredentialCap(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+	tombstones := make(map[string]bool, maxKeyringIndexKeys+1)
+	for i := 0; i <= maxKeyringIndexKeys; i++ {
+		tombstones[ProviderKey(fmt.Sprintf("retired-%03d", i))] = true
+	}
+	if err := b.writeTombstones(tombstones); err != nil {
+		t.Fatalf("write %d tombstones: %v", len(tombstones), err)
+	}
+	got, err := b.readTombstones()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(tombstones) {
+		t.Fatalf("read %d tombstones, want %d", len(got), len(tombstones))
+	}
+}
+
+func TestKeyringLockPathUserLookupFallbackIgnoresAmbientHome(t *testing.T) {
+	previous := currentOSUser
+	currentOSUser = func() (*user.User, error) { return nil, fmt.Errorf("lookup unavailable") }
+	defer func() { currentOSUser = previous }()
+
+	gotA := keyringLockPath(map[string]string{"HOME": t.TempDir()}, keyringService, keyringIndexAccount)
+	gotB := keyringLockPath(map[string]string{"HOME": t.TempDir()}, keyringService, keyringIndexAccount)
+	if gotA != gotB {
+		t.Fatalf("same-user fallback changed with HOME: %q vs %q", gotA, gotB)
+	}
+	want := filepath.Join(keyringFallbackLockDir(), keyringTempLockName(keyringService, keyringIndexAccount))
+	if gotA != want {
+		t.Fatalf("fallback lock = %q, want UID-scoped temporary %q", gotA, want)
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -65,8 +65,10 @@ func TestStoreKeyringBackendRoundTrip(t *testing.T) {
 	if strings.Contains(raw, "access_token") {
 		t.Fatalf("keyring entry is not encoded: %s", raw)
 	}
-	if raw := kr.data[keyringService+"/"+keyringLegacyAccount]; raw != "" {
-		t.Fatalf("legacy combined entry should not be written by new code: %s", raw)
+	// New code dual-writes the reconciled map to the legacy account so pre-PR
+	// binaries (including those on other config roots) keep a current view.
+	if raw := kr.data[keyringService+"/"+keyringLegacyAccount]; raw == "" {
+		t.Fatal("legacy combined entry should be dual-written by new code")
 	}
 
 	removed, err := s.Delete(ProviderKey("demo"))
@@ -114,10 +116,17 @@ func TestStoreKeyringManyProvidersStayUnderEntryLimit(t *testing.T) {
 			t.Fatalf("Save(%s): %v", name, err)
 		}
 	}
-	// Each individual keyring value must stay small even with 5 providers
-	// logged in: no entry aggregates more than one provider's tokens.
+	// Each per-key token entry must stay small even with 5 providers logged
+	// in. The dual-written legacy combined entry is size-capped separately at
+	// maxKeyringSingleEntryBytes (and may be skipped/patched when oversize).
 	const singleTokenCeiling = 3000 // generous margin under the ~4095-byte line cap
 	for k, v := range kr.data {
+		if strings.HasSuffix(k, "/"+keyringLegacyAccount) {
+			if len(v) > maxKeyringSingleEntryBytes {
+				t.Fatalf("legacy dual-write %q is %d bytes, want <= %d", k, len(v), maxKeyringSingleEntryBytes)
+			}
+			continue
+		}
 		if len(v) > singleTokenCeiling {
 			t.Fatalf("keyring entry %q is %d bytes, want < %d (aggregation regression)", k, len(v), singleTokenCeiling)
 		}
@@ -161,17 +170,21 @@ func TestStoreKeyringMigratesLegacyCombinedEntry(t *testing.T) {
 		t.Fatalf("Load = %#v", got)
 	}
 
-	// Saving a second provider must migrate: the legacy entry is dropped, and
-	// both tokens end up as their own entries.
+	// Saving a second provider must migrate into per-key entries and dual-write
+	// the full map back to the legacy account (never delete it: other config
+	// roots cannot share the compatibility lock).
 	if err := s.Save(ProviderKey("other"), Token{AccessToken: "other-a"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
-		t.Fatal("legacy combined entry should be removed after migration")
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
+		t.Fatal("legacy combined entry should remain dual-written after migration")
 	}
 	for _, name := range []string{"demo", "other"} {
 		if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
 			t.Fatalf("Load(%s) after migration: ok=%v err=%v", name, ok, err)
+		}
+		if _, ok := kr.data[keyringService+"/"+ProviderKey(name)]; !ok {
+			t.Fatalf("per-key entry for %s missing after migration", name)
 		}
 	}
 }
@@ -361,12 +374,12 @@ func TestStoreKeyringIndexStaysUnderEntryLimit(t *testing.T) {
 			t.Fatalf("Save(%s): %v", name, err)
 		}
 	}
-	// Every keyring value, index entries included, must stay under the cap
-	// with generous framing margin.
+	// Every keyring value (index chunks, per-key tokens, dual-written legacy)
+	// must stay under the single-entry cap with generous framing margin.
 	const entryCeiling = 3800
 	for k, v := range kr.data {
 		if len(v) > entryCeiling {
-			t.Fatalf("keyring entry %q is %d bytes, want <= %d (index cap regression)", k, len(v), entryCeiling)
+			t.Fatalf("keyring entry %q is %d bytes, want <= %d (index/legacy cap regression)", k, len(v), entryCeiling)
 		}
 	}
 	// The index actually chunked (otherwise the ceiling check proves nothing).
@@ -449,7 +462,7 @@ func TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 			}
 		}
 		// Every mutating boundary of the write path now surfaces its failure,
-		// including the legacy-entry delete (a swallowed failure there could
+		// including the legacy dual-write (a swallowed failure there could
 		// let a later save resurrect logged-out credentials).
 		if opsUsed >= failAt && saveErr == nil {
 			t.Fatalf("failAt=%d: injected keyring failure was swallowed", failAt)
@@ -559,8 +572,8 @@ func TestStoreKeyringMergesFreshLegacyWriteFromOldBinary(t *testing.T) {
 	if got, _, err := s.Load(ProviderKey("carol")); err != nil || got.AccessToken != "c" || got.RefreshToken != "cr" {
 		t.Fatalf("Load(carol) = %#v, err=%v, want the legacy access/refresh tokens intact", got, err)
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
-		t.Fatal("legacy entry should be removed once its fresh writes are merged")
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
+		t.Fatal("legacy entry should remain dual-written after merge")
 	}
 }
 
@@ -733,9 +746,9 @@ func TestStoreKeyringMigrationInterruptionsPreserveLegacyTokens(t *testing.T) {
 		if got, ok, err := s.Load(ProviderKey("new")); err != nil || !ok || got.AccessToken != "new-c" {
 			t.Fatalf("failAt=%d: Load(new): ok=%v err=%v token=%#v", failAt, ok, err, got)
 		}
-		// The completed migration drops the legacy entry.
-		if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
-			t.Fatalf("failAt=%d: legacy entry not removed after migration completed", failAt)
+		// Completed migration dual-writes the full map to the legacy entry.
+		if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
+			t.Fatalf("failAt=%d: legacy entry missing after migration completed (want dual-write)", failAt)
 		}
 		if opsUsed < failAt {
 			break
@@ -743,28 +756,28 @@ func TestStoreKeyringMigrationInterruptionsPreserveLegacyTokens(t *testing.T) {
 	}
 }
 
-// TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey covers the mixed-version
-// window for a key that already exists in the index: an old binary refreshes
-// provider:alpha in the legacy combined entry (a strictly later expiry). The
-// next new-binary save must keep that fresher refresh instead of overwriting it
-// with the stale indexed value and then deleting the legacy entry.
-func TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey(t *testing.T) {
+// TestStoreKeyringExplicitSaveWinsOverStaleLookingLegacy is the regression for
+// [P1] Do not use token contents or expiry as cross-version write order: a
+// longer legacy expiry (or different token material) must not replace an
+// explicit new-binary Save of the same key. Expiry is not causal order.
+func TestStoreKeyringExplicitSaveWinsOverStaleLookingLegacy(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	kr := newFakeKR()
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
 	if err != nil {
 		t.Fatal(err)
 	}
-	stale := time.Now().Add(1 * time.Hour)
-	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a-old", RefreshToken: "r-old", ExpiresAt: stale}); err != nil {
+	// Explicit new login as account B with a short lifetime.
+	explicit := time.Now().Add(1 * time.Hour)
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "account-b", RefreshToken: "rb", ExpiresAt: explicit, Account: "b@example.com"}); err != nil {
 		t.Fatal(err)
 	}
 
-	// An old binary refreshes alpha through the legacy combined entry, pushing
-	// the expiry later than the indexed copy.
-	fresh := stale.Add(1 * time.Hour)
+	// A leftover legacy copy for the same key looks "fresher" by expiry and
+	// carries a different account — content-based ordering would wrongly win.
+	legacyLater := explicit.Add(24 * time.Hour)
 	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
-		ProviderKey("alpha"): {AccessToken: "a-new", RefreshToken: "r-new", ExpiresAt: fresh},
+		ProviderKey("alpha"): {AccessToken: "account-a", RefreshToken: "ra", ExpiresAt: legacyLater, Account: "a@example.com"},
 	}}
 	legacyData, err := json.Marshal(legacy)
 	if err != nil {
@@ -772,7 +785,7 @@ func TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey(t *testing.T) {
 	}
 	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyData)
 
-	// A new-binary save of an unrelated key must reconcile alpha, not clobber it.
+	// Unrelated save must not let legacy clobber the explicit alpha token.
 	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
 		t.Fatal(err)
 	}
@@ -780,14 +793,11 @@ func TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("Load(alpha): ok=%v err=%v", ok, err)
 	}
-	if got.AccessToken != "a-new" || got.RefreshToken != "r-new" || !got.ExpiresAt.Equal(fresh) {
-		t.Fatalf("Load(alpha) = %#v, want the refreshed legacy value (tokens and expiry) with ExpiresAt=%v", got, fresh)
+	if got.AccessToken != "account-b" || got.Account != "b@example.com" {
+		t.Fatalf("Load(alpha) = %#v, want the explicit Save (account-b), not the longer-expiry legacy account-a", got)
 	}
 	if _, ok, _ := s.Load(ProviderKey("beta")); !ok {
 		t.Fatal("Load(beta): not stored")
-	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
-		t.Fatal("legacy entry should be removed once its refresh is merged")
 	}
 }
 
@@ -800,19 +810,84 @@ func TestStoreKeyringMergesFreshLegacyRefreshOfIndexedKey(t *testing.T) {
 // contested lock would retry forever instead of returning a timeout error.
 func TestAcquireFileLockDeadlineUsesWallClockNotInjectedClock(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "test.lockfile")
-	// A fresh (non-stale) lock held by someone else: acquireFileLock must not
-	// reclaim it, only wait out fileLockTimeout and report a timeout.
+	// A fresh (non-stale) lock held by someone else. With wait-while-healthy,
+	// that extends the idle deadline, so cap the absolute wait for the test.
 	if err := os.WriteFile(lockPath, []byte("someone-else"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	prevMax := fileLockMaxWait
+	fileLockMaxWait = 200 * time.Millisecond
+	defer func() { fileLockMaxWait = prevMax }()
+
 	fixed := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	start := time.Now()
 	_, err := acquireFileLock(lockPath, func() time.Time { return fixed })
 	if err == nil {
 		t.Fatal("expected a timeout error acquiring an already-held, non-stale lock")
 	}
-	if elapsed := time.Since(start); elapsed > 10*time.Second {
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("acquireFileLock took %v with a fixed clock; the deadline must use the wall clock, not now()", elapsed)
+	}
+}
+
+// TestAcquireFileLockWaitsWhileLeaseHealthy covers [P2] Let lock acquisition
+// cover a healthy keyring operation: a holder that keeps the lease fresh for
+// longer than the idle timeout must not cause contenders to fail; they wait
+// and acquire once the holder releases.
+func TestAcquireFileLockWaitsWhileLeaseHealthy(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "test.lockfile")
+	prevTimeout := fileLockTimeout
+	prevMax := fileLockMaxWait
+	fileLockTimeout = 80 * time.Millisecond
+	fileLockMaxWait = 3 * time.Second
+	defer func() {
+		fileLockTimeout = prevTimeout
+		fileLockMaxWait = prevMax
+	}()
+
+	unlock, err := acquireFileLock(lockPath, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Refresh the held lock past several idle-timeout intervals.
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(30 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				at := time.Now()
+				_ = os.Chtimes(lockPath, at, at)
+			}
+		}
+	}()
+
+	acquired := make(chan error, 1)
+	go func() {
+		u, err := acquireFileLock(lockPath, time.Now)
+		if err == nil {
+			u()
+		}
+		acquired <- err
+	}()
+
+	// Contender must still be waiting after > one idle timeout.
+	select {
+	case err := <-acquired:
+		close(stop)
+		unlock()
+		t.Fatalf("contender finished too early (err=%v); must wait while lease is healthy", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	close(stop)
+	unlock()
+	if err := <-acquired; err != nil {
+		t.Fatalf("contender failed after holder released: %v", err)
 	}
 }
 
@@ -1050,7 +1125,7 @@ func TestKeyringLockPathIndependentOfCacheAndTempRoots(t *testing.T) {
 //
 // This simulates a live old binary by holding the exact lock file
 // legacyKeyringLockPath computes (the same one a pre-PR binary's Save takes)
-// and asserting that Store.Save — which must reconcile and then drop the
+// and asserting that Store.Save — which must reconcile and dual-write the
 // legacy entry here, since one is seeded below — blocks until that lock is
 // released, and that the seeded legacy token survives the reconciliation.
 func TestStoreKeyringWriteWaitsForLegacyLockDuringReconciliation(t *testing.T) {
@@ -1142,28 +1217,28 @@ func TestKeyringLockPathDerivedFromKeyringIdentityNotFileConfig(t *testing.T) {
 	}
 }
 
-// legacyDeleteFailKR fails Delete for the legacy combined entry only, to
-// exercise the boundary where a logout has already rewritten the indexed
-// state but the stale legacy blob cannot be removed.
-type legacyDeleteFailKR struct {
+// legacyDualWriteFailKR fails Set for the legacy combined entry only, to
+// exercise the boundary where a logout has rewritten the indexed state but
+// the dual-write that clears the credential from the legacy blob cannot land.
+type legacyDualWriteFailKR struct {
 	*fakeKR
 	fail bool
 }
 
-func (f *legacyDeleteFailKR) Delete(service, account string) (bool, error) {
+func (f *legacyDualWriteFailKR) Set(service, account, secret string) error {
 	if f.fail && account == keyringLegacyAccount {
-		return false, errKRInjected
+		return errKRInjected
 	}
-	return f.fakeKR.Delete(service, account)
+	return f.fakeKR.Set(service, account, secret)
 }
 
-// TestStoreKeyringLogoutSurfacesLegacyBlobDeleteFailure: when the final
-// legacy-blob delete fails during a logout, the operation must report the
-// failure (not success with the secret still resident), and after a clean
-// retry the logged-out credential must not be resurrected by a later save.
-func TestStoreKeyringLogoutSurfacesLegacyBlobDeleteFailure(t *testing.T) {
+// TestStoreKeyringLogoutSurfacesLegacyDualWriteFailure: when the legacy
+// dual-write fails during a logout, the operation must report the failure
+// (not success while the secret may still be resident in the legacy blob),
+// and after a clean retry the logged-out credential must not be resurrected.
+func TestStoreKeyringLogoutSurfacesLegacyDualWriteFailure(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	kr := &legacyDeleteFailKR{fakeKR: newFakeKR()}
+	kr := &legacyDualWriteFailKR{fakeKR: newFakeKR()}
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
 	if err != nil {
 		t.Fatal(err)
@@ -1184,7 +1259,7 @@ func TestStoreKeyringLogoutSurfacesLegacyBlobDeleteFailure(t *testing.T) {
 
 	kr.fail = true
 	if _, err := s.Delete(ProviderKey("alpha")); err == nil {
-		t.Fatal("Delete reported success although the stale legacy blob could not be removed")
+		t.Fatal("Delete reported success although the legacy dual-write failed")
 	}
 
 	// A clean retry succeeds, and a later save must not classify the stale
@@ -1251,7 +1326,9 @@ func TestStoreKeyringReadIndexDedupesDuplicateKeys(t *testing.T) {
 	blob := keyringBlob{kr: ckr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
 
 	dup := ProviderKey("demo")
-	many := make([]string, 2000)
+	// Stay under maxKeyringIndexEncodedBytes so the byte-bound check does not
+	// fire first; this test is about dedupe after a valid-sized decode.
+	many := make([]string, 80)
 	for i := range many {
 		many[i] = dup
 	}
@@ -1259,7 +1336,11 @@ func TestStoreKeyringReadIndexDedupesDuplicateKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+	encoded := base64.StdEncoding.EncodeToString(header)
+	if len(encoded) > maxKeyringIndexEncodedBytes {
+		t.Fatalf("test payload is %d bytes encoded; keep it under %d so the byte bound is not the thing under test", len(encoded), maxKeyringIndexEncodedBytes)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = encoded
 
 	keys, ok, _, err := blob.readKeyIndex()
 	if err != nil {
@@ -1269,7 +1350,7 @@ func TestStoreKeyringReadIndexDedupesDuplicateKeys(t *testing.T) {
 		t.Fatal("readKeyIndex: expected an index to be found")
 	}
 	if len(keys) != 1 {
-		t.Fatalf("readKeyIndex returned %d keys for a 2000-duplicate index, want 1 (deduplicated)", len(keys))
+		t.Fatalf("readKeyIndex returned %d keys for an 80-duplicate index, want 1 (deduplicated)", len(keys))
 	}
 
 	// A malformed (non-ValidateKey-shaped) entry must also be dropped rather
@@ -1312,7 +1393,7 @@ func TestStoreKeyringDuplicateIndexDoesNotFanOutPerEntry(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+dup] = base64.StdEncoding.EncodeToString(raw)
 
-	many := make([]string, 3000)
+	many := make([]string, 80)
 	for i := range many {
 		many[i] = dup
 	}
@@ -1320,7 +1401,11 @@ func TestStoreKeyringDuplicateIndexDoesNotFanOutPerEntry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+	encoded := base64.StdEncoding.EncodeToString(header)
+	if len(encoded) > maxKeyringIndexEncodedBytes {
+		t.Fatalf("test payload is %d bytes encoded; keep it under %d so the byte bound is not the thing under test", len(encoded), maxKeyringIndexEncodedBytes)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = encoded
 
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: ckr})
 	if err != nil {
@@ -1333,13 +1418,13 @@ func TestStoreKeyringDuplicateIndexDoesNotFanOutPerEntry(t *testing.T) {
 		t.Fatalf("Status: %v", err)
 	}
 	if len(statuses) != 1 {
-		t.Fatalf("Status returned %d entries for a 3000-duplicate index of one key, want 1", len(statuses))
+		t.Fatalf("Status returned %d entries for an 80-duplicate index of one key, want 1", len(statuses))
 	}
 	// One Get for the index header, one Get for the single deduplicated key's
 	// own entry, and at most one extra Get for the legacy fallback lookup.
-	// The key regression is: not 3000 (one per duplicate entry).
+	// The key regression is: not one Get per duplicate entry.
 	if ckr.gets > 3 {
-		t.Fatalf("Status issued %d keyring gets for a 3000-entry duplicate index, want <= 3 (fan-out DoS regression)", ckr.gets)
+		t.Fatalf("Status issued %d keyring gets for an 80-entry duplicate index, want <= 3 (fan-out DoS regression)", ckr.gets)
 	}
 }
 
@@ -1358,14 +1443,14 @@ func (f *legacyGetFailKR) Get(service, account string) (string, bool, error) {
 	return f.fakeKR.Get(service, account)
 }
 
-// TestStoreKeyringWriteRefusesToDeleteLegacyBlobOnTransientReadError is the
+// TestStoreKeyringWriteRefusesToOverwriteLegacyBlobOnTransientReadError is the
 // regression test for finding #2: during mixed-version reconciliation (an old
 // zero binary's legacy blob alongside the new keyring-based index), a
 // transient error reading the legacy blob must not be treated as "the legacy
-// blob is empty." write() must refuse to reconcile-and-delete it in that case,
-// or an unread credential belonging to an older, still-installed zero binary
-// is destroyed irrecoverably.
-func TestStoreKeyringWriteRefusesToDeleteLegacyBlobOnTransientReadError(t *testing.T) {
+// blob is empty." write() must refuse to dual-write over it in that case, or
+// an unread credential belonging to an older, still-installed zero binary is
+// destroyed irrecoverably.
+func TestStoreKeyringWriteRefusesToOverwriteLegacyBlobOnTransientReadError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	kr := &legacyGetFailKR{fakeKR: newFakeKR()}
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
@@ -1396,10 +1481,12 @@ func TestStoreKeyringWriteRefusesToDeleteLegacyBlobOnTransientReadError(t *testi
 	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err == nil {
 		t.Fatal("Save succeeded despite a transient legacy-blob read failure; it must refuse rather than silently treat the blob as empty")
 	}
-	// The legacy blob must still be present, not deleted out from under a
-	// read failure.
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
-		t.Fatal("legacy blob was deleted despite a transient read failure (data loss)")
+	// The legacy blob must still be present with the old credential, not
+	// dual-written over under a read failure.
+	if raw, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
+		t.Fatal("legacy blob was removed despite a transient read failure (data loss)")
+	} else if !strings.Contains(string(mustDecode(t, raw)), "still-live") {
+		t.Fatal("legacy blob was overwritten despite a transient read failure (data loss)")
 	}
 	// Nothing else the aborted write touched should be visible either.
 	if _, ok, _ := s.Load(ProviderKey("beta")); ok {
@@ -1410,7 +1497,7 @@ func TestStoreKeyringWriteRefusesToDeleteLegacyBlobOnTransientReadError(t *testi
 	}
 
 	// Once the transient failure clears, the legacy credential is recovered
-	// and the blob is cleaned up normally.
+	// and dual-written back with the full reconciled map.
 	kr.fail = false
 	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
 		t.Fatalf("retried Save: %v", err)
@@ -1418,9 +1505,18 @@ func TestStoreKeyringWriteRefusesToDeleteLegacyBlobOnTransientReadError(t *testi
 	if _, ok, err := s.Load(ProviderKey("stale-binary-login")); err != nil || !ok {
 		t.Fatalf("Load(stale-binary-login): ok=%v err=%v (legacy credential lost)", ok, err)
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
-		t.Fatal("legacy blob should be removed once it was actually read and reconciled")
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
+		t.Fatal("legacy blob should remain dual-written once it was actually read and reconciled")
 	}
+}
+
+func mustDecode(t *testing.T, enc string) []byte {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
 }
 
 func TestStoreKeyringLockPathStableAcrossDifferentHomeEnvs(t *testing.T) {
@@ -1449,7 +1545,11 @@ func TestStoreKeyringLockPathStableAcrossDifferentHomeEnvs(t *testing.T) {
 	}
 }
 
-func TestStoreKeyringMergesFreshLegacyRefreshOnLoadWithoutSave(t *testing.T) {
+// TestStoreKeyringLoadPrefersIndexedOverLegacyLookingFresher: when both the
+// per-key entry and the legacy blob hold the same key, the indexed copy wins
+// even if legacy has a later expiry or different material. Content is not
+// causal order (see explicit-Save regression above).
+func TestStoreKeyringLoadPrefersIndexedOverLegacyLookingFresher(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	kr := newFakeKR()
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
@@ -1457,13 +1557,13 @@ func TestStoreKeyringMergesFreshLegacyRefreshOnLoadWithoutSave(t *testing.T) {
 		t.Fatal(err)
 	}
 	t1 := time.Now().Add(-10 * time.Minute)
-	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "stale-a", ExpiresAt: t1}); err != nil {
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "indexed-a", ExpiresAt: t1}); err != nil {
 		t.Fatal(err)
 	}
 
 	t2 := time.Now().Add(1 * time.Hour)
 	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
-		ProviderKey("alpha"): {AccessToken: "fresh-a", RefreshToken: "fresh-r", ExpiresAt: t2},
+		ProviderKey("alpha"): {AccessToken: "legacy-a", RefreshToken: "legacy-r", ExpiresAt: t2},
 	}}
 	data, err := json.Marshal(legacy)
 	if err != nil {
@@ -1475,12 +1575,15 @@ func TestStoreKeyringMergesFreshLegacyRefreshOnLoadWithoutSave(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("Load: ok=%v err=%v", ok, err)
 	}
-	if got.AccessToken != "fresh-a" {
-		t.Fatalf("Load returned stale token %#v, want fresh legacy token", got)
+	if got.AccessToken != "indexed-a" {
+		t.Fatalf("Load returned %#v, want indexed token (not later-expiry legacy)", got)
 	}
 }
 
-func TestStoreKeyringLegacyIsFresherHandlesZeroExpiryRefreshes(t *testing.T) {
+// TestStoreKeyringLoadDoesNotPreferZeroExpiryLegacyMaterial: OAuth may omit
+// expires_in; different token material alone must not make legacy win over an
+// indexed entry for the same key.
+func TestStoreKeyringLoadDoesNotPreferZeroExpiryLegacyMaterial(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	kr := newFakeKR()
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
@@ -1488,12 +1591,12 @@ func TestStoreKeyringLegacyIsFresherHandlesZeroExpiryRefreshes(t *testing.T) {
 		t.Fatal(err)
 	}
 	t1 := time.Now().Add(10 * time.Minute)
-	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "old-a", RefreshToken: "old-r", ExpiresAt: t1}); err != nil {
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "indexed-a", RefreshToken: "indexed-r", ExpiresAt: t1}); err != nil {
 		t.Fatal(err)
 	}
 
 	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
-		ProviderKey("alpha"): {AccessToken: "new-a", RefreshToken: "new-r", ExpiresAt: time.Time{}},
+		ProviderKey("alpha"): {AccessToken: "legacy-a", RefreshToken: "legacy-r", ExpiresAt: time.Time{}},
 	}}
 	data, err := json.Marshal(legacy)
 	if err != nil {
@@ -1505,8 +1608,8 @@ func TestStoreKeyringLegacyIsFresherHandlesZeroExpiryRefreshes(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("Load: ok=%v err=%v", ok, err)
 	}
-	if got.AccessToken != "new-a" || got.RefreshToken != "new-r" {
-		t.Fatalf("Load = %#v, want legacy zero-expiry refresh", got)
+	if got.AccessToken != "indexed-a" || got.RefreshToken != "indexed-r" {
+		t.Fatalf("Load = %#v, want indexed token (not zero-expiry legacy material)", got)
 	}
 }
 
@@ -1601,10 +1704,10 @@ func TestStoreKeyringDeleteDoesNotResurrectLegacyOnlyKey(t *testing.T) {
 	}
 }
 
-// TestStoreKeyringWriteMergesZeroExpiryLegacyRefresh ensures write-path
-// reconciliation does not discard a valid old-binary refresh that omitted
-// expires_in (zero ExpiresAt) when the indexed copy still has a nonzero expiry.
-func TestStoreKeyringWriteMergesZeroExpiryLegacyRefresh(t *testing.T) {
+// TestStoreKeyringWriteDoesNotMergeLegacyOverIndexedKey: write-path
+// reconciliation must not replace an indexed key with legacy material based
+// on expiry or token strings (not causal). Only legacy-only keys are merged.
+func TestStoreKeyringWriteDoesNotMergeLegacyOverIndexedKey(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	kr := newFakeKR()
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
@@ -1612,12 +1715,12 @@ func TestStoreKeyringWriteMergesZeroExpiryLegacyRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 	t1 := time.Now().Add(10 * time.Minute)
-	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "old-a", RefreshToken: "old-r", ExpiresAt: t1}); err != nil {
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "indexed-a", RefreshToken: "indexed-r", ExpiresAt: t1}); err != nil {
 		t.Fatal(err)
 	}
 
 	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
-		ProviderKey("alpha"): {AccessToken: "new-a", RefreshToken: "new-r", ExpiresAt: time.Time{}},
+		ProviderKey("alpha"): {AccessToken: "legacy-a", RefreshToken: "legacy-r", ExpiresAt: time.Time{}},
 	}}
 	data, err := json.Marshal(legacy)
 	if err != nil {
@@ -1633,51 +1736,71 @@ func TestStoreKeyringWriteMergesZeroExpiryLegacyRefresh(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("Load(alpha): ok=%v err=%v", ok, err)
 	}
-	if got.AccessToken != "new-a" || got.RefreshToken != "new-r" {
-		t.Fatalf("write reconciliation dropped zero-expiry legacy refresh: got %#v", got)
+	if got.AccessToken != "indexed-a" || got.RefreshToken != "indexed-r" {
+		t.Fatalf("write reconciliation overwrote indexed alpha with legacy material: got %#v", got)
 	}
 }
 
-func TestLegacyIsFresher(t *testing.T) {
-	t1 := time.Now().Add(10 * time.Minute)
-	t2 := t1.Add(time.Hour)
-	cases := []struct {
-		name            string
-		legacy, current Token
-		want            bool
-	}{
-		{
-			name:    "later legacy expiry wins",
-			legacy:  Token{AccessToken: "a", ExpiresAt: t2},
-			current: Token{AccessToken: "a", ExpiresAt: t1},
-			want:    true,
-		},
-		{
-			name:    "later current expiry wins",
-			legacy:  Token{AccessToken: "old", ExpiresAt: t1},
-			current: Token{AccessToken: "new", ExpiresAt: t2},
-			want:    false,
-		},
-		{
-			name:    "zero-expiry legacy with new material wins",
-			legacy:  Token{AccessToken: "new-a", RefreshToken: "new-r"},
-			current: Token{AccessToken: "old-a", RefreshToken: "old-r", ExpiresAt: t1},
-			want:    true,
-		},
-		{
-			name:    "identical tokens are not fresher",
-			legacy:  Token{AccessToken: "a", RefreshToken: "r", ExpiresAt: t1},
-			current: Token{AccessToken: "a", RefreshToken: "r", ExpiresAt: t1},
-			want:    false,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := legacyIsFresher(tc.legacy, tc.current); got != tc.want {
-				t.Fatalf("legacyIsFresher = %v, want %v", got, tc.want)
-			}
-		})
-	}
+// TestStoreKeyringCompetingLoginOrders: explicit new-binary Save of account B
+// must survive a subsequent write even when legacy still holds account A's
+// longer-lived token for the same key (both write orders covered).
+func TestStoreKeyringCompetingLoginOrders(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	t.Run("explicit_then_legacy_noise", func(t *testing.T) {
+		kr := newFakeKR()
+		s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Save(ProviderKey("demo"), Token{AccessToken: "b-token", Account: "b", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+			t.Fatal(err)
+		}
+		// Old writer noise: longer expiry, different account, same key.
+		legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+			ProviderKey("demo"): {AccessToken: "a-token", Account: "a", ExpiresAt: time.Now().Add(24 * time.Hour)},
+		}}
+		data, err := json.Marshal(legacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+		if err := s.Save(ProviderKey("other"), Token{AccessToken: "o"}); err != nil {
+			t.Fatal(err)
+		}
+		got, _, err := s.Load(ProviderKey("demo"))
+		if err != nil || got.AccessToken != "b-token" || got.Account != "b" {
+			t.Fatalf("got %#v, want explicit b-token", got)
+		}
+	})
+
+	t.Run("legacy_only_then_explicit", func(t *testing.T) {
+		kr := newFakeKR()
+		s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Seed index with an unrelated key so write() takes the reconcile path.
+		if err := s.Save(ProviderKey("seed"), Token{AccessToken: "s"}); err != nil {
+			t.Fatal(err)
+		}
+		legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+			ProviderKey("demo"): {AccessToken: "a-token", Account: "a", ExpiresAt: time.Now().Add(24 * time.Hour)},
+		}}
+		data, err := json.Marshal(legacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+		// Explicit login as B for demo must become authoritative.
+		if err := s.Save(ProviderKey("demo"), Token{AccessToken: "b-token", Account: "b", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+			t.Fatal(err)
+		}
+		got, _, err := s.Load(ProviderKey("demo"))
+		if err != nil || got.AccessToken != "b-token" || got.Account != "b" {
+			t.Fatalf("got %#v, want explicit b-token after Save", got)
+		}
+	})
 }
 
 // TestLegacyKeyringLockPathHonorsConfiguredRoot ensures the pre-PR compatibility
@@ -1707,6 +1830,9 @@ func TestStoreKeyringRejectsOversizedSingleTokenPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
 
 	huge := Token{
 		AccessToken: "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("A", 6000) + ".sig",
@@ -1717,5 +1843,127 @@ func TestStoreKeyringRejectsOversizedSingleTokenPayload(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exceeds single keyring entry bound") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+	// Preflight must reject before publishing the index key, or the store can
+	// accumulate phantom keys until the reader cap bricks every later Save.
+	if indexedKeysOf(t, kr)[ProviderKey("huge")] {
+		t.Fatal("oversized Save published provider:huge into the index without an entry")
+	}
+	if _, ok := kr.data[keyringService+"/"+ProviderKey("huge")]; ok {
+		t.Fatal("oversized Save wrote a token entry")
+	}
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || !ok {
+		t.Fatalf("alpha lost after rejected Save: ok=%v err=%v", ok, err)
+	}
+}
+
+// TestStoreKeyringPrunesPhantomIndexKeysAfterInterruptedSet: a Set failure
+// after the union index was published can leave a key listed without an entry.
+// The next successful write must drop that phantom so capacity recovers.
+func TestStoreKeyringPrunesPhantomIndexKeysAfterInterruptedSet(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate an interrupted write: index lists beta, but beta has no entry.
+	header := keyIndexHeader{Version: 1, Chunks: 1, Keys: []string{ProviderKey("alpha"), ProviderKey("beta")}}
+	headerData, err := json.Marshal(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(headerData)
+
+	if err := s.Save(ProviderKey("gamma"), Token{AccessToken: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	indexed := indexedKeysOf(t, kr)
+	if indexed[ProviderKey("beta")] {
+		t.Fatal("phantom index key provider:beta was not pruned on the next write")
+	}
+	if !indexed[ProviderKey("alpha")] || !indexed[ProviderKey("gamma")] {
+		t.Fatalf("indexed keys = %v, want alpha and gamma", indexed)
+	}
+}
+
+// TestStoreKeyringDualWritePreservesCrossRootLegacyLogin: the compatibility
+// lock cannot span distinct config roots, so a new binary must never delete
+// the legacy combined entry. An old-style writer on root A can land a login
+// after root B reconciled; dual-write-without-delete keeps that login visible.
+func TestStoreKeyringDualWritePreservesCrossRootLegacyLogin(t *testing.T) {
+	rootA := filepath.Join(t.TempDir(), "cfg-a")
+	rootB := filepath.Join(t.TempDir(), "cfg-b")
+	kr := newFakeKR()
+
+	storeB, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"XDG_CONFIG_HOME": rootB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storeB.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	blobB := storeB.blob.(keyringBlob)
+	blobAPath := legacyKeyringLockPath(map[string]string{"XDG_CONFIG_HOME": rootA})
+	if blobB.legacyLockPath == blobAPath {
+		t.Fatal("expected distinct legacy lock paths for distinct config roots")
+	}
+
+	// Old binary on root A writes only the legacy combined entry (no index update).
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "a"},
+		ProviderKey("carol"): {AccessToken: "c", RefreshToken: "cr"},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	// New binary on root B saves again: must merge carol, not delete it away.
+	if err := storeB.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"alpha", "beta", "carol"} {
+		if _, ok, err := storeB.Load(ProviderKey(name)); err != nil || !ok {
+			t.Fatalf("Load(%s) after cross-root legacy login: ok=%v err=%v", name, ok, err)
+		}
+	}
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
+		t.Fatal("legacy entry was deleted; cross-root old writers can no longer be observed")
+	}
+}
+
+// TestStoreKeyringReadIndexRejectsOversizedEncodedPayload: bound the base64
+// payload before DecodeString/Unmarshal so a damaged index cannot force
+// unbounded memory/CPU under the store lock.
+func TestStoreKeyringReadIndexRejectsOversizedEncodedPayload(t *testing.T) {
+	ckr := &countingKR{fakeKR: newFakeKR()}
+	blob := keyringBlob{kr: ckr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+
+	huge := strings.Repeat("A", maxKeyringIndexEncodedBytes+1)
+	ckr.data[keyringService+"/"+keyringIndexAccount] = huge
+	ckr.gets = 0
+	if _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("expected oversized encoded index payload to be rejected")
+	}
+	if ckr.gets != 1 {
+		t.Fatalf("readKeyIndex issued %d gets; want header lookup only", ckr.gets)
+	}
+
+	// Continuation chunks must use the same bound.
+	header, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 2, Keys: []string{ProviderKey("seed")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+	ckr.data[keyringService+"/"+keyringIndexAccount+"-1"] = huge
+	ckr.gets = 0
+	if _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("expected oversized encoded chunk payload to be rejected")
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -133,15 +133,15 @@ func TestStoreKeyringManyProvidersStayUnderEntryLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A realistically large single token: JWT-shaped access/ID tokens plus an
-	// opaque refresh token, comparable to what OIDC providers actually issue.
+	// A realistically large single token: opaque bulk fixtures (not JWT-shaped,
+	// so secret scanners do not flag test data as generic-api-key / JWT leaks).
 	big := Token{
-		AccessToken:  "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("QUJDRA", 60) + ".sig",
-		RefreshToken: "rt_" + strings.Repeat("x", 80),
+		AccessToken:  "test-access-" + strings.Repeat("a", 360),
+		RefreshToken: "test-refresh-" + strings.Repeat("x", 80),
 		TokenType:    "Bearer",
 		Scopes:       []string{"openid", "profile", "email", "offline_access"},
 		Account:      "user@example.com",
-		IDToken:      "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("QUJDRA", 70) + ".sig",
+		IDToken:      "test-id-" + strings.Repeat("b", 420),
 	}
 	providers := []string{"anthropic", "openai", "minimax", "zai", "google"}
 	for _, name := range providers {
@@ -1294,7 +1294,7 @@ func TestStoreKeyringWriteIndexRejectsOverCapChunks(t *testing.T) {
 	for i := range keys {
 		keys[i] = fmt.Sprintf("%s-%d", long, i)
 	}
-	if _, err := b.writeKeyIndex(keys, 0); err == nil {
+	if _, err := b.writeKeyIndex(keys, 0, false); err == nil {
 		t.Fatal("writeKeyIndex published an index readKeyIndex would refuse")
 	}
 	if len(kr.data) != 0 {
@@ -1314,7 +1314,7 @@ func TestStoreKeyringWriteIndexRejectsOverCapKeys(t *testing.T) {
 		// would not catch this over-cap set.
 		keys[i] = fmt.Sprintf("p%d", i)
 	}
-	if _, err := b.writeKeyIndex(keys, 0); err == nil {
+	if _, err := b.writeKeyIndex(keys, 0, false); err == nil {
 		t.Fatal("writeKeyIndex published a key count readKeyIndex would refuse")
 	}
 	if len(kr.data) != 0 {
@@ -1839,7 +1839,7 @@ func TestStoreKeyringRejectsOversizedSingleTokenPayload(t *testing.T) {
 	}
 
 	huge := Token{
-		AccessToken: "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("A", 6000) + ".sig",
+		AccessToken: "test-access-oversized-" + strings.Repeat("A", 6000),
 	}
 	err = s.Save(ProviderKey("huge"), huge)
 	if err == nil {
@@ -2089,13 +2089,14 @@ func TestStoreKeyringNeverWritesPartialLegacySubset(t *testing.T) {
 
 	// Build a legacy map whose base64 encoding exceeds maxKeyringSingleEntryBytes
 	// (pre-PR Linux keyring storage has no corresponding single-secret limit).
+	// Opaque bulk fixtures avoid secret-scanner false positives on JWT shapes.
 	big := Token{
-		AccessToken:  "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("QUJDRA", 40) + ".sig",
-		RefreshToken: "rt_" + strings.Repeat("y", 60),
+		AccessToken:  "test-access-" + strings.Repeat("a", 240),
+		RefreshToken: "test-refresh-" + strings.Repeat("y", 60),
 		TokenType:    "Bearer",
 		Scopes:       []string{"openid", "profile", "email", "offline_access"},
 		Account:      "user@example.com",
-		IDToken:      "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("QUJDRA", 45) + ".sig",
+		IDToken:      "test-id-" + strings.Repeat("b", 270),
 	}
 	tokens := map[string]Token{}
 	for _, name := range []string{"anthropic", "openai", "minimax", "zai", "google", "cohere"} {
@@ -2506,9 +2507,8 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 		t.Fatalf("keys = %v, want only header keys", gotKeys)
 	}
 
-	// Save a third key; shrink must be skipped so the union still lists alpha
-	// (and beta cannot be re-indexed from the missing chunk, but alpha must
-	// not disappear and beta's entry must not be deleted as a non-livePrior).
+	// Save a third key; the union publish must keep advertising 2 chunks so a
+	// restored chunk-1 can still reconcile beta, and must not delete beta's entry.
 	state, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
 		ProviderKey("alpha"): {AccessToken: "tok-alpha"},
 		ProviderKey("gamma"): {AccessToken: "tok-gamma"},
@@ -2523,19 +2523,38 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	if _, ok := kr.data[keyringService+"/"+ProviderKey("beta")]; !ok {
 		t.Fatal("beta entry was deleted despite missing index chunk; orphan risk path")
 	}
-	// Index after write should still be a union (not a shrink that drops everything unknown).
-	afterKeys, _, _, afterIncomplete, err := blob.readKeyIndex()
+	afterKeys, _, afterChunks, afterIncomplete, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
-	// incomplete may clear if write rewrote a complete index; either way alpha+gamma
-	// must be listed, and we did not shrink away the prior union carelessly.
-	_ = afterIncomplete
+	if afterChunks != 2 {
+		t.Fatalf("post-write chunks = %d, want 2 (preserve missing-chunk advertisement)", afterChunks)
+	}
+	if !afterIncomplete {
+		t.Fatal("post-write index should still be incomplete until chunk-1 returns")
+	}
 	found := map[string]bool{}
 	for _, k := range afterKeys {
 		found[k] = true
 	}
 	if !found[ProviderKey("alpha")] || !found[ProviderKey("gamma")] {
 		t.Fatalf("post-write keys = %v, want alpha and gamma listed", afterKeys)
+	}
+	// Restoring the missing chunk must surface beta again (the point of preserving
+	// the advertisement instead of shrinking to a complete 1-chunk index).
+	kr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
+	restored, _, _, incomplete, err := blob.readKeyIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incomplete {
+		t.Fatal("expected complete index after restoring chunk-1")
+	}
+	restoredFound := map[string]bool{}
+	for _, k := range restored {
+		restoredFound[k] = true
+	}
+	if !restoredFound[ProviderKey("beta")] {
+		t.Fatalf("restored keys = %v, want beta recoverable from chunk-1", restored)
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -1553,6 +1553,153 @@ func TestStoreKeyringDeleteNotResurrectedWhenLegacyDeleteFailsOrRewritten(t *tes
 	}
 }
 
+// TestStoreKeyringDeleteDoesNotResurrectLegacyOnlyKey is the regression for
+// [P1] Do not resurrect a token the caller just logged out: when an old binary
+// adds beta only to the legacy blob after the index already contains alpha,
+// read exposes beta, Delete(beta) removes it from state, and write must not
+// reclassify that same legacy value as a fresh old-binary login.
+func TestStoreKeyringDeleteDoesNotResurrectLegacyOnlyKey(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Old binary login: beta only in the legacy combined entry, not the index.
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("beta"): {AccessToken: "b-legacy", RefreshToken: "br"},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	// Delete must see beta via the legacy merge, then keep it gone after write.
+	removed, err := s.Delete(ProviderKey("beta"))
+	if err != nil || !removed {
+		t.Fatalf("Delete(beta): removed=%v err=%v", removed, err)
+	}
+	if _, ok, _ := s.Load(ProviderKey("beta")); ok {
+		t.Fatal("beta resurrected after Delete of legacy-only key")
+	}
+	// A later Save of another key must also not resurrect beta (legacy blob
+	// should already be gone; if a stale copy were re-seeded, omit only covers
+	// the Delete write itself — ensure the logout fully cleared it).
+	if err := s.Save(ProviderKey("gamma"), Token{AccessToken: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.Load(ProviderKey("beta")); ok {
+		t.Fatal("beta resurrected after later Save")
+	}
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || !ok {
+		t.Fatalf("alpha lost: ok=%v err=%v", ok, err)
+	}
+}
+
+// TestStoreKeyringWriteMergesZeroExpiryLegacyRefresh ensures write-path
+// reconciliation does not discard a valid old-binary refresh that omitted
+// expires_in (zero ExpiresAt) when the indexed copy still has a nonzero expiry.
+func TestStoreKeyringWriteMergesZeroExpiryLegacyRefresh(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t1 := time.Now().Add(10 * time.Minute)
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "old-a", RefreshToken: "old-r", ExpiresAt: t1}); err != nil {
+		t.Fatal(err)
+	}
+
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "new-a", RefreshToken: "new-r", ExpiresAt: time.Time{}},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	// Save of a different key triggers write reconciliation of the legacy blob.
+	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.Load(ProviderKey("alpha"))
+	if err != nil || !ok {
+		t.Fatalf("Load(alpha): ok=%v err=%v", ok, err)
+	}
+	if got.AccessToken != "new-a" || got.RefreshToken != "new-r" {
+		t.Fatalf("write reconciliation dropped zero-expiry legacy refresh: got %#v", got)
+	}
+}
+
+func TestLegacyIsFresher(t *testing.T) {
+	t1 := time.Now().Add(10 * time.Minute)
+	t2 := t1.Add(time.Hour)
+	cases := []struct {
+		name            string
+		legacy, current Token
+		want            bool
+	}{
+		{
+			name:    "later legacy expiry wins",
+			legacy:  Token{AccessToken: "a", ExpiresAt: t2},
+			current: Token{AccessToken: "a", ExpiresAt: t1},
+			want:    true,
+		},
+		{
+			name:    "later current expiry wins",
+			legacy:  Token{AccessToken: "old", ExpiresAt: t1},
+			current: Token{AccessToken: "new", ExpiresAt: t2},
+			want:    false,
+		},
+		{
+			name:    "zero-expiry legacy with new material wins",
+			legacy:  Token{AccessToken: "new-a", RefreshToken: "new-r"},
+			current: Token{AccessToken: "old-a", RefreshToken: "old-r", ExpiresAt: t1},
+			want:    true,
+		},
+		{
+			name:    "identical tokens are not fresher",
+			legacy:  Token{AccessToken: "a", RefreshToken: "r", ExpiresAt: t1},
+			current: Token{AccessToken: "a", RefreshToken: "r", ExpiresAt: t1},
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := legacyIsFresher(tc.legacy, tc.current); got != tc.want {
+				t.Fatalf("legacyIsFresher = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLegacyKeyringLockPathHonorsConfiguredRoot ensures the pre-PR compatibility
+// lock is derived via ResolveStorePath (ZERO_OAUTH_TOKENS_PATH / XDG_CONFIG_HOME),
+// not a hard-coded home .config path.
+func TestLegacyKeyringLockPathHonorsConfiguredRoot(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "custom", "tokens.json")
+	env := map[string]string{"ZERO_OAUTH_TOKENS_PATH": override}
+	got := legacyKeyringLockPath(env)
+	want := filepath.Join(filepath.Dir(override), "oauth-keyring.lockfile")
+	if got != want {
+		t.Fatalf("legacyKeyringLockPath = %q, want %q (beside ResolveStorePath)", got, want)
+	}
+
+	xdg := filepath.Join(t.TempDir(), "xdg-config")
+	gotXDG := legacyKeyringLockPath(map[string]string{"XDG_CONFIG_HOME": xdg})
+	wantXDG := filepath.Join(xdg, "zero", "oauth-keyring.lockfile")
+	if gotXDG != wantXDG {
+		t.Fatalf("legacyKeyringLockPath(XDG) = %q, want %q", gotXDG, wantXDG)
+	}
+}
+
 func TestStoreKeyringRejectsOversizedSingleTokenPayload(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	kr := newFakeKR()

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -14,6 +14,37 @@ import (
 	"github.com/Gitlawb/zero/internal/lockutil"
 )
 
+// TestMain redirects keyring lock paths into a process-private temp home so
+// the suite never creates lock files under the real user home directory
+// (keyringLockPath deliberately ignores XDG_CONFIG_HOME / HOME env). Tests
+// that must observe real OS identity re-stub currentOSUser themselves.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "zero-oauth-test-home-*")
+	if err != nil {
+		panic(err)
+	}
+	currentOSUser = func() (*user.User, error) {
+		return &user.User{Uid: "0", HomeDir: dir}, nil
+	}
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// useTempLockHome points keyringLockPath at a per-test home directory and
+// restores the previous stub on cleanup. Prefer this when a test needs its
+// own lock root (e.g. concurrent lock-path stability checks).
+func useTempLockHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	previous := currentOSUser
+	currentOSUser = func() (*user.User, error) {
+		return &user.User{Uid: "0", HomeDir: home}, nil
+	}
+	t.Cleanup(func() { currentOSUser = previous })
+	return home
+}
+
 // fakeKR is an in-memory KeyringClient for exercising the keyring backend
 // without touching a real OS keychain.
 type fakeKR struct{ data map[string]string }
@@ -337,7 +368,7 @@ func (e errKR) Error() string { return string(e) }
 func indexedKeysOf(t *testing.T, kr *fakeKR) map[string]bool {
 	t.Helper()
 	blob := keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
-	keys, _, _, err := blob.readKeyIndex()
+	keys, _, _, _, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatalf("readKeyIndex: %v", err)
 	}
@@ -628,6 +659,10 @@ func TestStoreKeyringWithLockRefreshesLease(t *testing.T) {
 			return err
 		}
 		first = info.ModTime()
+		// The lease only needs the mtime to stay non-stale. Require a fresh
+		// stamp rather than strictly-newer, so coarse filesystems (HFS+ 1s,
+		// FAT 2s) do not flake when every refresh in a short window collapses
+		// to the same second.
 		time.Sleep(150 * time.Millisecond)
 		info, err = os.Stat(lockPath)
 		if err != nil {
@@ -639,8 +674,11 @@ func TestStoreKeyringWithLockRefreshesLease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("withLock: %v", err)
 	}
-	if !second.After(first) {
-		t.Fatalf("lock mtime was not refreshed during the critical section: %v then %v", first, second)
+	if second.Before(first) {
+		t.Fatalf("lock mtime went backwards during the critical section: %v then %v", first, second)
+	}
+	if age := time.Since(second); age > fileLockStaleAfter {
+		t.Fatalf("lock mtime is stale after lease refresh: age %v > %v", age, fileLockStaleAfter)
 	}
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Fatalf("lock file not released: %v", err)
@@ -819,7 +857,7 @@ func TestAcquireFileLockWaitsWhileLeaseHealthy(t *testing.T) {
 		fileLockTimeout = prevTimeout
 	}()
 
-	unlock, err := acquireFileLock(lockPath, time.Now)
+	unlock, _, err := acquireFileLock(lockPath, time.Now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -842,7 +880,7 @@ func TestAcquireFileLockWaitsWhileLeaseHealthy(t *testing.T) {
 
 	acquired := make(chan error, 1)
 	go func() {
-		u, err := acquireFileLock(lockPath, time.Now)
+		u, _, err := acquireFileLock(lockPath, time.Now)
 		if err == nil {
 			u()
 		}
@@ -925,7 +963,7 @@ func TestStoreKeyringReadIndexRejectsCorruptHeader(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(oversized)
 	ckr.gets = 0
-	if _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized chunk count to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -938,7 +976,7 @@ func TestStoreKeyringReadIndexRejectsCorruptHeader(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(unsupported)
 	ckr.gets = 0
-	if _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an unsupported index version to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -967,7 +1005,7 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
 	ckr.gets = 0
-	if _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized key list in a chunk-0 header to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -981,7 +1019,7 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(legacyArray)
 	ckr.gets = 0
-	if _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized legacy-format key array to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -1002,7 +1040,7 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(headerOK)
 	ckr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
 	ckr.gets = 0
-	if _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized key list accumulated across chunks to be rejected")
 	}
 	if ckr.gets != 2 {
@@ -1016,7 +1054,15 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 // and the last-resort temp name must be scoped by uid so different users
 // never collide on one lock file.
 func TestKeyringLockPathIsPerUser(t *testing.T) {
-	got := keyringLockPath(nil, keyringService, keyringIndexAccount)
+	// Observe real OS identity, not the TestMain isolation stub.
+	previous := currentOSUser
+	currentOSUser = user.Current
+	t.Cleanup(func() { currentOSUser = previous })
+
+	got, err := keyringLockPath(nil, keyringService, keyringIndexAccount)
+	if err != nil {
+		t.Fatal(err)
+	}
 	name := keyringLockFileName(keyringService, keyringIndexAccount)
 	if got == filepath.Join(os.TempDir(), "zero-"+name) {
 		t.Fatalf("lock path is the shared temp path %q; a co-tenant could grief it", got)
@@ -1125,7 +1171,7 @@ func TestStoreKeyringWriteWaitsForLegacyLockDuringReconciliation(t *testing.T) {
 	}
 
 	// Simulate an old binary holding the legacy lock for its own in-flight Save.
-	unlock, err := acquireFileLock(blob.legacyLockPath, s.now)
+	unlock, _, err := acquireFileLock(blob.legacyLockPath, s.now)
 	if err != nil {
 		t.Fatalf("acquire simulated legacy lock: %v", err)
 	}
@@ -1301,7 +1347,7 @@ func TestStoreKeyringReadIndexDedupesDuplicateKeys(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = encoded
 
-	keys, ok, _, err := blob.readKeyIndex()
+	keys, ok, _, _, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatalf("readKeyIndex: %v", err)
 	}
@@ -1319,7 +1365,7 @@ func TestStoreKeyringReadIndexDedupesDuplicateKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(mixed)
-	keys, _, _, err = blob.readKeyIndex()
+	keys, _, _, _, err = blob.readKeyIndex()
 	if err != nil {
 		t.Fatalf("readKeyIndex: %v", err)
 	}
@@ -1908,7 +1954,7 @@ func TestStoreKeyringReadIndexRejectsOversizedEncodedPayload(t *testing.T) {
 	huge := strings.Repeat("A", maxKeyringIndexEncodedBytes+1)
 	ckr.data[keyringService+"/"+keyringIndexAccount] = huge
 	ckr.gets = 0
-	if _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected oversized encoded index payload to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -1923,7 +1969,7 @@ func TestStoreKeyringReadIndexRejectsOversizedEncodedPayload(t *testing.T) {
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
 	ckr.data[keyringService+"/"+keyringIndexAccount+"-1"] = huge
 	ckr.gets = 0
-	if _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected oversized encoded chunk payload to be rejected")
 	}
 }
@@ -2110,7 +2156,7 @@ func TestStoreKeyringLeaseRefreshesWhileWaitingOnSecondLock(t *testing.T) {
 	// Hold the second lock as a healthy long-lived peer (refresh its mtime)
 	// so withLeasedLocks blocks on it after taking the first, without the
 	// waiter reclaiming a stale second lock.
-	holdLegacy, err := acquireFileLock(legacyLock, time.Now)
+	holdLegacy, _, err := acquireFileLock(legacyLock, time.Now)
 	if err != nil {
 		t.Fatalf("hold legacy lock: %v", err)
 	}
@@ -2289,13 +2335,207 @@ func TestKeyringLockPathUserLookupFallbackIgnoresAmbientHome(t *testing.T) {
 	currentOSUser = func() (*user.User, error) { return nil, fmt.Errorf("lookup unavailable") }
 	defer func() { currentOSUser = previous }()
 
-	gotA := keyringLockPath(map[string]string{"HOME": t.TempDir()}, keyringService, keyringIndexAccount)
-	gotB := keyringLockPath(map[string]string{"HOME": t.TempDir()}, keyringService, keyringIndexAccount)
+	gotA, err := keyringLockPath(map[string]string{"HOME": t.TempDir()}, keyringService, keyringIndexAccount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotB, err := keyringLockPath(map[string]string{"HOME": t.TempDir()}, keyringService, keyringIndexAccount)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if gotA != gotB {
 		t.Fatalf("same-user fallback changed with HOME: %q vs %q", gotA, gotB)
 	}
-	want := filepath.Join(keyringFallbackLockDir(), keyringTempLockName(keyringService, keyringIndexAccount))
+	fallbackDir, err := keyringFallbackLockDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(fallbackDir, keyringTempLockName(keyringService, keyringIndexAccount))
 	if gotA != want {
 		t.Fatalf("fallback lock = %q, want UID-scoped temporary %q", gotA, want)
+	}
+}
+
+// TestWithLeasedLocksReleasesOnPanic guards the critical finding that a panic
+// inside fn used to skip releaseAll: the lease goroutine kept Chtimes alive
+// forever and every later waiter blocked until process exit.
+func TestWithLeasedLocksReleasesOnPanic(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "panic.lock")
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected panic from fn")
+			}
+		}()
+		_ = withLeasedLocks([]string{lockPath}, time.Now, func() error {
+			panic("simulated critical-section panic")
+		})
+	}()
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock file still present after panic recovery: %v", err)
+	}
+	start := time.Now()
+	if err := withLeasedLocks([]string{lockPath}, time.Now, func() error { return nil }); err != nil {
+		t.Fatalf("second withLeasedLocks after panic: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("second acquisition took %v; lock was still being leased", elapsed)
+	}
+}
+
+// TestLeaseRefreshStopsWhenLockReplaced is the regression for ownership-aware
+// lease refresh: if a holder pauses past fileLockStaleAfter and a peer replaces
+// the lock, the original holder must not Chtimes the replacement (which would
+// keep both critical sections alive) and must fail closed.
+func TestLeaseRefreshStopsWhenLockReplaced(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "stolen.lock")
+	prevRefresh := fileLockRefreshInterval
+	fileLockRefreshInterval = 20 * time.Millisecond
+	defer func() { fileLockRefreshInterval = prevRefresh }()
+
+	var lostErr error
+	err := withLeasedLocks([]string{lockPath}, time.Now, func() error {
+		// Replace the lock as a reclaiming peer would after a long pause.
+		if err := os.WriteFile(lockPath, []byte("replacement-holder"), 0o600); err != nil {
+			return err
+		}
+		// Wait for at least one lease tick so startLease observes the theft.
+		time.Sleep(80 * time.Millisecond)
+		// Replacement mtime must not keep being refreshed by the original lease.
+		info, err := os.Stat(lockPath)
+		if err != nil {
+			return err
+		}
+		first := info.ModTime()
+		time.Sleep(80 * time.Millisecond)
+		info, err = os.Stat(lockPath)
+		if err != nil {
+			return err
+		}
+		// Allow equal (coarse FS) but not strictly newer from our stolen lease.
+		// A healthy original lease would refresh every 20ms and push mtime forward
+		// on sub-second filesystems; on coarse FS we rely on lost-lease error.
+		_ = first
+		_ = info
+		return nil
+	})
+	lostErr = err
+	if lostErr == nil {
+		t.Fatal("expected lost-lease error after lock replacement, got nil")
+	}
+	if !strings.Contains(lostErr.Error(), "lost token lock lease") {
+		t.Fatalf("error = %v, want lost token lock lease", lostErr)
+	}
+	// Replacement content must still be present: original release is ownership-aware.
+	data, err := os.ReadFile(lockPath)
+	if err == nil && string(data) == "replacement-holder" {
+		// Original unlock correctly left the thief's lock alone; clean up.
+		_ = os.Remove(lockPath)
+	}
+}
+
+// TestAcquireFileLockTimesOutOnFutureMtime rejects a lock whose mtime is in
+// the future as a healthy lease: without the non-negative age guard, every
+// wait loop extends idleDeadline forever.
+func TestAcquireFileLockTimesOutOnFutureMtime(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "future.lock")
+	if err := os.WriteFile(lockPath, []byte("hostile"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(lockPath, future, future); err != nil {
+		t.Fatal(err)
+	}
+	prevTimeout := fileLockTimeout
+	fileLockTimeout = 80 * time.Millisecond
+	defer func() { fileLockTimeout = prevTimeout }()
+
+	start := time.Now()
+	_, _, err := acquireFileLock(lockPath, time.Now)
+	if err == nil {
+		t.Fatal("expected timeout on future-mtime lock")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %v, want timed out", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("timed out too slowly (%v); future mtime was treated as healthy", elapsed)
+	}
+}
+
+// TestWriteSkipsIndexShrinkWhenChunkMissing ensures external keychain damage
+// that drops a continuation chunk does not orphan the unlisted entries on the
+// next Save: write keeps the union index instead of shrinking.
+func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
+	kr := newFakeKR()
+	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+
+	// Build a two-chunk index: header + chunk-1, then delete chunk-1.
+	keys := []string{ProviderKey("alpha"), ProviderKey("beta")}
+	// Force two chunks by writing via writeKeyIndex with a tiny budget: easier
+	// to hand-craft a header that advertises 2 chunks.
+	header, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 2, Keys: []string{ProviderKey("alpha")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk1, err := json.Marshal([]string{ProviderKey("beta")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+	kr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
+	// Entries for both keys.
+	for _, k := range keys {
+		raw, _ := json.Marshal(Token{AccessToken: "tok-" + k})
+		kr.data[keyringService+"/"+k] = base64.StdEncoding.EncodeToString(raw)
+	}
+	// Damage: drop chunk-1.
+	delete(kr.data, keyringService+"/"+keyringIndexAccount+"-1")
+
+	gotKeys, ok, chunks, incomplete, err := blob.readKeyIndex()
+	if err != nil || !ok {
+		t.Fatalf("readKeyIndex: ok=%v err=%v", ok, err)
+	}
+	if !incomplete {
+		t.Fatal("expected incomplete=true when chunk-1 is missing")
+	}
+	if chunks != 2 {
+		t.Fatalf("chunks = %d, want 2", chunks)
+	}
+	if len(gotKeys) != 1 || gotKeys[0] != ProviderKey("alpha") {
+		t.Fatalf("keys = %v, want only header keys", gotKeys)
+	}
+
+	// Save a third key; shrink must be skipped so the union still lists alpha
+	// (and beta cannot be re-indexed from the missing chunk, but alpha must
+	// not disappear and beta's entry must not be deleted as a non-livePrior).
+	state, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "tok-alpha"},
+		ProviderKey("gamma"): {AccessToken: "tok-gamma"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := blob.write(state, map[string]bool{ProviderKey("gamma"): false}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// beta entry must still exist (not deleted: it was absent from truncated livePrior).
+	if _, ok := kr.data[keyringService+"/"+ProviderKey("beta")]; !ok {
+		t.Fatal("beta entry was deleted despite missing index chunk; orphan risk path")
+	}
+	// Index after write should still be a union (not a shrink that drops everything unknown).
+	afterKeys, _, _, afterIncomplete, err := blob.readKeyIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// incomplete may clear if write rewrote a complete index; either way alpha+gamma
+	// must be listed, and we did not shrink away the prior union carelessly.
+	_ = afterIncomplete
+	found := map[string]bool{}
+	for _, k := range afterKeys {
+		found[k] = true
+	}
+	if !found[ProviderKey("alpha")] || !found[ProviderKey("gamma")] {
+		t.Fatalf("post-write keys = %v, want alpha and gamma listed", afterKeys)
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -971,7 +972,11 @@ func TestKeyringLockPathIsPerUser(t *testing.T) {
 	if got == filepath.Join(os.TempDir(), "zero-"+name) {
 		t.Fatalf("lock path is the shared temp path %q; a co-tenant could grief it", got)
 	}
-	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+	if u, err := user.Current(); err == nil && strings.TrimSpace(u.HomeDir) != "" {
+		if want := filepath.Join(u.HomeDir, ".cache", "zero", name); got != want {
+			t.Fatalf("lock path = %q, want per-user home-anchored path %q", got, want)
+		}
+	} else if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
 		if want := filepath.Join(home, ".cache", "zero", name); got != want {
 			t.Fatalf("lock path = %q, want per-user home-anchored path %q", got, want)
 		}
@@ -1415,5 +1420,155 @@ func TestStoreKeyringWriteRefusesToDeleteLegacyBlobOnTransientReadError(t *testi
 	}
 	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
 		t.Fatal("legacy blob should be removed once it was actually read and reconciled")
+	}
+}
+
+func TestStoreKeyringLockPathStableAcrossDifferentHomeEnvs(t *testing.T) {
+	kr := newFakeKR()
+	s1, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"HOME": filepath.Join(t.TempDir(), "home1")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"HOME": filepath.Join(t.TempDir(), "home2")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p1 := s1.blob.(keyringBlob).lockPath
+	p2 := s2.blob.(keyringBlob).lockPath
+	if p1 != p2 {
+		t.Fatalf("lockPath mismatch for different HOME envs: s1=%q, s2=%q", p1, p2)
+	}
+
+	if err := s1.Save(ProviderKey("alpha"), Token{AccessToken: "token1"}); err != nil {
+		t.Fatalf("s1.Save: %v", err)
+	}
+	got, ok, err := s2.Load(ProviderKey("alpha"))
+	if err != nil || !ok || got.AccessToken != "token1" {
+		t.Fatalf("s2.Load: got=%#v, ok=%v, err=%v", got, ok, err)
+	}
+}
+
+func TestStoreKeyringMergesFreshLegacyRefreshOnLoadWithoutSave(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t1 := time.Now().Add(-10 * time.Minute)
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "stale-a", ExpiresAt: t1}); err != nil {
+		t.Fatal(err)
+	}
+
+	t2 := time.Now().Add(1 * time.Hour)
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "fresh-a", RefreshToken: "fresh-r", ExpiresAt: t2},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	got, ok, err := s.Load(ProviderKey("alpha"))
+	if err != nil || !ok {
+		t.Fatalf("Load: ok=%v err=%v", ok, err)
+	}
+	if got.AccessToken != "fresh-a" {
+		t.Fatalf("Load returned stale token %#v, want fresh legacy token", got)
+	}
+}
+
+func TestStoreKeyringLegacyIsFresherHandlesZeroExpiryRefreshes(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t1 := time.Now().Add(10 * time.Minute)
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "old-a", RefreshToken: "old-r", ExpiresAt: t1}); err != nil {
+		t.Fatal(err)
+	}
+
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "new-a", RefreshToken: "new-r", ExpiresAt: time.Time{}},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	got, ok, err := s.Load(ProviderKey("alpha"))
+	if err != nil || !ok {
+		t.Fatalf("Load: ok=%v err=%v", ok, err)
+	}
+	if got.AccessToken != "new-a" || got.RefreshToken != "new-r" {
+		t.Fatalf("Load = %#v, want legacy zero-expiry refresh", got)
+	}
+}
+
+func TestStoreKeyringDeleteNotResurrectedWhenLegacyDeleteFailsOrRewritten(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed legacy blob with alpha (logged out token)
+	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "a-legacy"},
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+
+	// Delete alpha
+	removed, err := s.Delete(ProviderKey("alpha"))
+	if err != nil || !removed {
+		t.Fatalf("Delete(alpha): removed=%v err=%v", removed, err)
+	}
+
+	// Assert Load(alpha) returns empty
+	if _, ok, _ := s.Load(ProviderKey("alpha")); ok {
+		t.Fatal("alpha should not be exposed on Load after Delete")
+	}
+
+	// Save gamma, which triggers write() reconciliation
+	if err := s.Save(ProviderKey("gamma"), Token{AccessToken: "g"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert alpha was not resurrected into the index
+	if _, ok, _ := s.Load(ProviderKey("alpha")); ok {
+		t.Fatal("alpha was resurrected into index after Delete")
+	}
+}
+
+func TestStoreKeyringRejectsOversizedSingleTokenPayload(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	huge := Token{
+		AccessToken: "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("A", 6000) + ".sig",
+	}
+	err = s.Save(ProviderKey("huge"), huge)
+	if err == nil {
+		t.Fatal("Save succeeded for oversized single token payload; want error")
+	}
+	if !strings.Contains(err.Error(), "exceeds single keyring entry bound") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -225,6 +225,71 @@ func TestStoreKeyringSkipsIndexedKeyMissingItsEntry(t *testing.T) {
 	}
 }
 
+// TestStoreKeyringSkipsMissingChunkEntry covers the chunked index format:
+// a continuation chunk listed by the header is missing (torn write by a
+// killed process), and one of the keys that survives in the remaining chunk
+// has no corresponding entry in the keyring. read() must skip the missing
+// key without failing the whole read, and the missing chunk must be ignored
+// by readKeyIndex rather than causing an error.
+func TestStoreKeyringSkipsMissingChunkEntry(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+
+	// Seed one valid token entry that will be reachable via chunk 0.
+	valid := Token{AccessToken: "valid-a", RefreshToken: "valid-r"}
+	raw, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+ProviderKey("valid")] = base64.StdEncoding.EncodeToString(raw)
+
+	// Build a chunked header (2 chunks). Chunk 0 references "valid" and
+	// "orphan" (missing its entry). Chunk 1 exists and carries "extra".
+	// But we deliberately omit chunk 1 from the keyring to simulate a torn write.
+	header := keyIndexHeader{Version: 1, Chunks: 2, Keys: []string{ProviderKey("valid"), ProviderKey("orphan")}}
+	headerData, err := json.Marshal(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(headerData)
+
+	// Chunk 1 is intentionally absent — simulating a process killed mid-write.
+
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// "valid" must still be loadable (chunk 0 had it, and its entry exists).
+	got, ok, err := s.Load(ProviderKey("valid"))
+	if err != nil || !ok {
+		t.Fatalf("Load(valid): ok=%v err=%v", ok, err)
+	}
+	if got.AccessToken != valid.AccessToken {
+		t.Fatalf("Load(valid) = %#v", got)
+	}
+
+	// "orphan" has no entry and the legacy blob is empty, so it must be skipped.
+	if _, ok, err := s.Load(ProviderKey("orphan")); err != nil || ok {
+		t.Fatalf("Load(orphan): ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+
+	// "extra" lives in the missing chunk 1, so it must also be skipped.
+	if _, ok, err := s.Load(ProviderKey("extra")); err != nil || ok {
+		t.Fatalf("Load(extra): ok=%v err=%v, want ok=false err=nil (chunk 1 missing)", ok, err)
+	}
+
+	// Status must return only "valid" — the missing chunk and missing entry
+	// must not fail the read or return phantom tokens.
+	statuses, err := s.Status("")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Key != ProviderKey("valid") {
+		t.Fatalf("Status = %#v, want only the valid key", statuses)
+	}
+}
+
 // failingKR wraps fakeKR and fails the Nth mutating operation (Set/Delete),
 // for exercising every interruption boundary of the multi-step write.
 type failingKR struct {

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -1266,9 +1266,10 @@ func TestStoreKeyringDuplicateIndexDoesNotFanOutPerEntry(t *testing.T) {
 		t.Fatalf("Status returned %d entries for a 3000-duplicate index of one key, want 1", len(statuses))
 	}
 	// One Get for the index header, one Get for the single deduplicated key's
-	// own entry — not one per (duplicate) index entry.
-	if ckr.gets > 2 {
-		t.Fatalf("Status issued %d keyring gets for a 3000-entry duplicate index, want <= 2 (fan-out DoS regression)", ckr.gets)
+	// own entry, and at most one extra Get for the legacy fallback lookup.
+	// The key regression is: not 3000 (one per duplicate entry).
+	if ckr.gets > 3 {
+		t.Fatalf("Status issued %d keyring gets for a 3000-entry duplicate index, want <= 3 (fan-out DoS regression)", ckr.gets)
 	}
 }
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Gitlawb/zero/internal/lockutil"
 )
 
 // fakeKR is an in-memory KeyringClient for exercising the keyring backend
@@ -65,10 +67,10 @@ func TestStoreKeyringBackendRoundTrip(t *testing.T) {
 	if strings.Contains(raw, "access_token") {
 		t.Fatalf("keyring entry is not encoded: %s", raw)
 	}
-	// New code dual-writes the reconciled map to the legacy account so pre-PR
-	// binaries (including those on other config roots) keep a current view.
-	if raw := kr.data[keyringService+"/"+keyringLegacyAccount]; raw == "" {
-		t.Fatal("legacy combined entry should be dual-written by new code")
+	// New code never creates the legacy combined entry: that account is a
+	// read-only discovery source for pre-PR blobs, not a dual-written mirror.
+	if raw := kr.data[keyringService+"/"+keyringLegacyAccount]; raw != "" {
+		t.Fatal("legacy combined entry must not be dual-written by new code")
 	}
 
 	removed, err := s.Delete(ProviderKey("demo"))
@@ -117,15 +119,11 @@ func TestStoreKeyringManyProvidersStayUnderEntryLimit(t *testing.T) {
 		}
 	}
 	// Each per-key token entry must stay small even with 5 providers logged
-	// in. The dual-written legacy combined entry is size-capped separately at
-	// maxKeyringSingleEntryBytes (and may be skipped/patched when oversize).
+	// in. New code does not dual-write the legacy combined entry.
 	const singleTokenCeiling = 3000 // generous margin under the ~4095-byte line cap
 	for k, v := range kr.data {
 		if strings.HasSuffix(k, "/"+keyringLegacyAccount) {
-			if len(v) > maxKeyringSingleEntryBytes {
-				t.Fatalf("legacy dual-write %q is %d bytes, want <= %d", k, len(v), maxKeyringSingleEntryBytes)
-			}
-			continue
+			t.Fatalf("legacy account %q was written by new multi-provider saves", k)
 		}
 		if len(v) > singleTokenCeiling {
 			t.Fatalf("keyring entry %q is %d bytes, want < %d (aggregation regression)", k, len(v), singleTokenCeiling)
@@ -144,8 +142,8 @@ func TestStoreKeyringManyProvidersStayUnderEntryLimit(t *testing.T) {
 
 // TestStoreKeyringMigratesLegacyCombinedEntry ensures installs upgrading from
 // the original single-blob format keep reading their existing tokens, and get
-// migrated to per-key entries (with the legacy entry removed) the next time
-// anything is saved.
+// migrated to per-key entries the next time anything is saved. The legacy
+// entry is left untouched (never dual-written or deleted).
 func TestStoreKeyringMigratesLegacyCombinedEntry(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	kr := newFakeKR()
@@ -156,7 +154,8 @@ func TestStoreKeyringMigratesLegacyCombinedEntry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+	legacyEnc := base64.StdEncoding.EncodeToString(data)
+	kr.data[keyringService+"/"+keyringLegacyAccount] = legacyEnc
 
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
 	if err != nil {
@@ -170,14 +169,13 @@ func TestStoreKeyringMigratesLegacyCombinedEntry(t *testing.T) {
 		t.Fatalf("Load = %#v", got)
 	}
 
-	// Saving a second provider must migrate into per-key entries and dual-write
-	// the full map back to the legacy account (never delete it: other config
-	// roots cannot share the compatibility lock).
+	// Saving a second provider must migrate into per-key entries and leave the
+	// original legacy blob byte-identical (read-only coexistence).
 	if err := s.Save(ProviderKey("other"), Token{AccessToken: "other-a"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
-		t.Fatal("legacy combined entry should remain dual-written after migration")
+	if got := kr.data[keyringService+"/"+keyringLegacyAccount]; got != legacyEnc {
+		t.Fatalf("legacy combined entry was rewritten during migration (want frozen original)")
 	}
 	for _, name := range []string{"demo", "other"} {
 		if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
@@ -435,7 +433,9 @@ func TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 		indexed := indexedKeysOf(t, kr.fakeKR)
 		for entry := range kr.data {
 			account := strings.TrimPrefix(entry, keyringService+"/")
-			if account == keyringIndexAccount || strings.HasPrefix(account, keyringIndexAccount+"-") || account == keyringLegacyAccount {
+			if account == keyringIndexAccount || strings.HasPrefix(account, keyringIndexAccount+"-") ||
+				account == keyringLegacyAccount || account == keyringTombstoneAccount ||
+				strings.HasPrefix(account, keyringTombstoneAccount+"-") {
 				continue
 			}
 			if !indexed[account] {
@@ -461,9 +461,7 @@ func TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 				t.Fatalf("failAt=%d: Load(%s) after reconcile: ok=%v err=%v", failAt, name, ok, err)
 			}
 		}
-		// Every mutating boundary of the write path now surfaces its failure,
-		// including the legacy dual-write (a swallowed failure there could
-		// let a later save resurrect logged-out credentials).
+		// Every mutating boundary of the write path must surface its failure.
 		if opsUsed >= failAt && saveErr == nil {
 			t.Fatalf("failAt=%d: injected keyring failure was swallowed", failAt)
 		}
@@ -502,7 +500,9 @@ func TestStoreKeyringDeleteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 		indexed := indexedKeysOf(t, kr.fakeKR)
 		for entry := range kr.data {
 			account := strings.TrimPrefix(entry, keyringService+"/")
-			if account == keyringIndexAccount || strings.HasPrefix(account, keyringIndexAccount+"-") || account == keyringLegacyAccount {
+			if account == keyringIndexAccount || strings.HasPrefix(account, keyringIndexAccount+"-") ||
+				account == keyringLegacyAccount || account == keyringTombstoneAccount ||
+				strings.HasPrefix(account, keyringTombstoneAccount+"-") {
 				continue
 			}
 			if !indexed[account] {
@@ -573,7 +573,12 @@ func TestStoreKeyringMergesFreshLegacyWriteFromOldBinary(t *testing.T) {
 		t.Fatalf("Load(carol) = %#v, err=%v, want the legacy access/refresh tokens intact", got, err)
 	}
 	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
-		t.Fatal("legacy entry should remain dual-written after merge")
+		t.Fatal("legacy entry was deleted; old writers on other roots would lose their only copy")
+	}
+	// carol must also be promoted into an indexed entry so it survives without
+	// relying on a dual-written legacy mirror.
+	if _, ok := kr.data[keyringService+"/"+ProviderKey("carol")]; !ok {
+		t.Fatal("merged legacy-only carol was not promoted into a per-key entry")
 	}
 }
 
@@ -746,9 +751,10 @@ func TestStoreKeyringMigrationInterruptionsPreserveLegacyTokens(t *testing.T) {
 		if got, ok, err := s.Load(ProviderKey("new")); err != nil || !ok || got.AccessToken != "new-c" {
 			t.Fatalf("failAt=%d: Load(new): ok=%v err=%v token=%#v", failAt, ok, err, got)
 		}
-		// Completed migration dual-writes the full map to the legacy entry.
+		// Completed migration leaves the original legacy entry in place
+		// (read-only coexistence; never dual-write or delete).
 		if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
-			t.Fatalf("failAt=%d: legacy entry missing after migration completed (want dual-write)", failAt)
+			t.Fatalf("failAt=%d: legacy entry was removed during migration", failAt)
 		}
 		if opsUsed < failAt {
 			break
@@ -1217,28 +1223,13 @@ func TestKeyringLockPathDerivedFromKeyringIdentityNotFileConfig(t *testing.T) {
 	}
 }
 
-// legacyDualWriteFailKR fails Set for the legacy combined entry only, to
-// exercise the boundary where a logout has rewritten the indexed state but
-// the dual-write that clears the credential from the legacy blob cannot land.
-type legacyDualWriteFailKR struct {
-	*fakeKR
-	fail bool
-}
-
-func (f *legacyDualWriteFailKR) Set(service, account, secret string) error {
-	if f.fail && account == keyringLegacyAccount {
-		return errKRInjected
-	}
-	return f.fakeKR.Set(service, account, secret)
-}
-
-// TestStoreKeyringLogoutSurfacesLegacyDualWriteFailure: when the legacy
-// dual-write fails during a logout, the operation must report the failure
-// (not success while the secret may still be resident in the legacy blob),
-// and after a clean retry the logged-out credential must not be resurrected.
-func TestStoreKeyringLogoutSurfacesLegacyDualWriteFailure(t *testing.T) {
+// TestStoreKeyringLogoutTombstoneSurvivesStaleLegacyRewrite: after Delete,
+// an old binary can rewrite the legacy blob with the logged-out key still
+// present. Durable tombstones must keep Load empty and prevent a later Save
+// from reindexing it.
+func TestStoreKeyringLogoutTombstoneSurvivesStaleLegacyRewrite(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	kr := &legacyDualWriteFailKR{fakeKR: newFakeKR()}
+	kr := newFakeKR()
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
 	if err != nil {
 		t.Fatal(err)
@@ -1246,10 +1237,14 @@ func TestStoreKeyringLogoutSurfacesLegacyDualWriteFailure(t *testing.T) {
 	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
 		t.Fatal(err)
 	}
-	// A leftover legacy blob still carries alpha (e.g. written by an old
-	// binary during the upgrade window).
+	if _, err := s.Delete(ProviderKey("alpha")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Old binary rewrites a stale snapshot that still contains alpha.
 	legacy := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
 		ProviderKey("alpha"): {AccessToken: "stale-a"},
+		ProviderKey("beta"):  {AccessToken: "b"},
 	}}
 	data, err := json.Marshal(legacy)
 	if err != nil {
@@ -1257,22 +1252,18 @@ func TestStoreKeyringLogoutSurfacesLegacyDualWriteFailure(t *testing.T) {
 	}
 	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
 
-	kr.fail = true
-	if _, err := s.Delete(ProviderKey("alpha")); err == nil {
-		t.Fatal("Delete reported success although the legacy dual-write failed")
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || ok {
+		t.Fatalf("logged-out alpha exposed after stale legacy rewrite: ok=%v err=%v", ok, err)
 	}
-
-	// A clean retry succeeds, and a later save must not classify the stale
-	// legacy alpha as a fresh old-binary login.
-	kr.fail = false
-	if _, err := s.Delete(ProviderKey("alpha")); err != nil {
-		t.Fatalf("retried Delete: %v", err)
-	}
-	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
+	if err := s.Save(ProviderKey("gamma"), Token{AccessToken: "g"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || ok {
-		t.Fatalf("logged-out credential resurrected: ok=%v err=%v", ok, err)
+		t.Fatalf("logged-out alpha resurrected by later Save: ok=%v err=%v", ok, err)
+	}
+	// Unrelated legacy-only beta remains discoverable.
+	if _, ok, err := s.Load(ProviderKey("beta")); err != nil || !ok {
+		t.Fatalf("legacy-only beta lost: ok=%v err=%v", ok, err)
 	}
 }
 
@@ -1421,10 +1412,11 @@ func TestStoreKeyringDuplicateIndexDoesNotFanOutPerEntry(t *testing.T) {
 		t.Fatalf("Status returned %d entries for an 80-duplicate index of one key, want 1", len(statuses))
 	}
 	// One Get for the index header, one Get for the single deduplicated key's
-	// own entry, and at most one extra Get for the legacy fallback lookup.
-	// The key regression is: not one Get per duplicate entry.
-	if ckr.gets > 3 {
-		t.Fatalf("Status issued %d keyring gets for an 80-entry duplicate index, want <= 3 (fan-out DoS regression)", ckr.gets)
+	// own entry, one Get for durable tombstones, and at most one extra Get for
+	// the legacy fallback lookup. The key regression is: not one Get per
+	// duplicate entry.
+	if ckr.gets > 4 {
+		t.Fatalf("Status issued %d keyring gets for an 80-entry duplicate index, want <= 4 (fan-out DoS regression)", ckr.gets)
 	}
 }
 
@@ -1444,12 +1436,10 @@ func (f *legacyGetFailKR) Get(service, account string) (string, bool, error) {
 }
 
 // TestStoreKeyringWriteRefusesToOverwriteLegacyBlobOnTransientReadError is the
-// regression test for finding #2: during mixed-version reconciliation (an old
-// zero binary's legacy blob alongside the new keyring-based index), a
-// transient error reading the legacy blob must not be treated as "the legacy
-// blob is empty." write() must refuse to dual-write over it in that case, or
-// an unread credential belonging to an older, still-installed zero binary is
-// destroyed irrecoverably.
+// regression test for mixed-version reconciliation: a transient error reading
+// the legacy blob must not be treated as "the legacy blob is empty." write()
+// must abort rather than proceed without those credentials (and must never
+// overwrite the legacy account).
 func TestStoreKeyringWriteRefusesToOverwriteLegacyBlobOnTransientReadError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	kr := &legacyGetFailKR{fakeKR: newFakeKR()}
@@ -1473,7 +1463,8 @@ func TestStoreKeyringWriteRefusesToOverwriteLegacyBlobOnTransientReadError(t *te
 	if err != nil {
 		t.Fatal(err)
 	}
-	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+	legacyEnc := base64.StdEncoding.EncodeToString(data)
+	kr.data[keyringService+"/"+keyringLegacyAccount] = legacyEnc
 
 	// A transient failure reading it: Get returns a real error, not
 	// ok=false/err=nil ("doesn't exist").
@@ -1481,11 +1472,10 @@ func TestStoreKeyringWriteRefusesToOverwriteLegacyBlobOnTransientReadError(t *te
 	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err == nil {
 		t.Fatal("Save succeeded despite a transient legacy-blob read failure; it must refuse rather than silently treat the blob as empty")
 	}
-	// The legacy blob must still be present with the old credential, not
-	// dual-written over under a read failure.
+	// The legacy blob must still be present and byte-identical.
 	if raw, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
 		t.Fatal("legacy blob was removed despite a transient read failure (data loss)")
-	} else if !strings.Contains(string(mustDecode(t, raw)), "still-live") {
+	} else if raw != legacyEnc {
 		t.Fatal("legacy blob was overwritten despite a transient read failure (data loss)")
 	}
 	// Nothing else the aborted write touched should be visible either.
@@ -1497,7 +1487,7 @@ func TestStoreKeyringWriteRefusesToOverwriteLegacyBlobOnTransientReadError(t *te
 	}
 
 	// Once the transient failure clears, the legacy credential is recovered
-	// and dual-written back with the full reconciled map.
+	// into the indexed store; the legacy blob stays frozen.
 	kr.fail = false
 	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
 		t.Fatalf("retried Save: %v", err)
@@ -1505,8 +1495,8 @@ func TestStoreKeyringWriteRefusesToOverwriteLegacyBlobOnTransientReadError(t *te
 	if _, ok, err := s.Load(ProviderKey("stale-binary-login")); err != nil || !ok {
 		t.Fatalf("Load(stale-binary-login): ok=%v err=%v (legacy credential lost)", ok, err)
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
-		t.Fatal("legacy blob should remain dual-written once it was actually read and reconciled")
+	if raw := kr.data[keyringService+"/"+keyringLegacyAccount]; raw != legacyEnc {
+		t.Fatal("legacy blob was rewritten after a successful reconcile (must stay frozen)")
 	}
 }
 
@@ -1891,11 +1881,12 @@ func TestStoreKeyringPrunesPhantomIndexKeysAfterInterruptedSet(t *testing.T) {
 	}
 }
 
-// TestStoreKeyringDualWritePreservesCrossRootLegacyLogin: the compatibility
-// lock cannot span distinct config roots, so a new binary must never delete
-// the legacy combined entry. An old-style writer on root A can land a login
-// after root B reconciled; dual-write-without-delete keeps that login visible.
-func TestStoreKeyringDualWritePreservesCrossRootLegacyLogin(t *testing.T) {
+// TestStoreKeyringCrossRootLegacyLoginSurvivesWithoutDualWrite: the
+// compatibility lock cannot span distinct config roots, so a new binary must
+// never overwrite or delete the legacy combined entry. An old-style writer on
+// root A can land a login after root B reconciled; leaving legacy frozen and
+// merging on the next write keeps that login visible.
+func TestStoreKeyringCrossRootLegacyLoginSurvivesWithoutDualWrite(t *testing.T) {
 	rootA := filepath.Join(t.TempDir(), "cfg-a")
 	rootB := filepath.Join(t.TempDir(), "cfg-b")
 	kr := newFakeKR()
@@ -1922,9 +1913,10 @@ func TestStoreKeyringDualWritePreservesCrossRootLegacyLogin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(data)
+	legacyEnc := base64.StdEncoding.EncodeToString(data)
+	kr.data[keyringService+"/"+keyringLegacyAccount] = legacyEnc
 
-	// New binary on root B saves again: must merge carol, not delete it away.
+	// New binary on root B saves again: must merge carol, not clobber legacy.
 	if err := storeB.Save(ProviderKey("beta"), Token{AccessToken: "b"}); err != nil {
 		t.Fatal(err)
 	}
@@ -1933,8 +1925,8 @@ func TestStoreKeyringDualWritePreservesCrossRootLegacyLogin(t *testing.T) {
 			t.Fatalf("Load(%s) after cross-root legacy login: ok=%v err=%v", name, ok, err)
 		}
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
-		t.Fatal("legacy entry was deleted; cross-root old writers can no longer be observed")
+	if raw := kr.data[keyringService+"/"+keyringLegacyAccount]; raw != legacyEnc {
+		t.Fatal("legacy entry was rewritten; cross-root old writers can lose unobserved updates")
 	}
 }
 
@@ -1965,5 +1957,283 @@ func TestStoreKeyringReadIndexRejectsOversizedEncodedPayload(t *testing.T) {
 	ckr.gets = 0
 	if _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected oversized encoded chunk payload to be rejected")
+	}
+}
+
+// TestStoreKeyringPreservesUnobservedLegacyWriteDuringReconcile is the
+// regression for [P1] Preserve an old-writer update that lands during legacy
+// reconciliation: new B snapshots legacy, old A (other config root) writes a
+// new credential into the shared legacy account, then B finishes its Save.
+// B must not overwrite A's only copy with a stale dual-write.
+func TestStoreKeyringPreservesUnobservedLegacyWriteDuringReconcile(t *testing.T) {
+	rootA := filepath.Join(t.TempDir(), "cfg-a")
+	rootB := filepath.Join(t.TempDir(), "cfg-b")
+	kr := newFakeKR()
+
+	storeB, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"XDG_CONFIG_HOME": rootB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storeB.Save(ProviderKey("seed"), Token{AccessToken: "s"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Snapshot state as B would see it mid-reconcile, then A lands a login.
+	legacyBefore := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("seed"): {AccessToken: "s"},
+	}}
+	before, err := json.Marshal(legacyBefore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(before)
+
+	// Pause is simulated by injecting the post-snapshot old-writer update
+	// immediately before B's next Save (which would have dual-written a stale
+	// map under the previous protocol).
+	legacyAfter := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("seed"):   {AccessToken: "s"},
+		ProviderKey("from-a"): {AccessToken: "a-token", RefreshToken: "a-r"},
+	}}
+	after, err := json.Marshal(legacyAfter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterEnc := base64.StdEncoding.EncodeToString(after)
+	kr.data[keyringService+"/"+keyringLegacyAccount] = afterEnc
+
+	if err := storeB.Save(ProviderKey("from-b"), Token{AccessToken: "b-token"}); err != nil {
+		t.Fatal(err)
+	}
+	// A's credential remains in the frozen legacy blob and is discoverable.
+	if raw := kr.data[keyringService+"/"+keyringLegacyAccount]; raw != afterEnc {
+		t.Fatal("B overwrote A's unobserved legacy write during reconcile")
+	}
+	got, ok, err := storeB.Load(ProviderKey("from-a"))
+	if err != nil || !ok || got.AccessToken != "a-token" || got.RefreshToken != "a-r" {
+		t.Fatalf("Load(from-a) = ok=%v err=%v got=%#v (A's credential lost)", ok, err, got)
+	}
+	// Distinct roots cannot share the legacy lock; the protocol must still be safe.
+	if legacyKeyringLockPath(map[string]string{"XDG_CONFIG_HOME": rootA}) ==
+		legacyKeyringLockPath(map[string]string{"XDG_CONFIG_HOME": rootB}) {
+		t.Fatal("expected distinct legacy locks for distinct roots")
+	}
+}
+
+// TestStoreKeyringLogoutDurableAgainstOldWriterStaleSnapshot is the regression
+// for [P1] Keep a logout durable when an uncoordinated old binary rewrites its
+// stale snapshot: old writer read alpha, new writer deletes it, old writer
+// saves another key from its stale snapshot that still includes alpha.
+func TestStoreKeyringLogoutDurableAgainstOldWriterStaleSnapshot(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	// Old writer snapshot includes alpha (taken before delete).
+	oldSnapshot := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "a"},
+		ProviderKey("other"): {AccessToken: "o"},
+	}}
+	snap, err := json.Marshal(oldSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.Delete(ProviderKey("alpha")); err != nil {
+		t.Fatal(err)
+	}
+	// Old writer finishes its RMW of another key from the stale snapshot.
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(snap)
+
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || ok {
+		t.Fatalf("Load(alpha) after stale old-writer rewrite: ok=%v err=%v", ok, err)
+	}
+	if err := s.Save(ProviderKey("gamma"), Token{AccessToken: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := s.Load(ProviderKey("alpha")); err != nil || ok {
+		t.Fatalf("Load(alpha) after later Save: ok=%v err=%v (logout not durable)", ok, err)
+	}
+	// The other key from the stale snapshot is still a legitimate discovery.
+	if _, ok, err := s.Load(ProviderKey("other")); err != nil || !ok {
+		t.Fatalf("Load(other): ok=%v err=%v", ok, err)
+	}
+}
+
+// TestStoreKeyringNeverWritesPartialLegacySubset is the regression for [P1]
+// Do not replace a valid oversized legacy blob with an arbitrary subset: a
+// Linux-compatible multi-provider legacy payload that exceeds the macOS write
+// budget must stay complete for old-format readers.
+func TestStoreKeyringNeverWritesPartialLegacySubset(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+
+	// Build a legacy map whose base64 encoding exceeds maxKeyringSingleEntryBytes
+	// (pre-PR Linux keyring storage has no corresponding single-secret limit).
+	big := Token{
+		AccessToken:  "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("QUJDRA", 40) + ".sig",
+		RefreshToken: "rt_" + strings.Repeat("y", 60),
+		TokenType:    "Bearer",
+		Scopes:       []string{"openid", "profile", "email", "offline_access"},
+		Account:      "user@example.com",
+		IDToken:      "eyJhbGciOiJSUzI1NiJ9." + strings.Repeat("QUJDRA", 45) + ".sig",
+	}
+	tokens := map[string]Token{}
+	for _, name := range []string{"anthropic", "openai", "minimax", "zai", "google", "cohere"} {
+		tokens[ProviderKey(name)] = big
+	}
+	legacyRaw, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyEnc := base64.StdEncoding.EncodeToString(legacyRaw)
+	if len(legacyEnc) <= maxKeyringSingleEntryBytes {
+		t.Fatalf("test fixture legacy enc is %d bytes; need > %d to exercise oversize path", len(legacyEnc), maxKeyringSingleEntryBytes)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = legacyEnc
+
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("extra"), Token{AccessToken: "e"}); err != nil {
+		t.Fatal(err)
+	}
+	// Old-format reader must still observe the complete original map, not a
+	// nondeterministic subset written under the macOS-safe budget.
+	if got := kr.data[keyringService+"/"+keyringLegacyAccount]; got != legacyEnc {
+		// Decode both for a clearer failure when rewritten to a subset.
+		var before, after storeFile
+		_ = json.Unmarshal(mustDecode(t, legacyEnc), &before)
+		_ = json.Unmarshal(mustDecode(t, got), &after)
+		t.Fatalf("oversized legacy blob was rewritten: before %d keys, after %d keys (must leave complete map untouched)", len(before.Tokens), len(after.Tokens))
+	}
+	// Indexed store still has every legacy provider after migration.
+	for name := range tokens {
+		if _, ok, err := s.Load(name); err != nil || !ok {
+			t.Fatalf("Load(%s) after migrate: ok=%v err=%v", name, ok, err)
+		}
+	}
+}
+
+// TestStoreKeyringLeaseRefreshesWhileWaitingOnSecondLock is the regression for
+// [P1] Renew the index lease while waiting for the legacy lock: after the
+// shared index lock is acquired, a blocked wait on the config-root legacy lock
+// must keep refreshing the index lock so a competing root cannot reclaim it.
+func TestStoreKeyringLeaseRefreshesWhileWaitingOnSecondLock(t *testing.T) {
+	dir := t.TempDir()
+	indexLock := filepath.Join(dir, "index.lock")
+	legacyLock := filepath.Join(dir, "legacy.lock")
+
+	prevRefresh := fileLockRefreshInterval
+	prevStale := fileLockStaleAfter
+	fileLockRefreshInterval = 15 * time.Millisecond
+	fileLockStaleAfter = 80 * time.Millisecond
+	defer func() {
+		fileLockRefreshInterval = prevRefresh
+		fileLockStaleAfter = prevStale
+	}()
+
+	// Hold the second lock as a healthy long-lived peer (refresh its mtime)
+	// so withLeasedLocks blocks on it after taking the first, without the
+	// waiter reclaiming a stale second lock.
+	holdLegacy, err := acquireFileLock(legacyLock, time.Now)
+	if err != nil {
+		t.Fatalf("hold legacy lock: %v", err)
+	}
+	stopHold := make(chan struct{})
+	holdDone := make(chan struct{})
+	go func() {
+		defer close(holdDone)
+		ticker := time.NewTicker(fileLockRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopHold:
+				return
+			case <-ticker.C:
+				at := time.Now()
+				_ = os.Chtimes(legacyLock, at, at)
+			}
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- withLeasedLocks([]string{indexLock, legacyLock}, time.Now, func() error {
+			return nil
+		})
+	}()
+
+	// Wait until the first lock is actually held before measuring lease age.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(indexLock); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			close(stopHold)
+			<-holdDone
+			holdLegacy()
+			t.Fatal("index lock was never acquired while waiting on the legacy lock")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Wait longer than the stale threshold while the first lock is held and
+	// the second is still blocked. The lease must keep the index lock fresh.
+	time.Sleep(fileLockStaleAfter + 3*fileLockRefreshInterval)
+
+	info, err := os.Stat(indexLock)
+	if err != nil {
+		close(stopHold)
+		<-holdDone
+		holdLegacy()
+		t.Fatalf("index lock missing while waiter blocked on legacy: %v", err)
+	}
+	if age := time.Since(info.ModTime()); age > fileLockStaleAfter {
+		close(stopHold)
+		<-holdDone
+		holdLegacy()
+		t.Fatalf("index lock mtime is %v old while waiting on second lock; lease was not renewed", age)
+	}
+
+	// A competing reclaim must treat the still-leased index lock as live.
+	// Capture staleAfter once: the waiter goroutine is still reading the same
+	// package vars, so do not mutate them for the rest of this test.
+	staleAfter := fileLockStaleAfter
+	cleared, rerr := lockutil.ReclaimStaleLock(indexLock, "competitor-probe", func(reclaimedPath string) bool {
+		info, err := os.Stat(reclaimedPath)
+		return err == nil && time.Since(info.ModTime()) <= staleAfter
+	})
+	if rerr != nil {
+		close(stopHold)
+		<-holdDone
+		holdLegacy()
+		t.Fatalf("reclaim probe: %v", rerr)
+	}
+	if cleared {
+		close(stopHold)
+		<-holdDone
+		holdLegacy()
+		t.Fatal("competitor reclaimed the index lock while the multi-lock waiter still owned it")
+	}
+	if _, err := os.Stat(indexLock); err != nil {
+		close(stopHold)
+		<-holdDone
+		holdLegacy()
+		t.Fatalf("index lock missing after failed reclaim: %v", err)
+	}
+
+	close(stopHold)
+	<-holdDone
+	holdLegacy()
+	if err := <-done; err != nil {
+		t.Fatalf("withLeasedLocks after legacy release: %v", err)
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -2421,6 +2421,82 @@ func TestStoreKeyringPureNewFormatKeySurvivesLegacyReconciliation(t *testing.T) 
 	}
 }
 
+// TestWriteKeyIndexRejectsOverflowWithoutMutatingExistingChunks is the
+// regression for [P1] Preflight protected continuation-slot capacity before
+// modifying the index: the slot-assignment loop used to Set new continuation
+// chunks into existing, non-protected accounts as it went, and only computed
+// the resulting advertised chunk count (and checked it against the
+// reader-accepted cap) after every write had already landed. A rejection
+// therefore did not mean nothing happened: it meant the old header was left
+// describing a layout some of whose chunk accounts had just been overwritten
+// with pieces of the rejected new one, potentially stranding every key those
+// accounts held.
+//
+// A single protected (missing) slot at the cap is enough to force this: with
+// missingChunks=[maxKeyringIndexChunks], the "keep advertising protected
+// slots" bookkeeping alone pushes the final advertised count one past the
+// cap, regardless of how few new continuation chunks are actually needed —
+// exactly the "protected missing slots near the cap" shape the finding
+// describes, and it does not require constructing a realistic 128-chunk prior
+// index to trigger.
+func TestWriteKeyIndexRejectsOverflowWithoutMutatingExistingChunks(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+
+	// Enough keys that chunkIndexKeys needs several continuation chunks, so
+	// the old code's loop would have performed real Set calls before ever
+	// reaching the capacity check.
+	const keyLen = 130
+	keys := make([]string, 0, 80)
+	for i := 0; i < 80; i++ {
+		keys = append(keys, fmt.Sprintf("k%0*d", keyLen-1, i))
+	}
+	chunks := chunkIndexKeys(keys)
+	if len(chunks) < 3 {
+		t.Fatalf("test setup: keys only produced %d chunks, want at least 3 so the old loop would have written something before overflowing", len(chunks))
+	}
+
+	// Seed the accounts the write would target with recognizable prior
+	// content, standing in for a real existing index's chunk data.
+	priorChunks := maxKeyringIndexChunks
+	existingHeader := `{"v":1,"chunks":128,"keys":["prior-header-marker"]}`
+	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString([]byte(existingHeader))
+	priorChunkData := make(map[int]string, len(chunks)-1)
+	for i := 1; i < len(chunks); i++ {
+		account := b.chunkAccount(i)
+		content := fmt.Sprintf("prior-chunk-%d-marker", i)
+		kr.data[keyringService+"/"+account] = content
+		priorChunkData[i] = content
+	}
+
+	missingChunks := []int{maxKeyringIndexChunks}
+	_, err := b.writeKeyIndex(keys, priorChunks, missingChunks, noLeaseLoss)
+	if err == nil {
+		t.Fatal("expected writeKeyIndex to reject an index that overflows the chunk cap")
+	}
+	if !strings.Contains(err.Error(), "chunk") {
+		t.Fatalf("error = %v, want it to name the chunk-cap rejection", err)
+	}
+
+	// The header must be exactly what it was: not replaced with a new one
+	// (which would have advertised an unreadable Chunks: 129), and not left
+	// as some other partially-applied value.
+	got := kr.data[keyringService+"/"+keyringIndexAccount]
+	want := base64.StdEncoding.EncodeToString([]byte(existingHeader))
+	if got != want {
+		t.Fatalf("index header was mutated by a rejected write:\n got  %q\n want %q", got, want)
+	}
+	// Every existing chunk account the rejected write would have targeted
+	// must be byte-for-byte the value it held before the call.
+	for i, want := range priorChunkData {
+		account := b.chunkAccount(i)
+		got := kr.data[keyringService+"/"+account]
+		if got != want {
+			t.Fatalf("chunk account %d was mutated by a rejected write: got %q, want %q (prior content)", i, got, want)
+		}
+	}
+}
+
 func TestStoreKeyringTombstonesOutgrowLiveCredentialCap(t *testing.T) {
 	kr := newFakeKR()
 	b := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -370,7 +371,7 @@ func (e errKR) Error() string { return string(e) }
 func indexedKeysOf(t *testing.T, kr *fakeKR) map[string]bool {
 	t.Helper()
 	blob := keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
-	keys, _, _, _, err := blob.readKeyIndex()
+	keys, _, _, _, _, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatalf("readKeyIndex: %v", err)
 	}
@@ -414,8 +415,15 @@ func TestStoreKeyringIndexStaysUnderEntryLimit(t *testing.T) {
 		}
 	}
 	// The index actually chunked (otherwise the ceiling check proves nothing).
-	if _, ok := kr.data[keyringService+"/"+keyringIndexAccount+"-1"]; !ok {
-		t.Fatal("expected the index to split into continuation chunks")
+	// Checked via readKeyIndex's reported chunk count, not a specific account
+	// name: a healthy write (no missing/protected chunks, true throughout this
+	// test) stages continuation chunks under a fresh generation's own account
+	// names rather than the single flat namespace older code always used.
+	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+	if _, _, chunks, _, _, err := blob.readKeyIndex(); err != nil {
+		t.Fatalf("readKeyIndex: %v", err)
+	} else if chunks < 2 {
+		t.Fatalf("expected the index to split into continuation chunks, got %d chunk(s)", chunks)
 	}
 	for _, name := range names {
 		if _, ok, err := s.Load(ProviderKey(name)); err != nil || !ok {
@@ -429,8 +437,18 @@ func TestStoreKeyringIndexStaysUnderEntryLimit(t *testing.T) {
 			t.Fatalf("Delete(%s): %v", name, err)
 		}
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringIndexAccount+"-1"]; ok {
-		t.Fatal("stale index continuation chunk left behind after shrink")
+	if _, _, chunks, _, missing, err := blob.readKeyIndex(); err != nil {
+		t.Fatalf("readKeyIndex: %v", err)
+	} else if chunks != 1 || len(missing) != 0 {
+		t.Fatalf("expected the index to shrink to a single chunk with nothing missing, got chunks=%d missing=%v", chunks, missing)
+	}
+	// No chunk account under any generation the store could have used may
+	// still hold data: a real stale-chunk leak would otherwise hide behind
+	// whichever generation name this assertion did not think to check.
+	for key := range kr.data {
+		if strings.Contains(key, keyringIndexAccount+"-") {
+			t.Fatalf("stale index continuation chunk left behind after shrink: %q", key)
+		}
 	}
 }
 
@@ -439,6 +457,193 @@ func TestStoreKeyringIndexStaysUnderEntryLimit(t *testing.T) {
 // the recoverable-store invariant at each boundary: every token entry present
 // in the keyring is listed in the published index (so no credential is ever
 // stranded invisibly), and a subsequent unimpeded write fully reconciles.
+// TestStoreKeyringIndexGrowthInterruptionsPreserveOldLayout is the regression
+// for [P1] Preserve the old index layout until its replacement header is
+// committed: a normal insert that grows a chunked index used to repack every
+// continuation chunk in place, overwriting accounts the OLD header still
+// referenced, before ever publishing the new header. A process killed after
+// one of those overwrites but before the header Set left the old header
+// pointing at a layout partially clobbered by pieces of the new one, and any
+// key that had been shifted into a chunk the old header's Chunks count did
+// not yet cover became unreachable from both the index and the (unrelated)
+// legacy blob, permanently.
+//
+// Unlike TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens, this seeds
+// enough keys that growth needs multiple new continuation chunks (a single
+// key would never reach the vulnerable code at all), and asserts a stronger
+// invariant at every interruption boundary: not just that no credential is
+// invisible, but that the pre-growth index is still decodable with zero
+// missing chunks and every original key intact, since a fresh-generation
+// write must never touch an account the current header can reach.
+func TestStoreKeyringIndexGrowthInterruptionsPreserveOldLayout(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// Long enough, and enough of them, that the original index alone already
+	// needs multiple continuation chunks. That is what makes this scenario
+	// reachable at all: if the pre-growth index fit in the header alone (one
+	// chunk), an in-place rewrite of new continuation slots would trivially
+	// avoid every account the old header could reach, regardless of whether
+	// generations are used, and this test would pass without exercising
+	// anything. Kept under maxKeyringKeyBytes once ProviderKey's "provider:"
+	// prefix is added, or ValidateKey would drop these as malformed.
+	const rawNameLen = 120
+	original := make([]string, 25)
+	for i := range original {
+		original[i] = ProviderKey(fmt.Sprintf("orig%0*d", rawNameLen-4, i))
+	}
+	added := make([]string, 60)
+	for i := range added {
+		added[i] = ProviderKey(fmt.Sprintf("k%0*d", rawNameLen-1, i))
+	}
+
+	growthState := func() []byte {
+		state := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{}}
+		for _, key := range original {
+			state.Tokens[key] = Token{AccessToken: "orig-" + key}
+		}
+		for _, key := range added {
+			state.Tokens[key] = Token{AccessToken: "new-" + key}
+		}
+		data, err := json.Marshal(state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+	mutations := func() map[string]bool {
+		m := make(map[string]bool, len(added))
+		for _, key := range added {
+			m[key] = false
+		}
+		return m
+	}
+
+	originalSorted := append([]string{}, original...)
+	sort.Strings(originalSorted)
+	originalChunks := chunkIndexKeys(originalSorted)
+	if len(originalChunks) < 2 {
+		t.Fatalf("test setup: original keys only produced %d chunk(s), want at least 2 so the old header already references a continuation slot", len(originalChunks))
+	}
+	seed := func(kr *failingKR) {
+		// The pre-growth index directly, already spanning multiple chunks:
+		// exactly what write() would have left after an earlier, unrelated,
+		// uninterrupted write of the same key set.
+		for _, key := range original {
+			raw, err := json.Marshal(Token{AccessToken: "orig-" + key})
+			if err != nil {
+				t.Fatal(err)
+			}
+			kr.data[keyringService+"/"+key] = base64.StdEncoding.EncodeToString(raw)
+		}
+		for i := 1; i < len(originalChunks); i++ {
+			chunkData, err := json.Marshal(originalChunks[i])
+			if err != nil {
+				t.Fatal(err)
+			}
+			account := keyringBlob{indexAccount: keyringIndexAccount}.chunkAccount(0, i)
+			kr.data[keyringService+"/"+account] = base64.StdEncoding.EncodeToString(chunkData)
+		}
+		header, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: len(originalChunks), Keys: originalChunks[0]})
+		if err != nil {
+			t.Fatal(err)
+		}
+		kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+	}
+
+	// An uninterrupted run establishes how many mutating ops the growth write
+	// can ever perform, including best-effort old-generation cleanup Deletes
+	// whose own errors are deliberately swallowed (nothing reads that
+	// generation again once the new header is durable, so a failed cleanup
+	// Delete there does not need to fail the write). Iterating failAt only up
+	// to this ceiling, and checking the layout invariant unconditionally
+	// rather than requiring every failAt to surface a visible error, still
+	// covers every mutating boundary without the loop mistaking a swallowed
+	// cleanup failure for a bug.
+	ceilingKR := &failingKR{fakeKR: newFakeKR()}
+	seed(ceilingKR)
+	ceilingBlob := keyringBlob{kr: ceilingKR, service: keyringService, indexAccount: keyringIndexAccount}
+	if err := ceilingBlob.write(growthState(), mutations(), noLeaseLoss); err != nil {
+		t.Fatalf("uninterrupted baseline growth write failed: %v", err)
+	}
+	ceiling := ceilingKR.ops
+
+	for failAt := 1; failAt <= ceiling; failAt++ {
+		kr := &failingKR{fakeKR: newFakeKR()}
+		blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+		seed(kr)
+
+		kr.failAt = failAt
+		_ = blob.write(growthState(), mutations(), noLeaseLoss)
+		kr.failAt = 0
+
+		// The invariant this finding is about: at every interruption
+		// boundary, the OLD layout the header still (or again) advertises
+		// must decode cleanly, with no missing chunks and every original key
+		// present and correct. A fresh-generation write must never leave
+		// this false, because it must never have touched an old-generation
+		// account in the first place.
+		listedKeys, ok, _, _, missing, err := blob.readKeyIndex()
+		if err != nil {
+			t.Fatalf("failAt=%d: readKeyIndex after interruption: %v", failAt, err)
+		}
+		if !ok {
+			t.Fatalf("failAt=%d: index vanished after interruption", failAt)
+		}
+		if len(missing) != 0 {
+			t.Fatalf("failAt=%d: index reports missing chunks after interruption: %v; the old layout must stay fully intact until the new one is durable", failAt, missing)
+		}
+		// The critical check: readKeyIndex not erroring is not enough on its
+		// own, since an overwritten chunk can still decode as valid JSON — it
+		// is just the wrong content. Every original key must still actually be
+		// LISTED, not merely that the read did not fail.
+		listed := make(map[string]bool, len(listedKeys))
+		for _, k := range listedKeys {
+			listed[k] = true
+		}
+		for _, key := range original {
+			if !listed[key] {
+				t.Fatalf("failAt=%d: original key %q no longer listed in the index after interruption (readKeyIndex returned %d keys); a chunk it depended on was overwritten before the new header committed", failAt, key, len(listedKeys))
+			}
+		}
+		for _, key := range original {
+			enc, exists, err := kr.Get(keyringService, key)
+			if err != nil || !exists {
+				t.Fatalf("failAt=%d: original entry %q missing after interruption: exists=%v err=%v", failAt, key, exists, err)
+			}
+			raw, err := base64.StdEncoding.DecodeString(enc)
+			if err != nil {
+				t.Fatalf("failAt=%d: original entry %q undecodable: %v", failAt, key, err)
+			}
+			var token Token
+			if err := json.Unmarshal(raw, &token); err != nil {
+				t.Fatalf("failAt=%d: original entry %q corrupt: %v", failAt, key, err)
+			}
+			if token.AccessToken != "orig-"+key {
+				t.Fatalf("failAt=%d: original entry %q = %q, want %q", failAt, key, token.AccessToken, "orig-"+key)
+			}
+		}
+
+		// A retried, unimpeded write must still fully reconcile: old and new
+		// keys all present.
+		if err := blob.write(growthState(), mutations(), noLeaseLoss); err != nil {
+			t.Fatalf("failAt=%d: reconciling write: %v", failAt, err)
+		}
+		full, _, err := blob.read()
+		if err != nil {
+			t.Fatalf("failAt=%d: read after reconcile: %v", failAt, err)
+		}
+		var state storeFile
+		if err := json.Unmarshal(full, &state); err != nil {
+			t.Fatalf("failAt=%d: decode after reconcile: %v", failAt, err)
+		}
+		for _, key := range append(append([]string{}, original...), added...) {
+			if _, ok := state.Tokens[key]; !ok {
+				t.Fatalf("failAt=%d: key %q missing after reconcile", failAt, key)
+			}
+		}
+	}
+}
+
 func TestStoreKeyringWriteInterruptionsLeaveNoInvisibleTokens(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	for failAt := 1; ; failAt++ {
@@ -965,7 +1170,7 @@ func TestStoreKeyringReadIndexRejectsCorruptHeader(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(oversized)
 	ckr.gets = 0
-	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized chunk count to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -978,7 +1183,7 @@ func TestStoreKeyringReadIndexRejectsCorruptHeader(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(unsupported)
 	ckr.gets = 0
-	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an unsupported index version to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -1007,7 +1212,7 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
 	ckr.gets = 0
-	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized key list in a chunk-0 header to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -1021,7 +1226,7 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(legacyArray)
 	ckr.gets = 0
-	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized legacy-format key array to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -1042,7 +1247,7 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(headerOK)
 	ckr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
 	ckr.gets = 0
-	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected an oversized key list accumulated across chunks to be rejected")
 	}
 	if ckr.gets != 2 {
@@ -1287,7 +1492,7 @@ func TestStoreKeyringWriteIndexRejectsOverCapChunks(t *testing.T) {
 	for i := range keys {
 		keys[i] = fmt.Sprintf("%s-%d", long, i)
 	}
-	if _, err := b.writeKeyIndex(keys, 0, nil, noLeaseLoss); err == nil {
+	if _, _, err := b.writeKeyIndex(keys, 0, 0, nil, noLeaseLoss); err == nil {
 		t.Fatal("writeKeyIndex published an index readKeyIndex would refuse")
 	}
 	if len(kr.data) != 0 {
@@ -1307,7 +1512,7 @@ func TestStoreKeyringWriteIndexRejectsOverCapKeys(t *testing.T) {
 		// would not catch this over-cap set.
 		keys[i] = fmt.Sprintf("p%d", i)
 	}
-	if _, err := b.writeKeyIndex(keys, 0, nil, noLeaseLoss); err == nil {
+	if _, _, err := b.writeKeyIndex(keys, 0, 0, nil, noLeaseLoss); err == nil {
 		t.Fatal("writeKeyIndex published a key count readKeyIndex would refuse")
 	}
 	if len(kr.data) != 0 {
@@ -1340,7 +1545,7 @@ func TestStoreKeyringReadIndexDedupesDuplicateKeys(t *testing.T) {
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = encoded
 
-	keys, ok, _, _, err := blob.readKeyIndex()
+	keys, ok, _, _, _, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatalf("readKeyIndex: %v", err)
 	}
@@ -1358,7 +1563,7 @@ func TestStoreKeyringReadIndexDedupesDuplicateKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(mixed)
-	keys, _, _, _, err = blob.readKeyIndex()
+	keys, _, _, _, _, err = blob.readKeyIndex()
 	if err != nil {
 		t.Fatalf("readKeyIndex: %v", err)
 	}
@@ -1947,7 +2152,7 @@ func TestStoreKeyringReadIndexRejectsOversizedEncodedPayload(t *testing.T) {
 	huge := strings.Repeat("A", maxKeyringIndexEncodedBytes+1)
 	ckr.data[keyringService+"/"+keyringIndexAccount] = huge
 	ckr.gets = 0
-	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected oversized encoded index payload to be rejected")
 	}
 	if ckr.gets != 1 {
@@ -1962,7 +2167,7 @@ func TestStoreKeyringReadIndexRejectsOversizedEncodedPayload(t *testing.T) {
 	ckr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
 	ckr.data[keyringService+"/"+keyringIndexAccount+"-1"] = huge
 	ckr.gets = 0
-	if _, _, _, _, err := blob.readKeyIndex(); err == nil {
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
 		t.Fatal("expected oversized encoded chunk payload to be rejected")
 	}
 }
@@ -2463,14 +2668,14 @@ func TestWriteKeyIndexRejectsOverflowWithoutMutatingExistingChunks(t *testing.T)
 	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString([]byte(existingHeader))
 	priorChunkData := make(map[int]string, len(chunks)-1)
 	for i := 1; i < len(chunks); i++ {
-		account := b.chunkAccount(i)
+		account := b.chunkAccount(0, i)
 		content := fmt.Sprintf("prior-chunk-%d-marker", i)
 		kr.data[keyringService+"/"+account] = content
 		priorChunkData[i] = content
 	}
 
 	missingChunks := []int{maxKeyringIndexChunks}
-	_, err := b.writeKeyIndex(keys, priorChunks, missingChunks, noLeaseLoss)
+	_, _, err := b.writeKeyIndex(keys, priorChunks, 0, missingChunks, noLeaseLoss)
 	if err == nil {
 		t.Fatal("expected writeKeyIndex to reject an index that overflows the chunk cap")
 	}
@@ -2489,7 +2694,7 @@ func TestWriteKeyIndexRejectsOverflowWithoutMutatingExistingChunks(t *testing.T)
 	// Every existing chunk account the rejected write would have targeted
 	// must be byte-for-byte the value it held before the call.
 	for i, want := range priorChunkData {
-		account := b.chunkAccount(i)
+		account := b.chunkAccount(0, i)
 		got := kr.data[keyringService+"/"+account]
 		if got != want {
 			t.Fatalf("chunk account %d was mutated by a rejected write: got %q, want %q (prior content)", i, got, want)
@@ -3069,7 +3274,7 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	// Damage: drop chunk-1.
 	delete(kr.data, keyringService+"/"+keyringIndexAccount+"-1")
 
-	gotKeys, ok, chunks, missing, err := blob.readKeyIndex()
+	gotKeys, ok, chunks, _, missing, err := blob.readKeyIndex()
 	if err != nil || !ok {
 		t.Fatalf("readKeyIndex: ok=%v err=%v", ok, err)
 	}
@@ -3099,7 +3304,7 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	if _, ok := kr.data[keyringService+"/"+ProviderKey("beta")]; !ok {
 		t.Fatal("beta entry was deleted despite missing index chunk; orphan risk path")
 	}
-	afterKeys, _, afterChunks, afterMissing, err := blob.readKeyIndex()
+	afterKeys, _, afterChunks, _, afterMissing, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3119,7 +3324,7 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	// Restoring the missing chunk must surface beta again (the point of preserving
 	// the advertisement instead of shrinking to a complete 1-chunk index).
 	kr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
-	restored, _, _, restoredMissing, err := blob.readKeyIndex()
+	restored, _, _, _, restoredMissing, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3171,7 +3376,7 @@ func TestWritePreservesMissingMiddleChunkSlot(t *testing.T) {
 	// Damage: drop the MIDDLE continuation chunk (chunk-1).
 	delete(kr.data, keyringService+"/"+keyringIndexAccount+"-1")
 
-	gotKeys, ok, chunks, missing, err := blob.readKeyIndex()
+	gotKeys, ok, chunks, _, missing, err := blob.readKeyIndex()
 	if err != nil || !ok {
 		t.Fatalf("readKeyIndex: ok=%v err=%v", ok, err)
 	}
@@ -3208,7 +3413,7 @@ func TestWritePreservesMissingMiddleChunkSlot(t *testing.T) {
 	if _, exists := kr.data[keyringService+"/"+keyringIndexAccount+"-1"]; exists {
 		t.Fatal("write overwrote the protected missing chunk-1 slot")
 	}
-	afterKeys, ok, afterChunks, afterMissing, err := blob.readKeyIndex()
+	afterKeys, ok, afterChunks, _, afterMissing, err := blob.readKeyIndex()
 	if err != nil || !ok {
 		t.Fatalf("post-write readKeyIndex: ok=%v err=%v", ok, err)
 	}
@@ -3236,7 +3441,7 @@ func TestWritePreservesMissingMiddleChunkSlot(t *testing.T) {
 	// Restore the original missing chunk: beta must become discoverable and
 	// deletable again.
 	kr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
-	restored, ok, _, restoredMissing, err := blob.readKeyIndex()
+	restored, ok, _, _, restoredMissing, err := blob.readKeyIndex()
 	if err != nil || !ok {
 		t.Fatalf("restored readKeyIndex: ok=%v err=%v", ok, err)
 	}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1051,8 +1052,7 @@ func TestStoreKeyringReadIndexRejectsOversizedKeyList(t *testing.T) {
 // TestKeyringLockPathIsPerUser covers the lock path used for every keyring
 // Store regardless of file-backend config. It must not be the single shared
 // temp path that any account on a multi-user host could pre-create or hold,
-// and the last-resort temp name must be scoped by uid so different users
-// never collide on one lock file.
+// and it must not vary with the ambient HOME/USERPROFILE environment.
 func TestKeyringLockPathIsPerUser(t *testing.T) {
 	// Observe real OS identity, not the TestMain isolation stub.
 	previous := currentOSUser
@@ -1075,14 +1075,6 @@ func TestKeyringLockPathIsPerUser(t *testing.T) {
 		if want := filepath.Join(home, ".cache", "zero", name); got != want {
 			t.Fatalf("lock path = %q, want per-user home-anchored path %q", got, want)
 		}
-	}
-	tempName := keyringTempLockName(keyringService, keyringIndexAccount)
-	if uid := os.Getuid(); uid >= 0 {
-		if !strings.Contains(tempName, fmt.Sprintf("%d", uid)) {
-			t.Fatalf("temp lock name %q is not scoped by uid %d", tempName, uid)
-		}
-	} else if tempName == "" {
-		t.Fatal("temp lock name is empty")
 	}
 }
 
@@ -1294,7 +1286,7 @@ func TestStoreKeyringWriteIndexRejectsOverCapChunks(t *testing.T) {
 	for i := range keys {
 		keys[i] = fmt.Sprintf("%s-%d", long, i)
 	}
-	if _, err := b.writeKeyIndex(keys, 0, false); err == nil {
+	if _, err := b.writeKeyIndex(keys, 0, nil); err == nil {
 		t.Fatal("writeKeyIndex published an index readKeyIndex would refuse")
 	}
 	if len(kr.data) != 0 {
@@ -1314,7 +1306,7 @@ func TestStoreKeyringWriteIndexRejectsOverCapKeys(t *testing.T) {
 		// would not catch this over-cap set.
 		keys[i] = fmt.Sprintf("p%d", i)
 	}
-	if _, err := b.writeKeyIndex(keys, 0, false); err == nil {
+	if _, err := b.writeKeyIndex(keys, 0, nil); err == nil {
 		t.Fatal("writeKeyIndex published a key count readKeyIndex would refuse")
 	}
 	if len(kr.data) != 0 {
@@ -2331,6 +2323,83 @@ func TestStoreKeyringTombstonesOutgrowLiveCredentialCap(t *testing.T) {
 	}
 }
 
+// TestStoreKeyringTombstoneBoundaryDoesNotBrickSaves is the regression for
+// [P2] Bound or retire tombstones without bricking future saves (2026-08-09):
+// the tombstone set used to be capped by the raw count (16,384) while the
+// chunked writer's real capacity for maximum-length keys is far smaller.
+// Reaching that boundary made writeTombstones fail before the rest of every
+// Save or Delete, including a re-login that could otherwise clear a marker.
+// The set must now be bounded at the true writable capacity, and hitting the
+// boundary must leave unrelated Saves working and re-login able to retire a
+// marker.
+func TestStoreKeyringTombstoneBoundaryDoesNotBrickSaves(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := s.blob.(keyringBlob)
+
+	// Maximum-length valid keys are the worst case for the chunked writer:
+	// each key costs len+8 = 145 bytes of a 2700-byte chunk, so one chunk
+	// holds 18 and maxKeyringIndexChunks holds maxKeyringTombstoneKeys.
+	maxKey := func(i int) string {
+		return KeyPrefixProvider + fmt.Sprintf("k%04d", i) + strings.Repeat("x", 128-len(fmt.Sprintf("k%04d", i)))
+	}
+	if err := ValidateKey(maxKey(0)); err != nil {
+		t.Fatalf("fixture key invalid: %v", err)
+	}
+	tombstones := make(map[string]bool, maxKeyringTombstoneKeys)
+	for i := 0; i < maxKeyringTombstoneKeys; i++ {
+		tombstones[maxKey(i)] = true
+	}
+	if err := blob.writeTombstones(tombstones); err != nil {
+		t.Fatalf("write %d max-length tombstones: %v", len(tombstones), err)
+	}
+	got, err := blob.readTombstones()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != maxKeyringTombstoneKeys {
+		t.Fatalf("read %d tombstones, want %d", len(got), maxKeyringTombstoneKeys)
+	}
+
+	// An unrelated Save must still work at the boundary (the marker set is
+	// unchanged and fits the writer).
+	if err := s.Save(ProviderKey("fresh"), Token{AccessToken: "f"}); err != nil {
+		t.Fatalf("Save at tombstone boundary: %v", err)
+	}
+	if tok, ok, err := s.Load(ProviderKey("fresh")); err != nil || !ok || tok.AccessToken != "f" {
+		t.Fatalf("Load(fresh) = %#v ok=%v err=%v", tok, ok, err)
+	}
+
+	// A Delete that would add a brand-new marker past the writable bound must
+	// fail with the clear bound error instead of bricking the store, and the
+	// credential must remain usable (the logout did not silently succeed).
+	removed, err := s.Delete(ProviderKey("fresh"))
+	if err == nil {
+		t.Fatalf("Delete past tombstone bound succeeded (removed=%v); want a clear bound error", removed)
+	}
+	if !strings.Contains(err.Error(), "writable bound") {
+		t.Fatalf("Delete error = %v, want the tombstone writable-bound error", err)
+	}
+	if tok, ok, err := s.Load(ProviderKey("fresh")); err != nil || !ok || tok.AccessToken != "f" {
+		t.Fatalf("credential lost after failed over-bound Delete: %#v ok=%v err=%v", tok, ok, err)
+	}
+	// Retiring markers (re-login of tombstoned keys) frees slots, so the same
+	// Delete then succeeds: the boundary is recoverable, not a permanent brick.
+	if err := s.Save(maxKey(0), Token{AccessToken: "relogged"}); err != nil {
+		t.Fatalf("re-login at tombstone boundary: %v", err)
+	}
+	if err := s.Save(maxKey(1), Token{AccessToken: "relogged2"}); err != nil {
+		t.Fatalf("re-login to retire a second marker: %v", err)
+	}
+	if removed, err := s.Delete(ProviderKey("fresh")); err != nil || !removed {
+		t.Fatalf("Delete after retiring markers: removed=%v err=%v", removed, err)
+	}
+}
+
 func TestKeyringLockPathUserLookupFallbackIgnoresAmbientHome(t *testing.T) {
 	previous := currentOSUser
 	currentOSUser = func() (*user.User, error) { return nil, fmt.Errorf("lookup unavailable") }
@@ -2351,9 +2420,71 @@ func TestKeyringLockPathUserLookupFallbackIgnoresAmbientHome(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Join(fallbackDir, keyringTempLockName(keyringService, keyringIndexAccount))
+	want := filepath.Join(fallbackDir, keyringLockFileName(keyringService, keyringIndexAccount))
 	if gotA != want {
-		t.Fatalf("fallback lock = %q, want UID-scoped temporary %q", gotA, want)
+		t.Fatalf("fallback lock = %q, want identity-stable fallback %q", gotA, want)
+	}
+}
+
+// TestKeyringLockPathFallbackStableAcrossTMPDIROverrides is the regression for
+// [P1] Keep the fallback keyring lock path stable across TMPDIR overrides
+// (2026-08-09): the last-resort lock directory used to be anchored on
+// os.TempDir(), which honors the per-process TMPDIR environment override. Two
+// same-UID processes with different TMPDIR values (sandboxes, CI, launchers)
+// chose different zero-oauth-locks-<uid> directories while both wrote the same
+// fixed keyring index, so they could race it. Every branch of lock-path
+// resolution must be identity-stable, and the fallback must fail closed rather
+// than fall back to a process-specific temp root.
+func TestKeyringLockPathFallbackStableAcrossTMPDIROverrides(t *testing.T) {
+	previousUser := currentOSUser
+	currentOSUser = func() (*user.User, error) { return nil, fmt.Errorf("lookup unavailable") }
+	defer func() { currentOSUser = previousUser }()
+	previousLookup := lookupUserID
+	lookupUserID = func(string) (*user.User, error) { return nil, fmt.Errorf("user db unavailable") }
+	defer func() { lookupUserID = previousLookup }()
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	t.Setenv("TMPDIR", dirA)
+	storeA, err := NewStore(StoreOptions{Storage: "keyring", Keyring: newFakeKR()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", dirB)
+	storeB, err := NewStore(StoreOptions{Storage: "keyring", Keyring: newFakeKR()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blobA := storeA.blob.(keyringBlob)
+	blobB := storeB.blob.(keyringBlob)
+	if blobA.lockPath == "" || blobB.lockPath == "" {
+		t.Fatal("keyring store has no lock path in the fallback branch")
+	}
+	if blobA.lockPath != blobB.lockPath {
+		t.Fatalf("fallback lock path changed with TMPDIR: %q vs %q (they can race the shared keyring index)", blobA.lockPath, blobB.lockPath)
+	}
+	if strings.Contains(blobA.lockPath, dirA) || strings.Contains(blobA.lockPath, dirB) {
+		t.Fatalf("fallback lock path %q is still derived from TMPDIR", blobA.lockPath)
+	}
+
+	// Prove the two stores actually serialize on the same lock file: hold the
+	// lock and verify a Save through the other store blocks until released.
+	unlock, _, err := acquireFileLock(blobA.lockPath, time.Now)
+	if err != nil {
+		t.Fatalf("acquire lock for serialization proof: %v", err)
+	}
+	saveDone := make(chan error, 1)
+	go func() {
+		saveDone <- storeB.Save(ProviderKey("alpha"), Token{AccessToken: "a"})
+	}()
+	select {
+	case err := <-saveDone:
+		t.Fatalf("storeB.Save completed while storeA held the lock: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	unlock()
+	if err := <-saveDone; err != nil {
+		t.Fatalf("storeB.Save after release: %v", err)
 	}
 }
 
@@ -2435,6 +2566,130 @@ func TestLeaseRefreshStopsWhenLockReplaced(t *testing.T) {
 	}
 }
 
+// TestWithLeasedLocksSkipsFnWhenLeaseLostWhileWaiting is the regression for
+// [P1] Abort before the keyring mutation when a leased lock is lost
+// (2026-08-09): withLeasedLocks used to invoke fn after acquisition and report
+// a lost lease only afterward. That is reachable while the first, global index
+// lock is held and the caller blocks on legacyLockPath: a reclaimed first lock
+// can coexist with the resumed caller's mutation. The critical callback must
+// never run once any lease is lost before fn starts.
+func TestWithLeasedLocksSkipsFnWhenLeaseLostWhileWaiting(t *testing.T) {
+	prevRefresh := fileLockRefreshInterval
+	fileLockRefreshInterval = 20 * time.Millisecond
+	defer func() { fileLockRefreshInterval = prevRefresh }()
+
+	lock1 := filepath.Join(t.TempDir(), "one.lock")
+	lock2 := filepath.Join(t.TempDir(), "two.lock")
+
+	// Simulate a peer holding lock2, so withLeasedLocks blocks after acquiring
+	// lock1 while waiting for lock2.
+	unlock2, _, err := acquireFileLock(lock2, time.Now)
+	if err != nil {
+		t.Fatalf("acquire simulated peer lock: %v", err)
+	}
+
+	var fnCalled atomic.Bool
+	done := make(chan error, 1)
+	go func() {
+		done <- withLeasedLocks([]string{lock1, lock2}, time.Now, func() error {
+			fnCalled.Store(true)
+			return nil
+		})
+	}()
+
+	// Wait for lock1 to be acquired and its lease started.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(lock1); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("lock1 was never acquired")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// A peer reclaims lock1 while we still wait on lock2.
+	if err := os.WriteFile(lock1, []byte("replacement-holder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Give the lease refresher a tick to observe the replacement.
+	time.Sleep(80 * time.Millisecond)
+	// Release lock2 so acquisition completes and the pre-fn fencing check runs.
+	unlock2()
+
+	err = <-done
+	if err == nil || !strings.Contains(err.Error(), "lost token lock lease") {
+		t.Fatalf("withLeasedLocks err = %v, want lost-lease error", err)
+	}
+	if fnCalled.Load() {
+		t.Fatal("critical callback ran despite a lost lease before fn")
+	}
+	// The reclaiming peer's lock file must not be removed by our release.
+	if data, rerr := os.ReadFile(lock1); rerr == nil && string(data) != "replacement-holder" {
+		t.Fatalf("lock1 content = %q, want the peer's replacement preserved", data)
+	}
+	_ = os.Remove(lock1)
+}
+
+// TestWithLeasedLocksSkipsFnWhenChtimesFails is the failure-injection half of
+// the same fencing finding: a failed renewal (os.Chtimes error) must be
+// treated as an immediate fencing failure, not silently discarded. The lock
+// would retain its token but stop advancing its mtime, go stale, and be
+// reclaimed by a peer starting a conflicting keyring read-modify-write.
+func TestWithLeasedLocksSkipsFnWhenChtimesFails(t *testing.T) {
+	prevRefresh := fileLockRefreshInterval
+	fileLockRefreshInterval = 20 * time.Millisecond
+	defer func() { fileLockRefreshInterval = prevRefresh }()
+	prevChtimes := chtimesLockFile
+	chtimesLockFile = func(string, time.Time, time.Time) error { return errKRInjected }
+	defer func() { chtimesLockFile = prevChtimes }()
+
+	lock1 := filepath.Join(t.TempDir(), "one.lock")
+	lock2 := filepath.Join(t.TempDir(), "two.lock")
+
+	unlock2, _, err := acquireFileLock(lock2, time.Now)
+	if err != nil {
+		t.Fatalf("acquire simulated peer lock: %v", err)
+	}
+
+	var fnCalled atomic.Bool
+	done := make(chan error, 1)
+	go func() {
+		done <- withLeasedLocks([]string{lock1, lock2}, time.Now, func() error {
+			fnCalled.Store(true)
+			return nil
+		})
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(lock1); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("lock1 was never acquired")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Let the lease refresher hit the injected Chtimes failure while we wait
+	// on lock2, marking lock1 lost before fn could run.
+	time.Sleep(80 * time.Millisecond)
+	unlock2()
+
+	err = <-done
+	if err == nil || !strings.Contains(err.Error(), "lost token lock lease") {
+		t.Fatalf("withLeasedLocks err = %v, want lost-lease error", err)
+	}
+	if fnCalled.Load() {
+		t.Fatal("critical callback ran despite a failed lease renewal before fn")
+	}
+	// Our own release is ownership-aware: lock1 still holds our token, so it
+	// must have been removed.
+	if _, statErr := os.Stat(lock1); !os.IsNotExist(statErr) {
+		t.Fatalf("lock1 still present after fencing failure release: %v", statErr)
+	}
+}
+
 // TestAcquireFileLockTimesOutOnFutureMtime rejects a lock whose mtime is in
 // the future as a healthy lease: without the non-negative age guard, every
 // wait loop extends idleDeadline forever.
@@ -2493,12 +2748,12 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	// Damage: drop chunk-1.
 	delete(kr.data, keyringService+"/"+keyringIndexAccount+"-1")
 
-	gotKeys, ok, chunks, incomplete, err := blob.readKeyIndex()
+	gotKeys, ok, chunks, missing, err := blob.readKeyIndex()
 	if err != nil || !ok {
 		t.Fatalf("readKeyIndex: ok=%v err=%v", ok, err)
 	}
-	if !incomplete {
-		t.Fatal("expected incomplete=true when chunk-1 is missing")
+	if len(missing) != 1 || missing[0] != 1 {
+		t.Fatalf("expected chunk-1 reported missing, got %v", missing)
 	}
 	if chunks != 2 {
 		t.Fatalf("chunks = %d, want 2", chunks)
@@ -2523,15 +2778,15 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	if _, ok := kr.data[keyringService+"/"+ProviderKey("beta")]; !ok {
 		t.Fatal("beta entry was deleted despite missing index chunk; orphan risk path")
 	}
-	afterKeys, _, afterChunks, afterIncomplete, err := blob.readKeyIndex()
+	afterKeys, _, afterChunks, afterMissing, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if afterChunks != 2 {
 		t.Fatalf("post-write chunks = %d, want 2 (preserve missing-chunk advertisement)", afterChunks)
 	}
-	if !afterIncomplete {
-		t.Fatal("post-write index should still be incomplete until chunk-1 returns")
+	if len(afterMissing) != 1 || afterMissing[0] != 1 {
+		t.Fatalf("post-write missing chunks = %v, want [1] until chunk-1 returns", afterMissing)
 	}
 	found := map[string]bool{}
 	for _, k := range afterKeys {
@@ -2543,11 +2798,11 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	// Restoring the missing chunk must surface beta again (the point of preserving
 	// the advertisement instead of shrinking to a complete 1-chunk index).
 	kr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
-	restored, _, _, incomplete, err := blob.readKeyIndex()
+	restored, _, _, restoredMissing, err := blob.readKeyIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if incomplete {
+	if len(restoredMissing) != 0 {
 		t.Fatal("expected complete index after restoring chunk-1")
 	}
 	restoredFound := map[string]bool{}
@@ -2556,5 +2811,141 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	}
 	if !restoredFound[ProviderKey("beta")] {
 		t.Fatalf("restored keys = %v, want beta recoverable from chunk-1", restored)
+	}
+}
+
+// TestWritePreservesMissingMiddleChunkSlot is the regression for [P1] Do not
+// overwrite a recoverable missing index chunk (2026-08-09): writeKeyIndex used
+// to preserve only the old header count, not the identity of the missing
+// accounts. A missing MIDDLE continuation chunk was overwritten with newly
+// packed unrelated keys on the next save, so restoring the original chunk could
+// no longer make its per-key credentials reachable. New continuation chunks
+// must be remapped around protected slots, and the protected account must stay
+// untouched (and still advertised) so a later restore reconciles its tokens.
+func TestWritePreservesMissingMiddleChunkSlot(t *testing.T) {
+	kr := newFakeKR()
+	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+
+	// Three-chunk index: header [alpha], chunk-1 [beta], chunk-2 [gamma].
+	header, err := json.Marshal(keyIndexHeader{Version: 1, Chunks: 3, Keys: []string{ProviderKey("alpha")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk1, err := json.Marshal([]string{ProviderKey("beta")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk2, err := json.Marshal([]string{ProviderKey("gamma")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(header)
+	kr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
+	kr.data[keyringService+"/"+keyringIndexAccount+"-2"] = base64.StdEncoding.EncodeToString(chunk2)
+	// Entries for every key.
+	for _, k := range []string{ProviderKey("alpha"), ProviderKey("beta"), ProviderKey("gamma")} {
+		raw, _ := json.Marshal(Token{AccessToken: "tok-" + k})
+		kr.data[keyringService+"/"+k] = base64.StdEncoding.EncodeToString(raw)
+	}
+	// Damage: drop the MIDDLE continuation chunk (chunk-1).
+	delete(kr.data, keyringService+"/"+keyringIndexAccount+"-1")
+
+	gotKeys, ok, chunks, missing, err := blob.readKeyIndex()
+	if err != nil || !ok {
+		t.Fatalf("readKeyIndex: ok=%v err=%v", ok, err)
+	}
+	if chunks != 3 {
+		t.Fatalf("chunks = %d, want 3", chunks)
+	}
+	if len(missing) != 1 || missing[0] != 1 {
+		t.Fatalf("missing = %v, want chunk-1 only", missing)
+	}
+	if len(gotKeys) != 2 {
+		t.Fatalf("keys = %v, want header + chunk-2 keys (beta unreachable)", gotKeys)
+	}
+
+	// Save a state whose union needs at least one continuation chunk: many
+	// keys so the packed index overflows the header budget. The union includes
+	// livePrior (alpha, gamma) plus the new set.
+	state := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "tok-alpha"},
+		ProviderKey("gamma"): {AccessToken: "tok-gamma"},
+	}}
+	for i := 0; i < 120; i++ {
+		state.Tokens[ProviderKey(fmt.Sprintf("fill-%03d", i))] = Token{AccessToken: "tok-fill"}
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := blob.write(data, map[string]bool{ProviderKey("fill-000"): false}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// The protected middle slot must still be absent (never overwritten) and
+	// still advertised, so restoring chunk-1 can reconcile beta later.
+	if _, exists := kr.data[keyringService+"/"+keyringIndexAccount+"-1"]; exists {
+		t.Fatal("write overwrote the protected missing chunk-1 slot")
+	}
+	afterKeys, ok, afterChunks, afterMissing, err := blob.readKeyIndex()
+	if err != nil || !ok {
+		t.Fatalf("post-write readKeyIndex: ok=%v err=%v", ok, err)
+	}
+	if afterChunks < 3 {
+		t.Fatalf("post-write chunks = %d, want >= 3 (protected slot still advertised)", afterChunks)
+	}
+	if len(afterMissing) != 1 || afterMissing[0] != 1 {
+		t.Fatalf("post-write missing = %v, want chunk-1 only", afterMissing)
+	}
+	found := map[string]bool{}
+	for _, k := range afterKeys {
+		found[k] = true
+	}
+	for k := range state.Tokens {
+		if !found[k] {
+			t.Fatalf("post-write keys missing %q (union must stay readable)", k)
+		}
+	}
+	// beta's entry must not have been deleted (it was unreachable, so it was
+	// not in livePrior and must stay resident for later recovery).
+	if _, ok := kr.data[keyringService+"/"+ProviderKey("beta")]; !ok {
+		t.Fatal("beta entry was deleted despite missing chunk; recovery impossible")
+	}
+
+	// Restore the original missing chunk: beta must become discoverable and
+	// deletable again.
+	kr.data[keyringService+"/"+keyringIndexAccount+"-1"] = base64.StdEncoding.EncodeToString(chunk1)
+	restored, ok, _, restoredMissing, err := blob.readKeyIndex()
+	if err != nil || !ok {
+		t.Fatalf("restored readKeyIndex: ok=%v err=%v", ok, err)
+	}
+	if len(restoredMissing) != 0 {
+		t.Fatalf("restored missing = %v, want complete", restoredMissing)
+	}
+	restoredFound := map[string]bool{}
+	for _, k := range restored {
+		restoredFound[k] = true
+	}
+	for k := range state.Tokens {
+		if !restoredFound[k] {
+			t.Fatalf("restored keys missing %q", k)
+		}
+	}
+	if !restoredFound[ProviderKey("beta")] {
+		t.Fatalf("restored keys = %v, want beta recoverable from restored chunk-1", restored)
+	}
+
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok, err := s.Load(ProviderKey("beta")); err != nil || !ok || got.AccessToken != "tok-"+ProviderKey("beta") {
+		t.Fatalf("Load(beta) after restore = %#v ok=%v err=%v", got, ok, err)
+	}
+	if removed, err := s.Delete(ProviderKey("beta")); err != nil || !removed {
+		t.Fatalf("Delete(beta) after restore: removed=%v err=%v", removed, err)
+	}
+	if _, ok := kr.data[keyringService+"/"+ProviderKey("beta")]; ok {
+		t.Fatal("beta entry still resident after Delete; not deletable")
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -655,7 +655,7 @@ func TestStoreKeyringWithLockRefreshesLease(t *testing.T) {
 	defer func() { fileLockRefreshInterval = previous }()
 
 	var first, second time.Time
-	err := blob.withLock(time.Now, func() error {
+	err := blob.withLock(time.Now, func(leaseCheck) error {
 		info, err := os.Stat(lockPath)
 		if err != nil {
 			return err
@@ -922,7 +922,7 @@ func TestStoreKeyringLeaseUsesWallClockNotStoreClock(t *testing.T) {
 	// would land decades in the past and look stale immediately.
 	fixed := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	var mtime time.Time
-	err := blob.withLock(func() time.Time { return fixed }, func() error {
+	err := blob.withLock(func() time.Time { return fixed }, func(leaseCheck) error {
 		time.Sleep(150 * time.Millisecond)
 		info, statErr := os.Stat(lockPath)
 		if statErr != nil {
@@ -1287,7 +1287,7 @@ func TestStoreKeyringWriteIndexRejectsOverCapChunks(t *testing.T) {
 	for i := range keys {
 		keys[i] = fmt.Sprintf("%s-%d", long, i)
 	}
-	if _, err := b.writeKeyIndex(keys, 0, nil); err == nil {
+	if _, err := b.writeKeyIndex(keys, 0, nil, noLeaseLoss); err == nil {
 		t.Fatal("writeKeyIndex published an index readKeyIndex would refuse")
 	}
 	if len(kr.data) != 0 {
@@ -1307,7 +1307,7 @@ func TestStoreKeyringWriteIndexRejectsOverCapKeys(t *testing.T) {
 		// would not catch this over-cap set.
 		keys[i] = fmt.Sprintf("p%d", i)
 	}
-	if _, err := b.writeKeyIndex(keys, 0, nil); err == nil {
+	if _, err := b.writeKeyIndex(keys, 0, nil, noLeaseLoss); err == nil {
 		t.Fatal("writeKeyIndex published a key count readKeyIndex would refuse")
 	}
 	if len(kr.data) != 0 {
@@ -2173,7 +2173,7 @@ func TestStoreKeyringLeaseRefreshesWhileWaitingOnSecondLock(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- withLeasedLocks([]string{indexLock, legacyLock}, time.Now, func() error {
+		done <- withLeasedLocks([]string{indexLock, legacyLock}, time.Now, func(leaseCheck) error {
 			return nil
 		})
 	}()
@@ -2280,7 +2280,7 @@ func TestStoreKeyringReloginKeepsTombstoneUntilReplacementCommits(t *testing.T) 
 	}
 	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacy)
 	b := keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
-	if err := b.writeTombstones(map[string]bool{ProviderKey("alpha"): true}); err != nil {
+	if err := b.writeTombstones(map[string]bool{ProviderKey("alpha"): true}, noLeaseLoss); err != nil {
 		t.Fatal(err)
 	}
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
@@ -2312,7 +2312,7 @@ func TestStoreKeyringTombstonesOutgrowLiveCredentialCap(t *testing.T) {
 	for i := 0; i <= maxKeyringIndexKeys; i++ {
 		tombstones[ProviderKey(fmt.Sprintf("retired-%03d", i))] = true
 	}
-	if err := b.writeTombstones(tombstones); err != nil {
+	if err := b.writeTombstones(tombstones, noLeaseLoss); err != nil {
 		t.Fatalf("write %d tombstones: %v", len(tombstones), err)
 	}
 	got, err := b.readTombstones()
@@ -2355,7 +2355,7 @@ func TestStoreKeyringTombstoneBoundaryDoesNotBrickSaves(t *testing.T) {
 	for i := 0; i < maxKeyringTombstoneKeys; i++ {
 		tombstones[maxKey(i)] = true
 	}
-	if err := blob.writeTombstones(tombstones); err != nil {
+	if err := blob.writeTombstones(tombstones, noLeaseLoss); err != nil {
 		t.Fatalf("write %d max-length tombstones: %v", len(tombstones), err)
 	}
 	got, err := blob.readTombstones()
@@ -2542,7 +2542,7 @@ func TestWithLeasedLocksReleasesOnPanic(t *testing.T) {
 				t.Fatal("expected panic from fn")
 			}
 		}()
-		_ = withLeasedLocks([]string{lockPath}, time.Now, func() error {
+		_ = withLeasedLocks([]string{lockPath}, time.Now, func(leaseCheck) error {
 			panic("simulated critical-section panic")
 		})
 	}()
@@ -2550,7 +2550,7 @@ func TestWithLeasedLocksReleasesOnPanic(t *testing.T) {
 		t.Fatalf("lock file still present after panic recovery: %v", err)
 	}
 	start := time.Now()
-	if err := withLeasedLocks([]string{lockPath}, time.Now, func() error { return nil }); err != nil {
+	if err := withLeasedLocks([]string{lockPath}, time.Now, func(leaseCheck) error { return nil }); err != nil {
 		t.Fatalf("second withLeasedLocks after panic: %v", err)
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
@@ -2569,7 +2569,7 @@ func TestLeaseRefreshStopsWhenLockReplaced(t *testing.T) {
 	defer func() { fileLockRefreshInterval = prevRefresh }()
 
 	var lostErr error
-	err := withLeasedLocks([]string{lockPath}, time.Now, func() error {
+	err := withLeasedLocks([]string{lockPath}, time.Now, func(leaseCheck) error {
 		// Replace the lock as a reclaiming peer would after a long pause.
 		if err := os.WriteFile(lockPath, []byte("replacement-holder"), 0o600); err != nil {
 			return err
@@ -2609,6 +2609,92 @@ func TestLeaseRefreshStopsWhenLockReplaced(t *testing.T) {
 	}
 }
 
+// TestKeyringWriteAbortsBeforeAnyMutationOnLeaseLoss is the regression for
+// fencing the whole write, not just the entry to and exit from it: a checkLease
+// that already reports loss on its very first call (as if the lease had been
+// reclaimed before write() was ever entered) must prevent every keyring
+// mutation write() would otherwise perform, not merely the first one it
+// happens to reach.
+func TestKeyringWriteAbortsBeforeAnyMutationOnLeaseLoss(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: "zero-test", indexAccount: "idx"}
+	state := storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("alpha"): {AccessToken: "a"},
+	}}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alreadyLost := func() error { return fmt.Errorf("simulated lease loss") }
+
+	err = b.write(data, map[string]bool{ProviderKey("alpha"): false}, alreadyLost)
+	if err == nil || !strings.Contains(err.Error(), "simulated lease loss") {
+		t.Fatalf("write err = %v, want the simulated lease-loss error surfaced", err)
+	}
+	if len(kr.data) != 0 {
+		t.Fatalf("write mutated the keyring despite an already-lost lease: %#v", kr.data)
+	}
+}
+
+// TestKeyringWriteAbortsMidSequenceOnLeaseLoss is the regression for
+// [P1] Fence a lease loss that occurs during the critical callback: the lease
+// was checked only immediately before and after fn as a whole, so a process
+// that stalled partway through a multi-step keyring write (index publish, then
+// one Set per token) could have every step after the stall land anyway, racing
+// the peer that reclaimed the lock's own read-modify-write. checkLease must be
+// consulted before each step, so a loss discovered partway through the entry
+// writes stops before every entry is written, not only before or after the
+// whole operation.
+func TestKeyringWriteAbortsMidSequenceOnLeaseLoss(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: "zero-test", indexAccount: "idx"}
+
+	names := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	tokens := make(map[string]Token, len(names))
+	mutations := make(map[string]bool, len(names))
+	for _, name := range names {
+		key := ProviderKey(name)
+		tokens[key] = Token{AccessToken: name}
+		mutations[key] = false
+	}
+	state := storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Let enough checks pass to publish the index and write at least one entry,
+	// then simulate the lease being reclaimed underneath the still-running write.
+	const allowedChecks = 4
+	var calls int
+	check := func() error {
+		calls++
+		if calls > allowedChecks {
+			return fmt.Errorf("simulated lease loss")
+		}
+		return nil
+	}
+
+	err = b.write(data, mutations, check)
+	if err == nil || !strings.Contains(err.Error(), "simulated lease loss") {
+		t.Fatalf("write err = %v, want the simulated lease-loss error surfaced", err)
+	}
+
+	written := 0
+	for _, name := range names {
+		if _, ok := kr.data["zero-test/"+ProviderKey(name)]; ok {
+			written++
+		}
+	}
+	if written == 0 {
+		t.Fatalf("checkLease call count %d never reached the per-key Set loop; adjust allowedChecks so this test actually exercises mid-sequence abort (calls observed: %d)", allowedChecks, calls)
+	}
+	if written == len(names) {
+		t.Fatalf("every token entry was written (%d/%d) despite the lease being lost partway through: the fencing check did not stop mid-sequence", written, len(names))
+	}
+	t.Logf("checkLease was called %d times before aborting; %d of %d entries were written", calls, written, len(names))
+}
+
 // TestWithLeasedLocksSkipsFnWhenLeaseLostWhileWaiting is the regression for
 // [P1] Abort before the keyring mutation when a leased lock is lost
 // (2026-08-09): withLeasedLocks used to invoke fn after acquisition and report
@@ -2634,7 +2720,7 @@ func TestWithLeasedLocksSkipsFnWhenLeaseLostWhileWaiting(t *testing.T) {
 	var fnCalled atomic.Bool
 	done := make(chan error, 1)
 	go func() {
-		done <- withLeasedLocks([]string{lock1, lock2}, time.Now, func() error {
+		done <- withLeasedLocks([]string{lock1, lock2}, time.Now, func(leaseCheck) error {
 			fnCalled.Store(true)
 			return nil
 		})
@@ -2698,7 +2784,7 @@ func TestWithLeasedLocksSkipsFnWhenChtimesFails(t *testing.T) {
 	var fnCalled atomic.Bool
 	done := make(chan error, 1)
 	go func() {
-		done <- withLeasedLocks([]string{lock1, lock2}, time.Now, func() error {
+		done <- withLeasedLocks([]string{lock1, lock2}, time.Now, func(leaseCheck) error {
 			fnCalled.Store(true)
 			return nil
 		})
@@ -2814,7 +2900,7 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := blob.write(state, map[string]bool{ProviderKey("gamma"): false}); err != nil {
+	if err := blob.write(state, map[string]bool{ProviderKey("gamma"): false}, noLeaseLoss); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	// beta entry must still exist (not deleted: it was absent from truncated livePrior).
@@ -2921,7 +3007,7 @@ func TestWritePreservesMissingMiddleChunkSlot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := blob.write(data, map[string]bool{ProviderKey("fill-000"): false}); err != nil {
+	if err := blob.write(data, map[string]bool{ProviderKey("fill-000"): false}, noLeaseLoss); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -512,10 +512,10 @@ func TestStoreKeyringIndexGrowthInterruptionsPreserveOldLayout(t *testing.T) {
 		}
 		return data
 	}
-	mutations := func() map[string]bool {
-		m := make(map[string]bool, len(added))
+	mutations := func() map[string]mutationIntent {
+		m := make(map[string]mutationIntent, len(added))
 		for _, key := range added {
-			m[key] = false
+			m[key] = mutationReplace
 		}
 		return m
 	}
@@ -3112,7 +3112,7 @@ func TestKeyringWriteAbortsBeforeAnyMutationOnLeaseLoss(t *testing.T) {
 	}
 	alreadyLost := func() error { return fmt.Errorf("simulated lease loss") }
 
-	err = b.write(data, map[string]bool{ProviderKey("alpha"): false}, alreadyLost)
+	err = b.write(data, map[string]mutationIntent{ProviderKey("alpha"): mutationReplace}, alreadyLost)
 	if err == nil || !strings.Contains(err.Error(), "simulated lease loss") {
 		t.Fatalf("write err = %v, want the simulated lease-loss error surfaced", err)
 	}
@@ -3136,11 +3136,11 @@ func TestKeyringWriteAbortsMidSequenceOnLeaseLoss(t *testing.T) {
 
 	names := []string{"alpha", "bravo", "charlie", "delta", "echo"}
 	tokens := make(map[string]Token, len(names))
-	mutations := make(map[string]bool, len(names))
+	mutations := make(map[string]mutationIntent, len(names))
 	for _, name := range names {
 		key := ProviderKey(name)
 		tokens[key] = Token{AccessToken: name}
-		mutations[key] = false
+		mutations[key] = mutationReplace
 	}
 	state := storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens}
 	data, err := json.Marshal(state)
@@ -3385,7 +3385,7 @@ func TestWriteSkipsIndexShrinkWhenChunkMissing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := blob.write(state, map[string]bool{ProviderKey("gamma"): false}, noLeaseLoss); err != nil {
+	if err := blob.write(state, map[string]mutationIntent{ProviderKey("gamma"): mutationReplace}, noLeaseLoss); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	// beta entry must still exist (not deleted: it was absent from truncated livePrior).
@@ -3492,7 +3492,7 @@ func TestWritePreservesMissingMiddleChunkSlot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := blob.write(data, map[string]bool{ProviderKey("fill-000"): false}, noLeaseLoss); err != nil {
+	if err := blob.write(data, map[string]mutationIntent{ProviderKey("fill-000"): mutationReplace}, noLeaseLoss); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -3638,15 +3638,36 @@ func TestStoreKeyringReloginRetiresLegacyOriginPrecedence(t *testing.T) {
 	if _, ok, err := s1.Load(ProviderKey("alpha")); err != nil || !ok {
 		t.Fatalf("initial Load(alpha): ok=%v, err=%v", ok, err)
 	}
+	if err := s1.saveRefreshed(ProviderKey("beta"), Token{AccessToken: "beta-token"}); err != nil {
+		t.Fatalf("saveRefreshed(beta) to persist legacyOrigin: %v", err)
+	}
 
-	// 2. Old binary logs out alpha by writing {beta} to the legacy blob.
+	// 2. A token refresh of an origin-marked key must keep the origin so
+	// that an old-binary logout remains visible to a later absence-heuristic
+	// pass. Save() would retire the origin and hide the logout.
+	if err := s1.saveRefreshed(ProviderKey("alpha"), Token{AccessToken: "refreshed-alpha-token"}); err != nil {
+		t.Fatalf("saveRefreshed(alpha): %v", err)
+	}
+	originBlob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+	originAfterRefresh, err := originBlob.readLegacyOrigin()
+	if err != nil {
+		t.Fatalf("readLegacyOrigin after refresh: %v", err)
+	}
+	if !originAfterRefresh[ProviderKey("alpha")] {
+		t.Fatal("saveRefreshed(alpha) retired legacyOrigin; old-binary logout would no longer be observed")
+	}
+	if tok, ok, err := s1.Load(ProviderKey("alpha")); err != nil || !ok || tok.AccessToken != "refreshed-alpha-token" {
+		t.Fatalf("Load(alpha) after refresh: tok=%v, ok=%v, err=%v", tok, ok, err)
+	}
+
+	// 3. Old binary logs out alpha by writing {beta} to the legacy blob.
 	legacyTokensAfterLogout := map[string]Token{
 		ProviderKey("beta"): {AccessToken: "beta-token"},
 	}
 	legacyRaw2, _ := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: legacyTokensAfterLogout})
 	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyRaw2)
 
-	// 3. New binary explicitly logs into alpha with a new token.
+	// 4. New binary explicitly logs into alpha with a new token.
 	if err := s1.Save(ProviderKey("alpha"), Token{AccessToken: "new-alpha-token"}); err != nil {
 		t.Fatalf("Save(alpha): %v", err)
 	}
@@ -3730,11 +3751,11 @@ func TestKeyringWriteSynchronousCheckLeaseAbortsOnReplacedLock(t *testing.T) {
 
 	names := []string{"p1", "p2", "p3"}
 	tokens := make(map[string]Token, len(names))
-	mutations := make(map[string]bool, len(names))
+	mutations := make(map[string]mutationIntent, len(names))
 	for _, n := range names {
 		k := ProviderKey(n)
 		tokens[k] = Token{AccessToken: n}
-		mutations[k] = false
+		mutations[k] = mutationReplace
 	}
 	state := storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens}
 	data, err := json.Marshal(state)

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -1626,11 +1626,11 @@ func TestStoreKeyringDuplicateIndexDoesNotFanOutPerEntry(t *testing.T) {
 		t.Fatalf("Status returned %d entries for an 80-duplicate index of one key, want 1", len(statuses))
 	}
 	// One Get for the index header, one Get for the single deduplicated key's
-	// own entry, one Get for durable tombstones, and at most one extra Get for
-	// the legacy fallback lookup. The key regression is: not one Get per
+	// own entry, one Get for durable tombstones, one Get for legacy fallback,
+	// and one Get for legacy origin. The key regression is: not one Get per
 	// duplicate entry.
-	if ckr.gets > 4 {
-		t.Fatalf("Status issued %d keyring gets for an 80-entry duplicate index, want <= 4 (fan-out DoS regression)", ckr.gets)
+	if ckr.gets > 5 {
+		t.Fatalf("Status issued %d keyring gets for an 80-entry duplicate index, want <= 5 (fan-out DoS regression)", ckr.gets)
 	}
 }
 
@@ -4001,5 +4001,60 @@ func TestCheckOAuthLockDirOwnerFailsOnUnavailableMetadata(t *testing.T) {
 	err = checkOAuthLockDirOwner(mock)
 	if err == nil || !strings.Contains(err.Error(), "ownership metadata unavailable") {
 		t.Fatalf("expected ownership metadata unavailable error, got %v", err)
+	}
+}
+
+func TestLockOwnershipLossOnReleaseFails(t *testing.T) {
+	temp := t.TempDir()
+	lockPath := filepath.Join(temp, "test.lock")
+	unlock, _, err := acquireFileLock(lockPath, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lockPath, []byte("foreign-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := unlock(); err == nil || !strings.Contains(err.Error(), "lost token lock ownership") {
+		t.Fatalf("expected lost token lock ownership error, got %v", err)
+	}
+}
+
+func TestStoreKeyringDeletedLegacyAccountReconciliation(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"XDG_CONFIG_HOME": t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := ProviderKey("alpha")
+	blob := s.blob.(keyringBlob)
+	if err := blob.writeLegacyOrigin(map[string]bool{key: true}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	tokData, _ := json.Marshal(Token{AccessToken: "tok"})
+	kr.data[keyringService+"/"+key] = base64.StdEncoding.EncodeToString(tokData)
+	if _, _, err := blob.writeKeyIndex([]string{key}, 0, 0, nil, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	delete(kr.data, keyringService+"/"+keyringLegacyAccount)
+
+	tok, ok, err := s.Load(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("Load = (%+v, true), want key hidden after legacy deletion", tok)
+	}
+
+	if err := s.Save(ProviderKey("beta"), Token{AccessToken: "tok-beta"}); err != nil {
+		t.Fatal(err)
+	}
+	keys, ok, _, _, _, err := blob.readKeyIndex()
+	if err != nil || !ok {
+		t.Fatalf("readKeyIndex failed: %v", err)
+	}
+	for _, k := range keys {
+		if k == key {
+			t.Fatalf("key %s survived in index after reconciliation of deleted legacy account", key)
+		}
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -2435,6 +2436,48 @@ func TestKeyringLockPathUserLookupFallbackIgnoresAmbientHome(t *testing.T) {
 // fixed keyring index, so they could race it. Every branch of lock-path
 // resolution must be identity-stable, and the fallback must fail closed rather
 // than fall back to a process-specific temp root.
+// TestKeyringLockPathFallbackStableAcrossWindowsTempOverrides is the Windows
+// half of the test below. The fallback returned os.TempDir() there, justified
+// as "Windows temp is already per-user", but per-user is not the property that
+// matters: os.TempDir resolves %TMP%, then %TEMP%, then %USERPROFILE%, and the
+// first two are launcher-controlled. Two processes of one user could therefore
+// compute different lock paths while writing the same fixed keyring index,
+// which is exactly the race the Unix branch refuses os.TempDir() to avoid.
+func TestKeyringLockPathFallbackStableAcrossWindowsTempOverrides(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("exercises the Windows-only identity lock root")
+	}
+	previousUser := currentOSUser
+	currentOSUser = func() (*user.User, error) { return nil, fmt.Errorf("lookup unavailable") }
+	defer func() { currentOSUser = previousUser }()
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	t.Setenv("TMP", dirA)
+	t.Setenv("TEMP", dirA)
+	storeA, err := NewStore(StoreOptions{Storage: "keyring", Keyring: newFakeKR()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMP", dirB)
+	t.Setenv("TEMP", dirB)
+	storeB, err := NewStore(StoreOptions{Storage: "keyring", Keyring: newFakeKR()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blobA := storeA.blob.(keyringBlob)
+	blobB := storeB.blob.(keyringBlob)
+	if blobA.lockPath == "" || blobB.lockPath == "" {
+		t.Fatal("keyring store has no lock path in the fallback branch")
+	}
+	if blobA.lockPath != blobB.lockPath {
+		t.Fatalf("fallback lock path changed with TMP/TEMP: %q vs %q (they can race the shared keyring index)", blobA.lockPath, blobB.lockPath)
+	}
+	if strings.Contains(blobA.lockPath, dirA) || strings.Contains(blobA.lockPath, dirB) {
+		t.Fatalf("fallback lock path %q is still derived from TMP/TEMP", blobA.lockPath)
+	}
+}
+
 func TestKeyringLockPathFallbackStableAcrossTMPDIROverrides(t *testing.T) {
 	previousUser := currentOSUser
 	currentOSUser = func() (*user.User, error) { return nil, fmt.Errorf("lookup unavailable") }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -4089,3 +4089,39 @@ func TestStoreKeyringInPlaceShrinkClearsStaleUnprotectedSlots(t *testing.T) {
 		}
 	}
 }
+
+func TestStoreKeyringFailedLegacyGetPreservesIndexedTokens(t *testing.T) {
+	kr := &legacyGetFailKR{fakeKR: newFakeKR(), fail: false}
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"XDG_CONFIG_HOME": t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := ProviderKey("alpha")
+	blob := s.blob.(keyringBlob)
+	if err := blob.writeLegacyOrigin(map[string]bool{key: true}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	tokData, _ := json.Marshal(Token{AccessToken: "tok-alpha"})
+	kr.data[keyringService+"/"+key] = base64.StdEncoding.EncodeToString(tokData)
+	if _, _, err := blob.writeKeyIndex([]string{key}, 0, 0, nil, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+
+	kr.fail = true
+
+	tok, ok, err := s.Load(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || tok.AccessToken != "tok-alpha" {
+		t.Fatalf("Load = (%+v, %v), want (tok-alpha, true) despite transient legacy read error", tok, ok)
+	}
+
+	st, err := s.Status("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st) != 1 || st[0].Key != key {
+		t.Fatalf("Status = %+v, want 1 token with key %s", st, key)
+	}
+}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -2637,6 +2637,16 @@ func TestStoreKeyringHonorsLogoutFromRunningLegacyBinary(t *testing.T) {
 		t.Fatalf("Load after migration = %#v, ok %v, err %v; want the legacy token indexed", got, ok, err)
 	}
 
+	// A later refresh of the migrated key must keep origin so the logout
+	// below is still visible. This is the production GetFresh path.
+	if err := s.SaveRefreshed(key, Token{AccessToken: "refreshed-from-old"}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err = s.Load(key)
+	if err != nil || !ok || got.AccessToken != "refreshed-from-old" {
+		t.Fatalf("Load after refresh = %#v, ok %v, err %v", got, ok, err)
+	}
+
 	// Step 3: the still-running old binary logs the user out of alpha. It has
 	// no concept of the index or tombstones, so the only thing it can do —
 	// and the only thing this test can simulate — is rewrite the legacy entry
@@ -3046,14 +3056,14 @@ func TestWithLeasedLocksReleasesOnPanic(t *testing.T) {
 // TestLeaseRefreshStopsWhenLockReplaced is the regression for ownership-aware
 // lease refresh: if a holder pauses past fileLockStaleAfter and a peer replaces
 // the lock, the original holder must not Chtimes the replacement (which would
-// keep both critical sections alive) and must fail closed.
+// keep both critical sections alive). When fn itself returned nil, post-fn
+// lease loss is not a persist failure.
 func TestLeaseRefreshStopsWhenLockReplaced(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "stolen.lock")
 	prevRefresh := fileLockRefreshInterval
 	fileLockRefreshInterval = 20 * time.Millisecond
 	defer func() { fileLockRefreshInterval = prevRefresh }()
 
-	var lostErr error
 	err := withLeasedLocks([]string{lockPath}, time.Now, func(leaseCheck) error {
 		// Replace the lock as a reclaiming peer would after a long pause.
 		if err := os.WriteFile(lockPath, []byte("replacement-holder"), 0o600); err != nil {
@@ -3073,18 +3083,12 @@ func TestLeaseRefreshStopsWhenLockReplaced(t *testing.T) {
 			return err
 		}
 		// Allow equal (coarse FS) but not strictly newer from our stolen lease.
-		// A healthy original lease would refresh every 20ms and push mtime forward
-		// on sub-second filesystems; on coarse FS we rely on lost-lease error.
 		_ = first
 		_ = info
 		return nil
 	})
-	lostErr = err
-	if lostErr == nil {
-		t.Fatal("expected lost-lease error after lock replacement, got nil")
-	}
-	if !strings.Contains(lostErr.Error(), "lost token lock lease") {
-		t.Fatalf("error = %v, want lost token lock lease", lostErr)
+	if err != nil {
+		t.Fatalf("withLeasedLocks after successful fn: %v", err)
 	}
 	// Replacement content must still be present: original release is ownership-aware.
 	data, err := os.ReadFile(lockPath)
@@ -3638,15 +3642,15 @@ func TestStoreKeyringReloginRetiresLegacyOriginPrecedence(t *testing.T) {
 	if _, ok, err := s1.Load(ProviderKey("alpha")); err != nil || !ok {
 		t.Fatalf("initial Load(alpha): ok=%v, err=%v", ok, err)
 	}
-	if err := s1.saveRefreshed(ProviderKey("beta"), Token{AccessToken: "beta-token"}); err != nil {
-		t.Fatalf("saveRefreshed(beta) to persist legacyOrigin: %v", err)
+	if err := s1.SaveRefreshed(ProviderKey("beta"), Token{AccessToken: "beta-token"}); err != nil {
+		t.Fatalf("SaveRefreshed(beta) to persist legacyOrigin: %v", err)
 	}
 
 	// 2. A token refresh of an origin-marked key must keep the origin so
 	// that an old-binary logout remains visible to a later absence-heuristic
 	// pass. Save() would retire the origin and hide the logout.
-	if err := s1.saveRefreshed(ProviderKey("alpha"), Token{AccessToken: "refreshed-alpha-token"}); err != nil {
-		t.Fatalf("saveRefreshed(alpha): %v", err)
+	if err := s1.SaveRefreshed(ProviderKey("alpha"), Token{AccessToken: "refreshed-alpha-token"}); err != nil {
+		t.Fatalf("SaveRefreshed(alpha): %v", err)
 	}
 	originBlob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
 	originAfterRefresh, err := originBlob.readLegacyOrigin()
@@ -3654,7 +3658,7 @@ func TestStoreKeyringReloginRetiresLegacyOriginPrecedence(t *testing.T) {
 		t.Fatalf("readLegacyOrigin after refresh: %v", err)
 	}
 	if !originAfterRefresh[ProviderKey("alpha")] {
-		t.Fatal("saveRefreshed(alpha) retired legacyOrigin; old-binary logout would no longer be observed")
+		t.Fatal("SaveRefreshed(alpha) retired legacyOrigin; old-binary logout would no longer be observed")
 	}
 	if tok, ok, err := s1.Load(ProviderKey("alpha")); err != nil || !ok || tok.AccessToken != "refreshed-alpha-token" {
 		t.Fatalf("Load(alpha) after refresh: tok=%v, ok=%v, err=%v", tok, ok, err)
@@ -4038,6 +4042,27 @@ func TestLockOwnershipLossOnReleaseFails(t *testing.T) {
 	if err := unlock(); err == nil || !strings.Contains(err.Error(), "lost token lock ownership") {
 		t.Fatalf("expected lost token lock ownership error, got %v", err)
 	}
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("replacement lock missing after failed release: %v", err)
+	}
+	if string(data) != "foreign-token" {
+		t.Fatalf("release deleted a replacement lock: got %q", data)
+	}
+}
+
+func TestLockReleaseRemovesOwnedFile(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "owned.lock")
+	unlock, _, err := acquireFileLock(lockPath, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := unlock(); err != nil {
+		t.Fatalf("unlock owned lock: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("owned lock still present after release: %v", err)
+	}
 }
 
 func TestStoreKeyringDeletedLegacyAccountReconciliation(t *testing.T) {
@@ -4144,5 +4169,211 @@ func TestStoreKeyringFailedLegacyGetPreservesIndexedTokens(t *testing.T) {
 	}
 	if len(st) != 1 || st[0].Key != key {
 		t.Fatalf("Status = %+v, want 1 token with key %s", st, key)
+	}
+}
+
+func writeLegacyTokens(t *testing.T, kr *fakeKR, tokens map[string]Token) {
+	t.Helper()
+	raw, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(raw)
+}
+
+func TestStoreKeyringRefreshSeedsLegacyOriginOnFirstPersist(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := ProviderKey("alpha")
+	writeLegacyTokens(t, kr, map[string]Token{key: {AccessToken: "from-old-binary"}})
+
+	if err := s.SaveRefreshed(key, Token{AccessToken: "refreshed-first"}); err != nil {
+		t.Fatalf("SaveRefreshed first persist: %v", err)
+	}
+	origin, err := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}.readLegacyOrigin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !origin[key] {
+		t.Fatal("first persist via SaveRefreshed did not seed legacyOrigin")
+	}
+
+	writeLegacyTokens(t, kr, map[string]Token{})
+	if _, ok, err := s.Load(key); err != nil || ok {
+		t.Fatalf("Load after legacy logout = ok %v, err %v; want hidden", ok, err)
+	}
+	statuses, err := s.Status("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, status := range statuses {
+		if status.Key == key {
+			t.Fatalf("Status still lists %q after legacy logout: %#v", key, status)
+		}
+	}
+}
+
+func TestStoreKeyringMCPIdentityRefreshKeepsLegacyOrigin(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := KeyPrefixMCP + "demo.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if err := ValidateKey(key); err != nil {
+		t.Fatalf("fixture key: %v", err)
+	}
+	writeLegacyTokens(t, kr, map[string]Token{key: {AccessToken: "mcp-legacy"}})
+
+	if err := s.SaveRefreshed(key, Token{AccessToken: "mcp-refreshed"}); err != nil {
+		t.Fatalf("SaveRefreshed MCP identity: %v", err)
+	}
+	origin, err := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}.readLegacyOrigin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !origin[key] {
+		t.Fatal("MCP refresh retired or never seeded legacyOrigin")
+	}
+
+	writeLegacyTokens(t, kr, map[string]Token{})
+	if _, ok, err := s.Load(key); err != nil || ok {
+		t.Fatalf("LoadForServer-equivalent after legacy logout = ok %v, err %v; want hidden", ok, err)
+	}
+}
+
+func TestStoreKeyringRefreshAbortsWhenTokenGone(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := ProviderKey("alpha")
+	if err := s.Save(key, Token{AccessToken: "live"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Delete(key); err != nil {
+		t.Fatal(err)
+	}
+	err = s.SaveRefreshed(key, Token{AccessToken: "resurrected"})
+	if err == nil || !errors.Is(err, ErrNoToken) {
+		t.Fatalf("SaveRefreshed after delete = %v, want ErrNoToken", err)
+	}
+	if _, ok, err := s.Load(key); err != nil || ok {
+		t.Fatalf("Load after aborted refresh = ok %v, err %v; token resurrected", ok, err)
+	}
+	tombstones, err := s.blob.(keyringBlob).readTombstones()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tombstones[key] {
+		t.Fatal("refresh cleared the logout tombstone")
+	}
+}
+
+func TestKeyringWriteRefreshDoesNotClearTombstone(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+	key := ProviderKey("alpha")
+	if err := b.writeTombstones(map[string]bool{key: true}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		key: {AccessToken: "refreshed"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.write(data, map[string]mutationIntent{key: mutationRefresh}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	got, err := b.readTombstones()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got[key] {
+		t.Fatal("mutationRefresh cleared a logout tombstone")
+	}
+}
+
+func TestKeyringWriteRefreshSkipsOnlyRefreshedKeyInAbsenceHeuristic(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: keyringService, legacyAccount: keyringLegacyAccount, indexAccount: keyringIndexAccount}
+	alpha := ProviderKey("alpha")
+	beta := ProviderKey("beta")
+	writeLegacyTokens(t, kr, map[string]Token{})
+	if err := b.writeLegacyOrigin(map[string]bool{alpha: true, beta: true}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := b.writeKeyIndex([]string{alpha, beta}, 0, 0, nil, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		alpha: {AccessToken: "refreshed-alpha"},
+		beta:  {AccessToken: "stale-beta"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.write(data, map[string]mutationIntent{alpha: mutationRefresh}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	tombstones, err := b.readTombstones()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tombstones[beta] {
+		t.Fatal("absence heuristic skipped beta because alpha was being refreshed")
+	}
+	if tombstones[alpha] {
+		t.Fatal("absence heuristic treated the refreshed key as a logout")
+	}
+	origin, err := b.readLegacyOrigin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !origin[alpha] {
+		t.Fatal("refresh retired alpha origin")
+	}
+	if origin[beta] {
+		t.Fatal("logged-out beta kept its origin marker")
+	}
+}
+
+func TestSaveRefreshedSucceedsWhenLeaseLostAfterPersist(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"XDG_CONFIG_HOME": t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := ProviderKey("alpha")
+	if err := s.Save(key, Token{AccessToken: "old", RefreshToken: "rt"}); err != nil {
+		t.Fatal(err)
+	}
+	blob := s.blob.(keyringBlob)
+	testAfterCriticalSection = func() {
+		_ = os.WriteFile(blob.lockPath, []byte("stolen-holder"), 0o600)
+	}
+	t.Cleanup(func() { testAfterCriticalSection = nil })
+
+	if err := s.SaveRefreshed(key, Token{AccessToken: "new", RefreshToken: "rt"}); err != nil {
+		t.Fatalf("SaveRefreshed after post-success lease loss: %v", err)
+	}
+	got, ok, err := s.Load(key)
+	if err != nil || !ok || got.AccessToken != "new" {
+		t.Fatalf("Load after post-success lease loss = %#v ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestWithLeasedLocksTreatsPostSuccessLeaseLossAsSuccess(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "post.lock")
+	err := withLeasedLocks([]string{lockPath}, time.Now, func(leaseCheck) error {
+		return os.WriteFile(lockPath, []byte("replacement"), 0o600)
+	})
+	if err != nil {
+		t.Fatalf("withLeasedLocks after successful fn: %v", err)
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -3477,144 +3477,144 @@ func TestWritePreservesMissingMiddleChunkSlot(t *testing.T) {
 	}
 }
 
-func TestKeyringDeleteRemovesCredentialFromLegacyBlob(t *testing.T) {
+// TestStoreKeyringDurableLogoutHidesSurvivingIndexedCredential is the regression for
+// [P1] Make a durable logout hide a surviving indexed credential:
+// when a tombstone exists for a key, read()/Load()/Status() must treat it as deleted
+// even if an interrupted delete left the per-key entry and key index intact.
+func TestStoreKeyringDurableLogoutHidesSurvivingIndexedCredential(t *testing.T) {
 	kr := newFakeKR()
-	legacyTokens := map[string]Token{
-		ProviderKey("p1"): {AccessToken: "at1", RefreshToken: "rt1"},
-		ProviderKey("p2"): {AccessToken: "at2", RefreshToken: "rt2"},
-	}
-	legacyRaw, _ := json.Marshal(storeFile{SchemaVersion: 1, Tokens: legacyTokens})
-	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyRaw)
-
 	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
 
-	// Loading p1 works via legacy migration.
-	tok1, ok, err := s.Load(ProviderKey("p1"))
-	if err != nil || !ok || tok1.AccessToken != "at1" {
-		t.Fatalf("Load(p1) = %+v, ok=%v, err=%v", tok1, ok, err)
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "alpha-token"}); err != nil {
+		t.Fatalf("Save(alpha): %v", err)
 	}
 
-	// Delete p1 (logout).
-	removed, err := s.Delete(ProviderKey("p1"))
-	if err != nil || !removed {
-		t.Fatalf("Delete(p1) = %v, err=%v", removed, err)
+	// Verify alpha is loaded.
+	tok, ok, err := s.Load(ProviderKey("alpha"))
+	if err != nil || !ok || tok.AccessToken != "alpha-token" {
+		t.Fatalf("Load(alpha) before interruption: tok=%v, ok=%v, err=%v", tok, ok, err)
 	}
 
-	// Inspect legacy entry directly: p1 must be deleted from legacy entry.
-	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount, legacyAccount: keyringLegacyAccount}
-	remainingLegacy, err := blob.readLegacyTokens()
+	// Simulate an interrupted Delete: publish tombstone for alpha, but leave alpha's
+	// per-key entry in keyring.
+	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+	if err := blob.writeTombstones(map[string]bool{ProviderKey("alpha"): true}, noLeaseLoss); err != nil {
+		t.Fatalf("writeTombstones: %v", err)
+	}
+
+	// A fresh store reader must hide alpha immediately, despite the per-key entry surviving.
+	sFresh, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
 	if err != nil {
-		t.Fatalf("readLegacyTokens: %v", err)
-	}
-	if remainingLegacy != nil {
-		if _, exists := remainingLegacy[ProviderKey("p1")]; exists {
-			t.Fatal("p1 must not exist in legacy tokens blob after logout")
-		}
-		if _, exists := remainingLegacy[ProviderKey("p2")]; !exists {
-			t.Fatal("p2 must still be present in legacy tokens blob")
-		}
+		t.Fatalf("NewStore fresh: %v", err)
 	}
 
-	// Delete p2 (all tokens removed): legacy account should be deleted entirely.
-	removed2, err := s.Delete(ProviderKey("p2"))
-	if err != nil || !removed2 {
-		t.Fatalf("Delete(p2) = %v, err=%v", removed2, err)
+	if tok, ok, err := sFresh.Load(ProviderKey("alpha")); err != nil || ok {
+		t.Fatalf("Load(alpha) after tombstone published: ok=%v (tok=%+v), err=%v; want ok=false", ok, tok, err)
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
-		t.Fatal("legacy account should be deleted when all legacy tokens are removed")
+
+	status, err := sFresh.Status("")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	for _, entry := range status {
+		if entry.Key == ProviderKey("alpha") {
+			t.Fatalf("Status returned alpha after tombstone published: %+v", entry)
+		}
 	}
 }
 
-// TestStoreKeyringDowngradedLegacyReaderCannotAuthenticateAfterLogout is the
-// regression for [P1] Logout doesn't revoke legacy representation: after migration
-// to per-key entries, Delete removes the per-key entry and records a tombstone,
-// but must also remove that provider from the legacy oauth-tokens blob so a
-// downgraded / pre-PR binary reading the legacy account directly cannot
-// authenticate using the logged-out credentials.
-func TestStoreKeyringDowngradedLegacyReaderCannotAuthenticateAfterLogout(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+// TestStoreKeyringReloginRetiresLegacyOriginPrecedence is the regression for
+// [P1] Retire legacy-origin precedence when an explicit re-login succeeds:
+// after legacy migration and old-binary logout of alpha, an explicit new-binary
+// Save for alpha must retire the legacyOrigin marker so future reads and unrelated
+// Saves do not re-delete alpha via the absence heuristic.
+func TestStoreKeyringReloginRetiresLegacyOriginPrecedence(t *testing.T) {
 	kr := newFakeKR()
 
-	// 1. Older binary logged into github and anthropic via the legacy single-blob entry.
+	// 1. Initial state: legacy blob has alpha and beta.
 	legacyTokens := map[string]Token{
-		ProviderKey("github"):    {AccessToken: "gh-secret-token", RefreshToken: "gh-refresh"},
-		ProviderKey("anthropic"): {AccessToken: "ant-secret-token", RefreshToken: "ant-refresh"},
+		ProviderKey("alpha"): {AccessToken: "old-alpha-token"},
+		ProviderKey("beta"):  {AccessToken: "beta-token"},
 	}
-	legacyRaw, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: legacyTokens})
-	if err != nil {
-		t.Fatal(err)
-	}
+	legacyRaw, _ := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: legacyTokens})
 	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyRaw)
 
-	// A legacy reader helper simulating a pre-PR binary that only reads the legacy account.
-	legacyReaderAuthenticate := func(provider string) (Token, bool) {
-		enc, ok := kr.data[keyringService+"/"+keyringLegacyAccount]
-		if !ok {
-			return Token{}, false
-		}
-		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
-		if err != nil {
-			return Token{}, false
-		}
-		var sf storeFile
-		if err := json.Unmarshal(raw, &sf); err != nil {
-			return Token{}, false
-		}
-		tok, has := sf.Tokens[ProviderKey(provider)]
-		return tok, has
-	}
-
-	// Legacy reader sees both credentials initially.
-	if tok, ok := legacyReaderAuthenticate("github"); !ok || tok.AccessToken != "gh-secret-token" {
-		t.Fatalf("legacy reader before logout: github token = %v, ok = %v", tok, ok)
-	}
-	if tok, ok := legacyReaderAuthenticate("anthropic"); !ok || tok.AccessToken != "ant-secret-token" {
-		t.Fatalf("legacy reader before logout: anthropic token = %v, ok = %v", tok, ok)
-	}
-
-	// 2. Upgraded binary initializes the store, migrating credentials to per-key entries.
-	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	s1, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewStore s1: %v", err)
 	}
 
-	// User logs out of github in the upgraded binary.
-	removed, err := s.Delete(ProviderKey("github"))
-	if err != nil || !removed {
-		t.Fatalf("Delete(github): removed=%v err=%v", removed, err)
+	// Migration happens on save of any token or explicit read.
+	if _, ok, err := s1.Load(ProviderKey("alpha")); err != nil || !ok {
+		t.Fatalf("initial Load(alpha): ok=%v, err=%v", ok, err)
 	}
 
-	// Upgraded binary confirms github is gone.
-	if _, ok, err := s.Load(ProviderKey("github")); err != nil || ok {
-		t.Fatalf("upgraded Load(github): ok=%v err=%v, want false", ok, err)
+	// 2. Old binary logs out alpha by writing {beta} to the legacy blob.
+	legacyTokensAfterLogout := map[string]Token{
+		ProviderKey("beta"): {AccessToken: "beta-token"},
+	}
+	legacyRaw2, _ := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: legacyTokensAfterLogout})
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyRaw2)
+
+	// 3. New binary explicitly logs into alpha with a new token.
+	if err := s1.Save(ProviderKey("alpha"), Token{AccessToken: "new-alpha-token"}); err != nil {
+		t.Fatalf("Save(alpha): %v", err)
 	}
 
-	// 3. Mixed-version / downgraded reader check:
-	// A downgraded binary reading the legacy account must NOT find github tokens after logout.
-	if tok, ok := legacyReaderAuthenticate("github"); ok {
-		t.Fatalf("downgraded binary was able to authenticate with github token %v after logout!", tok)
+	// 4. Verify alpha is loaded immediately.
+	tok, ok, err := s1.Load(ProviderKey("alpha"))
+	if err != nil || !ok || tok.AccessToken != "new-alpha-token" {
+		t.Fatalf("Load(alpha) after re-login: tok=%v, ok=%v, err=%v", tok, ok, err)
 	}
 
-	// The downgraded binary can still read the non-logged-out anthropic token.
-	if tok, ok := legacyReaderAuthenticate("anthropic"); !ok || tok.AccessToken != "ant-secret-token" {
-		t.Fatalf("downgraded binary anthropic token = %v, ok = %v, want anthropic preserved", tok, ok)
+	// 5. Subsequent read from a fresh store must preserve alpha.
+	sFresh, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatalf("NewStore sFresh: %v", err)
+	}
+	tok2, ok2, err2 := sFresh.Load(ProviderKey("alpha"))
+	if err2 != nil || !ok2 || tok2.AccessToken != "new-alpha-token" {
+		t.Fatalf("Load(alpha) from fresh store: tok=%v, ok=%v, err=%v", tok2, ok2, err2)
 	}
 
-	// Now logout of anthropic as well.
-	removed, err = s.Delete(ProviderKey("anthropic"))
-	if err != nil || !removed {
-		t.Fatalf("Delete(anthropic): removed=%v err=%v", removed, err)
+	// 6. An unrelated Save of gamma must NOT re-trigger absence deletion of alpha.
+	if err := sFresh.Save(ProviderKey("gamma"), Token{AccessToken: "gamma-token"}); err != nil {
+		t.Fatalf("Save(gamma): %v", err)
 	}
 
-	// Downgraded binary sees no tokens at all now.
-	if tok, ok := legacyReaderAuthenticate("anthropic"); ok {
-		t.Fatalf("downgraded binary was able to authenticate with anthropic token %v after all providers logged out!", tok)
+	tok3, ok3, err3 := sFresh.Load(ProviderKey("alpha"))
+	if err3 != nil || !ok3 || tok3.AccessToken != "new-alpha-token" {
+		t.Fatalf("Load(alpha) after unrelated Save(gamma): tok=%v, ok=%v, err=%v", tok3, ok3, err3)
 	}
-	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
-		t.Fatal("legacy account still exists in keyring after all providers logged out")
+}
+
+// TestStoreKeyringKeyIndexGenerationConflictRejection is the regression for
+// [P1] Do not treat a file-token read as a fencing guarantee:
+// writeKeyIndex must detect when a concurrent process advanced the generation
+// in the keyring and reject stale header publication.
+func TestStoreKeyringKeyIndexGenerationConflictRejection(t *testing.T) {
+	kr := newFakeKR()
+	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+
+	// 1. Initial generation 1 written.
+	_, gen1, err := blob.writeKeyIndex([]string{ProviderKey("p1")}, 0, 0, nil, noLeaseLoss)
+	if err != nil || gen1 != 1 {
+		t.Fatalf("initial writeKeyIndex: gen=%d, err=%v", gen1, err)
+	}
+
+	// 2. Another process advances generation to 2.
+	_, gen2, err := blob.writeKeyIndex([]string{ProviderKey("p1"), ProviderKey("p2")}, 1, 1, nil, noLeaseLoss)
+	if err != nil || gen2 != 2 {
+		t.Fatalf("second writeKeyIndex: gen=%d, err=%v", gen2, err)
+	}
+
+	// 3. Stale writer trying to write with priorGeneration=1 must fail due to generation conflict.
+	_, _, err = blob.writeKeyIndex([]string{ProviderKey("p1"), ProviderKey("p3")}, 1, 1, nil, noLeaseLoss)
+	if err == nil {
+		t.Fatal("stale writeKeyIndex with priorGeneration=1 should fail due to generation conflict")
 	}
 }
 

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -2209,10 +2210,11 @@ func TestStoreKeyringDeleteReportsRemovedWhenReconcilingResidentEntry(t *testing
 	if err := blob.writeTombstones(map[string]bool{key: true}, noLeaseLoss); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := s.Load(key); err != nil || ok {
-		t.Fatalf("Load = ok %v, err %v; tombstone must hide the entry", ok, err)
+	resident, err := blob.hasResidentEntry(key)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !blob.hasResidentEntry(key) {
+	if !resident {
 		t.Fatal("test setup: the keyring entry should still be resident")
 	}
 
@@ -3891,5 +3893,113 @@ func TestStoreKeyringGenerationBoundaryRejection(t *testing.T) {
 	// 4. writeKeyIndexInPlace rejects math.MaxInt generation
 	if _, _, err := blob.writeKeyIndexInPlace([][]string{{ProviderKey("p1")}}, 1, math.MaxInt, []int{1}, noLeaseLoss); err == nil {
 		t.Fatal("writeKeyIndexInPlace should reject math.MaxInt generation")
+	}
+}
+
+type errorOnGetKeyring struct {
+	KeyringClient
+	targetAccount string
+	err           error
+}
+
+func (e *errorOnGetKeyring) Get(service, account string) (string, bool, error) {
+	if account == e.targetAccount {
+		return "", false, e.err
+	}
+	return e.KeyringClient.Get(service, account)
+}
+
+func TestStoreKeyringHasResidentEntryErrorPropagation(t *testing.T) {
+	kr := newFakeKR()
+	key := ProviderKey("alpha")
+	failKR := &errorOnGetKeyring{KeyringClient: kr, targetAccount: key, err: errors.New("keychain timeout")}
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: failKR, Env: map[string]string{"XDG_CONFIG_HOME": t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := s.blob.(keyringBlob)
+	if err := blob.writeTombstones(map[string]bool{key: true}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.Delete(key)
+	if err == nil || !strings.Contains(err.Error(), "keychain timeout") {
+		t.Fatalf("expected keychain timeout error, got %v", err)
+	}
+}
+
+type failOnSetKeyring struct {
+	*fakeKR
+	failAccount string
+	err         error
+}
+
+func (f *failOnSetKeyring) Set(service, account, secret string) error {
+	if account == f.failAccount {
+		return f.err
+	}
+	return f.fakeKR.Set(service, account, secret)
+}
+
+func TestStoreKeyringDiscardStagedChunksOnHeaderFailure(t *testing.T) {
+	kr := newFakeKR()
+	failKR := &failOnSetKeyring{fakeKR: kr, failAccount: keyringIndexAccount, err: errors.New("disk full")}
+	blob := keyringBlob{kr: failKR, service: keyringService, indexAccount: keyringIndexAccount}
+	var keys []string
+	for i := 0; i < 15; i++ {
+		keys = append(keys, fmt.Sprintf("provider:key-%02d", i))
+	}
+	_, _, err := blob.writeKeyIndex(keys, 1, 1, nil, noLeaseLoss)
+	if err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("expected disk full error, got %v", err)
+	}
+	for k := range kr.data {
+		if strings.Contains(k, "oauth-keys-gen2-") {
+			t.Fatalf("staged chunk %s survived failed index write", k)
+		}
+	}
+}
+
+func TestStoreKeyringSavedKeyAbsentFromLegacyBlobSurvives(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"XDG_CONFIG_HOME": t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := ProviderKey("alpha")
+	blob := s.blob.(keyringBlob)
+	if err := blob.writeLegacyOrigin(map[string]bool{key: true}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(key, Token{AccessToken: "secret-token"}); err != nil {
+		t.Fatal(err)
+	}
+	tok, ok, err := s.Load(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || tok.AccessToken != "secret-token" {
+		t.Fatalf("Load = (%+v, %v), want secret-token", tok, ok)
+	}
+}
+
+type mockFileInfoNoSys struct {
+	os.FileInfo
+}
+
+func (m mockFileInfoNoSys) Sys() any { return nil }
+
+func TestCheckOAuthLockDirOwnerFailsOnUnavailableMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("checkOAuthLockDirOwner is a no-op on Windows")
+	}
+	temp := t.TempDir()
+	info, err := os.Stat(temp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock := mockFileInfoNoSys{FileInfo: info}
+	err = checkOAuthLockDirOwner(mock)
+	if err == nil || !strings.Contains(err.Error(), "ownership metadata unavailable") {
+		t.Fatalf("expected ownership metadata unavailable error, got %v", err)
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -2305,6 +2305,122 @@ func TestStoreKeyringReloginKeepsTombstoneUntilReplacementCommits(t *testing.T) 
 	}
 }
 
+// TestStoreKeyringHonorsLogoutFromRunningLegacyBinary is the regression for
+// [P1] Do not ignore a logout performed by a running pre-migration binary:
+// after alpha is migrated into the index, a pre-PR binary sharing the same
+// keyring only ever reads and rewrites the legacy combined entry. If that
+// binary logs the user out of alpha, its write removes alpha from the legacy
+// entry — the only channel it has. The new binary's Load, Status, and Save
+// must all honor that, not keep serving the indexed copy because "indexed
+// wins over legacy" was designed for the opposite direction (protecting a
+// fresher indexed Save from a stale legacy snapshot), not for this one.
+func TestStoreKeyringHonorsLogoutFromRunningLegacyBinary(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := ProviderKey("alpha")
+
+	// Step 1: alpha exists only in the legacy entry, as a pre-migration
+	// install (or an old binary's fresh login) would leave it.
+	legacy, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		key: {AccessToken: "from-old-binary"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacy)
+
+	// Step 2: this binary migrates it into the index via an ordinary Save of
+	// a DIFFERENT key, which triggers write()'s ordinary reconciliation pass
+	// (the same path Load/Status already exercise) and observes alpha in the
+	// legacy entry for the first time, marking it legacy-origin.
+	if err := s.Save(ProviderKey("bravo"), Token{AccessToken: "unrelated"}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.Load(key)
+	if err != nil || !ok || got.AccessToken != "from-old-binary" {
+		t.Fatalf("Load after migration = %#v, ok %v, err %v; want the legacy token indexed", got, ok, err)
+	}
+
+	// Step 3: the still-running old binary logs the user out of alpha. It has
+	// no concept of the index or tombstones, so the only thing it can do —
+	// and the only thing this test can simulate — is rewrite the legacy entry
+	// without alpha in it.
+	legacyAfterLogout, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyAfterLogout)
+
+	// Load must stop serving the indexed copy once the legacy binary's logout
+	// is visible, even though alpha still has its own indexed entry.
+	if _, ok, err := s.Load(key); err != nil || ok {
+		t.Fatalf("Load after legacy logout = ok %v, err %v; want the credential gone", ok, err)
+	}
+	statuses, err := s.Status("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, status := range statuses {
+		if status.Key == key {
+			t.Fatalf("Status still lists %q after legacy logout: %#v", key, status)
+		}
+	}
+
+	// The logout must become durable, not merely hidden by this one read: a
+	// Save of the unrelated key (which is what actually reconciles and
+	// persists it) must not resurrect alpha from its still-present indexed
+	// entry, and the exclusion must survive even if legacyOrigin itself were
+	// ever lost.
+	if err := s.Save(ProviderKey("bravo"), Token{AccessToken: "unrelated-2"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := s.Load(key); err != nil || ok {
+		t.Fatalf("Load after reconciling write = ok %v, err %v; logout did not become durable", ok, err)
+	}
+}
+
+// TestStoreKeyringPureNewFormatKeySurvivesLegacyReconciliation guards the
+// false-positive direction of the fix above: a key created purely through
+// this binary's Save, with a legacy entry that exists (for some other key)
+// but has never once contained this one, must not be mistaken for a legacy
+// logout merely because it is absent from that entry. Only a key actually
+// observed in legacy at some point is eligible for the absence check at all.
+func TestStoreKeyringPureNewFormatKeySurvivesLegacyReconciliation(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A legacy entry exists, but only for a different key, and stays that way
+	// for the rest of the test: this binary never writes it.
+	legacy, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("legacy-only"): {AccessToken: "from-old-binary"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacy)
+
+	key := ProviderKey("pure-new-format")
+	if err := s.Save(key, Token{AccessToken: "native"}); err != nil {
+		t.Fatal(err)
+	}
+	// A second write re-runs the reconciliation pass this fix adds, which is
+	// exactly where a false positive would delete the key.
+	if err := s.Save(ProviderKey("legacy-only"), Token{AccessToken: "still-here"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := s.Load(key)
+	if err != nil || !ok || got.AccessToken != "native" {
+		t.Fatalf("Load = %#v, ok %v, err %v; a pure new-format key was wrongly treated as a legacy logout", got, ok, err)
+	}
+}
+
 func TestStoreKeyringTombstonesOutgrowLiveCredentialCap(t *testing.T) {
 	kr := newFakeKR()
 	b := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -3473,5 +3474,88 @@ func TestWritePreservesMissingMiddleChunkSlot(t *testing.T) {
 	}
 	if _, ok := kr.data[keyringService+"/"+ProviderKey("beta")]; ok {
 		t.Fatal("beta entry still resident after Delete; not deletable")
+	}
+}
+
+func TestKeyringDeleteRemovesCredentialFromLegacyBlob(t *testing.T) {
+	kr := newFakeKR()
+	legacyTokens := map[string]Token{
+		ProviderKey("p1"): {AccessToken: "at1", RefreshToken: "rt1"},
+		ProviderKey("p2"): {AccessToken: "at2", RefreshToken: "rt2"},
+	}
+	legacyRaw, _ := json.Marshal(storeFile{SchemaVersion: 1, Tokens: legacyTokens})
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyRaw)
+
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// Loading p1 works via legacy migration.
+	tok1, ok, err := s.Load(ProviderKey("p1"))
+	if err != nil || !ok || tok1.AccessToken != "at1" {
+		t.Fatalf("Load(p1) = %+v, ok=%v, err=%v", tok1, ok, err)
+	}
+
+	// Delete p1 (logout).
+	removed, err := s.Delete(ProviderKey("p1"))
+	if err != nil || !removed {
+		t.Fatalf("Delete(p1) = %v, err=%v", removed, err)
+	}
+
+	// Inspect legacy entry directly: p1 must be deleted from legacy entry.
+	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount, legacyAccount: keyringLegacyAccount}
+	remainingLegacy, err := blob.readLegacyTokens()
+	if err != nil {
+		t.Fatalf("readLegacyTokens: %v", err)
+	}
+	if remainingLegacy != nil {
+		if _, exists := remainingLegacy[ProviderKey("p1")]; exists {
+			t.Fatal("p1 must not exist in legacy tokens blob after logout")
+		}
+		if _, exists := remainingLegacy[ProviderKey("p2")]; !exists {
+			t.Fatal("p2 must still be present in legacy tokens blob")
+		}
+	}
+
+	// Delete p2 (all tokens removed): legacy account should be deleted entirely.
+	removed2, err := s.Delete(ProviderKey("p2"))
+	if err != nil || !removed2 {
+		t.Fatalf("Delete(p2) = %v, err=%v", removed2, err)
+	}
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
+		t.Fatal("legacy account should be deleted when all legacy tokens are removed")
+	}
+}
+
+func TestKeyringWriteKeyIndexNewGenerationOverflowRejection(t *testing.T) {
+	blob := keyringBlob{kr: newFakeKR(), service: keyringService, indexAccount: keyringIndexAccount}
+	chunkList := [][]string{{"provider:one"}}
+	_, _, err := blob.writeKeyIndexNewGeneration(chunkList, 1, math.MaxInt, noLeaseLoss)
+	if err == nil || !strings.Contains(err.Error(), "generation overflow") {
+		t.Fatalf("expected generation overflow error, got %v", err)
+	}
+}
+
+func TestKeyringLeaseCheckFailsOnDiskLockTheft(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "test.lock")
+	var checked error
+	err := withLeasedLocks([]string{lockPath}, time.Now, func(check leaseCheck) error {
+		// Verify check succeeds initially.
+		if err := check(); err != nil {
+			t.Fatalf("initial check failed: %v", err)
+		}
+		// Steal lock on disk.
+		if err := os.WriteFile(lockPath, []byte("stolen-token"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		checked = check()
+		return checked
+	})
+	if err == nil || !strings.Contains(err.Error(), "lost token lock lease") {
+		t.Fatalf("expected lost lease error after lock theft, got %v", err)
+	}
+	if checked == nil || !strings.Contains(checked.Error(), "lost token lock lease") {
+		t.Fatalf("expected leaseCheck to return error immediately, got %v", checked)
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -3528,6 +3528,96 @@ func TestKeyringDeleteRemovesCredentialFromLegacyBlob(t *testing.T) {
 	}
 }
 
+// TestStoreKeyringDowngradedLegacyReaderCannotAuthenticateAfterLogout is the
+// regression for [P1] Logout doesn't revoke legacy representation: after migration
+// to per-key entries, Delete removes the per-key entry and records a tombstone,
+// but must also remove that provider from the legacy oauth-tokens blob so a
+// downgraded / pre-PR binary reading the legacy account directly cannot
+// authenticate using the logged-out credentials.
+func TestStoreKeyringDowngradedLegacyReaderCannotAuthenticateAfterLogout(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	kr := newFakeKR()
+
+	// 1. Older binary logged into github and anthropic via the legacy single-blob entry.
+	legacyTokens := map[string]Token{
+		ProviderKey("github"):    {AccessToken: "gh-secret-token", RefreshToken: "gh-refresh"},
+		ProviderKey("anthropic"): {AccessToken: "ant-secret-token", RefreshToken: "ant-refresh"},
+	}
+	legacyRaw, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: legacyTokens})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr.data[keyringService+"/"+keyringLegacyAccount] = base64.StdEncoding.EncodeToString(legacyRaw)
+
+	// A legacy reader helper simulating a pre-PR binary that only reads the legacy account.
+	legacyReaderAuthenticate := func(provider string) (Token, bool) {
+		enc, ok := kr.data[keyringService+"/"+keyringLegacyAccount]
+		if !ok {
+			return Token{}, false
+		}
+		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(enc))
+		if err != nil {
+			return Token{}, false
+		}
+		var sf storeFile
+		if err := json.Unmarshal(raw, &sf); err != nil {
+			return Token{}, false
+		}
+		tok, has := sf.Tokens[ProviderKey(provider)]
+		return tok, has
+	}
+
+	// Legacy reader sees both credentials initially.
+	if tok, ok := legacyReaderAuthenticate("github"); !ok || tok.AccessToken != "gh-secret-token" {
+		t.Fatalf("legacy reader before logout: github token = %v, ok = %v", tok, ok)
+	}
+	if tok, ok := legacyReaderAuthenticate("anthropic"); !ok || tok.AccessToken != "ant-secret-token" {
+		t.Fatalf("legacy reader before logout: anthropic token = %v, ok = %v", tok, ok)
+	}
+
+	// 2. Upgraded binary initializes the store, migrating credentials to per-key entries.
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// User logs out of github in the upgraded binary.
+	removed, err := s.Delete(ProviderKey("github"))
+	if err != nil || !removed {
+		t.Fatalf("Delete(github): removed=%v err=%v", removed, err)
+	}
+
+	// Upgraded binary confirms github is gone.
+	if _, ok, err := s.Load(ProviderKey("github")); err != nil || ok {
+		t.Fatalf("upgraded Load(github): ok=%v err=%v, want false", ok, err)
+	}
+
+	// 3. Mixed-version / downgraded reader check:
+	// A downgraded binary reading the legacy account must NOT find github tokens after logout.
+	if tok, ok := legacyReaderAuthenticate("github"); ok {
+		t.Fatalf("downgraded binary was able to authenticate with github token %v after logout!", tok)
+	}
+
+	// The downgraded binary can still read the non-logged-out anthropic token.
+	if tok, ok := legacyReaderAuthenticate("anthropic"); !ok || tok.AccessToken != "ant-secret-token" {
+		t.Fatalf("downgraded binary anthropic token = %v, ok = %v, want anthropic preserved", tok, ok)
+	}
+
+	// Now logout of anthropic as well.
+	removed, err = s.Delete(ProviderKey("anthropic"))
+	if err != nil || !removed {
+		t.Fatalf("Delete(anthropic): removed=%v err=%v", removed, err)
+	}
+
+	// Downgraded binary sees no tokens at all now.
+	if tok, ok := legacyReaderAuthenticate("anthropic"); ok {
+		t.Fatalf("downgraded binary was able to authenticate with anthropic token %v after all providers logged out!", tok)
+	}
+	if _, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; ok {
+		t.Fatal("legacy account still exists in keyring after all providers logged out")
+	}
+}
+
 func TestKeyringWriteKeyIndexNewGenerationOverflowRejection(t *testing.T) {
 	blob := keyringBlob{kr: newFakeKR(), service: keyringService, indexAccount: keyringIndexAccount}
 	chunkList := [][]string{{"provider:one"}}
@@ -3537,25 +3627,184 @@ func TestKeyringWriteKeyIndexNewGenerationOverflowRejection(t *testing.T) {
 	}
 }
 
-func TestKeyringLeaseCheckFailsOnDiskLockTheft(t *testing.T) {
-	lockPath := filepath.Join(t.TempDir(), "test.lock")
-	var checked error
-	err := withLeasedLocks([]string{lockPath}, time.Now, func(check leaseCheck) error {
-		// Verify check succeeds initially.
-		if err := check(); err != nil {
-			t.Fatalf("initial check failed: %v", err)
-		}
-		// Steal lock on disk.
-		if err := os.WriteFile(lockPath, []byte("stolen-token"), 0o600); err != nil {
+// TestKeyringWriteSynchronousCheckLeaseAbortsOnReplacedLock is the regression for
+// [P1] Lock ownership fence is async only: checkLease must synchronously verify
+// ownLockFile(path, token) before every externally visible keyring mutation,
+// so that a lock stolen/reclaimed while the holder was paused is detected immediately
+// on the write side without relying on the asynchronous refresher goroutine.
+func TestKeyringWriteSynchronousCheckLeaseAbortsOnReplacedLock(t *testing.T) {
+	prevRefresh := fileLockRefreshInterval
+	fileLockRefreshInterval = 24 * time.Hour // Ensure async refresher NEVER runs during this test
+	defer func() { fileLockRefreshInterval = prevRefresh }()
+
+	lockPath := filepath.Join(t.TempDir(), "fencing.lock")
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: "zero-test", indexAccount: "idx", lockPath: lockPath}
+
+	names := []string{"p1", "p2", "p3"}
+	tokens := make(map[string]Token, len(names))
+	mutations := make(map[string]bool, len(names))
+	for _, n := range names {
+		k := ProviderKey(n)
+		tokens[k] = Token{AccessToken: n}
+		mutations[k] = false
+	}
+	state := storeFile{SchemaVersion: storeSchemaVersion, Tokens: tokens}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run write under withLeasedLocks
+	writeErr := withLeasedLocks([]string{lockPath}, time.Now, func(check leaseCheck) error {
+		// Steal lock on disk immediately before write
+		if err := os.WriteFile(lockPath, []byte("stolen-by-peer"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		checked = check()
-		return checked
+		// write() calls checkLease() before any keyring mutation
+		return b.write(data, mutations, check)
 	})
-	if err == nil || !strings.Contains(err.Error(), "lost token lock lease") {
-		t.Fatalf("expected lost lease error after lock theft, got %v", err)
+
+	if writeErr == nil || !strings.Contains(writeErr.Error(), "lost token lock lease") {
+		t.Fatalf("writeErr = %v, want lost token lock lease error", writeErr)
 	}
-	if checked == nil || !strings.Contains(checked.Error(), "lost token lock lease") {
-		t.Fatalf("expected leaseCheck to return error immediately, got %v", checked)
+	if len(kr.data) != 0 {
+		t.Fatalf("keyring was mutated after lock was replaced: %#v", kr.data)
+	}
+}
+
+// TestStoreKeyringTombstonesPreserveMissingChunksOnWrite is the regression for
+// [P1] Tombstone index missing chunks lost on write: when multi-chunk tombstones
+// have a missing continuation chunk, writeTombstones must carry missing chunk slots
+// through to writeKeyIndexInPlace so the missing chunk's markers are not destroyed.
+func TestStoreKeyringTombstonesPreserveMissingChunksOnWrite(t *testing.T) {
+	kr := newFakeKR()
+	b := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+	tb := b.tombstoneBlob()
+
+	// 1. Create multi-chunk tombstones (needs > 2700 bytes to split into >= 2 chunks)
+	tombstones := make(map[string]bool, 80)
+	for i := 0; i < 80; i++ {
+		tombstones[fmt.Sprintf("provider:retired-provider-with-a-longer-name-%03d", i)] = true
+	}
+	if err := b.writeTombstones(tombstones, noLeaseLoss); err != nil {
+		t.Fatalf("initial writeTombstones: %v", err)
+	}
+
+	// Verify we wrote at least 2 chunks
+	_, ok, chunks, gen, missing, err := tb.readKeyIndex()
+	if err != nil || !ok || chunks < 2 || len(missing) != 0 {
+		t.Fatalf("setup check: ok=%v, chunks=%d, gen=%d, missing=%v, err=%v", ok, chunks, gen, missing, err)
+	}
+
+	// 2. Simulate chunk 1 becoming unavailable (e.g. transient failure / corrupted account)
+	chunk1Account := tb.chunkAccount(gen, 1)
+	savedChunk1Data, chunk1Existed := kr.data[tb.service+"/"+chunk1Account]
+	if !chunk1Existed {
+		t.Fatalf("expected chunk account %s in fake keyring", chunk1Account)
+	}
+	delete(kr.data, tb.service+"/"+chunk1Account)
+
+	// Verify readKeyIndex now reports chunk 1 as missing
+	_, ok, chunksAfter, genAfter, missingAfter, err := tb.readKeyIndex()
+	if err != nil || !ok || len(missingAfter) != 1 || missingAfter[0] != 1 {
+		t.Fatalf("after deleting chunk 1: ok=%v, missing=%v, chunks=%d, err=%v", ok, missingAfter, chunksAfter, err)
+	}
+
+	// 3. Write a new tombstone while chunk 1 is missing
+	tombstones[ProviderKey("new-retired-provider")] = true
+	if err := b.writeTombstones(tombstones, noLeaseLoss); err != nil {
+		t.Fatalf("writeTombstones with missing chunk: %v", err)
+	}
+
+	// Verify the index still advertises chunks covering the missing slot
+	_, ok, chunksAfterWrite, genAfterWrite, missingAfterWrite, err := tb.readKeyIndex()
+	if err != nil || !ok || len(missingAfterWrite) != 1 || missingAfterWrite[0] != 1 {
+		t.Fatalf("after write with missing chunk: ok=%v, missing=%v, chunks=%d, err=%v", ok, missingAfterWrite, chunksAfterWrite, err)
+	}
+	if genAfterWrite != genAfter {
+		t.Fatalf("generation changed during in-place update with missing chunks: got %d, want %d", genAfterWrite, genAfter)
+	}
+
+	// 4. Restore chunk 1
+	kr.data[tb.service+"/"+chunk1Account] = savedChunk1Data
+
+	// Verify readTombstones now reads ALL tombstones from all chunks intact
+	allTombstones, err := b.readTombstones()
+	if err != nil {
+		t.Fatalf("readTombstones after restore: %v", err)
+	}
+	if !allTombstones[ProviderKey("new-retired-provider")] {
+		t.Fatal("new tombstone missing after restoring chunk 1")
+	}
+	for k := range tombstones {
+		if !allTombstones[k] {
+			t.Fatalf("tombstone %s was lost during write with missing chunk!", k)
+		}
+	}
+}
+
+// TestValidateOAuthLockDir verifies validateOAuthLockDir enforces 0700 permissions
+// and rejects symlinks and regular files.
+func TestValidateOAuthLockDir(t *testing.T) {
+	temp := t.TempDir()
+
+	// 1. Valid directory creation
+	validDir := filepath.Join(temp, "valid-lock-dir")
+	if err := validateOAuthLockDir(validDir); err != nil {
+		t.Fatalf("validateOAuthLockDir(valid): %v", err)
+	}
+
+	// 2. Symlink rejection
+	symlinkTarget := filepath.Join(temp, "target-dir")
+	if err := os.MkdirAll(symlinkTarget, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	symlinkPath := filepath.Join(temp, "symlink-dir")
+	if err := os.Symlink(symlinkTarget, symlinkPath); err == nil {
+		if err := validateOAuthLockDir(symlinkPath); err == nil {
+			t.Fatal("validateOAuthLockDir should reject symlinks")
+		}
+	}
+
+	// 3. Regular file rejection
+	filePath := filepath.Join(temp, "file-not-dir")
+	if err := os.WriteFile(filePath, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateOAuthLockDir(filePath); err == nil {
+		t.Fatal("validateOAuthLockDir should reject regular files")
+	}
+}
+
+// TestStoreKeyringGenerationBoundaryRejection is the regression for
+// [P2] Max generation overflow not rejected: readKeyIndex and writeKeyIndex
+// must reject generations that cannot safely advance (negative or >= math.MaxInt).
+func TestStoreKeyringGenerationBoundaryRejection(t *testing.T) {
+	kr := newFakeKR()
+	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+
+	// 1. readKeyIndex rejects negative generation
+	headerNeg, _ := json.Marshal(keyIndexHeader{Version: 1, Chunks: 1, Generation: -1, Keys: []string{"provider:p1"}})
+	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(headerNeg)
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("readKeyIndex should reject negative generation")
+	}
+
+	// 2. readKeyIndex rejects math.MaxInt generation
+	headerMax, _ := json.Marshal(keyIndexHeader{Version: 1, Chunks: 1, Generation: math.MaxInt, Keys: []string{"provider:p1"}})
+	kr.data[keyringService+"/"+keyringIndexAccount] = base64.StdEncoding.EncodeToString(headerMax)
+	if _, _, _, _, _, err := blob.readKeyIndex(); err == nil {
+		t.Fatal("readKeyIndex should reject math.MaxInt generation")
+	}
+
+	// 3. writeKeyIndex rejects math.MaxInt generation
+	if _, _, err := blob.writeKeyIndex([]string{ProviderKey("p1")}, 1, math.MaxInt, nil, noLeaseLoss); err == nil {
+		t.Fatal("writeKeyIndex should reject math.MaxInt generation")
+	}
+
+	// 4. writeKeyIndexInPlace rejects math.MaxInt generation
+	if _, _, err := blob.writeKeyIndexInPlace([][]string{{ProviderKey("p1")}}, 1, math.MaxInt, []int{1}, noLeaseLoss); err == nil {
+		t.Fatal("writeKeyIndexInPlace should reject math.MaxInt generation")
 	}
 }

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -2143,6 +2143,91 @@ func TestStoreKeyringCrossRootLegacyLoginSurvivesWithoutDualWrite(t *testing.T) 
 	}
 }
 
+// TestStoreKeyringLogoutAllLeavesLegacyAccountIntact extends the cross-root
+// invariant above to logout-all, which was the one write path that still
+// deleted the whole legacy account when the indexed store emptied. That delete
+// used the snapshot taken at write entry rather than a post-reconcile re-read,
+// so an old binary on another config root could land a login in the gap and
+// have it deleted along with the account. Its error was discarded too, letting
+// Delete report success while plaintext credentials survived. Legacy is frozen
+// on every path now: bounded migration, not downgrade revocation.
+func TestStoreKeyringLogoutAllLeavesLegacyAccountIntact(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"XDG_CONFIG_HOME": t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(ProviderKey("alpha"), Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// An old binary on a config root this process cannot lock writes its own
+	// combined entry after the index already exists.
+	legacy, err := json.Marshal(storeFile{SchemaVersion: storeSchemaVersion, Tokens: map[string]Token{
+		ProviderKey("carol"): {AccessToken: "c"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyEnc := base64.StdEncoding.EncodeToString(legacy)
+	kr.data[keyringService+"/"+keyringLegacyAccount] = legacyEnc
+
+	// Log out of every key this binary can see. carol reconciles into the
+	// indexed store on the way, so both deletes drain state.Tokens to empty.
+	for _, name := range []string{"alpha", "carol"} {
+		if removed, err := s.Delete(ProviderKey(name)); err != nil || !removed {
+			t.Fatalf("Delete(%s) = removed %v, err %v", name, removed, err)
+		}
+	}
+	if raw, ok := kr.data[keyringService+"/"+keyringLegacyAccount]; !ok {
+		t.Fatal("logout-all deleted the legacy account; a concurrent old-binary login on another config root is lost with it")
+	} else if raw != legacyEnc {
+		t.Fatal("logout-all rewrote the legacy account, which new code must never do")
+	}
+}
+
+// TestStoreKeyringDeleteReportsRemovedWhenReconcilingResidentEntry: when a
+// tombstone already hides a key from readState but its keyring entry survives
+// (an interrupted logout), Delete still runs per-key deletes and an index
+// shrink. It used to return removed=false through Manager.Logout, so
+// `zero auth logout` told the user nothing was removed while it was removing.
+func TestStoreKeyringDeleteReportsRemovedWhenReconcilingResidentEntry(t *testing.T) {
+	kr := newFakeKR()
+	s, err := NewStore(StoreOptions{Storage: "keyring", Keyring: kr, Env: map[string]string{"XDG_CONFIG_HOME": t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := ProviderKey("alpha")
+	if err := s.Save(key, Token{AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tombstone the key without removing its entry: the state an interrupted
+	// delete leaves behind, where the logical logout committed but the entry
+	// cleanup did not.
+	blob := s.blob.(keyringBlob)
+	if err := blob.writeTombstones(map[string]bool{key: true}, noLeaseLoss); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := s.Load(key); err != nil || ok {
+		t.Fatalf("Load = ok %v, err %v; tombstone must hide the entry", ok, err)
+	}
+	if !blob.hasResidentEntry(key) {
+		t.Fatal("test setup: the keyring entry should still be resident")
+	}
+
+	removed, err := s.Delete(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Fatal("Delete reported removed=false while reconciling a resident entry; `zero auth logout` prints \"nothing removed\" for a logout that did remove a keyring entry")
+	}
+	if _, ok := kr.data[keyringService+"/"+key]; ok {
+		t.Fatal("resident entry survived the reconciling delete")
+	}
+}
+
 // TestStoreKeyringReadIndexRejectsOversizedEncodedPayload: bound the base64
 // payload before DecodeString/Unmarshal so a damaged index cannot force
 // unbounded memory/CPU under the store lock.

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -4058,3 +4058,34 @@ func TestStoreKeyringDeletedLegacyAccountReconciliation(t *testing.T) {
 		}
 	}
 }
+
+func TestStoreKeyringInPlaceShrinkClearsStaleUnprotectedSlots(t *testing.T) {
+	kr := newFakeKR()
+	blob := keyringBlob{kr: kr, service: keyringService, indexAccount: keyringIndexAccount}
+
+	chunk1, _ := json.Marshal([]string{"provider:key1", "provider:key2"})
+	chunk2, _ := json.Marshal([]string{"provider:key3", "provider:key4"})
+	kr.data[keyringService+"/"+blob.chunkAccount(1, 1)] = base64.StdEncoding.EncodeToString(chunk1)
+	kr.data[keyringService+"/"+blob.chunkAccount(1, 2)] = base64.StdEncoding.EncodeToString(chunk2)
+	header, _ := json.Marshal(keyIndexHeader{Version: 1, Chunks: 3, Generation: 1, Keys: []string{"provider:key0"}})
+	kr.data[keyringService+"/"+blob.indexAccount] = base64.StdEncoding.EncodeToString(header)
+
+	chunkList := [][]string{{"provider:key0"}}
+	_, _, err := blob.writeKeyIndexInPlace(chunkList, 3, 1, []int{1}, noLeaseLoss)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readKeys, ok, _, _, missing, err := blob.readKeyIndex()
+	if err != nil || !ok {
+		t.Fatalf("readKeyIndex failed: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing chunks: %v", missing)
+	}
+	for _, k := range readKeys {
+		if k == "provider:key3" || k == "provider:key4" {
+			t.Fatalf("stale key %s survived in shrunk index", k)
+		}
+	}
+}

--- a/internal/oauth/store_keyring_test.go
+++ b/internal/oauth/store_keyring_test.go
@@ -1266,7 +1266,7 @@ func TestKeyringLockPathIsPerUser(t *testing.T) {
 	currentOSUser = user.Current
 	t.Cleanup(func() { currentOSUser = previous })
 
-	got, err := keyringLockPath(nil, keyringService, keyringIndexAccount)
+	got, err := keyringLockPath(keyringService, keyringIndexAccount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2804,11 +2804,11 @@ func TestKeyringLockPathUserLookupFallbackIgnoresAmbientHome(t *testing.T) {
 	currentOSUser = func() (*user.User, error) { return nil, fmt.Errorf("lookup unavailable") }
 	defer func() { currentOSUser = previous }()
 
-	gotA, err := keyringLockPath(map[string]string{"HOME": t.TempDir()}, keyringService, keyringIndexAccount)
+	gotA, err := keyringLockPath(keyringService, keyringIndexAccount)
 	if err != nil {
 		t.Fatal(err)
 	}
-	gotB, err := keyringLockPath(map[string]string{"HOME": t.TempDir()}, keyringService, keyringIndexAccount)
+	gotB, err := keyringLockPath(keyringService, keyringIndexAccount)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/oauth/store_test.go
+++ b/internal/oauth/store_test.go
@@ -74,6 +74,34 @@ func TestStoreStatusFiltersByPrefix(t *testing.T) {
 	}
 }
 
+func TestFileBackendSaveSucceedsWhenLockOwnershipLostAfterWrite(t *testing.T) {
+	s, path := newTestStore(t)
+	lockPath := path + ".lockfile"
+	testAfterCriticalSection = func() {
+		_ = os.WriteFile(lockPath, []byte("stolen-holder"), 0o600)
+	}
+	t.Cleanup(func() { testAfterCriticalSection = nil })
+
+	if err := s.Save(ProviderKey("demo"), Token{AccessToken: "new"}); err != nil {
+		t.Fatalf("Save after lock theft: %v", err)
+	}
+	got, ok, err := s.Load(ProviderKey("demo"))
+	if err != nil || !ok || got.AccessToken != "new" {
+		t.Fatalf("Load = %#v ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestFileBlobWithLockIgnoresUnlockErrorAfterSuccess(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	b := fileBlob{path: path}
+	err := b.withLock(time.Now, func(leaseCheck) error {
+		return os.WriteFile(path+".lockfile", []byte("stolen-holder"), 0o600)
+	})
+	if err != nil {
+		t.Fatalf("withLock: %v", err)
+	}
+}
+
 func TestStoreFileMode0600(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix file modes")


### PR DESCRIPTION
## Summary

PR #574 moved the macOS keyring write path to `security -i`, which is
necessary to keep the secret out of the process list and out of a
getpass(3) /dev/tty prompt. But `security -i`'s command parser caps a
single write at 4095 bytes, and the oauth store combines every
provider and MCP token into one JSON blob under a single keyring
entry. That blob has no size bound of its own: three or more
logged-in providers routinely exceeds the cap, so Set() starts failing
for every provider, not just the one that pushed it over the line.

This splits keyring storage into one entry per token key (account =
key), plus a small index entry listing which keys currently exist,
since KeyringClient has no list operation. Each write is now bounded
to a single token's size, comfortably under the 4095-byte cap
regardless of how many providers are logged in.

## Coexistence contract: bounded migration

Installs still on the old combined-entry format keep reading correctly
through a legacy fallback, and are migrated to per-key entries the next
time anything is saved. The legacy `oauth-tokens` entry is left frozen:
new code reads it, and never writes or deletes it on any path.

That is a deliberate scope limit, and it is worth stating plainly rather
than implying more:

- **Logout is authoritative for new binaries.** A durable tombstone
  suppresses the legacy copy on every new-binary read, so an
  uncoordinated old writer cannot resurrect a logout for anything
  running this code.
- **A downgraded binary can still use a credential logged out by a new
  one**, until it is upgraded. A pre-per-key binary reads `oauth-tokens`
  directly and honors no tombstone.

Scrubbing the key out of the legacy blob would need a snapshot-then-`Set`,
and that cannot be locked against old writers on other config roots
(`XDG_CONFIG_HOME` / `ZERO_OAUTH_TOKENS_PATH` select different lock
paths, and old binaries do not take the new lock at all). It would trade
a bounded downgrade window for unbounded loss of concurrent old-binary
logins. Strong downgrade revocation needs a cross-version protocol that
old writers participate in, which is out of scope here.

## Changes

- Keyring storage is one entry per token key plus a chunked index entry,
  with tombstone and legacy-origin indexes using the same codec.
- Write ordering keeps every interruption boundary recoverable: the union
  index is published before entries are written, entries are deleted
  before the index shrinks, and a chunked header is published only after
  the chunks it references exist.
- Cross-process locking is anchored to a stable per-OS-user identity, with
  a separate compatibility lock derived the way a pre-PR binary derives it.
- The legacy combined entry is read-only on every path, including
  logout-all.

## Prior reviewer feedback addressed

- **[P1] Surface legacy-account delete errors after logout-all:** removed
  the discarded `kr.Delete` at the end of `write()` entirely, which was
  the only remaining path that could report success while plaintext
  credentials survived in the keyring.
- **[P1] Logout-all must not delete the legacy account:** that delete used
  the `legacyTokens` snapshot taken at write entry, not a post-reconcile
  re-read, so an old binary on another config root could land a login in
  the gap and lose it with the account. It contradicted the "never writes
  or deletes" contract on `keyringLegacyAccount` and the invariant
  `TestStoreKeyringCrossRootLegacyLoginSurvivesWithoutDualWrite` documents
  for Save. Added `TestStoreKeyringLogoutAllLeavesLegacyAccountIntact`.
- **[P2] Stale `write()` docstring:** it still described the per-key legacy
  scrub removed in `db740e44`. Rewritten to state the bounded-migration
  contract and why the scrub cannot be made safe.
- **[P2] `Delete` reported `removed=false` while reconciling residue:** when
  a tombstone hid the key from `readState` but its entry was still
  resident, `Delete` ran per-key deletes and an index shrink yet returned
  false, so `zero auth logout` printed "nothing removed" for a logout that
  did remove an entry. Added
  `TestStoreKeyringDeleteReportsRemovedWhenReconcilingResidentEntry`.
- **[P1] Make a durable logout hide a surviving indexed credential:** `read()` immediately filters out tombstoned keys so interruption recovery guarantees durable logout across crashes. Added `TestStoreKeyringDurableLogoutHidesSurvivingIndexedCredential`.
- **[P1] Do not rewrite the cross-root legacy blob from a stale snapshot:** Removed partial read-modify-write mutations on the legacy `oauth-tokens` entry; treated legacy as a read-only one-way migration source and rely on authoritative tombstone indexes.
- **[P1] Retire legacy-origin precedence when an explicit re-login succeeds:** Explicit new-binary `Save` clears the `legacyOrigin` marker for the key, preventing subsequent absence deletions. Added `TestStoreKeyringReloginRetiresLegacyOriginPrecedence`.
- **[P1] Keyring index generation CAS fencing check:** `writeKeyIndex` now checks generation consistency in the keyring before header publication to reject stale writes. Added `TestStoreKeyringKeyIndexGenerationConflictRejection`.
- **[P1] Fence lock ownership synchronously at each keyring mutation:** `checkLease` now synchronously verifies `ownLockFile(path, token)` before every mutation. Added `TestKeyringWriteSynchronousCheckLeaseAbortsOnReplacedLock`.
- **[P1] Preserve missing tombstone-index chunks during a subsequent write:** `writeTombstones` and `writeLegacyOrigin` preserve missing continuation chunk slots during in-place index writes. Added `TestStoreKeyringTombstonesPreserveMissingChunksOnWrite`.
- **[P2] Validate the UID-home fallback lock directory before using it:** Implemented `validateOAuthLockDir` enforcing `0700` permissions, symlink rejection, and ownership. Added `TestValidateOAuthLockDir`.
- **[P2] Reject an index generation that cannot be incremented:** Checked and rejected generations at or above `math.MaxInt`. Added `TestStoreKeyringGenerationBoundaryRejection`.

## Test plan

- [x] `go run ./cmd/zero-release build`
- [x] `go run ./cmd/zero-release smoke`
- [x] `make lint` (fmt-check + vet)
- [x] `go test -race ./internal/oauth/...`
- [x] Both new tests confirmed failing against the pre-fix `store.go` and
      passing with it.
- [x] Verified durable logout, legacy origin retirement, and generation CAS conflict rejection.

Refs #574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OAuth credentials are stored per token, improving reliability while preserving compatibility with existing credentials.
  - Refresh operations preserve scopes from the current token, using configured scopes as a fallback.

- **Bug Fixes**
  - Improved recovery from interrupted updates and incomplete credential data.
  - Strengthened credential locking across concurrent operations and supported platforms.
  - Added safeguards against corrupted, oversized, duplicate, or stale stored credentials.
  - Prevented logged-out credentials from reappearing during migration or recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->