### PR TITLE
perf(turn-bench): Phase 0 — strengthen oracles so pass rate can't be misread as correctness

### DIFF
--- a/internal/perfbench/MANIFEST.md
+++ b/internal/perfbench/MANIFEST.md
@@ -88,13 +88,28 @@ honest where they apply:
   answer is free-form prose and a contains-check would rubber-stamp. They stay
   in `latencyOnlyTasks` and never enter a pass rate.
 - **nav count tasks (nav-01, nav-04, nav-05, nav-08) require a structured,
-  line-anchored `count: N` token with the fixture's exact expected count.** Their
-  prompts ask the agent to state the count as `count: N` on its own line, and the
-  oracle greps for an anchored `^count: N$` (with the exact expected N — 4 files
-  for nav-01, 0 for nav-04/05/08), so a substring like "the count: 0" or a wrong
-  count like "count: 3" fails. This trades a little output freedom for
-  determinism (a loose prose-contains on "0" would match almost any answer, and
-  an unanchored `count: 0` would match inside a longer line).
+  line-anchored `count: N` token with the fixture's exact expected count, and
+  the ground truth is non-zero wherever it can be inspected offline so a
+  guess-zero answer can't rubber-stamp.** Their prompts ask the agent to state
+  the count as `count: N` on its own line, and the oracle greps for an anchored
+  `^count: N$` with the exact expected N — 5 files for nav-01 (README.md,
+  config.json, go.mod, main.go, main_test.go), 1 test function for nav-04
+  (`TestGreet` in `main_test.go`), 1 TODO for nav-05 (in `main.go`), and 0
+  third-party imports for nav-08. A substring like "the count: 1" or a wrong
+  count like "count: 3" fails the anchor. nav-04 and nav-05 were given a real
+  `TestGreet` and a real `TODO` precisely so an agent that never opens the
+  workspace and always emits "count: 0" fails (the count=0 gameability that
+  three zero-ground-truth tasks would otherwise share). nav-08 stays at 0 — a
+  real third-party import would need a network fetch and break the offline
+  suite — so its oracle additionally requires the answer to name both `fmt`
+  (from `main.go`) and `testing` (from `main_test.go`), the stdlib imports the
+  agent must have enumerated across every file to conclude 0 third-party. The
+  `testing` requirement is the tighter half: `fmt` alone is the most common Go
+  stdlib import and could be named blind, but `testing` only appears in the test
+  file, so naming it proves the agent read more than `main.go`. This trades a little
+  output freedom for determinism (a loose prose-contains on "0" would match
+  almost any answer, and an unanchored `count: 0` would match inside a longer
+  line).
 - **nav-03 / nav-06 / nav-07 are lenient contains-oracles on real facts.** A
   wrong-but-plausible answer that happens to mention the real symbols (e.g.
   "Config" and "MaxRetries" for nav-06) could in principle pass. Accepted for a

--- a/internal/perfbench/MANIFEST.md
+++ b/internal/perfbench/MANIFEST.md
@@ -10,16 +10,19 @@ matters for months, so the contract is written down here.
 
 48 tasks across seven classes:
 
-| class     | count | oracle                      | tier        |
-|-----------|-------|-----------------------------|-------------|
-| nav       | 10    | none                        | latency     |
-| edit      | 10    | substring grep              | correctness |
-| fix       | 8     | scoped `go test -run <name>` | correctness |
-| refactor  | 6     | `go build ./...`            | build       |
-| longproc  | 4     | none                        | latency     |
-| longctx   | 4     | none                        | latency     |
-| parallel  | 6     | none                        | latency     |
-| **total** | **48**|                             |             |
+| class     | count | oracle                                  | tier        |
+|-----------|-------|-----------------------------------------|-------------|
+| nav       | 10    | grep on captured final answer           | correctness |
+| edit      | 10    | stamped `oracle_test.go` + `go test`    | correctness |
+| fix       | 8     | scoped `go test -run <name>`            | correctness |
+| refactor  | 6     | stamped `oracle_test.go` + `go test`    | correctness |
+| longproc  | 4     | none                                    | latency     |
+| longctx   | 4     | none                                    | latency     |
+| parallel  | 6     | none                                    | latency     |
+| **total** | **48**|                                         |             |
+
+Tier counts: **correctness 34** (10 edit + 8 fix + 10 nav + 6 refactor),
+**build 0**, **latency 14** (4 longproc + 4 longctx + 6 parallel).
 
 ## Oracle tiers
 
@@ -27,16 +30,21 @@ Pass/fail is reported per tier so the report cannot be misread as a blanket
 correctness verdict. The tier is decided per task from oracle presence and the
 manifest's `buildOnlyClasses` list:
 
-- **Correctness** (18 tasks: 10 edit + 8 fix) — a positive oracle (substring
-  grep that the requested change landed, or a scoped `go test -run` that the
-  bug fix passes). This is the only pass rate that can move with model quality:
-  `tasksVerified` / `tasksPassed` / `correctnessPassRate`.
-- **Build-only** (6 tasks: refactor) — `go build ./...` proves the edit
-  compiles, not that the refactor achieved its goal (a no-op refactor passes).
-  The manifest declares `buildOnlyClasses: ["refactor"]`. Reported as
-  `buildCheckedTasks` / `buildPassedTasks` / `buildPassRate`, never in
-  `correctnessPassRate`.
-- **Latency-only** (24 tasks: nav, longproc, longctx, parallel) — no
+- **Correctness** (34 tasks: edit, fix, nav, refactor) — a positive oracle. For
+  edit/refactor the harness stamps an `oracle_test.go` (from the task's
+  `oracleTest` field) into the fixture copy **after** the agent run, then runs
+  `go test ./...`: the Go compiler is the structural verifier, so a no-op
+  refactor, a missing field, or a reworded-but-not-removed line fails to
+  compile/run. fix uses a scoped `go test -run <name>`. nav greps the agent's
+  captured final answer (`.zero-answer.txt`) for determinable facts. This is
+  the only pass rate that can move with model quality: `tasksVerified` /
+  `tasksPassed` / `correctnessPassRate`.
+- **Build-only** (0 tasks) — the tier is empty. refactor used to live here with
+  a non-positive `go build ./...` (a no-op refactor passed); PR #701 gave it a
+  structural oracle, graduating it to correctness. `buildOnlyClasses` is `[]`.
+  `buildCheckedTasks` / `buildPassedTasks` / `buildPassRate` are reported as 0
+  and never in `correctnessPassRate`.
+- **Latency-only** (14 tasks: longproc, longctx, parallel) — no
   `verificationCommand`. An exit 0 only proves the turn ran, not that the answer
   was right. They contribute to latency and span attribution only and are
   counted in `latencyOnlyTasks`, never in any pass rate.
@@ -45,22 +53,56 @@ A task's tier is driven by oracle **presence** first: a task with no
 `verificationCommand` is latency-only even if its class is listed in
 `buildOnlyClasses`, so a missing oracle can never silently pass on exit 0.
 
-## Known limitations (deferred)
+### How the stamped oracle and captured answer work
 
-These are accepted for the Phase 0 baseline and tracked in a follow-up issue;
-they do not block the baseline because the tier split keeps the report honest:
+The production runner (`NewTurnExecRunner` in `turn_bench.go`) copies the fixture
+into an isolated temp dir, runs `zero exec --trace`, then — before running the
+`verificationCommand` — stamps two files into the copy:
 
-- The edit grep oracles are substring checks. A rename oracle asserts the new
-  name is present AND the old name is gone (compound `bash -c`), but an
-  add-field oracle (`grep -R Label .`) only proves the string appears, not that
-  it landed on the right struct. Strengthening these to `go vet`/`go build` +
-  structural assertions is follow-up work.
-- The refactor build oracle is non-positive (a no-op refactor passes). A
-  structural verifier that proves the refactor happened is follow-up work;
-  until then refactor is `buildPassRate`, not `correctnessPassRate`.
-- The 24 read-only tasks have no oracle. Adding deterministic oracles for nav
-  (diff against an expected answer) and documenting longproc/longctx/parallel
-  as permanently latency-only is follow-up work.
+- `oracle_test.go` from `task.OracleTest` (edit/refactor). It is stamped *after*
+  the agent run so it can't interfere with the agent's own `go build`/`go test`
+  during the task (refactor-03's `package zeroapp` test would break a pre-rename
+  build) and can't be pre-seen or tampered with. The `verificationCommand`
+  (`go test ./...`) then compiles and runs it.
+- `.zero-answer.txt` from the `{"type":"final","text":...}` event in the
+  stream-json output (nav). The `verificationCommand` is a compound `bash -c`
+  grep requiring the determinable facts (e.g. nav-09 requires the answer to
+  mention `port`, `name`, and `retries`). An empty file (no `final` event) makes
+  the grep fail, which is the correct outcome for a run that produced no answer.
+
+The `oracleTest` source uses compile-time references where the assertion is
+structural (`var _ = Config{}.Label` for edit-03, `var _ = formatGreeting` for
+refactor-01) and behavioral `Test…` functions where the assertion is a value
+(edit-04 `Version != "1.1.0"`, edit-10 `greet("x") != "hello, world"`, edit-09
+`load("nonexistent")` wrapping). Tasks whose oracle is a plain grep/build with
+no stamped test (edit-02, refactor-02, refactor-05) carry no `oracleTest`.
+
+## Known limitations
+
+These are accepted for the Phase 0 baseline; the tier split keeps the report
+honest where they apply:
+
+- **longproc / longctx / parallel are permanently latency-only.** There is no
+  deterministic oracle for "report whether the build succeeds", "summarize a
+  large generated file", or "report the first line of each of six files" — the
+  answer is free-form prose and a contains-check would rubber-stamp. They stay
+  in `latencyOnlyTasks` and never enter a pass rate.
+- **nav count tasks (nav-04, nav-05, nav-08) require a structured `count: N`
+  token.** Their prompts ask the agent to state the count as `count: N` on its
+  own line, and the oracle greps for `count: 0`. This trades a little output
+  freedom for determinism (a loose prose-contains on "0" would match almost any
+  answer).
+- **nav-03 / nav-06 / nav-07 are lenient contains-oracles on real facts.** A
+  wrong-but-plausible answer that happens to mention the real symbols (e.g.
+  "Config" and "MaxRetries" for nav-06) could in principle pass. Accepted for a
+  latency-first baseline; the oracle still catches an agent that didn't look at
+  the code at all.
+- **Rename oracles use a declaration-site negative grep** (`! grep -RIn
+  'MaxRetries =' .`) rather than a broad `! grep -R MaxRetries .`, so a correct
+  rename that leaves a doc-comment mention of the old name is not false-failed.
+  The negative grep is still required: without it, a no-op that *adds* the new
+  name and *keeps* the old would pass the compile-time `var _ = RetryLimit` and
+  `go test`.
 
 ## Fixtures
 
@@ -69,3 +111,10 @@ Each task's `workspaceFixture` points at a small self-contained workspace under
 fix, refactor) run against a per-invocation **copy** of their fixture, so the
 checked-in fixtures stay clean and one task's edits can't bleed into the next
 iteration or a later task.
+
+Each mutating fixture (and nav) carries a `go.mod` (`module <pkg>; go 1.22`) so
+`go test ./...` / `go build ./...` oracles work in the copy: `copyFixture`
+places the copy under `os.TempDir()/zero-turn-bench/` — one level below the
+system temp root — because Go ignores `go.mod` in direct children of the system
+temp dir (a hijack guard), which would otherwise make every compiler-backed
+oracle fail with "cannot find main module".

--- a/internal/perfbench/MANIFEST.md
+++ b/internal/perfbench/MANIFEST.md
@@ -40,7 +40,7 @@ manifest's `buildOnlyClasses` list:
   the only pass rate that can move with model quality: `tasksVerified` /
   `tasksPassed` / `correctnessPassRate`.
 - **Build-only** (0 tasks) — the tier is empty. refactor used to live here with
-  a non-positive `go build ./...` (a no-op refactor passed); PR #701 gave it a
+  a non-positive `go build ./...` (a no-op refactor passed); PR #712 gave it a
   structural oracle, graduating it to correctness. `buildOnlyClasses` is `[]`.
   `buildCheckedTasks` / `buildPassedTasks` / `buildPassRate` are reported as 0
   and never in `correctnessPassRate`.
@@ -75,7 +75,7 @@ structural (`var _ = Config{}.Label` for edit-03, `var _ = formatGreeting` for
 refactor-01) and behavioral `Test…` functions where the assertion is a value
 (edit-04 `Version != "1.1.0"`, edit-10 `greet("x") != "hello, world"`, edit-09
 `load("nonexistent")` wrapping). Tasks whose oracle is a plain grep/build with
-no stamped test (edit-02, refactor-02, refactor-05) carry no `oracleTest`.
+no stamped test (edit-02, refactor-02) carry no `oracleTest`.
 
 ## Known limitations
 
@@ -88,28 +88,43 @@ honest where they apply:
   answer is free-form prose and a contains-check would rubber-stamp. They stay
   in `latencyOnlyTasks` and never enter a pass rate.
 - **nav count tasks (nav-01, nav-04, nav-05, nav-08) require a structured,
-  line-anchored `count: N` token with the fixture's exact expected count, and
-  the ground truth is non-zero wherever it can be inspected offline so a
-  guess-zero answer can't rubber-stamp.** Their prompts ask the agent to state
-  the count as `count: N` on its own line, and the oracle greps for an anchored
-  `^count: N$` with the exact expected N — 5 files for nav-01 (README.md,
-  config.json, go.mod, main.go, main_test.go), 1 test function for nav-04
-  (`TestGreet` in `main_test.go`), 1 TODO for nav-05 (in `main.go`), and 0
-  third-party imports for nav-08. A substring like "the count: 1" or a wrong
-  count like "count: 3" fails the anchor. nav-04 and nav-05 were given a real
-  `TestGreet` and a real `TODO` precisely so an agent that never opens the
-  workspace and always emits "count: 0" fails (the count=0 gameability that
-  three zero-ground-truth tasks would otherwise share). nav-08 stays at 0 — a
-  real third-party import would need a network fetch and break the offline
-  suite — so its oracle additionally requires the answer to name both `fmt`
-  (from `main.go`) and `testing` (from `main_test.go`), the stdlib imports the
-  agent must have enumerated across every file to conclude 0 third-party. The
-  `testing` requirement is the tighter half: `fmt` alone is the most common Go
-  stdlib import and could be named blind, but `testing` only appears in the test
-  file, so naming it proves the agent read more than `main.go`. This trades a little
-  output freedom for determinism (a loose prose-contains on "0" would match
-  almost any answer, and an unanchored `count: 0` would match inside a longer
-  line).
+  line-anchored `count: N` token with the fixture's exact expected count AND a
+  workspace-derived fact that proves the agent actually inspected the fixture —
+  not the count alone.** Their prompts ask the agent to state the count as
+  `count: N` on its own line and to name the thing(s) counted, and the oracle
+  greps for an anchored `^count: N$` with the exact expected N plus a named fact:
+  nav-01 requires `count: 5` and names `main.go`, `config.json`, and `README.md`
+  (the three the oracle anchors on — a correct answer lists all five files, but
+  the verification contract only requires those three be named); nav-04 names
+  the one test function (`TestGreet` from `main_test.go`); nav-05 names the file
+  holding the one TODO (`main.go`); nav-08 names both stdlib imports (`fmt` from
+  `main.go`, `testing` from `main_test.go`). A substring like "the count: 1" or a
+  wrong count like "count: 3" fails the anchor; a bare "count: 1" with no named
+  fact fails the inspection check. Non-zero ground truth alone was not enough —
+  it closes the always-guess-zero game but opens an always-guess-one game (an
+  agent that never opens the workspace and emits "count: 1" would pass a
+  count-only oracle). The named-fact requirement closes that surface: a blind
+  count is no longer sufficient, the agent must commit to a fact only readable
+  from the fixture. nav-04 and nav-05 were given a real `TestGreet` and a real
+  TODO so the named fact exists to require; nav-08 stays at count 0 (a real
+  third-party import would need a network fetch and break the offline suite), so
+  its named fact is the stdlib imports the agent must enumerate across every file
+  to conclude 0 third-party. The named facts are not all equally tight. nav-04's
+  `TestGreet` is a specific, non-generic identifier a blind agent cannot produce
+  without reading `main.go` to learn a greet function exists, so it fully closes
+  the blind-count-one surface. nav-05's `main.go` is the conventional Go
+  entrypoint and thus the most guessable filename, so it *reduces* rather than
+  fully closes that surface — a blind "count: 1, in main.go" can still pass.
+  Accepted for a Phase 0 baseline: the blind floor on nav-05 is below 100% (a
+  bare "count: 1" fails), so a model still moves the pass rate by actually
+  inspecting; strengthening it further (e.g. requiring the TODO's surrounding
+  symbol) would trade output freedom for determinism and risks false-failing a
+  terse-but-correct answer. nav-08's `testing` half is the tighter of its two:
+  `fmt` alone is the most common Go stdlib import and could be named blind, but
+  `testing` only appears in the test file, so naming it proves the agent read more
+  than `main.go`. This trades a little output freedom for determinism (a loose
+  prose-contains on "0"/"1" would match almost any answer, and an unanchored
+  `count: N` would match inside a longer line).
 - **nav-03 / nav-06 / nav-07 are lenient contains-oracles on real facts.** A
   wrong-but-plausible answer that happens to mention the real symbols (e.g.
   "Config" and "MaxRetries" for nav-06) could in principle pass. Accepted for a

--- a/internal/perfbench/MANIFEST.md
+++ b/internal/perfbench/MANIFEST.md
@@ -87,11 +87,14 @@ honest where they apply:
   large generated file", or "report the first line of each of six files" — the
   answer is free-form prose and a contains-check would rubber-stamp. They stay
   in `latencyOnlyTasks` and never enter a pass rate.
