### PR TITLE
test(tui): isolate provider wizard credentials

### DIFF
--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -181,6 +181,7 @@ func TestProviderWizardAdvancesProviderAPIKeyAndModelSteps(t *testing.T) {
 	if got := next.providerWizard.currentProvider().ID; got != "anthropic" {
 		t.Fatalf("after down, selected provider = %q, want anthropic", got)
 	}
+	clearProviderAuthEnvForTest(t, next.providerWizard.currentProvider())
 
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)


### PR DESCRIPTION
## Summary

- clear the selected provider's declared credential environment variables in the provider wizard progression test
- reuse the existing provider-aware test helper so future credential variable additions remain isolated

## Root cause

`TestProviderWizardAdvancesProviderAPIKeyAndModelSteps` asserted the empty-credential footer without controlling the selected provider's ambient credential variables. When `ANTHROPIC_API_KEY` was set, the wizard correctly considered the credential ready and rendered `Enter/→ continue`, making the test depend on the developer or CI environment.

## Validation

- exact reproducer with `ANTHROPIC_API_KEY=test` passes 20 consecutive runs
- `go test ./internal/tui -count=1` passes with `ANTHROPIC_API_KEY=test`
- `go fmt ./...`
- `go vet ./...`
- `govulncheck ./...` (no vulnerabilities)
- full `go test ./...` with `ANTHROPIC_API_KEY=test`: TUI and all other packages pass except the existing Windows process-cleanup failures in `internal/tools`
- pinned golangci-lint: existing repository-wide findings tracked in #680; no finding on the added line
- `make lint`: blocked by the existing Windows-incompatible `fmt-check` shell command

Fixes #679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by clearing authentication environment variables before validating the provider credential flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->