### PR TITLE
docs(readme): note govulncheck/golangci-lint install to GOPATH/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,11 +377,13 @@ go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 ```
 
-The installed binaries land in `$GOPATH/bin` (default `~/go/bin`), which must be on
-your `PATH` to run them directly. If it isn't, add it:
+The installed binaries land in `$GOBIN` when it is set, otherwise in
+`$GOPATH/bin` (default `~/go/bin`). That directory must be on your `PATH` to
+run them directly. If it isn't, add it:
 
 ```bash
-export PATH="$PATH:$(go env GOPATH)/bin"
+gobin="$(go env GOBIN)"; [ -z "$gobin" ] && gobin="$(go env GOPATH)/bin"
+case ":$PATH:" in *":$gobin:"*) ;; *) export PATH="$PATH:$gobin" ;; esac
 ```
 
 ### Cross-Compile Examples

--- a/README.md
+++ b/README.md
@@ -377,6 +377,13 @@ go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 ```
 
+The installed binary lands in `$GOPATH/bin` (default `~/go/bin`), which must be on
+your `PATH` to run `govulncheck` directly. If it isn't, add it:
+
+```bash
+export PATH="$PATH:$(go env GOPATH)/bin"
+```
+
 ### Cross-Compile Examples
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -377,8 +377,8 @@ go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 ```
 
-The installed binary lands in `$GOPATH/bin` (default `~/go/bin`), which must be on
-your `PATH` to run `govulncheck` directly. If it isn't, add it:
+The installed binaries land in `$GOPATH/bin` (default `~/go/bin`), which must be on
+your `PATH` to run them directly. If it isn't, add it:
 
 ```bash
 export PATH="$PATH:$(go env GOPATH)/bin"


### PR DESCRIPTION
## Summary

The contributor setup in `README.md` tells readers to `go install` `golangci-lint` and `govulncheck`, but does not mention that the resulting binaries land in `$GOPATH/bin` (default `~/go/bin`). If that directory is not already on `PATH`, the tools cannot be run directly, which silently breaks the documented lint/security workflow. This adds a short note and an `export PATH` snippet so the tooling actually resolves.

## Changes

- `README.md` (contributor/lint-tooling section): document that installed binaries go to `$GOPATH/bin`, and add a copy-paste `export PATH="$PATH:$(go env GOPATH)/bin"` snippet.

## Test plan

- `make lint` and `govulncheck ./...` resolve after adding `$(go env GOPATH)/bin` to `PATH`.
- Visual check of the rendered README section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to clarify where Go-installed vulnerability scanning tools (e.g., `govulncheck`) are placed, including the default `~/go/bin` when `$GOBIN` isn’t set.
  - Added instructions to ensure the Go bin directory is included in your `PATH`, with a shell snippet to set it if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->