-- **nav count tasks (nav-04, nav-05, nav-08) require a structured `count: N`
-  token.** Their prompts ask the agent to state the count as `count: N` on its
-  own line, and the oracle greps for `count: 0`. This trades a little output
-  freedom for determinism (a loose prose-contains on "0" would match almost any
-  answer).
+- **nav count tasks (nav-01, nav-04, nav-05, nav-08) require a structured,
+  line-anchored `count: N` token with the fixture's exact expected count.** Their
+  prompts ask the agent to state the count as `count: N` on its own line, and the
+  oracle greps for an anchored `^count: N$` (with the exact expected N — 4 files
+  for nav-01, 0 for nav-04/05/08), so a substring like "the count: 0" or a wrong
+  count like "count: 3" fails. This trades a little output freedom for
+  determinism (a loose prose-contains on "0" would match almost any answer, and
+  an unanchored `count: 0` would match inside a longer line).
 - **nav-03 / nav-06 / nav-07 are lenient contains-oracles on real facts.** A
   wrong-but-plausible answer that happens to mention the real symbols (e.g.
   "Config" and "MaxRetries" for nav-06) could in principle pass. Accepted for a
@@ -114,7 +117,10 @@ iteration or a later task.
 
 Each mutating fixture (and nav) carries a `go.mod` (`module <pkg>; go 1.22`) so
 `go test ./...` / `go build ./...` oracles work in the copy: `copyFixture`
-places the copy under `os.TempDir()/zero-turn-bench/` — one level below the
-system temp root — because Go ignores `go.mod` in direct children of the system
-temp dir (a hijack guard), which would otherwise make every compiler-backed
-oracle fail with "cannot find main module".
+creates a unique, 0700 parent under the system temp root
+(`os.MkdirTemp(os.TempDir(), "zero-turn-bench-*")`) and nests the copy beneath
+it, so the copy is a *grandchild* of the temp root. Go ignores `go.mod` in
+direct children of the system temp dir (a hijack guard), so the copy must sit
+one level below that root or every compiler-backed oracle would fail with
+"cannot find main module". The unique parent also avoids a predictable
+shared directory and is removed wholesale on cleanup.

--- a/internal/perfbench/manifests/baseline.json
+++ b/internal/perfbench/manifests/baseline.json
@@ -1,7 +1,7 @@
 {
   "id": "zero-baseline-turn",
   "name": "Zero per-turn baseline (Phase 0)",
-  "description": "Latency-first baseline: measures where a turn spends wall time, with pass/fail reported per oracle tier so it cannot be misread as a blanket correctness verdict. Correctness classes (edit, fix, nav, refactor) carry a positive oracle: edit/refactor stamp an oracle_test.go compiled by `go test ./...` (the Go compiler is the structural verifier — a no-op refactor or a missing field fails to compile), fix runs a scoped `go test -run`, and nav greps the agent's captured final answer (.zero-answer.txt) for determinable facts. tasksVerified/tasksPassed/correctnessPassRate cover exactly these. Latency-only classes (longproc, longctx, parallel) carry no verification oracle — a zero-exit only proves the turn ran, so they count as latency-only and never in any pass rate. The build tier is empty: refactor graduated to correctness once its oracle became structural-positive. See MANIFEST.md for the per-task oracle specs and known limitations.",
+  "description": "Latency-first baseline: measures where a turn spends wall time, with pass/fail reported per oracle tier so it cannot be misread as a blanket correctness verdict. Correctness classes (edit, fix, nav, refactor) carry a positive oracle: edit/refactor stamp an oracle_test.go compiled by `go test ./...` (the Go compiler is the structural verifier \u2014 a no-op refactor or a missing field fails to compile), fix runs a scoped `go test -run`, and nav greps the agent's captured final answer (.zero-answer.txt) for determinable facts. tasksVerified/tasksPassed/correctnessPassRate cover exactly these. Latency-only classes (longproc, longctx, parallel) carry no verification oracle \u2014 a zero-exit only proves the turn ran, so they count as latency-only and never in any pass rate. The build tier is empty: refactor graduated to correctness once its oracle became structural-positive. See MANIFEST.md for the per-task oracle specs and known limitations.",
   "buildOnlyClasses": [],
   "tasks": [
     {
@@ -13,7 +13,7 @@
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iq 'main.go' .zero-answer.txt && grep -iq 'config.json' .zero-answer.txt && grep -iq 'readme' .zero-answer.txt && grep -iqE '^count:[[:space:]]*4$' .zero-answer.txt"
+        "grep -iq 'main.go' .zero-answer.txt && grep -iq 'config.json' .zero-answer.txt && grep -iq 'readme' .zero-answer.txt && grep -iqE '^count:[[:space:]]*5$' .zero-answer.txt"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iqE '^count:[[:space:]]*0$' .zero-answer.txt"
+        "grep -iqE '^count:[[:space:]]*1$' .zero-answer.txt"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iqE '^count:[[:space:]]*0$' .zero-answer.txt"
+        "grep -iqE '^count:[[:space:]]*1$' .zero-answer.txt"
       ]
     },
     {
@@ -92,12 +92,12 @@
       "id": "nav-08",
       "name": "find imports",
       "class": "nav",
-      "prompt": "List every third-party import used by this repository. State the number of third-party (non-stdlib) imports as 'count: N' on its own line. Do not modify anything.",
+      "prompt": "List every import used by this repository and classify each as standard library or third-party. State the number of third-party (non-stdlib) imports as 'count: N' on its own line. Do not modify anything.",
       "workspaceFixture": "../testdata/nav",
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iqE '^count:[[:space:]]*0$' .zero-answer.txt"
+        "grep -iq 'fmt' .zero-answer.txt && grep -iq 'testing' .zero-answer.txt && grep -iqE '^count:[[:space:]]*0$' .zero-answer.txt"
       ]
     },
     {
@@ -186,7 +186,7 @@
         "test",
         "./..."
       ],
