### PR TITLE
feat(cli): show ZERO wordmark on --version

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -339,7 +339,7 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 				return 0
 			}
 		}
-		if _, err := fmt.Fprintf(stdout, "zero %s\n", version); err != nil {
+		if _, err := fmt.Fprintf(stdout, "%s\n\nversion: %s\n", tui.Wordmark(stdout), version); err != nil {
 			return 1
 		}
 		return 0

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Gitlawb/zero/internal/worktrees"
 	"github.com/Gitlawb/zero/internal/zerogit"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
+	"github.com/charmbracelet/x/term"
 )
 
 var version = "dev"
@@ -339,7 +340,17 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 				return 0
 			}
 		}
-		if _, err := fmt.Fprintf(stdout, "%s\n\nversion: %s\n", tui.Wordmark(stdout), version); err != nil {
+		// Pipes and redirects keep the machine-readable contract exactly as it
+		// was: a single "zero <version>" line. Scripts, command substitutions,
+		// and the NPM wrapper smoke check all parse that record, so the banner
+		// is strictly a TTY affordance.
+		if !stdoutIsTerminal(stdout) {
+			if _, err := fmt.Fprintf(stdout, "zero %s\n", version); err != nil {
+				return 1
+			}
+			return 0
+		}
+		if _, err := fmt.Fprintf(stdout, "%s\n\nzero %s\n", tui.Wordmark(), version); err != nil {
 			return 1
 		}
 		return 0
@@ -1113,6 +1124,17 @@ func closeSpecialistRuntime(stderr io.Writer, runtime *agentToolRuntime) {
 			_, _ = fmt.Fprintf(stderr, "[zero] specialist_cleanup_error: %s\n", err)
 		}
 	}
