### PR TITLE
fix(lsp): make real-gopls integration test opt-in via env var

### DIFF
--- a/internal/lsp/real_gopls_manual_test.go
+++ b/internal/lsp/real_gopls_manual_test.go
@@ -11,9 +11,13 @@ import (
 
 // TestManagerCheckRealGopls drives the exact path the self-correct LSP wiring
 // uses (NewManager -> Check) against a REAL gopls and asserts a real diagnostic
-// comes back. Skips when gopls is not installed. Temporary manual-verification
-// test (the rest of the suite uses a fake server).
+// comes back. Opt-in manual-verification test (the rest of the suite uses a
+// fake server): the health, version, or cache state of a developer's globally
+// installed gopls must not fail the default hermetic suite.
 func TestManagerCheckRealGopls(t *testing.T) {
+	if os.Getenv("ZERO_LSP_REAL_GOPLS_TEST") == "" {
+		t.Skip("set ZERO_LSP_REAL_GOPLS_TEST=1 to run the real gopls integration test")
+	}
 	if _, err := exec.LookPath("gopls"); err != nil {
 		t.Skip("gopls not on PATH; skipping real-server check")
 	}

--- a/internal/lsp/real_gopls_manual_test.go
+++ b/internal/lsp/real_gopls_manual_test.go
@@ -15,7 +15,7 @@ import (
 // fake server): the health, version, or cache state of a developer's globally
 // installed gopls must not fail the default hermetic suite.
 func TestManagerCheckRealGopls(t *testing.T) {
-	if os.Getenv("ZERO_LSP_REAL_GOPLS_TEST") == "" {
+	if os.Getenv("ZERO_LSP_REAL_GOPLS_TEST") != "1" {
 		t.Skip("set ZERO_LSP_REAL_GOPLS_TEST=1 to run the real gopls integration test")
 	}
 	if _, err := exec.LookPath("gopls"); err != nil {


### PR DESCRIPTION
## Summary

Fixes #684 — `TestManagerCheckRealGopls` ran as part of the default `go test ./...` suite whenever any `gopls` binary was on `PATH`, so an installed but unusable gopls (e.g. a broken persistent-index cache) failed the whole suite with `lsp error -1: EOF`.

## Changes

The test is now gated behind an explicit `ZERO_LSP_REAL_GOPLS_TEST=1` opt-in, following the repo's existing convention for real-dependency smoke tests (`ZERO_STT_DOWNLOAD_TEST`, `ZERO_STT_STREAM_SERVER`, …). The `gopls`-on-PATH skip is kept as a secondary guard for the opt-in path. Default hermetic coverage continues to run against the fake LSP server.

## Verification

On Windows (go1.26.5 windows/amd64):
- Default run: `go test ./internal/lsp -run '^TestManagerCheckRealGopls$' -v` → SKIP with a clear opt-in message.
- Opt-in run: `ZERO_LSP_REAL_GOPLS_TEST=1 go test ...` → PASS against a real gopls (1 compiler diagnostic reported).
- Full `go test ./internal/lsp` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * The real-language-server verification test now runs only when explicitly enabled with the `ZERO_LSP_REAL_GOPLS_TEST` environment variable.
  * The test continues to skip automatically when the required language server is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->