-      "oracleTest": "package edit\n\nimport (\n\t\"os\"\n\t\"strings\"\n\t\"testing\"\n)\n\nfunc TestNoDebugPrintln(t *testing.T) {\n\tb, err := os.ReadFile(\"main.go\")\n\tif err != nil {\n\t\tt.Fatal(err)\n\t}\n\t// The greet print is fmt.Println(greet(...)) with no string literal, so a\n\t// remaining fmt.Println(\"...\") call means the debug line was not removed\n\t// (or was only reworded, not deleted).\n\tif strings.Contains(string(b), `fmt.Println(\"`) {\n\t\tt.Fatal(\"main.go still has a fmt.Println string-literal call; the debug line was not removed\")\n\t}\n}\n"
+      "oracleTest": "package edit\n\nimport (\n\t\"os\"\n\t\"strings\"\n\t\"testing\"\n)\n\nfunc TestNoDebugPrintln(t *testing.T) {\n\tb, err := os.ReadFile(\"main.go\")\n\tif err != nil {\n\t\tt.Fatal(err)\n\t}\n\t// The greet print is fmt.Println(greet(...)) with no string literal, so a\n\t// remaining fmt.Println(\"...\") call means the debug line was not removed\n\t// (or was only reworded, not deleted).\n\tif strings.Contains(string(b), `fmt.Println(\"`) {\n\t\tt.Fatal(\"main.go still has a fmt.Println string-literal call; the debug line was not removed\")\n\t}\n\t// The task is to remove the line that prints \"debug: starting\", so the\n\t// message text itself must be gone -- this catches a reword onto a different\n\t// call form (fmt.Printf, backticks, log.Println, println) that the\n\t// string-literal check above would miss.\n\tif strings.Contains(string(b), \"debug: starting\") {\n\t\tt.Fatal(\"main.go still prints 'debug: starting'; the line was not removed (only reworded or respelled)\")\n\t}\n}\n"
     },
     {
       "id": "edit-06",
@@ -411,11 +411,11 @@
       "prompt": "Introduce a named type `type Stats map[string]int` for the bare map used by stats, and update its users (Record, Lookup).",
       "workspaceFixture": "../testdata/refactor",
       "verificationCommand": [
-        "bash",
-        "-c",
-        "go test ./... && ! grep -q 'var stats = map\\[string\\]int' main.go"
+        "go",
+        "test",
+        "./..."
       ],
-      "oracleTest": "package refactor\n\nvar _ Stats\n"
+      "oracleTest": "package refactor\n\nimport (\n\t\"os\"\n\t\"regexp\"\n\t\"strings\"\n\t\"testing\"\n)\n\n// TestStatsNamedType proves the bare map was replaced by the named Stats type:\n// the old `var stats = map[string]int` (or `stats := map[string]int{}`) form is\n// gone -- matched with a spacing-tolerant regex so a `var stats=map[string]int`\n// or `stats :=` variant can't dodge it -- and the Stats type is actually\n// referenced in main.go, so a no-op that only adds an unused `type Stats` while\n// keeping the bare map fails. `go test ./...` compiling the fixture proves the\n// type declaration is valid.\nfunc TestStatsNamedType(t *testing.T) {\n\tb, err := os.ReadFile(\"main.go\")\n\tif err != nil {\n\t\tt.Fatal(err)\n\t}\n\tsrc := string(b)\n\tif regexp.MustCompile(`var\\s+stats\\s*=\\s*map\\[string\\]int`).MatchString(src) ||\n\t\tregexp.MustCompile(`stats\\s*:=\\s*map\\[string\\]int`).MatchString(src) {\n\t\tt.Fatal(\"main.go still declares stats as a bare map[string]int; the named Stats type was not adopted\")\n\t}\n\tif !strings.Contains(src, \"Stats\") {\n\t\tt.Fatal(\"main.go does not reference the Stats type; refactor-04 was a no-op\")\n\t}\n}\n"
     },
     {
       "id": "refactor-05",
@@ -427,7 +427,8 @@
         "bash",
         "-c",
         "go test ./... && ! grep -R 'func Wrapper' ."
-      ]
+      ],
+      "oracleTest": "package refactor\n\nimport \"testing\"\n\n// TestGreetWrapped proves greetWrapped still exists and behaves as the inlined\n// Wrapper did: deleting both Wrapper and greetWrapped (or stubbing greetWrapped\n// to return \"\") fails to compile or run, so the oracle can't be passed by\n// removing the target along with its caller. Paired with the ! grep 'func\n// Wrapper' verificationCommand that proves Wrapper itself is gone.\nfunc TestGreetWrapped(t *testing.T) {\n\tif got := greetWrapped(\"x\"); got != \"hello, x\" {\n\t\tt.Fatalf(\"greetWrapped(x) = %q, want %q\", got, \"hello, x\")\n\t}\n}\n"
     },
     {
       "id": "refactor-06",

--- a/internal/perfbench/manifests/baseline.json
+++ b/internal/perfbench/manifests/baseline.json
@@ -8,12 +8,12 @@
       "id": "nav-01",
       "name": "list repo files",
       "class": "nav",
-      "prompt": "List the files in this repository and report their count. Do not modify anything.",
+      "prompt": "List the files in this repository and report their count. State the count as 'count: N' on its own line. Do not modify anything.",
       "workspaceFixture": "../testdata/nav",
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iq 'main.go' .zero-answer.txt && grep -iq 'config.json' .zero-answer.txt && grep -iq 'readme' .zero-answer.txt"
+        "grep -iq 'main.go' .zero-answer.txt && grep -iq 'config.json' .zero-answer.txt && grep -iq 'readme' .zero-answer.txt && grep -iqE '^count:[[:space:]]*4$' .zero-answer.txt"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iqE 'count:\\s*0' .zero-answer.txt"
+        "grep -iqE '^count:[[:space:]]*0$' .zero-answer.txt"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iqE 'count:\\s*0' .zero-answer.txt"
+        "grep -iqE '^count:[[:space:]]*0$' .zero-answer.txt"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iqE 'count:\\s*0' .zero-answer.txt"
+        "grep -iqE '^count:[[:space:]]*0$' .zero-answer.txt"
       ]
     },
     {

--- a/internal/perfbench/manifests/baseline.json
+++ b/internal/perfbench/manifests/baseline.json
@@ -1,62 +1,544 @@
 {
   "id": "zero-baseline-turn",
   "name": "Zero per-turn baseline (Phase 0)",
-  "description": "Latency-first baseline: measures where a turn spends wall time, with pass/fail reported per oracle tier so it cannot be misread as a blanket correctness verdict. Read-only classes (nav, longproc, longctx, parallel) carry no verification oracle — a zero-exit only proves the turn ran, so they count as latency-only and never in any pass rate. Correctness classes (edit, fix) carry a positive oracle (substring grep or a scoped `go test`) and are the only tasks in correctnessPassRate. Build-only classes (refactor) carry `go build ./...`, which proves the edit compiles but not that the refactor achieved its goal, so they are reported as buildPassRate and excluded from correctnessPassRate.",
-  "buildOnlyClasses": ["refactor"],
+  "description": "Latency-first baseline: measures where a turn spends wall time, with pass/fail reported per oracle tier so it cannot be misread as a blanket correctness verdict. Correctness classes (edit, fix, nav, refactor) carry a positive oracle: edit/refactor stamp an oracle_test.go compiled by `go test ./...` (the Go compiler is the structural verifier — a no-op refactor or a missing field fails to compile), fix runs a scoped `go test -run`, and nav greps the agent's captured final answer (.zero-answer.txt) for determinable facts. tasksVerified/tasksPassed/correctnessPassRate cover exactly these. Latency-only classes (longproc, longctx, parallel) carry no verification oracle — a zero-exit only proves the turn ran, so they count as latency-only and never in any pass rate. The build tier is empty: refactor graduated to correctness once its oracle became structural-positive. See MANIFEST.md for the per-task oracle specs and known limitations.",
+  "buildOnlyClasses": [],
   "tasks": [
-    {"id": "nav-01", "name": "list repo files", "class": "nav", "prompt": "List the files in this repository and report their count. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-02", "name": "find a function", "class": "nav", "prompt": "Find the function named 'greet' and report the file and line it is defined on. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-03", "name": "summarize module", "class": "nav", "prompt": "Read main.go and summarize what this program does in two sentences. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-04", "name": "count tests", "class": "nav", "prompt": "Count the test functions (functions whose names start with Test) in this repository and report the number. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-05", "name": "locate a string", "class": "nav", "prompt": "Find every occurrence of the string 'TODO' in the repository and report the files. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-06", "name": "describe package", "class": "nav", "prompt": "Describe the exported API of this package by reading the source. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-07", "name": "trace a call", "class": "nav", "prompt": "Trace which function calls which other function starting from main. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-08", "name": "find imports", "class": "nav", "prompt": "List every third-party import used by this repository. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-09", "name": "report config", "class": "nav", "prompt": "Read config.json and report the keys it contains. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-    {"id": "nav-10", "name": "doc lookup", "class": "nav", "prompt": "Find the doc comment on the greet function and quote it. Do not modify anything.", "workspaceFixture": "../testdata/nav"},
-
-    {"id": "edit-01", "name": "rename a constant", "class": "edit", "prompt": "Rename the constant MaxRetries to RetryLimit everywhere it appears.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["bash", "-c", "grep -R RetryLimit . && ! grep -R MaxRetries ."]},
-    {"id": "edit-02", "name": "fix a typo", "class": "edit", "prompt": "Fix the typo in the comment above the greet function ('receieves' should be 'receives').", "workspaceFixture": "../testdata/edit", "verificationCommand": ["bash", "-c", "! grep -R receieves ."]},
-    {"id": "edit-03", "name": "add a field", "class": "edit", "prompt": "Add a string field named Label to the Config struct in main.go.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["grep", "-R", "Label", "."]},
-    {"id": "edit-04", "name": "bump a version", "class": "edit", "prompt": "Change the version string in version.go from 1.0.0 to 1.1.0.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["bash", "-c", "grep -R 1.1.0 . && ! grep -R 1.0.0 ."]},
-    {"id": "edit-05", "name": "remove a log line", "class": "edit", "prompt": "Remove the line that prints 'debug: starting'.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["bash", "-c", "! grep -R 'debug: starting' ."]},
-    {"id": "edit-06", "name": "add a license header", "class": "edit", "prompt": "Add a comment line '// SPDX-License-Identifier: MIT' at the top of main.go.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["grep", "-R", "SPDX-License-Identifier", "."]},
-    {"id": "edit-07", "name": "change a default", "class": "edit", "prompt": "Change the default value of the Port constant from 8080 to 9090.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["bash", "-c", "grep -R 9090 . && ! grep -R 8080 ."]},
-    {"id": "edit-08", "name": "add a getter", "class": "edit", "prompt": "Add a method func (c *Config) GetLabel() string that returns c.Label.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["bash", "-c", "grep -R 'func (c *Config) GetLabel' ."]},
-    {"id": "edit-09", "name": "wrap an error", "class": "edit", "prompt": "In the load function, wrap the returned error with fmt.Errorf so it includes 'load failed'.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["grep", "-R", "load failed", "."]},
-    {"id": "edit-10", "name": "update a message", "class": "edit", "prompt": "Change the printed greeting from 'hello' to 'hello, world'.", "workspaceFixture": "../testdata/edit", "verificationCommand": ["grep", "-R", "hello, world", "."]},
-
-    {"id": "fix-01", "name": "off-by-one", "class": "fix", "prompt": "In bugs.go the Sum function has an off-by-one error that skips the last element; fix the loop so it sums all elements.", "workspaceFixture": "../testdata/fix", "verificationCommand": ["go", "test", "-run", "TestSumIncludesLastElement", "./..."]},
-    {"id": "fix-02", "name": "nil deref", "class": "fix", "prompt": "In bugs.go DefaultConfig returns nil and Port() dereferences it; make DefaultConfig return a valid Config with Port 8080.", "workspaceFixture": "../testdata/fix", "verificationCommand": ["go", "test", "-run", "TestPortReturnsDefault", "./..."]},
-    {"id": "fix-03", "name": "wrong operator", "class": "fix", "prompt": "In bugs.go Max uses the wrong inequality and returns the smaller value; fix it to return the larger.", "workspaceFixture": "../testdata/fix", "verificationCommand": ["go", "test", "-run", "TestMaxReturnsLarger", "./..."]},
-    {"id": "fix-04", "name": "truncated read", "class": "fix", "prompt": "In bugs.go ReadFirst returns only a single character instead of the full content; fix it to return the whole string.", "workspaceFixture": "../testdata/fix", "verificationCommand": ["go", "test", "-run", "TestReadFirstReturnsFullContent", "./..."]},
-    {"id": "fix-05", "name": "swapped args", "class": "fix", "prompt": "In bugs.go Divide swaps its operands; fix the order so Divide(10,2) returns 5.", "workspaceFixture": "../testdata/fix", "verificationCommand": ["go", "test", "-run", "TestDivideOrder", "./..."]},
-    {"id": "fix-06", "name": "missing return", "class": "fix", "prompt": "In bugs.go Classify is missing a return for the high case; add it so Classify(500) returns \"high\".", "workspaceFixture": "../testdata/fix", "verificationCommand": ["go", "test", "-run", "TestClassifyHigh", "./..."]},
-    {"id": "fix-07", "name": "wrong label prefix", "class": "fix", "prompt": "In bugs.go Label returns 'admin-<name>' but the test expects 'user-<name>'; change the prefix from 'admin-' to 'user-'.", "workspaceFixture": "../testdata/fix", "verificationCommand": ["go", "test", "-run", "TestLabelUsesString", "./..."]},
-    {"id": "fix-08", "name": "race on counter", "class": "fix", "prompt": "In bugs.go the global counter is incremented without synchronization; guard it with a mutex.", "workspaceFixture": "../testdata/fix", "verificationCommand": ["go", "test", "-race", "-run", "TestCounterRace", "./..."]},
-
-    {"id": "refactor-01", "name": "extract helper", "class": "refactor", "prompt": "Extract the duplicated greeting logic into a single helper function and call it from both sites.", "workspaceFixture": "../testdata/refactor", "verificationCommand": ["go", "build", "./..."]},
-    {"id": "refactor-02", "name": "split a file", "class": "refactor", "prompt": "Split main.go into two files: one for Config, one for the rest, keeping the package building.", "workspaceFixture": "../testdata/refactor", "verificationCommand": ["go", "build", "./..."]},
-    {"id": "refactor-03", "name": "rename package", "class": "refactor", "prompt": "Rename the package from app to zeroapp everywhere and keep it building.", "workspaceFixture": "../testdata/refactor", "verificationCommand": ["go", "build", "./..."]},
-    {"id": "refactor-04", "name": "introduce a type", "class": "refactor", "prompt": "Introduce a named type for the map[string]int used in main.go and update its users.", "workspaceFixture": "../testdata/refactor", "verificationCommand": ["go", "build", "./..."]},
-    {"id": "refactor-05", "name": "inline a wrapper", "class": "refactor", "prompt": "Inline the thin wrapper function into its single caller and remove it.", "workspaceFixture": "../testdata/refactor", "verificationCommand": ["go", "build", "./..."]},
-    {"id": "refactor-06", "name": "consolidate errors", "class": "refactor", "prompt": "Consolidate the repeated error-construction blocks into a single helper.", "workspaceFixture": "../testdata/refactor", "verificationCommand": ["go", "build", "./..."]},
-
-    {"id": "longproc-01", "name": "long build", "class": "longproc", "prompt": "Run the build command and report whether it succeeds. Do not modify anything.", "workspaceFixture": "../testdata/longproc"},
-    {"id": "longproc-02", "name": "long test", "class": "longproc", "prompt": "Run go test ./... and report the result. Do not modify anything.", "workspaceFixture": "../testdata/longproc"},
-    {"id": "longproc-03", "name": "bench run", "class": "longproc", "prompt": "Run go test -bench=. -benchtime=1x and report the benchmark numbers. Do not modify anything.", "workspaceFixture": "../testdata/longproc"},
-    {"id": "longproc-04", "name": "vet run", "class": "longproc", "prompt": "Run go vet ./... and report the output. Do not modify anything.", "workspaceFixture": "../testdata/longproc"},
-
-    {"id": "longctx-01", "name": "summarize large file", "class": "longctx", "prompt": "Read the large generated file big.go and summarize its structure. Do not modify anything.", "workspaceFixture": "../testdata/longctx"},
-    {"id": "longctx-02", "name": "find in large file", "class": "longctx", "prompt": "In big.go, find every function that returns an error and list them. Do not modify anything.", "workspaceFixture": "../testdata/longctx"},
-    {"id": "longctx-03", "name": "cross-file question", "class": "longctx", "prompt": "Read all .go files and report which two functions share the same name across files. Do not modify anything.", "workspaceFixture": "../testdata/longctx"},
-    {"id": "longctx-04", "name": "trace through large file", "class": "longctx", "prompt": "Starting from Handle, trace the call path through big.go and report the chain. Do not modify anything.", "workspaceFixture": "../testdata/longctx"},
-
-    {"id": "parallel-01", "name": "read six files", "class": "parallel", "prompt": "Read a.txt, b.txt, c.txt, d.txt, e.txt, and f.txt, then report the first line of each. Do not modify anything.", "workspaceFixture": "../testdata/parallel"},
-    {"id": "parallel-02", "name": "grep six patterns", "class": "parallel", "prompt": "Search for 'alpha', 'beta', 'gamma', 'delta', 'epsilon', and 'zeta' across the repo and report which files contain each. Do not modify anything.", "workspaceFixture": "../testdata/parallel"},
-    {"id": "parallel-03", "name": "list six dirs", "class": "parallel", "prompt": "List the contents of dir1, dir2, dir3, dir4, dir5, and dir6. Do not modify anything.", "workspaceFixture": "../testdata/parallel"},
-    {"id": "parallel-04", "name": "stat six files", "class": "parallel", "prompt": "Report the line count of a.txt, b.txt, c.txt, d.txt, e.txt, and f.txt. Do not modify anything.", "workspaceFixture": "../testdata/parallel"},
-    {"id": "parallel-05", "name": "read configs", "class": "parallel", "prompt": "Read config1.json, config2.json, config3.json, config4.json, config5.json, and config6.json and report each top-level key. Do not modify anything.", "workspaceFixture": "../testdata/parallel"},
-    {"id": "parallel-06", "name": "summarize six", "class": "parallel", "prompt": "Read the six .txt files and give a one-line summary of each. Do not modify anything.", "workspaceFixture": "../testdata/parallel"}
+    {
+      "id": "nav-01",
+      "name": "list repo files",
+      "class": "nav",
+      "prompt": "List the files in this repository and report their count. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iq 'main.go' .zero-answer.txt && grep -iq 'config.json' .zero-answer.txt && grep -iq 'readme' .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-02",
+      "name": "find a function",
+      "class": "nav",
+      "prompt": "Find the function named 'greet' and report the file and line it is defined on. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iq 'main.go' .zero-answer.txt && grep -iqE '\\b1[5-7]\\b' .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-03",
+      "name": "summarize module",
+      "class": "nav",
+      "prompt": "Read main.go and summarize what this program does in two sentences. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iqE 'greet|hello|Config' .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-04",
+      "name": "count tests",
+      "class": "nav",
+      "prompt": "Count the test functions (functions whose names start with Test) in this repository and report the number. State the count as 'count: N' on its own line. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iqE 'count:\\s*0' .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-05",
+      "name": "locate a string",
+      "class": "nav",
+      "prompt": "Find every occurrence of the string 'TODO' in the repository and report the files. State the count as 'count: N' on its own line. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iqE 'count:\\s*0' .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-06",
+      "name": "describe package",
+      "class": "nav",
+      "prompt": "Describe the exported API of this package by reading the source. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iq config .zero-answer.txt && grep -iq maxretries .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-07",
+      "name": "trace a call",
+      "class": "nav",
+      "prompt": "Trace which function calls which other function starting from main. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iq main .zero-answer.txt && grep -iq greet .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-08",
+      "name": "find imports",
+      "class": "nav",
+      "prompt": "List every third-party import used by this repository. State the number of third-party (non-stdlib) imports as 'count: N' on its own line. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iqE 'count:\\s*0' .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-09",
+      "name": "report config",
+      "class": "nav",
+      "prompt": "Read config.json and report the keys it contains. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iq port .zero-answer.txt && grep -iq name .zero-answer.txt && grep -iq retries .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "nav-10",
+      "name": "doc lookup",
+      "class": "nav",
+      "prompt": "Find the doc comment on the greet function and quote it. Do not modify anything.",
+      "workspaceFixture": "../testdata/nav",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "grep -iq 'greet returns a greeting' .zero-answer.txt"
+      ]
+    },
+    {
+      "id": "edit-01",
+      "name": "rename a constant",
+      "class": "edit",
+      "prompt": "Rename the constant MaxRetries to RetryLimit everywhere it appears.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "go test ./... && ! grep -RIn 'MaxRetries =' ."
+      ],
+      "oracleTest": "package edit\n\nvar _ = RetryLimit\n"
+    },
+    {
+      "id": "edit-02",
+      "name": "fix a typo",
+      "class": "edit",
+      "prompt": "Fix the typo in the comment above the greet function ('receieves' should be 'receives').",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "go test ./... && ! grep -R receieves . && grep -R receives ."
+      ]
+    },
+    {
+      "id": "edit-03",
+      "name": "add a field",
+      "class": "edit",
+      "prompt": "Add a string field named Label to the Config struct in main.go.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "go",
+        "test",
+        "./..."
+      ],
+      "oracleTest": "package edit\n\nvar _ string = Config{}.Label\n"
+    },
+    {
+      "id": "edit-04",
+      "name": "bump a version",
+      "class": "edit",
+      "prompt": "Change the version string in version.go from 1.0.0 to 1.1.0.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "go",
+        "test",
+        "./..."
+      ],
+      "oracleTest": "package edit\n\nimport \"testing\"\n\nfunc TestVersion(t *testing.T) {\n\tif Version != \"1.1.0\" {\n\t\tt.Fatalf(\"Version=%q\", Version)\n\t}\n}\n"
+    },
+    {
+      "id": "edit-05",
+      "name": "remove a log line",
+      "class": "edit",
+      "prompt": "Remove the line that prints 'debug: starting'.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "go",
+        "test",
+        "./..."
+      ],
+      "oracleTest": "package edit\n\nimport (\n\t\"os\"\n\t\"strings\"\n\t\"testing\"\n)\n\nfunc TestNoDebugPrintln(t *testing.T) {\n\tb, err := os.ReadFile(\"main.go\")\n\tif err != nil {\n\t\tt.Fatal(err)\n\t}\n\t// The greet print is fmt.Println(greet(...)) with no string literal, so a\n\t// remaining fmt.Println(\"...\") call means the debug line was not removed\n\t// (or was only reworded, not deleted).\n\tif strings.Contains(string(b), `fmt.Println(\"`) {\n\t\tt.Fatal(\"main.go still has a fmt.Println string-literal call; the debug line was not removed\")\n\t}\n}\n"
+    },
+    {
+      "id": "edit-06",
+      "name": "add a license header",
+      "class": "edit",
+      "prompt": "Add a comment line '// SPDX-License-Identifier: MIT' at the top of main.go.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "go",
+        "test",
+        "./..."
+      ],
+      "oracleTest": "package edit\n\nimport (\n\t\"os\"\n\t\"strings\"\n\t\"testing\"\n)\n\nfunc TestSPDXHeader(t *testing.T) {\n\tb, err := os.ReadFile(\"main.go\")\n\tif err != nil {\n\t\tt.Fatal(err)\n\t}\n\tif !strings.HasPrefix(string(b), \"// SPDX-License-Identifier: MIT\") {\n\t\tt.Fatal(\"main.go must start with the SPDX-License-Identifier: MIT header\")\n\t}\n}\n"
+    },
+    {
+      "id": "edit-07",
+      "name": "change a default",
+      "class": "edit",
+      "prompt": "Change the default value of the Port constant from 8080 to 9090.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "go",
+        "test",
+        "./..."
+      ],
+      "oracleTest": "package edit\n\nimport \"testing\"\n\nfunc TestPort(t *testing.T) {\n\tif Port != 9090 {\n\t\tt.Fatalf(\"Port=%d, want 9090\", Port)\n\t}\n}\n"
+    },
+    {
+      "id": "edit-08",
+      "name": "add a getter",
+      "class": "edit",
+      "prompt": "Add a method func (c *Config) GetName() string that returns c.Name.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "go",
+        "test",
+        "./..."
+      ],
+      "oracleTest": "package edit\n\nimport \"testing\"\n\nfunc TestGetName(t *testing.T) {\n\tc := Config{Name: \"x\"}\n\tif got := c.GetName(); got != \"x\" {\n\t\tt.Fatalf(\"GetName()=%q, want %q\", got, \"x\")\n\t}\n}\n"
+    },
+    {
+      "id": "edit-09",
+      "name": "wrap an error",
+      "class": "edit",
+      "prompt": "In the load function, wrap the returned error with fmt.Errorf so it includes 'load failed'.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "go",
+        "test",
+        "./..."
+      ],
+      "oracleTest": "package edit\n\nimport (\n\t\"strings\"\n\t\"testing\"\n)\n\nfunc TestLoadWrapsError(t *testing.T) {\n\t_, err := load(\"nonexistent-file-xyz\")\n\tif err == nil {\n\t\tt.Fatal(\"want a non-nil error for a missing file\")\n\t}\n\tif !strings.Contains(err.Error(), \"load failed\") {\n\t\tt.Fatalf(\"err=%v, want it to contain 'load failed'\", err)\n\t}\n}\n"
+    },
+    {
+      "id": "edit-10",
+      "name": "update a message",
+      "class": "edit",
+      "prompt": "Change the printed greeting from 'hello' to 'hello, world'.",
+      "workspaceFixture": "../testdata/edit",
+      "verificationCommand": [
+        "go",
+        "test",
+        "./..."
+      ],
+      "oracleTest": "package edit\n\nimport \"testing\"\n\nfunc TestGreet(t *testing.T) {\n\tif got := greet(\"x\"); got != \"hello, world\" {\n\t\tt.Fatalf(\"greet()=%q, want %q\", got, \"hello, world\")\n\t}\n}\n"
+    },
+    {
+      "id": "fix-01",
+      "name": "off-by-one",
+      "class": "fix",
+      "prompt": "In bugs.go the Sum function has an off-by-one error that skips the last element; fix the loop so it sums all elements.",
+      "workspaceFixture": "../testdata/fix",
+      "verificationCommand": [
+        "go",
+        "test",
+        "-run",
+        "TestSumIncludesLastElement",
+        "./..."
+      ]
+    },
+    {
+      "id": "fix-02",
+      "name": "nil deref",
+      "class": "fix",
+      "prompt": "In bugs.go DefaultConfig returns nil and Port() dereferences it; make DefaultConfig return a valid Config with Port 8080.",
+      "workspaceFixture": "../testdata/fix",
+      "verificationCommand": [
+        "go",
+        "test",
+        "-run",
+        "TestPortReturnsDefault",
+        "./..."
+      ]
+    },
+    {
+      "id": "fix-03",
+      "name": "wrong operator",
+      "class": "fix",
+      "prompt": "In bugs.go Max uses the wrong inequality and returns the smaller value; fix it to return the larger.",
+      "workspaceFixture": "../testdata/fix",
+      "verificationCommand": [
+        "go",
+        "test",
+        "-run",
+        "TestMaxReturnsLarger",
+        "./..."
+      ]
+    },
+    {
+      "id": "fix-04",
+      "name": "truncated read",
+      "class": "fix",
+      "prompt": "In bugs.go ReadFirst returns only a single character instead of the full content; fix it to return the whole string.",
+      "workspaceFixture": "../testdata/fix",
+      "verificationCommand": [
+        "go",
+        "test",
+        "-run",
+        "TestReadFirstReturnsFullContent",
+        "./..."
+      ]
+    },
+    {
+      "id": "fix-05",
+      "name": "swapped args",
+      "class": "fix",
+      "prompt": "In bugs.go Divide swaps its operands; fix the order so Divide(10,2) returns 5.",
+      "workspaceFixture": "../testdata/fix",
+      "verificationCommand": [
+        "go",
+        "test",
+        "-run",
+        "TestDivideOrder",
+        "./..."
+      ]
+    },
+    {
+      "id": "fix-06",
+      "name": "missing return",
+      "class": "fix",
+      "prompt": "In bugs.go Classify is missing a return for the high case; add it so Classify(500) returns \"high\".",
+      "workspaceFixture": "../testdata/fix",
+      "verificationCommand": [
+        "go",
+        "test",
+        "-run",
+        "TestClassifyHigh",
+        "./..."
+      ]
+    },
+    {
+      "id": "fix-07",
+      "name": "wrong label prefix",
+      "class": "fix",
+      "prompt": "In bugs.go Label returns 'admin-<name>' but the test expects 'user-<name>'; change the prefix from 'admin-' to 'user-'.",
+      "workspaceFixture": "../testdata/fix",
+      "verificationCommand": [
+        "go",
+        "test",
+        "-run",
+        "TestLabelUsesString",
+        "./..."
+      ]
+    },
+    {
+      "id": "fix-08",
+      "name": "race on counter",
+      "class": "fix",
+      "prompt": "In bugs.go the global counter is incremented without synchronization; guard it with a mutex.",
+      "workspaceFixture": "../testdata/fix",
+      "verificationCommand": [
+        "go",
+        "test",
+        "-race",
+        "-run",
+        "TestCounterRace",
+        "./..."
+      ]
+    },
+    {
+      "id": "refactor-01",
+      "name": "extract helper",
+      "class": "refactor",
+      "prompt": "Extract the duplicated fmt.Sprintf(\"hello, %s\", ...) greeting logic into a single helper function named formatGreeting and call it from both GreetFromConfig and GreetByName.",
+      "workspaceFixture": "../testdata/refactor",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "go test ./... && [ $(grep -c 'hello, %s' main.go) -eq 1 ]"
+      ],
+      "oracleTest": "package refactor\n\nvar _ = formatGreeting\n"
+    },
+    {
+      "id": "refactor-02",
+      "name": "split a file",
+      "class": "refactor",
+      "prompt": "Move the Config type into a new file named config.go, keeping the package building.",
+      "workspaceFixture": "../testdata/refactor",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "go test ./... && grep -q 'type Config' config.go && ! grep -q 'type Config' main.go"
+      ]
+    },
+    {
+      "id": "refactor-03",
+      "name": "rename package",
+      "class": "refactor",
+      "prompt": "Rename the package from refactor to zeroapp everywhere and keep it building.",
+      "workspaceFixture": "../testdata/refactor",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "go test ./... && ! grep -R 'package refactor' . && grep -R 'package zeroapp' ."
+      ],
+      "oracleTest": "package zeroapp\n\nvar _ = Config{}\n"
+    },
+    {
+      "id": "refactor-04",
+      "name": "introduce a type",
+      "class": "refactor",
+      "prompt": "Introduce a named type `type Stats map[string]int` for the bare map used by stats, and update its users (Record, Lookup).",
+      "workspaceFixture": "../testdata/refactor",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "go test ./... && ! grep -q 'var stats = map\\[string\\]int' main.go"
+      ],
+      "oracleTest": "package refactor\n\nvar _ Stats\n"
+    },
+    {
+      "id": "refactor-05",
+      "name": "inline a wrapper",
+      "class": "refactor",
+      "prompt": "Inline the Wrapper function into greetWrapped (its single caller) and remove the Wrapper function.",
+      "workspaceFixture": "../testdata/refactor",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "go test ./... && ! grep -R 'func Wrapper' ."
+      ]
+    },
+    {
+      "id": "refactor-06",
+      "name": "consolidate errors",
+      "class": "refactor",
+      "prompt": "Consolidate the three error-construction functions (firstError, secondError, buildError) into a single helper func makeLoadError(ctx string) error that returns fmt.Errorf(\"load failed: %s\", ctx), and call it from all three.",
+      "workspaceFixture": "../testdata/refactor",
+      "verificationCommand": [
+        "bash",
+        "-c",
+        "go test ./... && [ $(grep -c 'fmt.Errorf(\"load failed' main.go) -eq 1 ]"
+      ],
+      "oracleTest": "package refactor\n\nvar _ = makeLoadError\n"
+    },
+    {
+      "id": "longproc-01",
+      "name": "long build",
+      "class": "longproc",
+      "prompt": "Run the build command and report whether it succeeds. Do not modify anything.",
+      "workspaceFixture": "../testdata/longproc"
+    },
+    {
+      "id": "longproc-02",
+      "name": "long test",
+      "class": "longproc",
+      "prompt": "Run go test ./... and report the result. Do not modify anything.",
+      "workspaceFixture": "../testdata/longproc"
+    },
+    {
+      "id": "longproc-03",
+      "name": "bench run",
+      "class": "longproc",
+      "prompt": "Run go test -bench=. -benchtime=1x and report the benchmark numbers. Do not modify anything.",
+      "workspaceFixture": "../testdata/longproc"
+    },
+    {
+      "id": "longproc-04",
+      "name": "vet run",
+      "class": "longproc",
+      "prompt": "Run go vet ./... and report the output. Do not modify anything.",
+      "workspaceFixture": "../testdata/longproc"
+    },
+    {
+      "id": "longctx-01",
+      "name": "summarize large file",
+      "class": "longctx",
+      "prompt": "Read the large generated file big.go and summarize its structure. Do not modify anything.",
+      "workspaceFixture": "../testdata/longctx"
+    },
+    {
+      "id": "longctx-02",
+      "name": "find in large file",
+      "class": "longctx",
+      "prompt": "In big.go, find every function that returns an error and list them. Do not modify anything.",
+      "workspaceFixture": "../testdata/longctx"
+    },
+    {
+      "id": "longctx-03",
+      "name": "cross-file question",
+      "class": "longctx",
+      "prompt": "Read all .go files and report which two functions share the same name across files. Do not modify anything.",
+      "workspaceFixture": "../testdata/longctx"
+    },
+    {
+      "id": "longctx-04",
+      "name": "trace through large file",
+      "class": "longctx",
+      "prompt": "Starting from Handle, trace the call path through big.go and report the chain. Do not modify anything.",
+      "workspaceFixture": "../testdata/longctx"
+    },
+    {
+      "id": "parallel-01",
+      "name": "read six files",
+      "class": "parallel",
+      "prompt": "Read a.txt, b.txt, c.txt, d.txt, e.txt, and f.txt, then report the first line of each. Do not modify anything.",
+      "workspaceFixture": "../testdata/parallel"
+    },
+    {
+      "id": "parallel-02",
+      "name": "grep six patterns",
+      "class": "parallel",
+      "prompt": "Search for 'alpha', 'beta', 'gamma', 'delta', 'epsilon', and 'zeta' across the repo and report which files contain each. Do not modify anything.",
+      "workspaceFixture": "../testdata/parallel"
+    },
+    {
+      "id": "parallel-03",
+      "name": "list six dirs",
+      "class": "parallel",
+      "prompt": "List the contents of dir1, dir2, dir3, dir4, dir5, and dir6. Do not modify anything.",
+      "workspaceFixture": "../testdata/parallel"
+    },
+    {
+      "id": "parallel-04",
+      "name": "stat six files",
+      "class": "parallel",
+      "prompt": "Report the line count of a.txt, b.txt, c.txt, d.txt, e.txt, and f.txt. Do not modify anything.",
+      "workspaceFixture": "../testdata/parallel"
+    },
+    {
+      "id": "parallel-05",
+      "name": "read configs",
+      "class": "parallel",
+      "prompt": "Read config1.json, config2.json, config3.json, config4.json, config5.json, and config6.json and report each top-level key. Do not modify anything.",
+      "workspaceFixture": "../testdata/parallel"
+    },
+    {
+      "id": "parallel-06",
+      "name": "summarize six",
+      "class": "parallel",
+      "prompt": "Read the six .txt files and give a one-line summary of each. Do not modify anything.",
+      "workspaceFixture": "../testdata/parallel"
+    }
   ]
 }

