### PR TITLE
fix(providers): update xAI catalog default to grok-4.5

### DIFF
--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -139,7 +139,7 @@ var descriptors = []Descriptor{
 	openAICompat("github", "GitHub Models", "https://models.inference.ai.azure.com", "openai/gpt-4.1", []string{"GITHUB_TOKEN"}, "github-models"),
 	transportDescriptor("bedrock", "Amazon Bedrock", TransportBedrock, "https://bedrock-runtime.${AWS_REGION}.amazonaws.com", "anthropic.claude-3-5-sonnet-20241022-v2:0", []string{"AWS_ACCESS_KEY_ID", "AWS_PROFILE"}, []APIFormat{APIFormatBedrockConverse}, true),
 	transportDescriptor("vertex", "Vertex AI", TransportVertex, "https://aiplatform.googleapis.com", "gemini-2.5-pro", []string{"GOOGLE_APPLICATION_CREDENTIALS"}, []APIFormat{APIFormatVertexGenerateContent}, true),
-	oauthProvider(openAICompat("xai", "xAI", "https://api.x.ai/v1", "grok-4", []string{"XAI_API_KEY"}), false, true),
+	oauthProvider(openAICompat("xai", "xAI", "https://api.x.ai/v1", "grok-4.5", []string{"XAI_API_KEY"}), false, true),
 	openAICompat("venice", "Venice AI", "https://api.venice.ai/api/v1", "qwen-2.5-qwq-32b", []string{"VENICE_API_KEY"}),
 	openAICompat("xiaomi-mimo", "Xiaomi MiMo", "https://api.mimo.xiaomi.com/openai/v1", "mimo-vl", []string{"MIMO_API_KEY", "XIAOMI_API_KEY"}, "xiaomi mimo"),
 	openAICompat("bankr", "Bankr", "https://api.bankr.bot/v1", "bankr-large", []string{"BANKR_API_KEY"}),

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -143,7 +143,8 @@ var curatedModels = map[string][]Model{
 		{ID: "mistral-ai/codestral-2501", Description: "coding model"},
 	},
 	"xai": {
-		{ID: "grok-4", Description: "catalog default"},
+		{ID: "grok-4.5", Description: "catalog default"},
+		{ID: "grok-4", Description: "previous flagship"},
 		{ID: "grok-3", Description: "general model"},
 		{ID: "grok-3-mini", Description: "fast reasoning model"},
 		{ID: "grok-code-fast-1", Description: "coding model"},

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -1373,7 +1373,7 @@ func setupAtOAuthList(t *testing.T) model {
 		Visible: true,
 		Providers: []SetupProviderOption{
 			{ID: "openrouter", Name: "OpenRouter", RequiresAuth: true, EnvVar: "OPENROUTER_API_KEY"},
-			{ID: "xai", Name: "xAI", DefaultModel: "grok-4", RequiresAuth: true, EnvVar: "XAI_API_KEY"},
+			{ID: "xai", Name: "xAI", DefaultModel: "grok-4.5", RequiresAuth: true, EnvVar: "XAI_API_KEY"},
 		},
 	}})
 	m.width = 100


### PR DESCRIPTION
Add grok-4.5 as the curated xAI default and keep grok-4 as the previous flagship for offline/fallback model selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Added xAI’s Grok 4.5 to the available model list.
  * Set Grok 4.5 as the default xAI model for new sessions and OAuth setup.
  * Kept Grok 4 available, labeled as the previous flagship model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->