+}
+
+// stdoutIsTerminal reports whether w is an interactive terminal. Tests pass
+// bytes.Buffer writers and pipes/redirects fail term.IsTerminal, so both take
+// the machine-readable path.
+func stdoutIsTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(f.Fd())
 }
 
 func writeAppError(stderr io.Writer, message string, exitCode int) int {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -41,14 +41,37 @@ func TestRunPrintsVersion(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
-	wantWordmark := "███████╗███████╗██████╗  ██████╗ \n" +
-		"╚══███╔╝██╔════╝██╔══██╗██╔═══██╗\n" +
-		"  ███╔╝ █████╗  ██████╔╝██║   ██║\n" +
-		" ███╔╝  ██╔══╝  ██╔══██╗██║   ██║\n" +
-		"███████╗███████╗██║  ██║╚██████╔╝\n" +
-		"╚══════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ \n"
-	if got, want := stdout.String(), wantWordmark+"\nversion: dev\n"; got != want {
-		t.Fatalf("expected version output %q, got %q", want, got)
+	// Non-terminal stdout keeps the machine-readable contract: exactly one
+	// "zero <version>" record, no wordmark banner, no ANSI.
+	if got := stdout.String(); got != "zero dev\n" {
+		t.Fatalf("expected version output, got %q", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+// TestRunVersionRedirectedFile covers the `zero --version > file` path: stdout
+// is a real *os.File but not a terminal, so the single-line contract must hold.
+func TestRunVersionRedirectedFile(t *testing.T) {
+	stdout, err := os.CreateTemp(t.TempDir(), "version-stdout")
+	if err != nil {
+		t.Fatalf("create temp stdout: %v", err)
+	}
+	defer stdout.Close()
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"--version"}, stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	content, err := os.ReadFile(stdout.Name())
+	if err != nil {
+		t.Fatalf("read temp stdout: %v", err)
+	}
+	if got := string(content); got != "zero dev\n" {
+		t.Fatalf("expected version output, got %q", got)
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -41,8 +41,14 @@ func TestRunPrintsVersion(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
-	if got := stdout.String(); got != "zero dev\n" {
-		t.Fatalf("expected version output, got %q", got)
+	wantWordmark := "███████╗███████╗██████╗  ██████╗ \n" +
+		"╚══███╔╝██╔════╝██╔══██╗██╔═══██╗\n" +
+		"  ███╔╝ █████╗  ██████╔╝██║   ██║\n" +
+		" ███╔╝  ██╔══╝  ██╔══██╗██║   ██║\n" +
+		"███████╗███████╗██║  ██║╚██████╔╝\n" +
+		"╚══════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ \n"
+	if got, want := stdout.String(), wantWordmark+"\nversion: dev\n"; got != want {
+		t.Fatalf("expected version output %q, got %q", want, got)
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -675,9 +675,9 @@ func smokeVersion(ctx context.Context, binaryPath string, version string) error 
 		}
 		return fmt.Errorf("smoke release binary: %s", output)
 	}
-	expected := "zero " + version
-	if output != expected {
-		return fmt.Errorf("expected %s --version to print %s, got %s", filepath.Base(binaryPath), expected, output)
+	expected := "version: " + version
+	if !strings.HasSuffix(output, expected) {
+		return fmt.Errorf("expected %s --version to end with %s, got %s", filepath.Base(binaryPath), expected, output)
 	}
 	return nil
 }

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -675,9 +675,9 @@ func smokeVersion(ctx context.Context, binaryPath string, version string) error 
 		}
 		return fmt.Errorf("smoke release binary: %s", output)
 	}
-	expected := "version: " + version
-	if !strings.HasSuffix(output, expected) {
-		return fmt.Errorf("expected %s --version to end with %s, got %s", filepath.Base(binaryPath), expected, output)
+	expected := "zero " + version
+	if output != expected {
+		return fmt.Errorf("expected %s --version to print %s, got %s", filepath.Base(binaryPath), expected, output)
 	}
 	return nil
 }

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -1,13 +1,10 @@
 package tui
 
 import (
-	"io"
-	"os"
 	"strings"
 	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/x/term"
 )
 
 const (
@@ -141,37 +138,16 @@ func zeroWordmarkLines() []string {
 }
 
 // Wordmark renders the brand ASCII art shown on the TUI's empty state, for
-// reuse outside the TUI (e.g. `zero --version`). w decides whether color is
-// applied: lipgloss.Style.Render doesn't check isatty on its own, so without
-// this gate every `zero --version > file` or `| grep` would carry raw ANSI.
-func Wordmark(w io.Writer) string {
-	lines := zeroWordmarkPlainLines()
-	if wordmarkColorEnabled(w) {
-		lines = zeroWordmarkLines()
-	}
-	return strings.Join(lines, "\n")
-}
-
-func zeroWordmarkPlainLines() []string {
+// reuse outside the TUI (e.g. `zero --version`). It is deliberately
+// uncolored: only newModel resolves --theme/ZERO_THEME, so painting the
+// global palette here would ignore a selected light theme and be unreadable
+// on light terminals. The terminal's default foreground works everywhere.
+func Wordmark() string {
 	lines := make([]string, 0, minInt(len(zeroWordmarkPrefixLines), len(zeroWordmarkOLines)))
 	for index := 0; index < len(zeroWordmarkPrefixLines) && index < len(zeroWordmarkOLines); index++ {
 		lines = append(lines, zeroWordmarkPrefixLines[index]+zeroWordmarkOLines[index])
 	}
-	return lines
-}
-
-// wordmarkColorEnabled honors NO_COLOR and requires w to be a real terminal,
-// matching the no-color.org handling already applied to the interactive TUI
-// in run.go.
-func wordmarkColorEnabled(w io.Writer) bool {
-	if os.Getenv("NO_COLOR") != "" {
-		return false
-	}
-	f, ok := w.(*os.File)
-	if !ok {
-		return false
-	}
-	return term.IsTerminal(f.Fd())
+	return strings.Join(lines, "\n")
 }
 
 func borderedBlock(width int, lines []string) string {

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -1,10 +1,13 @@
 package tui
 
 import (
+	"io"
+	"os"
 	"strings"
 	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/term"
 )
 
 const (
@@ -135,6 +138,40 @@ func zeroWordmarkLines() []string {
 		lines = append(lines, zeroTheme.ink.Render(zeroWordmarkPrefixLines[index])+zeroTheme.accent.Render(zeroWordmarkOLines[index]))
 	}
 	return lines
+}
+
+// Wordmark renders the brand ASCII art shown on the TUI's empty state, for
+// reuse outside the TUI (e.g. `zero --version`). w decides whether color is
+// applied: lipgloss.Style.Render doesn't check isatty on its own, so without
+// this gate every `zero --version > file` or `| grep` would carry raw ANSI.
+func Wordmark(w io.Writer) string {
+	lines := zeroWordmarkPlainLines()
+	if wordmarkColorEnabled(w) {
+		lines = zeroWordmarkLines()
+	}
+	return strings.Join(lines, "\n")
+}
+
+func zeroWordmarkPlainLines() []string {
+	lines := make([]string, 0, minInt(len(zeroWordmarkPrefixLines), len(zeroWordmarkOLines)))
+	for index := 0; index < len(zeroWordmarkPrefixLines) && index < len(zeroWordmarkOLines); index++ {
+		lines = append(lines, zeroWordmarkPrefixLines[index]+zeroWordmarkOLines[index])
+	}
+	return lines
+}
+
+// wordmarkColorEnabled honors NO_COLOR and requires w to be a real terminal,
+// matching the no-color.org handling already applied to the interactive TUI
+// in run.go.
+func wordmarkColorEnabled(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(f.Fd())
 }
 
 func borderedBlock(width int, lines []string) string {

--- a/internal/tui/startup_test.go
+++ b/internal/tui/startup_test.go
@@ -21,6 +21,25 @@ func TestEmptyStateShowsBrandAndTaglineOnly(t *testing.T) {
 	assertNotContains(t, view, "fix the failing test in internal/tools")
 }
 
+// TestWordmarkIsPlain guards the --version banner: it must carry no ANSI
+// escapes, because this renderer never resolves --theme/ZERO_THEME and any
+// palette color could be unreadable on the user's background.
+func TestWordmarkIsPlain(t *testing.T) {
+	wordmark := Wordmark()
+	if strings.Contains(wordmark, "\x1b") {
+		t.Fatalf("expected uncolored wordmark, got %q", wordmark)
+	}
+	lines := strings.Split(wordmark, "\n")
+	if len(lines) != len(zeroWordmarkPrefixLines) {
+		t.Fatalf("expected %d wordmark lines, got %d", len(zeroWordmarkPrefixLines), len(lines))
+	}
+	for index, line := range lines {
+		if want := zeroWordmarkPrefixLines[index] + zeroWordmarkOLines[index]; line != want {
+			t.Fatalf("wordmark line %d: expected %q, got %q", index, want, line)
+		}
+	}
+}
+
 func TestEmptyStateShowsVersion(t *testing.T) {
 	m := newModel(context.Background(), Options{Version: "0.2.0"})
 	m.width, m.height = 100, 30


### PR DESCRIPTION
## Summary
- Exposes the TUI's empty-state ZERO ascii wordmark via a new `tui.Wordmark` helper and prints it above the version line for `zero -v`/`--version`, as an easter egg.
- Coloring only applies when stdout is a real TTY and `NO_COLOR` isn't set, so redirected or piped output (e.g. scripts parsing the version) stays plain text.
- Version line changed from `zero <version>` to `version: <version>` to read correctly under the wordmark.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/cli/... ./internal/tui/...`
- [x] Manually verified `zero --version` shows colored wordmark in a TTY, plain text when redirected to a file, and stays plain with `NO_COLOR=1` set even in a TTY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a formatted ZERO wordmark to version output when displayed in an interactive terminal.

* **Bug Fixes**
  * Preserved the concise, machine-readable `zero <version>` format when version output is redirected or piped.
  * Ensured redirected version output contains no extra banner or formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->