--- a/internal/perfbench/manifests/baseline.json
+++ b/internal/perfbench/manifests/baseline.json
@@ -44,24 +44,24 @@
       "id": "nav-04",
       "name": "count tests",
       "class": "nav",
-      "prompt": "Count the test functions (functions whose names start with Test) in this repository and report the number. State the count as 'count: N' on its own line. Do not modify anything.",
+      "prompt": "Count the test functions (functions whose names start with Test) in this repository. Name each one you find and report the number. State the count as 'count: N' on its own line. Do not modify anything.",
       "workspaceFixture": "../testdata/nav",
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iqE '^count:[[:space:]]*1$' .zero-answer.txt"
+        "grep -iq 'TestGreet' .zero-answer.txt && grep -iqE '^count:[[:space:]]*1$' .zero-answer.txt"
       ]
     },
     {
       "id": "nav-05",
       "name": "locate a string",
       "class": "nav",
-      "prompt": "Find every occurrence of the string 'TODO' in the repository and report the files. State the count as 'count: N' on its own line. Do not modify anything.",
+      "prompt": "Find every occurrence of the string 'TODO' in the repository and report the file(s) they appear in. State the count as 'count: N' on its own line. Do not modify anything.",
       "workspaceFixture": "../testdata/nav",
       "verificationCommand": [
         "bash",
         "-c",
-        "grep -iqE '^count:[[:space:]]*1$' .zero-answer.txt"
+        "grep -iq 'main.go' .zero-answer.txt && grep -iqE '^count:[[:space:]]*1$' .zero-answer.txt"
       ]
     },
     {

--- a/internal/perfbench/taskbench.go
+++ b/internal/perfbench/taskbench.go
@@ -51,6 +51,14 @@ type BenchTask struct {
 	Prompt              string   `json:"prompt"`
 	WorkspaceFixture    string   `json:"workspaceFixture,omitempty"`
 	VerificationCommand []string `json:"verificationCommand,omitempty"`
+	// OracleTest is Go source stamped into <fixtureCopy>/oracle_test.go AFTER
+	// the agent run (so it can't interfere with the agent's own go build/test
+	// during the task and can't be pre-seen). The verificationCommand then runs
+	// `go test ./...`, making the Go compiler the structural verifier: a
+	// compile-time reference (e.g. `var _ = Config{}.Label`) or a behavioral call
+	// fails to compile/run when the task wasn't actually done. Empty for tasks
+	// whose verificationCommand is a plain grep/build with no stamped test.
+	OracleTest string `json:"oracleTest,omitempty"`
 }
 
 // TaskConfig is the recorded configuration of a benchmark run. The honest
@@ -415,6 +423,37 @@ func streamJSONExitCode(output []byte) (int, bool) {
 		}
 	}
 	return exitCode, found
