### PR TITLE
feat(cli): wire MCP serve WorkspaceRoot and --add-dir scope

### DIFF
--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -240,10 +240,13 @@ OAuth server names ending in `.<32 hex chars>` are reserved for token storage.
 
 ```bash
 zero serve --mcp
+zero serve --mcp -C /path/to/workspace
+zero serve --mcp --add-dir /path/to/extra
 ```
 
 The server speaks MCP over stdio. Configure it from the receiving side as a `stdio` server whose command is `zero serve --mcp`.
 
+`-C/--cwd` sets the workspace root exposed as MCP resources and used by core tools. `--add-dir` (repeatable) widens that resource/tool scope beyond the workspace without granting the sandbox temp roots used by interactive runs.
 ## 6. Plugins
 
 A plugin is a self-contained directory that bundles tools, hooks, and skills for one capability. Plugins live at:

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/mcp"
@@ -14,7 +16,19 @@ import (
 type serveOptions struct {
 	mcp              bool
 	cwd              string
+	addDirs          []string
 	allowUnsafeTools bool
+}
+
+// serveRootsScope is a PathScope used only for MCP serve: the workspace root
+// plus optional --add-dir roots, without the sandbox temp write roots that
+// would otherwise pollute resources/list.
+type serveRootsScope []string
+
+func (s serveRootsScope) Roots() []string {
+	roots := make([]string, len(s))
+	copy(roots, s)
+	return roots
 }
 
 func runServe(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -36,7 +50,11 @@ func runServe(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) i
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
-	registry := newServeRegistry(workspaceRoot, options.allowUnsafeTools)
+	scope, err := buildServeScope(workspaceRoot, options.addDirs)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	registry := newServeRegistry(workspaceRoot, scope, options.allowUnsafeTools)
 	if options.allowUnsafeTools {
 		if _, err := fmt.Fprintln(stderr, "[zero] Unsafe MCP server tools enabled because --allow-unsafe-tools was passed."); err != nil {
 			return exitCrash
@@ -47,6 +65,8 @@ func runServe(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) i
 		Name:              "zero",
 		Version:           version,
 		PermissionGranted: options.allowUnsafeTools,
+		WorkspaceRoot:     workspaceRoot,
+		Scope:             scope,
 	})
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
@@ -54,16 +74,62 @@ func runServe(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) i
 	return exitSuccess
 }
 
-func newServeRegistry(workspaceRoot string, allowUnsafeTools bool) *tools.Registry {
+func newServeRegistry(workspaceRoot string, scope tools.PathScope, allowUnsafeTools bool) *tools.Registry {
 	registry := tools.NewRegistry()
-	toolset := tools.CoreReadOnlyTools(workspaceRoot)
+	toolset := tools.CoreReadOnlyToolsScoped(workspaceRoot, scope)
 	if allowUnsafeTools {
-		toolset = tools.CoreTools(workspaceRoot)
+		toolset = tools.CoreToolsScoped(workspaceRoot, scope)
 	}
 	for _, tool := range toolset {
 		registry.Register(tool)
 	}
 	return registry
+}
+
+// buildServeScope returns nil when there are no extra roots (workspace-only),
+// otherwise a PathScope listing the workspace first followed by each --add-dir.
+func buildServeScope(workspaceRoot string, addDirs []string) (tools.PathScope, error) {
+	if len(addDirs) == 0 {
+		return nil, nil
+	}
+	roots := make([]string, 0, 1+len(addDirs))
+	workspaceRoot = filepath.Clean(workspaceRoot)
+	if absolute, err := filepath.Abs(workspaceRoot); err == nil {
+		workspaceRoot = filepath.Clean(absolute)
+	}
+	if resolved, err := filepath.EvalSymlinks(workspaceRoot); err == nil {
+		workspaceRoot = resolved
+	}
+	roots = append(roots, workspaceRoot)
+
+	seen := map[string]struct{}{workspaceRoot: {}}
+	for _, dir := range addDirs {
+		trimmed := strings.TrimSpace(dir)
+		if trimmed == "" {
+			return nil, execUsageError{"--add-dir requires a path"}
+		}
+		absolute, err := filepath.Abs(trimmed)
+		if err != nil {
+			return nil, execUsageError{fmt.Sprintf("--add-dir %q: %v", trimmed, err)}
+		}
+		absolute = filepath.Clean(absolute)
+		info, err := os.Stat(absolute)
+		if err != nil {
+			return nil, execUsageError{fmt.Sprintf("--add-dir %q: %v", trimmed, err)}
+		}
+		if !info.IsDir() {
+			return nil, execUsageError{fmt.Sprintf("--add-dir %q is not a directory", trimmed)}
+		}
+		if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+			absolute = resolved
+		}
+		if _, ok := seen[absolute]; ok {
+			continue
+		}
+		seen[absolute] = struct{}{}
+		roots = append(roots, absolute)
+	}
+	return serveRootsScope(roots), nil
 }
 
 func parseServeArgs(args []string) (serveOptions, bool, error) {
@@ -85,6 +151,18 @@ func parseServeArgs(args []string) (serveOptions, bool, error) {
 			options.cwd = args[index]
 		case strings.HasPrefix(arg, "--cwd="):
 			options.cwd = strings.TrimPrefix(arg, "--cwd=")
+		case arg == "--add-dir":
+			index++
+			if index >= len(args) {
+				return options, false, execUsageError{"--add-dir requires a path"}
+			}
+			options.addDirs = append(options.addDirs, args[index])
+		case strings.HasPrefix(arg, "--add-dir="):
+			value := strings.TrimPrefix(arg, "--add-dir=")
+			if strings.TrimSpace(value) == "" {
+				return options, false, execUsageError{"--add-dir requires a path"}
+			}
+			options.addDirs = append(options.addDirs, value)
 		default:
 			return options, false, execUsageError{fmt.Sprintf("unknown serve flag %q", arg)}
 		}
@@ -100,7 +178,8 @@ Starts Zero as an MCP stdio server.
 
 Flags:
       --mcp                   Run the MCP stdio server
-  -C, --cwd <path>            Set the workspace directory
+  -C, --cwd <path>            Set the workspace directory (resources + tools)
+      --add-dir <path>        Extra resource/tool root (repeatable)
       --allow-unsafe-tools    Expose write and shell tools to the MCP host
   -h, --help                  Show this help
 `)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -94,15 +94,20 @@ func buildServeScope(workspaceRoot string, addDirs []string) (tools.PathScope, e
 	}
 	roots := make([]string, 0, 1+len(addDirs))
 	workspaceRoot = filepath.Clean(workspaceRoot)
-	if absolute, err := filepath.Abs(workspaceRoot); err == nil {
-		workspaceRoot = filepath.Clean(absolute)
+	if abs, err := filepath.Abs(workspaceRoot); err == nil {
+		workspaceRoot = abs
 	}
+
+	// Keep lexical absolute paths in roots so path checks stay aligned with the
+	// un-evaluated WorkspaceRoot used when Scope is nil. Symlink-resolved forms
+	// are only keys for duplicate detection.
+	workspaceResolved := workspaceRoot
 	if resolved, err := filepath.EvalSymlinks(workspaceRoot); err == nil {
-		workspaceRoot = resolved
+		workspaceResolved = resolved
 	}
 	roots = append(roots, workspaceRoot)
 
-	seen := map[string]struct{}{workspaceRoot: {}}
+	seen := map[string]struct{}{workspaceResolved: {}}
 	for _, dir := range addDirs {
 		trimmed := strings.TrimSpace(dir)
 		if trimmed == "" {
@@ -112,7 +117,6 @@ func buildServeScope(workspaceRoot string, addDirs []string) (tools.PathScope, e
 		if err != nil {
 			return nil, execUsageError{fmt.Sprintf("--add-dir %q: %v", trimmed, err)}
 		}
-		absolute = filepath.Clean(absolute)
 		info, err := os.Stat(absolute)
 		if err != nil {
 			return nil, execUsageError{fmt.Sprintf("--add-dir %q: %v", trimmed, err)}
@@ -120,13 +124,15 @@ func buildServeScope(workspaceRoot string, addDirs []string) (tools.PathScope, e
 		if !info.IsDir() {
 			return nil, execUsageError{fmt.Sprintf("--add-dir %q is not a directory", trimmed)}
 		}
-		if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
-			absolute = resolved
+
+		resolved := absolute
+		if r, err := filepath.EvalSymlinks(absolute); err == nil {
+			resolved = r
 		}
-		if _, ok := seen[absolute]; ok {
+		if _, ok := seen[resolved]; ok {
 			continue
 		}
-		seen[absolute] = struct{}{}
+		seen[resolved] = struct{}{}
 		roots = append(roots, absolute)
 	}
 	return serveRootsScope(roots), nil

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -157,6 +157,45 @@ func TestBuildServeScopeNilWithoutExtras(t *testing.T) {
 	}
 }
 
+func TestBuildServeScopeKeepsLexicalPaths(t *testing.T) {
+	base := t.TempDir()
+	realWorkspace := filepath.Join(base, "real-workspace")
+	realExtra := filepath.Join(base, "real-extra")
+	for _, dir := range []string{realWorkspace, realExtra} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkWorkspace := filepath.Join(base, "link-workspace")
+	linkExtra := filepath.Join(base, "link-extra")
+	if err := os.Symlink(realWorkspace, linkWorkspace); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realExtra, linkExtra); err != nil {
+		t.Fatal(err)
+	}
+
+	scope, err := buildServeScope(linkWorkspace, []string{linkExtra})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope == nil {
+		t.Fatal("expected non-nil scope")
+	}
+	roots := scope.Roots()
+	wantWorkspace, err := filepath.Abs(linkWorkspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantExtra, err := filepath.Abs(linkExtra)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 2 || roots[0] != wantWorkspace || roots[1] != wantExtra {
+		t.Fatalf("roots=%v want [%q %q]", roots, wantWorkspace, wantExtra)
+	}
+}
+
 func serveMCPInput(t *testing.T) []byte {
 	t.Helper()
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -80,6 +82,81 @@ func TestRunServeRequiresMCPMode(t *testing.T) {
 	}
 }
 
+func TestRunServeMCPWiresWorkspaceRootAndAddDirIntoResources(t *testing.T) {
+	workspace := t.TempDir()
+	extra := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "workspace.txt"), []byte("ws\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extra, "extra.txt"), []byte("ex\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps(
+		[]string{"serve", "--mcp", "-C", workspace, "--add-dir", extra},
+		&stdout,
+		&stderr,
+		appDeps{stdin: bytes.NewReader(serveMCPResourcesInput(t))},
+	)
+	if exitCode != exitSuccess {
+		t.Fatalf("exit=%d stderr=%q", exitCode, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "workspace.txt") {
+		t.Fatalf("expected workspace resource, got %q", output)
+	}
+	if !strings.Contains(output, "extra.txt") {
+		t.Fatalf("expected --add-dir resource, got %q", output)
+	}
+}
+
+func TestRunServeMCPRejectsMissingAddDir(t *testing.T) {
+	workspace := t.TempDir()
+	missing := filepath.Join(workspace, "does-not-exist")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps(
+		[]string{"serve", "--mcp", "-C", workspace, "--add-dir", missing},
+		&stdout,
+		&stderr,
+		appDeps{stdin: bytes.NewReader(nil)},
+	)
+	if exitCode != exitUsage {
+		t.Fatalf("exit=%d want %d stderr=%q", exitCode, exitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--add-dir") {
+		t.Fatalf("expected --add-dir error, got %q", stderr.String())
+	}
+}
+
+func TestParseServeArgsCollectsAddDirs(t *testing.T) {
+	options, help, err := parseServeArgs([]string{"--mcp", "--add-dir", "/one", "--add-dir=/two", "-C", "/ws"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if help {
+		t.Fatal("unexpected help")
+	}
+	if !options.mcp || options.cwd != "/ws" {
+		t.Fatalf("options=%#v", options)
+	}
+	if len(options.addDirs) != 2 || options.addDirs[0] != "/one" || options.addDirs[1] != "/two" {
+		t.Fatalf("addDirs=%v", options.addDirs)
+	}
+}
+
+func TestBuildServeScopeNilWithoutExtras(t *testing.T) {
+	scope, err := buildServeScope(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope != nil {
+		t.Fatalf("expected nil scope, got %#v", scope)
+	}
+}
+
 func serveMCPInput(t *testing.T) []byte {
 	t.Helper()
 
@@ -99,6 +176,30 @@ func serveMCPInput(t *testing.T) []byte {
 		"jsonrpc": "2.0",
 		"id":      2,
 		"method":  "tools/list",
+		"params":  map[string]any{},
+	})
+	return input.Bytes()
+}
+
+func serveMCPResourcesInput(t *testing.T) []byte {
+	t.Helper()
+
+	var input bytes.Buffer
+	writeServeMCPMessage(t, &input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params":  map[string]any{},
+	})
+	writeServeMCPMessage(t, &input, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+		"params":  map[string]any{},
+	})
+	writeServeMCPMessage(t, &input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "resources/list",
 		"params":  map[string]any{},
 	})
 	return input.Bytes()


### PR DESCRIPTION
## Summary
- Pass `WorkspaceRoot` into `mcp.ServeOptions` from `zero serve --mcp` (`-C/--cwd`)
- Add repeatable `--add-dir` on serve to widen MCP resource/tool roots via `ServeOptions.Scope`
- Use a serve-specific PathScope (no sandbox temp roots) so `resources/list` stays clean
- Document the flags in `docs/EXTENDING.md`

## Test plan
- [x] `go test ./internal/cli/ ./internal/mcp/ -count=1` (892 passed)
- [x] Serve-specific tests: WorkspaceRoot + `--add-dir` resource listing, missing `--add-dir` rejection, arg parsing
- [x] `go vet ./internal/cli/`
- [x] `govulncheck ./internal/cli/ ./internal/mcp/` — no vulnerabilities
- [x] Manual: `zero serve --mcp -C <ws> --add-dir <extra>` and confirm `resources/list` includes files from both roots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--add-dir` support to `zero serve --mcp` to expose extra directories as MCP resources/tool scope.
  * Supports providing multiple `--add-dir` values using both `--add-dir <path>` and `--add-dir=<path>` formats.
  * Ensures workspace root wiring via `-C/--cwd` is reflected in MCP resource output.
* **Documentation**
  * Updated `docs/EXTENDING.md` with new `zero serve --mcp` examples and clearer flag behavior.
* **Bug Fixes**
  * Validates `--add-dir` entries (rejects missing/invalid directories) and resolves/deduplicates paths.
* **Tests**
  * Added/expanded MCP resource and argument parsing coverage for `--add-dir` and workspace scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->