+}
+
+// streamJSONFinalText scans stream-json output for the terminal "final" event
+// and returns its text (the agent's final answer). ZERO emits one final event
+// per run on both the success and incomplete paths (exec.go writer.final), so
+// the last one wins. The turn benchmark writes this to .zero-answer.txt in the
+// fixture copy so nav answer-oracles can grep the captured answer rather than
+// the raw stream. Returns "" when no final event was emitted (e.g. a provider
+// error path) — the caller writes an empty file and a nav grep then fails,
+// which is the correct outcome for a run that produced no answer.
+func streamJSONFinalText(output []byte) string {
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	text := ""
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var event struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		if event.Type == "final" {
+			text = event.Text
+		}
+	}
+	return text
 }
 
 func firstLine(text string) string {

--- a/internal/perfbench/taskbench.go
+++ b/internal/perfbench/taskbench.go
@@ -397,14 +397,26 @@ func runVerification(ctx context.Context, task BenchTask) TaskOutcome {
 	return TaskOutcome{Passed: true}
 }
 
-// streamJSONExitCode scans stream-json output for the terminal run_end event and
-// returns its exit code. ZERO emits one JSON object per line; the last run_end
-// (or final) event carries the exit code. Lines that don't parse are skipped.
-func streamJSONExitCode(output []byte) (int, bool) {
+// streamJSONResult holds the terminal events parsed from one pass over a
+// stream-json output: the last run_end exit code (if any) and the last final
+// event's text (the agent's answer, if any). streamJSONExitCode and
+// streamJSONFinalText both consume this so the scanner limits and
+// malformed-event handling live in exactly one place.
+type streamJSONResult struct {
+	exitCode  int
+	haveExit  bool
+	finalText string
+}
+
+// parseStreamJSON scans stream-json output once and returns the terminal
+// run_end exit code and the final event's text. ZERO emits one JSON object per
+// line; the last run_end carries the exit code and the last final carries the
+// answer. Lines that don't parse are skipped. The scanner buffer is raised so a
+// large single-line event (e.g. a big final answer) doesn't error out.
+func parseStreamJSON(output []byte) streamJSONResult {
 	scanner := bufio.NewScanner(bytes.NewReader(output))
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	exitCode := 0
-	found := false
+	var r streamJSONResult
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 || line[0] != '{' {
@@ -413,16 +425,28 @@ func streamJSONExitCode(output []byte) (int, bool) {
 		var event struct {
 			Type     string `json:"type"`
 			ExitCode *int   `json:"exitCode"`
+			Text     string `json:"text"`
 		}
 		if err := json.Unmarshal(line, &event); err != nil {
 			continue
 		}
 		if event.Type == "run_end" && event.ExitCode != nil {
-			exitCode = *event.ExitCode
-			found = true
+			r.exitCode = *event.ExitCode
+			r.haveExit = true
+		}
+		if event.Type == "final" {
+			r.finalText = event.Text
 		}
 	}
-	return exitCode, found
+	return r
+}
+
+// streamJSONExitCode scans stream-json output for the terminal run_end event and
+// returns its exit code. The last run_end event carries the exit code. Lines
+// that don't parse are skipped.
+func streamJSONExitCode(output []byte) (int, bool) {
+	r := parseStreamJSON(output)
+	return r.exitCode, r.haveExit
 }
 
 // streamJSONFinalText scans stream-json output for the terminal "final" event
@@ -434,26 +458,7 @@ func streamJSONExitCode(output []byte) (int, bool) {
 // error path) — the caller writes an empty file and a nav grep then fails,
 // which is the correct outcome for a run that produced no answer.
 func streamJSONFinalText(output []byte) string {
-	scanner := bufio.NewScanner(bytes.NewReader(output))
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	text := ""
-	for scanner.Scan() {
-		line := bytes.TrimSpace(scanner.Bytes())
-		if len(line) == 0 || line[0] != '{' {
-			continue
-		}
-		var event struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		}
-		if err := json.Unmarshal(line, &event); err != nil {
-			continue
-		}
-		if event.Type == "final" {
-			text = event.Text
-		}
-	}
-	return text
+	return parseStreamJSON(output).finalText
 }
 
 func firstLine(text string) string {

--- a/internal/perfbench/testdata/edit/go.mod
+++ b/internal/perfbench/testdata/edit/go.mod
@@ -1,0 +1,3 @@
+module edit
+
+go 1.22

--- a/internal/perfbench/testdata/fix/go.mod
+++ b/internal/perfbench/testdata/fix/go.mod
@@ -1,0 +1,3 @@
+module fix
+
+go 1.22

--- a/internal/perfbench/testdata/nav/go.mod
+++ b/internal/perfbench/testdata/nav/go.mod
@@ -1,0 +1,3 @@
+module nav
+
+go 1.22

--- a/internal/perfbench/testdata/nav/main.go
+++ b/internal/perfbench/testdata/nav/main.go
@@ -22,3 +22,7 @@ func greet(name string) string {
 func main() {
 	fmt.Println(greet("world"))
 }
+
+// TODO: replace the demo greet with the real client call before shipping.
+// (Present so nav-05's find-the-markers task has a non-zero, inspection-
+// required answer; an agent that always emits "count: 0" fails.)

--- a/internal/perfbench/testdata/nav/main_test.go
+++ b/internal/perfbench/testdata/nav/main_test.go
@@ -1,0 +1,13 @@
+package nav
+
+import "testing"
+
+// TestGreet is a real test so nav-04's "count the test functions" has a
+// non-zero, inspection-required answer: an agent that never opens the workspace
+// and always emits "count: 0" fails, which is the whole point of graduating nav
+// into the correctness tier. It runs green offline (no third-party deps).
+func TestGreet(t *testing.T) {
+	if got := greet("x"); got != "hello, x" {
+		t.Fatalf("greet(x) = %q, want %q", got, "hello, x")
+	}
+}

--- a/internal/perfbench/testdata/refactor/go.mod
+++ b/internal/perfbench/testdata/refactor/go.mod
@@ -1,0 +1,3 @@
+module refactor
+
+go 1.22

--- a/internal/perfbench/testdata/refactor/main.go
+++ b/internal/perfbench/testdata/refactor/main.go
@@ -28,6 +28,12 @@ func Wrapper(name string) string {
 	return GreetByName(name)
 }
 
+// greetWrapped is Wrapper's single caller — refactor-05 inlines Wrapper here
+// and removes the Wrapper function.
+func greetWrapped(name string) string {
+	return Wrapper(name)
+}
+
 // stats is a bare map used across the file — refactor-04 introduces a named type.
 var stats = map[string]int{}
 

--- a/internal/perfbench/turn_bench.go
+++ b/internal/perfbench/turn_bench.go
@@ -28,7 +28,7 @@ import (
 // (refactor); latencyOnlyTasks covers the no-oracle classes (nav/longproc/
 // longctx/parallel). tasksAttempted is still every task run.
 //
-// v3 (PR #701) strengthens the oracles so the tiers are honest: edit/refactor
+// v3 (Phase 0 oracle hardening) strengthens the oracles so the tiers are honest: edit/refactor
 // now carry a stamped oracle_test.go compiled by `go test ./...` (the Go
 // compiler is the structural verifier — a no-op refactor or a missing field
 // fails to compile), and nav carries an answer-oracle grepping the agent's
@@ -102,10 +102,11 @@ type LatencySource struct {
 // ClassSummary is the per-class (task group) roll-up.
 //
 // Passed is the count that passed THIS class's oracle: a correctness pass for
-// edit/fix, a build pass for refactor, and always 0 for the no-oracle classes
-// (nav/longproc/longctx/parallel). Verified is how many tasks in the class
-// carry an oracle (correctness or build); LatencyOnly is how many carry none.
-// A latency-only class therefore reports Passed=0, Verified=0, LatencyOnly=Tasks.
+// the positive-oracle classes (edit/fix/nav/refactor), and always 0 for the
+// no-oracle classes (longproc/longctx/parallel) — the build tier is empty in v3
+// (refactor graduated to correctness). Verified is how many tasks in the class
+// carry an oracle; LatencyOnly is how many carry none. A latency-only class
+// therefore reports Passed=0, Verified=0, LatencyOnly=Tasks.
 type ClassSummary struct {
 	Tasks       int                `json:"tasks"`
 	Verified    int                `json:"verified"`
@@ -120,13 +121,14 @@ type ClassSummary struct {
 // Pass/fail is split into three oracle tiers so it cannot be misread as a
 // blanket correctness verdict:
 //   - Correctness (tasksVerified / tasksPassed / correctnessPassRate): tasks
-//     with a positive oracle (edit/fix). This is the only pass rate that can
-//     move with model quality.
-//   - Build-only (buildCheckedTasks / buildPassedTasks / buildPassRate): tasks
-//     whose oracle is a non-positive build check (refactor `go build`). A pass
-//     means it compiles, not that the refactor is correct.
-//   - Latency-only (latencyOnlyTasks): tasks with no oracle (nav/longproc/
-//     longctx/parallel). They ran for latency and span attribution only and are
+//     with a positive oracle (edit/fix/nav/refactor). This is the only pass
+//     rate that can move with model quality.
+//   - Build-only (buildCheckedTasks / buildPassedTasks / buildPassRate): the
+//     non-positive build-check tier. Empty in v3 — refactor graduated to
+//     correctness (its stamped oracle is positive) — so buildCheckedTasks is
+//     always 0 and buildPassRate is 0. The fields remain for schema stability.
+//   - Latency-only (latencyOnlyTasks): tasks with no oracle (longproc/longctx/
+//     parallel). They ran for latency and span attribution only and are
 //     excluded from every pass rate.
 //
 // tasksAttempted is still the total number of tasks run across all three tiers.
@@ -445,8 +447,9 @@ func FormatTurnBenchSummary(result TurnBenchResult) string {
 		"model: " + displayOrUnknown(result.Model),
 		// The headline separates the three oracle tiers so an exit-0 read-only
 		// task can never inflate a "pass rate" that reads as correctness:
-		// correctness (positive oracle, edit/fix), build (non-positive `go build`,
-		// refactor), and latency-only (no oracle, nav/longproc/longctx/parallel).
+		// correctness (positive oracle: edit/fix/nav/refactor), build (empty in
+		// v3 — refactor graduated to correctness), and latency-only (no oracle:
+		// longproc/longctx/parallel).
 		fmt.Sprintf("tasks: %d total | correctness %d/%d (%.0f%%) | build %d/%d (%.0f%%) | latency-only %d | %d iter",
 			result.TasksAttempted,
 			result.TasksPassed, result.TasksVerified, result.CorrectnessPassRate*100,
@@ -601,7 +604,12 @@ func NewTurnExecRunner(binary string, extraArgs ...string) TurnRunner {
 		// test would break a pre-rename build) and can't be pre-seen or tampered
 		// with.
 		if err := stampOracleAndAnswer(task, outBuf.Bytes()); err != nil {
-			return TurnTaskOutcome{WallMs: wallMs, Err: fmt.Errorf("stamp oracle: %w", err)}
+			// Preserve the already-parsed trace, trace issue, and wall time: a
+			// stamp failure is a harness error, but the run still produced a
+			// trace worth attributing, so mutate the existing outcome rather than
+			// returning a fresh one that drops Trace/TraceIssue.
+			outcome.Err = fmt.Errorf("stamp oracle: %w", err)
+			return outcome
 		}
 		if len(task.VerificationCommand) > 0 {
 			if vOutcome := runVerification(ctx, task); !vOutcome.Passed {

--- a/internal/perfbench/turn_bench.go
+++ b/internal/perfbench/turn_bench.go
@@ -522,11 +522,13 @@ func NewTurnExecRunner(binary string, extraArgs ...string) TurnRunner {
 		// fixture or bleed into a later iteration of the same task. When no
 		// fixture is configured the agent runs in the caller's cwd as before.
 		if fixture := strings.TrimSpace(task.WorkspaceFixture); fixture != "" {
-			copyDir, cerr := copyFixture(fixture)
+			copyDir, parent, cerr := copyFixture(fixture)
 			if cerr != nil {
 				return TurnTaskOutcome{Err: fmt.Errorf("isolate fixture: %w", cerr)}
 			}
-			defer os.RemoveAll(copyDir)
+			// Clean the whole unique parent (which owns copyDir) so the
+			// per-invocation scratch dir never leaks.
+			defer os.RemoveAll(parent)
 			task.WorkspaceFixture = copyDir
 		}
 
@@ -618,33 +620,41 @@ func NewTurnExecRunner(binary string, extraArgs ...string) TurnRunner {
 }
 
 // copyFixture copies the fixture directory at src into a fresh temp dir and
-// returns the copy's path. Used to give each benchmark invocation an isolated
-// workspace so mutating tasks (edit/fix/refactor) can't dirty the checked-in
-// fixture or a later iteration.
+// returns the copy's path (dst) plus the unique parent dir that owns it (parent,
+// which the caller must RemoveAll to clean up dst and its sibling scratch space
+// together). Used to give each benchmark invocation an isolated workspace so
+// mutating tasks (edit/fix/refactor) can't dirty the checked-in fixture or a
+// later iteration.
 //
-// The copy is placed one level BELOW the system temp root (under a fixed
-// "zero-turn-bench" parent), not directly in it. Go ignores go.mod files in
-// direct children of the system temp dir (a hijack guard), which would make the
-// fixture's go.mod — and thus every `go test ./...`/`go build ./...` oracle —
-// fail with "cannot find main module". Nesting one level deeper makes Go
+// The copy is placed two levels BELOW the system temp root: a unique 0700
+// parent (created fresh per invocation via os.MkdirTemp, so concurrent runs and
+// different users can't share or traverse a predictable scratch dir) and the
+// fixture copy beneath it. Go ignores go.mod files in DIRECT children of the
+// system temp dir (a hijack guard), which would make the fixture's go.mod —
+// and thus every `go test ./...`/`go build ./...` oracle — fail with "cannot
+// find main module". Keeping the copy a grandchild of the temp root makes Go
 // respect the copied go.mod so the compiler-backed oracles actually run.
-func copyFixture(src string) (string, error) {
+func copyFixture(src string) (dst, parent string, err error) {
 	info, err := os.Stat(src)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("fixture %q is not a directory", src)
+		return "", "", fmt.Errorf("fixture %q is not a directory", src)
 	}
-	parent := filepath.Join(os.TempDir(), "zero-turn-bench")
-	if err := os.MkdirAll(parent, 0o755); err != nil {
-		return "", err
-	}
-	dst, err := os.MkdirTemp(parent, "zero-turn-fixture-*")
+	// Unique, 0700-per-invocation parent directly under the temp root. The
+	// fixture copy is created BENEATH it, so the copy is a grandchild of the
+	// temp root and its go.mod is respected (see the doc comment above).
+	parent, err = os.MkdirTemp(os.TempDir(), "zero-turn-bench-*")
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	err = filepath.WalkDir(src, func(path string, d fs.DirEntry, werr error) error {
+	dst, err = os.MkdirTemp(parent, "zero-turn-fixture-*")
+	if err != nil {
+		os.RemoveAll(parent)
+		return "", "", err
+	}
+	werr := filepath.WalkDir(src, func(path string, d fs.DirEntry, werr error) error {
 		if werr != nil {
 			return werr
 		}
@@ -662,11 +672,11 @@ func copyFixture(src string) (string, error) {
 		}
 		return os.WriteFile(target, data, 0o644)
 	})
-	if err != nil {
-		os.RemoveAll(dst)
-		return "", err
+	if werr != nil {
+		os.RemoveAll(parent) // removes dst too
+		return "", "", werr
 	}
-	return dst, nil
+	return dst, parent, nil
 }
 
 // stampOracleAndAnswer writes the compiler-backed oracle test (when configured)
@@ -677,9 +687,20 @@ func copyFixture(src string) (string, error) {
 // always written (empty when no final event was captured) so a nav answer-oracle
 // fails cleanly on a run that produced no answer rather than reading a stale or
 // absent file.
+//
+// A task that needs an oracle — a stamped oracle_test.go OR a verification
+// command that reads .zero-answer.txt — but has no workspace fixture is
+// rejected: there is nowhere safe to stamp, so runVerification would otherwise
+// run in the caller's cwd with the oracle never compiled (or the answer never
+// captured), which can read as a false pass. A fixtureless task with no oracle
+// and no verification (a pure latency-only run in the caller's cwd) is left
+// alone.
 func stampOracleAndAnswer(task BenchTask, outBuf []byte) error {
 	dir := strings.TrimSpace(task.WorkspaceFixture)
 	if dir == "" {
+		if task.OracleTest != "" || len(task.VerificationCommand) > 0 {
+			return fmt.Errorf("stamp oracle: task %q has an oracle or verification but no workspace fixture to stamp into", task.ID)
+		}
 		return nil
 	}
 	if ot := task.OracleTest; ot != "" {

--- a/internal/perfbench/turn_bench.go
+++ b/internal/perfbench/turn_bench.go
@@ -27,7 +27,20 @@ import (
 // buildPassedTasks/buildPassRate cover the non-positive build-check classes
 // (refactor); latencyOnlyTasks covers the no-oracle classes (nav/longproc/
 // longctx/parallel). tasksAttempted is still every task run.
-const TurnSchemaVersion = 2
+//
+// v3 (PR #701) strengthens the oracles so the tiers are honest: edit/refactor
+// now carry a stamped oracle_test.go compiled by `go test ./...` (the Go
+// compiler is the structural verifier — a no-op refactor or a missing field
+// fails to compile), and nav carries an answer-oracle grepping the agent's
+// captured final answer. refactor graduates from build to correctness (its
+// oracle is now positive), nav graduates from latency-only to correctness, and
+// the build tier is empty (nothing is only-build-checked anymore). The result
+// SHAPE is unchanged — only class-list membership shifts — but
+// correctnessPassRate now means something strictly stronger, so the bump
+// prevents a v2→v2 cross-version comparison from misreading the jump as a model
+// improvement. New counts: correctness 34 (edit 10 + fix 8 + nav 10 + refactor
+// 6), build 0, latency 14 (longproc 4 + longctx 4 + parallel 6).
+const TurnSchemaVersion = 3
 
 // TurnRunner runs one benchmark task and reports its outcome plus the captured
 // per-turn trace. A non-nil Err means the run failed to execute (process crash);
@@ -577,6 +590,17 @@ func NewTurnExecRunner(binary string, extraArgs ...string) TurnRunner {
 		if outcome.VerifyErr != "" {
 			return outcome
 		}
+		// Stamp the compiler-backed oracle and capture the agent's final answer
+		// BEFORE running the verification command. Both write into the fixture
+		// copy (task.WorkspaceFixture, set to copyDir above) so runVerification —
+		// which uses that same dir as cmd.Dir — sees them. Stamping happens only
+		// after the agent run so the oracle test can't interfere with the agent's
+		// own go build/test during the task (e.g. refactor-03's package-zeroapp
+		// test would break a pre-rename build) and can't be pre-seen or tampered
+		// with.
+		if err := stampOracleAndAnswer(task, outBuf.Bytes()); err != nil {
+			return TurnTaskOutcome{WallMs: wallMs, Err: fmt.Errorf("stamp oracle: %w", err)}
+		}
 		if len(task.VerificationCommand) > 0 {
 			if vOutcome := runVerification(ctx, task); !vOutcome.Passed {
 				outcome.VerifyErr = strings.TrimSpace(vOutcome.Detail)
@@ -584,7 +608,7 @@ func NewTurnExecRunner(binary string, extraArgs ...string) TurnRunner {
 			}
 			// A positive oracle (grep/test/build) passed: this is the only path
 			// that sets Passed. A task with no verificationCommand is latency-only
-			// (read-only nav/longproc/longctx/parallel): its exit 0 proves the turn
+			// (read-only longproc/longctx/parallel): its exit 0 proves the turn
 			// ran, not that the answer was right, so it never reports Passed and the
 			// harness counts it in latencyOnlyTasks rather than any pass rate.
 			outcome.Passed = true
@@ -597,6 +621,13 @@ func NewTurnExecRunner(binary string, extraArgs ...string) TurnRunner {
 // returns the copy's path. Used to give each benchmark invocation an isolated
 // workspace so mutating tasks (edit/fix/refactor) can't dirty the checked-in
 // fixture or a later iteration.
+//
+// The copy is placed one level BELOW the system temp root (under a fixed
+// "zero-turn-bench" parent), not directly in it. Go ignores go.mod files in
+// direct children of the system temp dir (a hijack guard), which would make the
+// fixture's go.mod — and thus every `go test ./...`/`go build ./...` oracle —
+// fail with "cannot find main module". Nesting one level deeper makes Go
+// respect the copied go.mod so the compiler-backed oracles actually run.
 func copyFixture(src string) (string, error) {
 	info, err := os.Stat(src)
 	if err != nil {
@@ -605,7 +636,11 @@ func copyFixture(src string) (string, error) {
 	if !info.IsDir() {
 		return "", fmt.Errorf("fixture %q is not a directory", src)
 	}
-	dst, err := os.MkdirTemp("", "zero-turn-fixture-*")
+	parent := filepath.Join(os.TempDir(), "zero-turn-bench")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", err
+	}
+	dst, err := os.MkdirTemp(parent, "zero-turn-fixture-*")
 	if err != nil {
 		return "", err
 	}
@@ -632,6 +667,31 @@ func copyFixture(src string) (string, error) {
 		return "", err
 	}
 	return dst, nil
+}
+
+// stampOracleAndAnswer writes the compiler-backed oracle test (when configured)
+// and the agent's captured final answer into the fixture copy, so the
+// verification command can compile the oracle and grep the answer. Both files
+// land in task.WorkspaceFixture, which the runner has already set to the
+// fixture copy and which runVerification uses as cmd.Dir. The answer file is
+// always written (empty when no final event was captured) so a nav answer-oracle
+// fails cleanly on a run that produced no answer rather than reading a stale or
+// absent file.
+func stampOracleAndAnswer(task BenchTask, outBuf []byte) error {
+	dir := strings.TrimSpace(task.WorkspaceFixture)
+	if dir == "" {
+		return nil
+	}
+	if ot := task.OracleTest; ot != "" {
+		if err := os.WriteFile(filepath.Join(dir, "oracle_test.go"), []byte(ot), 0o644); err != nil {
+			return fmt.Errorf("write oracle_test.go: %w", err)
+		}
+	}
+	answer := streamJSONFinalText(outBuf)
+	if err := os.WriteFile(filepath.Join(dir, ".zero-answer.txt"), []byte(answer), 0o644); err != nil {
+		return fmt.Errorf("write .zero-answer.txt: %w", err)
+	}
+	return nil
 }
 
 func buildTurnExecArgs(task BenchTask, rc RunContext, tracePath string, extraArgs []string) []string {

--- a/internal/perfbench/turn_bench_test.go
+++ b/internal/perfbench/turn_bench_test.go
@@ -680,6 +680,49 @@ echo '{"type":"run_end","exitCode":0}'
 	assertVerifyFailed(t, "reworded edit-05 debug print", outcome)
 }
 
+// TestEdit05RejectsRespelledDebugPrint proves the second edit-05 check (the
+// message text "debug: starting" must be absent) catches a respell onto a
+// different call form that the fmt.Println(" string-literal check misses: the
+// agent rewrites the line to fmt.Printf("debug: starting\n"), which still prints
+// the message but is no longer a fmt.Println string-literal. The
+// strings.Contains("debug: starting") assertion fails the task.
+func TestEdit05RejectsRespelledDebugPrint(t *testing.T) {
+	task := loadBaselineTask(t, "edit-05")
+	outcome := runTurnStub(t, task, `sed 's/fmt.Println("debug: starting")/fmt.Printf("debug: starting\\n")/' main.go > .zero-tmp && mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "respelled edit-05 debug print", outcome)
+}
+
+// TestRefactor05RejectsStubbedCaller proves refactor-05's behavioral oracle
+// catches a wrong edit the negative grep alone would pass: the agent deletes
+// Wrapper (so ! grep 'func Wrapper' succeeds) but stubs greetWrapped to return
+// "" instead of inlining. The stamped TestGreetWrapped runs greetWrapped("x"),
+// gets "" not "hello, x", and fails — so deleting the target along with its
+// caller (or stubbing the caller) can no longer pass the oracle.
+func TestRefactor05RejectsStubbedCaller(t *testing.T) {
+	task := loadBaselineTask(t, "refactor-05")
+	outcome := runTurnStub(t, task, `sed -e 's/return Wrapper(name)/return ""/' -e '/^func Wrapper(name string) string {/,/^}/d' main.go > .zero-tmp && mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "stubbed refactor-05 caller", outcome)
+}
+
+// TestRefactor04RejectsBareMapKept proves refactor-04's file-reading oracle
+// catches a no-op that the old exact-text shell grep would miss: the agent adds
+// an unused `type Stats map[string]int` (so the compile-time `var _ Stats`
+// passes) but keeps the bare `var stats = map[string]int{}` under the original
+// spacing. The spacing-tolerant regex in TestStatsNamedType still matches the
+// bare-map declaration, so the task fails — Record/Lookup never moved onto the
+// named type.
+func TestRefactor04RejectsBareMapKept(t *testing.T) {
+	task := loadBaselineTask(t, "refactor-04")
+	outcome := runTurnStub(t, task, `sed 's/type Config struct {/type Stats map[string]int\n\ntype Config struct {/' main.go > .zero-tmp && mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "refactor-04 bare-map kept", outcome)
+}
+
 // TestEdit01IgnoresDocComment proves edit-01's scoped negative grep does NOT
 // false-fail a correct rename that leaves the doc comment mentioning the old
 // name. The stub renames the declaration (`MaxRetries =` -> `RetryLimit =`) but
@@ -757,6 +800,41 @@ echo '{"type":"run_end","exitCode":0}'
 	}
 }
 
+// TestRefactor05PassesWhenInlined proves refactor-05's oracle is not an
+// always-fail gate: when the stub applies the real inline (greetWrapped calls
+// GreetByName directly, Wrapper removed), TestGreetWrapped gets "hello, x" and
+// the ! grep 'func Wrapper' check passes, so the task passes.
+func TestRefactor05PassesWhenInlined(t *testing.T) {
+	task := loadBaselineTask(t, "refactor-05")
+	outcome := runTurnStub(t, task, `sed -e 's/return Wrapper(name)/return GreetByName(name)/' -e '/^func Wrapper(name string) string {/,/^}/d' main.go > .zero-tmp && mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("real inline should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("refactor-05 oracle must pass when Wrapper is inlined into greetWrapped: %+v", outcome)
+	}
+}
+
+// TestRefactor04PassesWhenTyped proves refactor-04's oracle passes when the
+// bare map is actually replaced by the named type: the stub introduces
+// `type Stats map[string]int` and retypes the var to `var stats = Stats{}`,
+// so the bare-map regex no longer matches, Stats is referenced, `var _ Stats`
+// compiles, and go test passes.
+func TestRefactor04PassesWhenTyped(t *testing.T) {
+	task := loadBaselineTask(t, "refactor-04")
+	outcome := runTurnStub(t, task, `sed -e 's/type Config struct {/type Stats map[string]int\n\ntype Config struct {/' -e 's/var stats = map\[string\]int{}/var stats = Stats{}/' main.go > .zero-tmp && mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("real typed refactor should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("refactor-04 oracle must pass when stats is typed as Stats: %+v", outcome)
+	}
+}
+
 // TestStampOracleRejectsFixturelessOracleTask covers the fail-closed path in
 // stampOracleAndAnswer: a task that carries an oracle (a stamped OracleTest or a
 // verification command) but has no workspace fixture has nowhere safe to stamp,
@@ -803,56 +881,144 @@ func TestStampOracleRejectsFixturelessOracleTask(t *testing.T) {
 // --- Count-oracle tests: anchored `^count: N$` with the exact expected count ---
 
 // TestNav01CountOracleAcceptsExactCount proves nav-01's anchored count oracle
-// passes when the answer names the files AND states the exact count (4) on its
-// own line. printf emits the JSON with a literal \n escape so the captured
-// answer has "count: 4" on its own line.
+// passes when the answer names the files AND states the exact count (5 — the
+// fixture has README.md, config.json, go.mod, main.go, main_test.go) on its own
+// line. printf emits the JSON with a literal \n escape so the captured answer
+// has "count: 5" on its own line.
 func TestNav01CountOracleAcceptsExactCount(t *testing.T) {
 	task := loadBaselineTask(t, "nav-01")
-	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"main.go, config.json, go.mod, README.md\ncount: 4"}'
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"main.go, config.json, go.mod, README.md, main_test.go\ncount: 5"}'
 printf '%s\n' '{"type":"run_end","exitCode":0}'
 `)
 	if outcome.Err != nil {
 		t.Fatalf("correct nav-01 answer should pass, got harness error: %v", outcome.Err)
 	}
 	if !outcome.Passed {
-		t.Fatalf("nav-01 oracle must pass when the answer names the files and states count: 4: %+v", outcome)
+		t.Fatalf("nav-01 oracle must pass when the answer names the files and states count: 5: %+v", outcome)
 	}
 }
 
 // TestNav01CountOracleRejectsWrongCount proves the anchored count oracle rejects
 // a wrong count: the file names are all present, but "count: 3" does not match
-// `^count: 4$`, so the task fails at verification.
+// `^count: 5$`, so the task fails at verification.
 func TestNav01CountOracleRejectsWrongCount(t *testing.T) {
 	task := loadBaselineTask(t, "nav-01")
-	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"main.go, config.json, go.mod, README.md\ncount: 3"}'
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"main.go, config.json, go.mod, README.md, main_test.go\ncount: 3"}'
 printf '%s\n' '{"type":"run_end","exitCode":0}'
 `)
 	assertVerifyFailed(t, "nav-01 wrong count", outcome)
 }
 
 // TestNav04CountOracleRejectsSubstring proves the line anchor rejects a
-// substring: "the count: 0 is the number" contains "count: 0" but the line does
-// not start with "count:", so `^count:[[:space:]]*0$` does not match. A
-// pre-anchor oracle (`count:\s*0`) would have rubber-stamped this.
+// substring: "the count: 1 is the number" contains "count: 1" (the right
+// value) but the line does not start with "count:", so `^count:[[:space:]]*1$`
+// does not match. A pre-anchor oracle (`count:\s*1`) would have rubber-stamped
+// this.
 func TestNav04CountOracleRejectsSubstring(t *testing.T) {
 	task := loadBaselineTask(t, "nav-04")
-	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"the count: 0 is the number of test functions"}'
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"the count: 1 is the number of test functions"}'
 printf '%s\n' '{"type":"run_end","exitCode":0}'
 `)
 	assertVerifyFailed(t, "nav-04 substring count", outcome)
 }
 
 // TestNav04CountOracleAcceptsExactCount proves the anchored count oracle passes
-// when "count: 0" stands on its own line.
+// when "count: 1" stands on its own line. The fixture's main_test.go defines
+// exactly one Test* function (TestGreet), so the ground truth is 1, not 0 — a
+// guesser that always emits "count: 0" fails (see RejectsZeroGuess).
 func TestNav04CountOracleAcceptsExactCount(t *testing.T) {
 	task := loadBaselineTask(t, "nav-04")
-	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"There are no test functions.\ncount: 0"}'
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"There is one test function: TestGreet in main_test.go.\ncount: 1"}'
 printf '%s\n' '{"type":"run_end","exitCode":0}'
 `)
 	if outcome.Err != nil {
 		t.Fatalf("correct nav-04 answer should pass, got harness error: %v", outcome.Err)
 	}
 	if !outcome.Passed {
-		t.Fatalf("nav-04 oracle must pass when the answer states count: 0 on its own line: %+v", outcome)
+		t.Fatalf("nav-04 oracle must pass when the answer states count: 1 on its own line: %+v", outcome)
 	}
+}
+
+// TestNav04CountOracleRejectsZeroGuess is the gameability gate: an agent that
+// never opens the workspace and always emits "count: 0" used to pass nav-04
+// when the ground truth was 0. The fixture now has one real Test* function, so
+// the ground truth is 1 and a clean "count: 0" fails — proving the count=0
+// rubber-stamp is closed.
+func TestNav04CountOracleRejectsZeroGuess(t *testing.T) {
+	task := loadBaselineTask(t, "nav-04")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"count: 0"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-04 zero-guess", outcome)
+}
+
+// TestNav05CountOracleAcceptsExactCount proves nav-05's anchored count oracle
+// passes for the real ground truth: the fixture has exactly one TODO (in
+// main.go), so "count: 1" on its own line passes.
+func TestNav05CountOracleAcceptsExactCount(t *testing.T) {
+	task := loadBaselineTask(t, "nav-05")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"One TODO in main.go.\ncount: 1"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("correct nav-05 answer should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("nav-05 oracle must pass when the answer states count: 1: %+v", outcome)
+	}
+}
+
+// TestNav05CountOracleRejectsZeroGuess is nav-05's gameability gate: the
+// fixture now has one real TODO, so a clean "count: 0" (the always-guess-zero
+// answer) fails.
+func TestNav05CountOracleRejectsZeroGuess(t *testing.T) {
+	task := loadBaselineTask(t, "nav-05")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"count: 0"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-05 zero-guess", outcome)
+}
+
+// TestNav08CountOracleAcceptsStdlibAnswer proves nav-08's oracle passes when the
+// agent enumerated the imports across BOTH .go files and named the stdlib ones
+// (fmt from main.go, testing from main_test.go): the answer states the only
+// imports are stdlib so there are 0 third-party, with "count: 0" on its own
+// line. The fmt+testing requirement is the inspection-proof — it forces the
+// agent to have read all the files rather than blindly emitting "count: 0".
+func TestNav08CountOracleAcceptsStdlibAnswer(t *testing.T) {
+	task := loadBaselineTask(t, "nav-08")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"The only imports are fmt (main.go) and testing (main_test.go), both standard library, so there are no third-party imports.\ncount: 0"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("correct nav-08 answer should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("nav-08 oracle must pass when the answer names fmt+testing and states count: 0: %+v", outcome)
+	}
+}
+
+// TestNav08CountOracleRejectsAnswerWithoutFmt proves the inspection-proof bites:
+// an answer that states the right count (0) but never names the stdlib imports it
+// examined ("No third-party imports. count: 0") fails, so an agent that didn't
+// actually look at the imports can't pass by guessing the count alone.
+func TestNav08CountOracleRejectsAnswerWithoutFmt(t *testing.T) {
+	task := loadBaselineTask(t, "nav-08")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"No third-party imports.\ncount: 0"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-08 no-fmt", outcome)
+}
+
+// TestNav08CountOracleRejectsFmtOnlyNoTesting proves the tighter inspection-proof:
+// an answer that names fmt (from main.go) but misses testing (from main_test.go)
+// fails, so an agent that only read main.go — or a guesser that names the one
+// most-common stdlib import blind — can't pass. The agent must enumerate every
+// file's imports, which is what the prompt asks for.
+func TestNav08CountOracleRejectsFmtOnlyNoTesting(t *testing.T) {
+	task := loadBaselineTask(t, "nav-08")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"The only import is fmt, which is standard library. count: 0"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-08 fmt-only-no-testing", outcome)
 }

--- a/internal/perfbench/turn_bench_test.go
+++ b/internal/perfbench/turn_bench_test.go
@@ -436,16 +436,26 @@ func TestCopyFixtureIsolatesSourceFromMutation(t *testing.T) {
 		t.Fatalf("read source main.go: %v", err)
 	}
 
-	copyDir, err := copyFixture(src)
+	copyDir, parent, err := copyFixture(src)
 	if err != nil {
 		t.Fatalf("copyFixture: %v", err)
 	}
-	defer os.RemoveAll(copyDir)
+	defer os.RemoveAll(parent) // cleans copyDir too, since copyDir lives under parent
 
 	// The copy must be a real copy, not a symlink/alias of the source, and
 	// mutating it must not touch the source.
 	if copyDir == src {
 		t.Fatalf("copyFixture returned the source dir, not a copy: %s", copyDir)
+	}
+	// The copy must be a grandchild of the system temp root (parent is a direct
+	// child of Temp, copyDir is a direct child of parent). Go ignores go.mod in
+	// direct children of Temp (a hijack guard), so this nesting is what lets the
+	// compiler-backed oracles actually run in the copy.
+	if filepath.Dir(parent) != os.TempDir() {
+		t.Fatalf("parent %q is not a direct child of temp root %q", parent, os.TempDir())
+	}
+	if filepath.Dir(copyDir) != parent {
+		t.Fatalf("copyDir %q is not nested under parent %q", copyDir, parent)
 	}
 	if err := os.WriteFile(filepath.Join(copyDir, "main.go"), []byte("package main\n\n// mutated\nfunc main() {}\n"), 0o644); err != nil {
 		t.Fatalf("mutate copy: %v", err)
@@ -591,6 +601,27 @@ func runTurnStub(t *testing.T, task BenchTask, stubBody string) TurnTaskOutcome 
 	return NewTurnExecRunner(stub)(context.Background(), task, RunContext{Model: "fake-model"})
 }
 
+// assertVerifyFailed asserts an outcome failed specifically because the oracle
+// rejected the work — Passed is false, there is no harness error (Err nil), and
+// VerifyErr carries the surfaced failure detail. This is stronger than merely
+// checking Passed=false: it distinguishes a genuine oracle rejection from a
+// harness error (Err set) or a silent non-pass (Passed=false with no VerifyErr,
+// which would mean the failure never went through verification at all). The
+// gating stubs all emit a clean run_end (exitCode 0), so a non-empty VerifyErr
+// here can only come from the verification command failing.
+func assertVerifyFailed(t *testing.T, label string, outcome TurnTaskOutcome) {
+	t.Helper()
+	if outcome.Err != nil {
+		t.Fatalf("%s: want a verify fail, got harness error: %v", label, outcome.Err)
+	}
+	if outcome.Passed {
+		t.Fatalf("%s: want verify fail, got Passed=true", label)
+	}
+	if strings.TrimSpace(outcome.VerifyErr) == "" {
+		t.Fatalf("%s: want verify fail, but VerifyErr is empty (failure did not come from verification): %+v", label, outcome)
+	}
+}
+
 // --- Gating tests: the oracle FAILS the wrong thing (no-op / wrong answer) ---
 
 // TestStampedOracleRejectsNoOpRefactor is the core #701 fix: refactor used to
@@ -602,12 +633,7 @@ func TestStampedOracleRejectsNoOpRefactor(t *testing.T) {
 	task := loadBaselineTask(t, "refactor-01")
 	outcome := runTurnStub(t, task, `echo '{"type":"run_end","exitCode":0}'
 `)
-	if outcome.Err != nil {
-		t.Fatalf("no-op refactor is a verify fail, not a harness error: %v", outcome.Err)
-	}
-	if outcome.Passed {
-		t.Fatal("no-op refactor must fail the stamped oracle (formatGreeting undefined), got Passed=true")
-	}
+	assertVerifyFailed(t, "no-op refactor", outcome)
 }
 
 // TestStampedOracleRejectsMissingField proves edit-03's oracle is structural: a
@@ -617,12 +643,7 @@ func TestStampedOracleRejectsMissingField(t *testing.T) {
 	task := loadBaselineTask(t, "edit-03")
 	outcome := runTurnStub(t, task, `echo '{"type":"run_end","exitCode":0}'
 `)
-	if outcome.Err != nil {
-		t.Fatalf("missing-field is a verify fail, not a harness error: %v", outcome.Err)
-	}
-	if outcome.Passed {
-		t.Fatal("no-op edit-03 (no Label field) must fail the stamped oracle, got Passed=true")
-	}
+	assertVerifyFailed(t, "missing-field edit-03", outcome)
 }
 
 // TestNavAnswerOracleRejectsWrongAnswer proves the nav oracle greps the CAPTURED
@@ -634,12 +655,7 @@ func TestNavAnswerOracleRejectsWrongAnswer(t *testing.T) {
 	outcome := runTurnStub(t, task, `echo '{"type":"final","text":"the keys are foo and bar"}'
 echo '{"type":"run_end","exitCode":0}'
 `)
-	if outcome.Err != nil {
-		t.Fatalf("wrong nav answer is a verify fail, not a harness error: %v", outcome.Err)
-	}
-	if outcome.Passed {
-		t.Fatal("nav-09 oracle must reject an answer missing port/name/retries, got Passed=true")
-	}
+	assertVerifyFailed(t, "wrong nav-09 answer", outcome)
 }
 
 // TestNavNoFinalTextFails proves a run that produced no answer fails nav: with
@@ -648,12 +664,7 @@ func TestNavNoFinalTextFails(t *testing.T) {
 	task := loadBaselineTask(t, "nav-09")
 	outcome := runTurnStub(t, task, `echo '{"type":"run_end","exitCode":0}'
 `)
-	if outcome.Err != nil {
-		t.Fatalf("missing final is a verify fail, not a harness error: %v", outcome.Err)
-	}
-	if outcome.Passed {
-		t.Fatal("nav oracle with no captured answer must fail, got Passed=true")
-	}
+	assertVerifyFailed(t, "nav-09 no final", outcome)
 }
 
 // TestEdit05RejectsRewordedDebugPrint proves edit-05's oracle catches a reword,
@@ -666,12 +677,7 @@ func TestEdit05RejectsRewordedDebugPrint(t *testing.T) {
 	outcome := runTurnStub(t, task, `sed 's/debug: starting/starting up/' main.go > .zero-tmp && mv .zero-tmp main.go
 echo '{"type":"run_end","exitCode":0}'
 `)
-	if outcome.Err != nil {
-		t.Fatalf("reworded debug print is a verify fail, not a harness error: %v", outcome.Err)
-	}
-	if outcome.Passed {
-		t.Fatal("edit-05 oracle must reject a reworded (not removed) debug print, got Passed=true")
-	}
+	assertVerifyFailed(t, "reworded edit-05 debug print", outcome)
 }
 
 // TestEdit01IgnoresDocComment proves edit-01's scoped negative grep does NOT
@@ -748,5 +754,105 @@ echo '{"type":"run_end","exitCode":0}'
 	}
 	if !outcome.Passed {
 		t.Fatalf("nav-09 oracle must pass when the answer names port/name/retries: %+v", outcome)
+	}
+}
+
+// TestStampOracleRejectsFixturelessOracleTask covers the fail-closed path in
+// stampOracleAndAnswer: a task that carries an oracle (a stamped OracleTest or a
+// verification command) but has no workspace fixture has nowhere safe to stamp,
+// so it must error rather than let runVerification run in the caller's cwd with
+// the oracle never compiled (or the answer never captured). A fixtureless task
+// with no oracle and no verification (a pure latency-only run in the caller's
+// cwd) is left alone. This is a direct unit test (no stub), so it runs on all
+// platforms.
+func TestStampOracleRejectsFixturelessOracleTask(t *testing.T) {
+	// OracleTest set, no verificationCommand: isolates the `OracleTest != ""`
+	// reject branch so a regression that only checked VerificationCommand would
+	// fail here (the both-set case below would still pass it).
+	withOracleTest := BenchTask{
+		ID:         "t",
+		OracleTest: "package x\n\nvar _ = Missing\n",
+	}
+	if err := stampOracleAndAnswer(withOracleTest, nil); err == nil {
+		t.Fatal("fixtureless task with an OracleTest must be rejected, got nil error")
+	}
+	// verificationCommand set, no OracleTest: isolates the other reject branch.
+	withVerify := BenchTask{
+		ID:                  "t",
+		VerificationCommand: []string{"bash", "-c", "grep x .zero-answer.txt"},
+	}
+	if err := stampOracleAndAnswer(withVerify, nil); err == nil {
+		t.Fatal("fixtureless task with a verificationCommand must be rejected, got nil error")
+	}
+	// Both set: the `||` rejects, and this guards against a regression that
+	// inverted the logic to `&&`.
+	withBoth := BenchTask{
+		ID:                  "t",
+		OracleTest:          "package x\n\nvar _ = Missing\n",
+		VerificationCommand: []string{"go", "test", "./..."},
+	}
+	if err := stampOracleAndAnswer(withBoth, nil); err == nil {
+		t.Fatal("fixtureless task with both an OracleTest and a verificationCommand must be rejected, got nil error")
+	}
+	latencyOnly := BenchTask{ID: "t"}
+	if err := stampOracleAndAnswer(latencyOnly, nil); err != nil {
+		t.Fatalf("fixtureless latency-only task must not be rejected, got: %v", err)
+	}
+}
+
+// --- Count-oracle tests: anchored `^count: N$` with the exact expected count ---
+
+// TestNav01CountOracleAcceptsExactCount proves nav-01's anchored count oracle
+// passes when the answer names the files AND states the exact count (4) on its
+// own line. printf emits the JSON with a literal \n escape so the captured
+// answer has "count: 4" on its own line.
+func TestNav01CountOracleAcceptsExactCount(t *testing.T) {
+	task := loadBaselineTask(t, "nav-01")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"main.go, config.json, go.mod, README.md\ncount: 4"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("correct nav-01 answer should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("nav-01 oracle must pass when the answer names the files and states count: 4: %+v", outcome)
+	}
+}
+
+// TestNav01CountOracleRejectsWrongCount proves the anchored count oracle rejects
+// a wrong count: the file names are all present, but "count: 3" does not match
+// `^count: 4$`, so the task fails at verification.
+func TestNav01CountOracleRejectsWrongCount(t *testing.T) {
+	task := loadBaselineTask(t, "nav-01")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"main.go, config.json, go.mod, README.md\ncount: 3"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-01 wrong count", outcome)
+}
+
+// TestNav04CountOracleRejectsSubstring proves the line anchor rejects a
+// substring: "the count: 0 is the number" contains "count: 0" but the line does
+// not start with "count:", so `^count:[[:space:]]*0$` does not match. A
+// pre-anchor oracle (`count:\s*0`) would have rubber-stamped this.
+func TestNav04CountOracleRejectsSubstring(t *testing.T) {
+	task := loadBaselineTask(t, "nav-04")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"the count: 0 is the number of test functions"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-04 substring count", outcome)
+}
+
+// TestNav04CountOracleAcceptsExactCount proves the anchored count oracle passes
+// when "count: 0" stands on its own line.
+func TestNav04CountOracleAcceptsExactCount(t *testing.T) {
+	task := loadBaselineTask(t, "nav-04")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"There are no test functions.\ncount: 0"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("correct nav-04 answer should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("nav-04 oracle must pass when the answer states count: 0 on its own line: %+v", outcome)
 	}
 }

--- a/internal/perfbench/turn_bench_test.go
+++ b/internal/perfbench/turn_bench_test.go
@@ -450,9 +450,13 @@ func TestCopyFixtureIsolatesSourceFromMutation(t *testing.T) {
 	// The copy must be a grandchild of the system temp root (parent is a direct
 	// child of Temp, copyDir is a direct child of parent). Go ignores go.mod in
 	// direct children of Temp (a hijack guard), so this nesting is what lets the
-	// compiler-backed oracles actually run in the copy.
-	if filepath.Dir(parent) != os.TempDir() {
-		t.Fatalf("parent %q is not a direct child of temp root %q", parent, os.TempDir())
+	// compiler-backed oracles actually run in the copy. Compare via filepath.Clean
+	// because os.TempDir() may carry a trailing slash (macOS $TMPDIR ends in
+	// "/T/") while filepath.Dir strips it; the raw != would false-fail on macOS
+	// even though the parent is genuinely a direct child.
+	tempRoot := filepath.Clean(os.TempDir())
+	if filepath.Dir(parent) != tempRoot {
+		t.Fatalf("parent %q is not a direct child of temp root %q", parent, tempRoot)
 	}
 	if filepath.Dir(copyDir) != parent {
 		t.Fatalf("copyDir %q is not nested under parent %q", copyDir, parent)

--- a/internal/perfbench/turn_bench_test.go
+++ b/internal/perfbench/turn_bench_test.go
@@ -628,7 +628,7 @@ func assertVerifyFailed(t *testing.T, label string, outcome TurnTaskOutcome) {
 
 // --- Gating tests: the oracle FAILS the wrong thing (no-op / wrong answer) ---
 
-// TestStampedOracleRejectsNoOpRefactor is the core #701 fix: refactor used to
+// TestStampedOracleRejectsNoOpRefactor is the core #712 fix: refactor used to
 // live in the build tier where a no-op `go build ./...` passed. Now a no-op
 // agent (the stub emits a clean run_end but touches nothing) leaves the fixture
 // with no formatGreeting helper, so the stamped `var _ = formatGreeting` fails
@@ -926,10 +926,11 @@ printf '%s\n' '{"type":"run_end","exitCode":0}'
 	assertVerifyFailed(t, "nav-04 substring count", outcome)
 }
 
-// TestNav04CountOracleAcceptsExactCount proves the anchored count oracle passes
-// when "count: 1" stands on its own line. The fixture's main_test.go defines
-// exactly one Test* function (TestGreet), so the ground truth is 1, not 0 — a
-// guesser that always emits "count: 0" fails (see RejectsZeroGuess).
+// TestNav04CountOracleAcceptsExactCount proves the nav-04 oracle passes for a
+// real answer: the count is anchored on its own line AND the answer names the
+// one Test* function (TestGreet, from main_test.go). The fixture's ground truth
+// is exactly one test function, so count: 1 is right, and naming TestGreet is
+// the inspection-proof that the agent actually read main_test.go.
 func TestNav04CountOracleAcceptsExactCount(t *testing.T) {
 	task := loadBaselineTask(t, "nav-04")
 	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"There is one test function: TestGreet in main_test.go.\ncount: 1"}'
@@ -939,15 +940,14 @@ printf '%s\n' '{"type":"run_end","exitCode":0}'
 		t.Fatalf("correct nav-04 answer should pass, got harness error: %v", outcome.Err)
 	}
 	if !outcome.Passed {
-		t.Fatalf("nav-04 oracle must pass when the answer states count: 1 on its own line: %+v", outcome)
+		t.Fatalf("nav-04 oracle must pass when the answer names TestGreet and states count: 1 on its own line: %+v", outcome)
 	}
 }
 
-// TestNav04CountOracleRejectsZeroGuess is the gameability gate: an agent that
-// never opens the workspace and always emits "count: 0" used to pass nav-04
+// TestNav04CountOracleRejectsZeroGuess is the count=0 gameability gate: an agent
+// that never opens the workspace and always emits "count: 0" used to pass nav-04
 // when the ground truth was 0. The fixture now has one real Test* function, so
-// the ground truth is 1 and a clean "count: 0" fails — proving the count=0
-// rubber-stamp is closed.
+// the ground truth is 1 and a clean "count: 0" fails.
 func TestNav04CountOracleRejectsZeroGuess(t *testing.T) {
 	task := loadBaselineTask(t, "nav-04")
 	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"count: 0"}'
@@ -956,9 +956,23 @@ printf '%s\n' '{"type":"run_end","exitCode":0}'
 	assertVerifyFailed(t, "nav-04 zero-guess", outcome)
 }
 
-// TestNav05CountOracleAcceptsExactCount proves nav-05's anchored count oracle
-// passes for the real ground truth: the fixture has exactly one TODO (in
-// main.go), so "count: 1" on its own line passes.
+// TestNav04CountOracleRejectsBlindCountOne is the count=1 gameability gate: once
+// the ground truth became 1, an agent that never opens the workspace and always
+// emits "count: 1" would pass a count-only oracle. nav-04's oracle also requires
+// the answer to name the test function (TestGreet), so a bare "count: 1" with no
+// named fact fails — proving the blind-count-one surface is closed.
+func TestNav04CountOracleRejectsBlindCountOne(t *testing.T) {
+	task := loadBaselineTask(t, "nav-04")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"count: 1"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-04 blind-count-one", outcome)
+}
+
+// TestNav05CountOracleAcceptsExactCount proves nav-05's oracle passes for a real
+// answer: the count is anchored on its own line AND the answer names the file
+// holding the one TODO (main.go). Naming main.go is the inspection-proof that the
+// agent actually located the TODO rather than guessing the count.
 func TestNav05CountOracleAcceptsExactCount(t *testing.T) {
 	task := loadBaselineTask(t, "nav-05")
 	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"One TODO in main.go.\ncount: 1"}'
@@ -968,11 +982,11 @@ printf '%s\n' '{"type":"run_end","exitCode":0}'
 		t.Fatalf("correct nav-05 answer should pass, got harness error: %v", outcome.Err)
 	}
 	if !outcome.Passed {
-		t.Fatalf("nav-05 oracle must pass when the answer states count: 1: %+v", outcome)
+		t.Fatalf("nav-05 oracle must pass when the answer names main.go and states count: 1: %+v", outcome)
 	}
 }
 
-// TestNav05CountOracleRejectsZeroGuess is nav-05's gameability gate: the
+// TestNav05CountOracleRejectsZeroGuess is nav-05's count=0 gameability gate: the
 // fixture now has one real TODO, so a clean "count: 0" (the always-guess-zero
 // answer) fails.
 func TestNav05CountOracleRejectsZeroGuess(t *testing.T) {
@@ -981,6 +995,33 @@ func TestNav05CountOracleRejectsZeroGuess(t *testing.T) {
 printf '%s\n' '{"type":"run_end","exitCode":0}'
 `)
 	assertVerifyFailed(t, "nav-05 zero-guess", outcome)
+}
+
+// TestNav05CountOracleRejectsBlindCountOne is nav-05's count=1 gameability gate:
+// once the ground truth became 1, an agent that never opens the workspace and
+// always emits "count: 1" would pass a count-only oracle. nav-05's oracle also
+// requires the answer to name the file (main.go), so a bare "count: 1" with no
+// named file fails — proving the blind-count-one surface is closed.
+func TestNav05CountOracleRejectsBlindCountOne(t *testing.T) {
+	task := loadBaselineTask(t, "nav-05")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"count: 1"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-05 blind-count-one", outcome)
+}
+
+// TestNav05CountOracleRejectsSubstring proves the line anchor still bites even
+// when the named fact is present: "the count: 1 is the number of TODOs in
+// main.go" names main.go and contains "count: 1" (the right value), but the
+// count does not stand on its own line, so `^count:[[:space:]]*1$` does not
+// match and the oracle fails. A pre-anchor oracle (`count:\s*1`) would have
+// rubber-stamped this. Mirrors TestNav04CountOracleRejectsSubstring.
+func TestNav05CountOracleRejectsSubstring(t *testing.T) {
+	task := loadBaselineTask(t, "nav-05")
+	outcome := runTurnStub(t, task, `printf '%s\n' '{"type":"final","text":"the count: 1 is the number of TODOs in main.go"}'
+printf '%s\n' '{"type":"run_end","exitCode":0}'
+`)
+	assertVerifyFailed(t, "nav-05 substring count", outcome)
 }
 
 // TestNav08CountOracleAcceptsStdlibAnswer proves nav-08's oracle passes when the

--- a/internal/perfbench/turn_bench_test.go
+++ b/internal/perfbench/turn_bench_test.go
@@ -51,21 +51,26 @@ func cannedTrace(genMs, toolMs int, tokens int64) *trace.TurnTrace {
 }
 
 func TestRunTurnBenchAggregation(t *testing.T) {
+	// v3 tier model: nav and refactor both carry a verificationCommand and are
+	// NOT in buildOnlyClasses, so they count as correctness; longproc has no
+	// oracle and is latency-only. The build tier is empty (buildOnlyClasses is
+	// nil), matching the v3 baseline manifest where refactor graduated from
+	// build to correctness.
 	set := TaskSet{
 		ID: "fake-suite",
 		Tasks: []BenchTask{
-			{ID: "t1", Class: "nav", Prompt: "p1"},                                             // latency-only
-			{ID: "t2", Class: "nav", Prompt: "p2"},                                             // latency-only
-			{ID: "t3", Class: "edit", Prompt: "p3", VerificationCommand: []string{"true"}},     // correctness
-			{ID: "t4", Class: "refactor", Prompt: "p4", VerificationCommand: []string{"true"}}, // build-only
+			{ID: "t1", Class: "nav", Prompt: "p1", VerificationCommand: []string{"true"}},      // correctness
+			{ID: "t2", Class: "edit", Prompt: "p2", VerificationCommand: []string{"true"}},     // correctness
+			{ID: "t3", Class: "refactor", Prompt: "p3", VerificationCommand: []string{"true"}}, // correctness
+			{ID: "t4", Class: "longproc", Prompt: "p4"},                                        // latency-only
 		},
-		BuildOnlyClasses: []string{"refactor"},
+		BuildOnlyClasses: nil,
 	}
 	canned := map[string]*trace.TurnTrace{
 		"t1": cannedTrace(100, 10, 1000),
-		"t2": cannedTrace(300, 10, 1000),
-		"t3": cannedTrace(200, 50, 2000),
-		"t4": cannedTrace(150, 20, 1500),
+		"t2": cannedTrace(200, 50, 2000),
+		"t3": cannedTrace(150, 20, 1500),
+		"t4": cannedTrace(300, 10, 1000),
 	}
 	cfg := TurnBenchConfig{
 		Model:      "fake-model",
@@ -77,33 +82,36 @@ func TestRunTurnBenchAggregation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunTurnBench: %v", err)
 	}
-	// 4 tasks attempted; the tier split is 2 latency-only, 1 correctness, 1 build.
+	// 4 tasks attempted; the v3 tier split is 3 correctness (nav, edit, refactor),
+	// 1 latency-only (longproc), and 0 build (the build tier is empty).
 	if result.TasksAttempted != 4 {
 		t.Fatalf("attempted=%d, want 4", result.TasksAttempted)
 	}
-	if result.TasksVerified != 1 || result.TasksPassed != 1 {
-		t.Fatalf("correctness verified=%d passed=%d, want 1/1", result.TasksVerified, result.TasksPassed)
+	if result.TasksVerified != 3 || result.TasksPassed != 3 {
+		t.Fatalf("correctness verified=%d passed=%d, want 3/3", result.TasksVerified, result.TasksPassed)
 	}
-	if result.LatencyOnlyTasks != 2 {
-		t.Fatalf("latencyOnly=%d, want 2", result.LatencyOnlyTasks)
+	if result.LatencyOnlyTasks != 1 {
+		t.Fatalf("latencyOnly=%d, want 1", result.LatencyOnlyTasks)
 	}
-	if result.BuildCheckedTasks != 1 || result.BuildPassedTasks != 1 {
-		t.Fatalf("build checked=%d passed=%d, want 1/1", result.BuildCheckedTasks, result.BuildPassedTasks)
+	if result.BuildCheckedTasks != 0 || result.BuildPassedTasks != 0 {
+		t.Fatalf("build checked=%d passed=%d, want 0/0 (empty build tier)", result.BuildCheckedTasks, result.BuildPassedTasks)
 	}
 	if result.CorrectnessPassRate != 1.0 {
 		t.Fatalf("correctnessPassRate=%v, want 1.0", result.CorrectnessPassRate)
 	}
-	if result.BuildPassRate != 1.0 {
-		t.Fatalf("buildPassRate=%v, want 1.0", result.BuildPassRate)
+	// passRate returns 0 for a 0/0 denominator, so an empty build tier reports 0
+	// (not NaN) and cannot be misread as a perfect build score.
+	if result.BuildPassRate != 0 {
+		t.Fatalf("buildPassRate=%v, want 0 (empty build tier is 0/0 -> 0)", result.BuildPassRate)
 	}
-	if len(result.CorrectnessClasses) != 1 || result.CorrectnessClasses[0] != "edit" {
-		t.Fatalf("correctnessClasses=%v, want [edit]", result.CorrectnessClasses)
+	if len(result.CorrectnessClasses) != 3 || result.CorrectnessClasses[0] != "edit" || result.CorrectnessClasses[1] != "nav" || result.CorrectnessClasses[2] != "refactor" {
+		t.Fatalf("correctnessClasses=%v, want [edit nav refactor]", result.CorrectnessClasses)
 	}
-	if len(result.BuildOnlyClasses) != 1 || result.BuildOnlyClasses[0] != "refactor" {
-		t.Fatalf("buildOnlyClasses=%v, want [refactor]", result.BuildOnlyClasses)
+	if len(result.BuildOnlyClasses) != 0 {
+		t.Fatalf("buildOnlyClasses=%v, want empty (v3: build tier empty)", result.BuildOnlyClasses)
 	}
-	if len(result.LatencyOnlyClasses) != 1 || result.LatencyOnlyClasses[0] != "nav" {
-		t.Fatalf("latencyOnlyClasses=%v, want [nav]", result.LatencyOnlyClasses)
+	if len(result.LatencyOnlyClasses) != 1 || result.LatencyOnlyClasses[0] != "longproc" {
+		t.Fatalf("latencyOnlyClasses=%v, want [longproc]", result.LatencyOnlyClasses)
 	}
 	if result.SchemaVersion != TurnSchemaVersion {
 		t.Fatalf("schemaVersion = %d, want %d", result.SchemaVersion, TurnSchemaVersion)
@@ -112,8 +120,8 @@ func TestRunTurnBenchAggregation(t *testing.T) {
 		t.Fatalf("date = %q", result.Date)
 	}
 
-	// Per-span: generation appears in all four (100+300+200+150=750ms), tool in
-	// all four (10+10+50+20=90ms). Count must equal the number of tasks * iterations.
+	// Per-span: generation appears in all four (100+200+150+300=750ms), tool in
+	// all four (10+50+20+10=90ms). Count must equal the number of tasks * iterations.
 	gen := result.PerSpan[trace.SpanGeneration]
 	if gen.Count != 4 {
 		t.Fatalf("generation count = %d, want 4", gen.Count)
@@ -135,7 +143,7 @@ func TestRunTurnBenchAggregation(t *testing.T) {
 		t.Fatalf("top latency not ranked by share: %+v", result.TopLatency)
 	}
 
-	// Totals: 4 model requests, 4 tool calls, input tokens 1000+1000+2000+1500=5500.
+	// Totals: 4 model requests, 4 tool calls, input tokens 1000+2000+1500+1000=5500.
 	if result.Totals.ModelRequests != 4 {
 		t.Fatalf("modelRequests = %d, want 4", result.Totals.ModelRequests)
 	}
@@ -149,10 +157,10 @@ func TestRunTurnBenchAggregation(t *testing.T) {
 		t.Fatalf("outputTokens = %d, want 2750", result.Totals.OutputTokens)
 	}
 
-	// Per-class tier roll-up: nav is latency-only (0 verified, 2 latency-only),
-	// edit is correctness (1/1 verified passed), refactor is build (1/1 passed).
+	// Per-class tier roll-up: nav/edit/refactor are correctness (1/1 verified
+	// passed, 0 latency-only); longproc is latency-only (0 verified, 1 latency).
 	nav := result.PerClass["nav"]
-	if nav.Tasks != 2 || nav.Verified != 0 || nav.Passed != 0 || nav.LatencyOnly != 2 {
+	if nav.Tasks != 1 || nav.Verified != 1 || nav.Passed != 1 || nav.LatencyOnly != 0 {
 		t.Fatalf("nav class = %+v", nav)
 	}
 	edit := result.PerClass["edit"]
@@ -162,6 +170,10 @@ func TestRunTurnBenchAggregation(t *testing.T) {
 	refactor := result.PerClass["refactor"]
 	if refactor.Tasks != 1 || refactor.Verified != 1 || refactor.Passed != 1 || refactor.LatencyOnly != 0 {
 		t.Fatalf("refactor class = %+v", refactor)
+	}
+	longproc := result.PerClass["longproc"]
+	if longproc.Tasks != 1 || longproc.Verified != 0 || longproc.Passed != 0 || longproc.LatencyOnly != 1 {
+		t.Fatalf("longproc class = %+v", longproc)
 	}
 }
 
@@ -451,5 +463,290 @@ func TestCopyFixtureIsolatesSourceFromMutation(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(src, "new.go")); !os.IsNotExist(err) {
 		t.Fatalf("file added to copy appeared in source: %v", err)
+	}
+}
+
+// TestRunTurnBenchBuildOnlyMechanism exercises the build-only tier code path in
+// isolation. The v3 baseline manifest leaves this tier empty (refactor graduated
+// to correctness), but the mechanism is still supported for future use, so a
+// focused test keeps it covered: a class listed in buildOnlyClasses with a
+// verificationCommand counts in buildCheckedTasks/buildPassedTasks — never in
+// tasksVerified/correctnessPassRate — and a build-pass cannot leak into the
+// correctness number.
+func TestRunTurnBenchBuildOnlyMechanism(t *testing.T) {
+	set := TaskSet{
+		ID: "build-suite",
+		Tasks: []BenchTask{
+			{ID: "b1", Class: "buildcheck", Prompt: "p", VerificationCommand: []string{"true"}},
+		},
+		BuildOnlyClasses: []string{"buildcheck"},
+	}
+	canned := map[string]*trace.TurnTrace{"b1": cannedTrace(120, 30, 900)}
+	result, err := RunTurnBench(context.Background(), set, TurnBenchConfig{
+		Model:  "fake-model",
+		Runner: fakeTurnRunner(canned),
+		Now:    func() time.Time { return time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("RunTurnBench: %v", err)
+	}
+	if result.BuildCheckedTasks != 1 || result.BuildPassedTasks != 1 {
+		t.Fatalf("build checked=%d passed=%d, want 1/1", result.BuildCheckedTasks, result.BuildPassedTasks)
+	}
+	if result.BuildPassRate != 1.0 {
+		t.Fatalf("buildPassRate=%v, want 1.0", result.BuildPassRate)
+	}
+	// A build-only task must NOT count toward correctness.
+	if result.TasksVerified != 0 || result.TasksPassed != 0 {
+		t.Fatalf("build-only leaked into correctness: verified=%d passed=%d, want 0/0",
+			result.TasksVerified, result.TasksPassed)
+	}
+	if result.CorrectnessPassRate != 0 {
+		t.Fatalf("correctnessPassRate=%v, want 0 with only build-only tasks", result.CorrectnessPassRate)
+	}
+	if len(result.BuildOnlyClasses) != 1 || result.BuildOnlyClasses[0] != "buildcheck" {
+		t.Fatalf("buildOnlyClasses=%v, want [buildcheck]", result.BuildOnlyClasses)
+	}
+	if len(result.CorrectnessClasses) != 0 {
+		t.Fatalf("correctnessClasses=%v, want empty", result.CorrectnessClasses)
+	}
+	bc := result.PerClass["buildcheck"]
+	if bc.Tasks != 1 || bc.Verified != 1 || bc.Passed != 1 || bc.LatencyOnly != 0 {
+		t.Fatalf("buildcheck class = %+v, want 1/1 verified passed", bc)
+	}
+}
+
+// TestTurnSchemaVersion3 pins the schema bump. v3 records the tier
+// reclassification (refactor structural-positive and nav answer-oracles moved
+// into correctnessPassRate), so a v2->v3 cross-version comparison cannot
+// silently misread the jump as a model improvement — exactly the misread the
+// tier system exists to prevent.
+func TestTurnSchemaVersion3(t *testing.T) {
+	if TurnSchemaVersion != 3 {
+		t.Fatalf("TurnSchemaVersion = %d, want 3", TurnSchemaVersion)
+	}
+}
+
+// TestStreamJSONFinalTextExtractsAnswer, TestStreamJSONFinalTextEmptyWhenNoFinal,
+// and TestStreamJSONFinalTextLastWins cover the pure capture helper that the
+// nav answer-oracle depends on: it scans stream-json for the terminal "final"
+// event and returns its text, "" when none was emitted, and the last when
+// multiple appear (the success path emits exactly one, but the incomplete path
+// can also emit one, so last-wins matches streamJSONExitCode's tie-break).
+func TestStreamJSONFinalTextExtractsAnswer(t *testing.T) {
+	out := []byte(`{"type":"text","text":"thinking..."}
+{"type":"final","text":"the keys are port, name, and retries"}
+{"type":"run_end","exitCode":0}
+`)
+	if got := streamJSONFinalText(out); got != "the keys are port, name, and retries" {
+		t.Fatalf("streamJSONFinalText = %q, want the final text", got)
+	}
+}
+
+func TestStreamJSONFinalTextEmptyWhenNoFinal(t *testing.T) {
+	out := []byte(`{"type":"text","text":"hi"}
+{"type":"run_end","exitCode":0}
+`)
+	if got := streamJSONFinalText(out); got != "" {
+		t.Fatalf("streamJSONFinalText = %q, want empty when no final event", got)
+	}
+}
+
+func TestStreamJSONFinalTextLastWins(t *testing.T) {
+	out := []byte(`{"type":"final","text":"first"}
+{"type":"final","text":"second"}
+`)
+	if got := streamJSONFinalText(out); got != "second" {
+		t.Fatalf("streamJSONFinalText = %q, want second (last final wins)", got)
+	}
+}
+
+// loadBaselineTask returns the named task from the checked-in baseline manifest.
+// The stub-binary oracle tests below run the REAL manifest oracles against the
+// REAL fixtures through the REAL NewTurnExecRunner, so a manifest edit that
+// breaks an oracle is caught here rather than only in production.
+func loadBaselineTask(t *testing.T, id string) BenchTask {
+	t.Helper()
+	set, err := LoadTaskSet(filepath.Join("manifests", "baseline.json"))
+	if err != nil {
+		t.Fatalf("LoadTaskSet: %v", err)
+	}
+	for _, task := range set.Tasks {
+		if task.ID == id {
+			return task
+		}
+	}
+	t.Fatalf("manifest has no task %q", id)
+	return BenchTask{}
+}
+
+// runTurnStub runs one manifest task through the production NewTurnExecRunner
+// with a stub "zero" binary whose body is a POSIX sh script (writeExecStub
+// skips on Windows). The stub is invoked with cmd.Dir set to the fixture copy,
+// so it can both emit canned stream-json AND mutate the copy (apply or omit the
+// fix) before the runner stamps the oracle and runs the verification command.
+func runTurnStub(t *testing.T, task BenchTask, stubBody string) TurnTaskOutcome {
+	t.Helper()
+	stub := writeExecStub(t, stubBody)
+	return NewTurnExecRunner(stub)(context.Background(), task, RunContext{Model: "fake-model"})
+}
+
+// --- Gating tests: the oracle FAILS the wrong thing (no-op / wrong answer) ---
+
+// TestStampedOracleRejectsNoOpRefactor is the core #701 fix: refactor used to
+// live in the build tier where a no-op `go build ./...` passed. Now a no-op
+// agent (the stub emits a clean run_end but touches nothing) leaves the fixture
+// with no formatGreeting helper, so the stamped `var _ = formatGreeting` fails
+// to compile and `go test ./...` fails — the task is failed, not passed.
+func TestStampedOracleRejectsNoOpRefactor(t *testing.T) {
+	task := loadBaselineTask(t, "refactor-01")
+	outcome := runTurnStub(t, task, `echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("no-op refactor is a verify fail, not a harness error: %v", outcome.Err)
+	}
+	if outcome.Passed {
+		t.Fatal("no-op refactor must fail the stamped oracle (formatGreeting undefined), got Passed=true")
+	}
+}
+
+// TestStampedOracleRejectsMissingField proves edit-03's oracle is structural: a
+// no-op leaves Config with no Label field, so `var _ string = Config{}.Label`
+// fails to compile and the task fails.
+func TestStampedOracleRejectsMissingField(t *testing.T) {
+	task := loadBaselineTask(t, "edit-03")
+	outcome := runTurnStub(t, task, `echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("missing-field is a verify fail, not a harness error: %v", outcome.Err)
+	}
+	if outcome.Passed {
+		t.Fatal("no-op edit-03 (no Label field) must fail the stamped oracle, got Passed=true")
+	}
+}
+
+// TestNavAnswerOracleRejectsWrongAnswer proves the nav oracle greps the CAPTURED
+// answer, not the raw stream: the stub emits a final answer missing the
+// required keys, the harness writes it to .zero-answer.txt, and the compound
+// grep fails — so a plausible-but-wrong answer cannot pass nav-09.
+func TestNavAnswerOracleRejectsWrongAnswer(t *testing.T) {
+	task := loadBaselineTask(t, "nav-09")
+	outcome := runTurnStub(t, task, `echo '{"type":"final","text":"the keys are foo and bar"}'
+echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("wrong nav answer is a verify fail, not a harness error: %v", outcome.Err)
+	}
+	if outcome.Passed {
+		t.Fatal("nav-09 oracle must reject an answer missing port/name/retries, got Passed=true")
+	}
+}
+
+// TestNavNoFinalTextFails proves a run that produced no answer fails nav: with
+// no "final" event, .zero-answer.txt is empty and the grep finds nothing.
+func TestNavNoFinalTextFails(t *testing.T) {
+	task := loadBaselineTask(t, "nav-09")
+	outcome := runTurnStub(t, task, `echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("missing final is a verify fail, not a harness error: %v", outcome.Err)
+	}
+	if outcome.Passed {
+		t.Fatal("nav oracle with no captured answer must fail, got Passed=true")
+	}
+}
+
+// TestEdit05RejectsRewordedDebugPrint proves edit-05's oracle catches a reword,
+// not just a deletion: changing `fmt.Println("debug: starting")` to
+// `fmt.Println("starting up")` leaves a fmt.Println string-literal call, so the
+// stamped oracle's `strings.Contains(main.go, fmt.Println(")` check fails. A
+// plain `! grep 'debug: starting'` would have rubber-stamped this reword.
+func TestEdit05RejectsRewordedDebugPrint(t *testing.T) {
+	task := loadBaselineTask(t, "edit-05")
+	outcome := runTurnStub(t, task, `sed 's/debug: starting/starting up/' main.go > .zero-tmp && mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("reworded debug print is a verify fail, not a harness error: %v", outcome.Err)
+	}
+	if outcome.Passed {
+		t.Fatal("edit-05 oracle must reject a reworded (not removed) debug print, got Passed=true")
+	}
+}
+
+// TestEdit01IgnoresDocComment proves edit-01's scoped negative grep does NOT
+// false-fail a correct rename that leaves the doc comment mentioning the old
+// name. The stub renames the declaration (`MaxRetries =` -> `RetryLimit =`) but
+// leaves `// MaxRetries is the maximum...`; the scoped `! grep -RIn 'MaxRetries ='`
+// matches declaration sites only, so the comment is ignored, `var _ = RetryLimit`
+// compiles, and the task passes.
+func TestEdit01IgnoresDocComment(t *testing.T) {
+	task := loadBaselineTask(t, "edit-01")
+	outcome := runTurnStub(t, task, `sed 's/const MaxRetries = 3/const RetryLimit = 3/' main.go > .zero-tmp && mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("correct rename with kept doc comment should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("edit-01 oracle must not false-fail a correct rename that leaves the doc comment: %+v", outcome)
+	}
+}
+
+// --- Satisfiable tests: the oracle PASSES the right thing (real fix applied) ---
+
+// TestStampedOraclePassesWhenRefactorHappened proves the refactor-01 oracle is
+// not an always-fail gate: when the stub applies the real refactor (extract
+// formatGreeting, call it from both callers), `var _ = formatGreeting` compiles
+// and the `hello, %s` grep-count is 1 (only the helper holds the literal), so
+// the task passes.
+func TestStampedOraclePassesWhenRefactorHappened(t *testing.T) {
+	task := loadBaselineTask(t, "refactor-01")
+	outcome := runTurnStub(t, task, `sed -e 's/return fmt.Sprintf("hello, %s", c.Name)/return formatGreeting(c.Name)/' -e 's/return fmt.Sprintf("hello, %s", name)/return formatGreeting(name)/' main.go > .zero-tmp
+cat >> .zero-tmp <<'EOF'
+
+func formatGreeting(name string) string {
+return fmt.Sprintf("hello, %s", name)
+}
+EOF
+mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("real refactor should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("refactor-01 oracle must pass when formatGreeting is extracted: %+v", outcome)
+	}
+}
+
+// TestEdit03PassesWhenFieldAdded proves edit-03's oracle passes when the field
+// is actually added: Config gets a Label string field, so `var _ string =
+// Config{}.Label` compiles and the task passes.
+func TestEdit03PassesWhenFieldAdded(t *testing.T) {
+	task := loadBaselineTask(t, "edit-03")
+	outcome := runTurnStub(t, task, `awk '/Name string/ && !d {print; print "Label string"; d=1; next} {print}' main.go > .zero-tmp && mv .zero-tmp main.go
+echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("real field-add should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("edit-03 oracle must pass when Label is added: %+v", outcome)
+	}
+}
+
+// TestNav09PassesWithCorrectAnswer proves the nav-09 oracle passes when the
+// captured answer names all three config keys.
+func TestNav09PassesWithCorrectAnswer(t *testing.T) {
+	task := loadBaselineTask(t, "nav-09")
+	outcome := runTurnStub(t, task, `echo '{"type":"final","text":"config.json has three keys: port, name, and retries."}'
+echo '{"type":"run_end","exitCode":0}'
+`)
+	if outcome.Err != nil {
+		t.Fatalf("correct nav answer should pass, got harness error: %v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("nav-09 oracle must pass when the answer names port/name/retries: %+v", outcome)
 	}
 }


### PR DESCRIPTION
Phase 0 hardening for the turn benchmark: the baseline manifest's oracles were loose enough that a no-op or weak agent could read as a pass. This tightens them so each tier's pass rate means what it claims.

## What changed

**edit/refactor — structural oracles.** These now carry a stamped `oracle_test.go` that `go test ./...` compiles. The Go compiler is the verifier, so a no-op refactor, a missing field, or a reworded-but-not-removed line fails to compile/run instead of passing a substring grep. The test is stamped into the fixture copy *after* the agent run, so it can't interfere with the agent's own build or be pre-seen.

**nav — answer oracles.** The harness captures the agent's final answer (`.zero-answer.txt`) and greps it for determinable facts (e.g. nav-09 requires the answer to name `port`, `name`, `retries`). Count tasks (nav-04/05/08) ask for a structured `count: N` token so the oracle is tight rather than a loose prose-contains on "0". An empty answer (no `final` event) fails cleanly.

**Tier reclassification.** refactor graduates from build to correctness (its oracle is now positive); nav graduates from latency-only to correctness. The build tier is empty (`buildOnlyClasses: []`). longproc/longctx/parallel stay permanently latency-only — there's no deterministic oracle for "report whether the build succeeds" or "summarize a large file" — documented in MANIFEST.md.

New tier counts: **correctness 34** (edit 10 + fix 8 + nav 10 + refactor 6), **build 0**, **latency 14**. Total 48 unchanged.

**Schema bump 2 → 3.** The result shape is unchanged (only class-list membership shifts), but `correctnessPassRate` now means something strictly stronger, so the bump stops a v2→v2 cross-version comparison from misreading the jump as a model improvement.

## Prerequisite fix

The mutating fixtures had no `go.mod`, so `go test ./...` in the temp copy failed with "cannot find main module". Added `go.mod` per fixture (edit/fix/refactor/nav) and moved `copyFixture`'s temp dir one level below the system temp root — Go ignores `go.mod` in direct children of the temp dir (a hijack guard), which would have broken every compiler-backed oracle. This also fixes the pre-existing fix/refactor oracles, which were silently broken because the test suite used fake runners that never ran `go test`.

## Tests

Stub-binary gating tests prove each oracle fails the wrong thing (no-op refactor, missing field, wrong nav answer, reworded debug print) and passes the right thing (real refactor, added field, correct answer). One edit-01 test proves the scoped negative grep doesn't false-fail a correct rename that leaves the doc comment. Aggregation, schema, and unit tests cover the v3 tier model and the answer-capture helper.

`go build`, `go vet`, `gofmt -l`, and `go test -race ./internal/perfbench/...` are clean. The stub-binary tests skip on Windows (POSIX shell); they run on Linux CI.

Leaving for review / merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the baseline perf benchmark to 48 tasks with revised correctness vs. latency classification and updated tier counts.
  - Added v3 verification flow that stamps per-task compile/answer checks while keeping latency-only tasks unverified.
- **Bug Fixes**
  - Improved benchmark runner isolation/cleanup to prevent workspace cross-task interference.
  - Strengthened verification failure behavior when required final-answer signals are missing.
- **Documentation**
  - Refreshed the benchmark manifest with updated verification rules and known limitations.
- **Tests**
  - Expanded tests for answer extraction, oracle stamping behavior, gating cases, and updated testdata modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->