### PR TITLE
feat(tui): add Dune Dark theme and keep light Dune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,12 +235,12 @@ tagged. Until then, source builds report the version `dev`.
   GitHub issue/PR templates.
 - Interactive `/theme` picker: bare `/theme` opens a popup that live-previews each palette as you move
   and applies on select (Esc reverts).
-- Twelve built-in color themes alongside the `dark`/`light` built-ins — `dracula`, `nord`, `gruvbox`,
+- Thirteen built-in color themes alongside the `dark`/`light` built-ins — `dracula`, `nord`, `gruvbox`,
   `tokyo-night`, `catppuccin`, `one-dark`, `solarized-dark`, `rose-pine`, `everforest`,
-  `solarized-light`, `dune`, and `neon` — selectable via `/theme <name>`, `--theme <name>`, or
+  `solarized-light`, `dune`, `dune-dark`, and `neon` — selectable via `/theme <name>`, `--theme <name>`, or
   `ZERO_THEME`. Every palette is contrast-audited to WCAG AA, and the new presets are additionally
-  audited after xterm-256 downsampling; see [docs/THEMES.md](docs/THEMES.md). The built-in light
-  theme was reworked for legibility.
+  audited after xterm-256 downsampling (Dune Dark also after 16-color ANSI conversion); see
+  [docs/THEMES.md](docs/THEMES.md). The built-in light theme was reworked for legibility.
 - `--theme <name>` flag for the TUI, accepting `auto` or any registered theme (previously only the
   `ZERO_THEME` env var existed).
 - "Accessibility / Appearance" section in the README documenting `NO_COLOR`, `ZERO_THEME`, `/theme`,

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ manifest.
 | Control | Effect |
 |---|---|
 | `NO_COLOR=<anything>` | disables color output |
-| `ZERO_THEME=<name>` | selects the startup theme (`auto`, `dark`, `light`, or a color theme like `dracula`, `nord`, `gruvbox`, `tokyo-night`, `catppuccin`, `one-dark`, `solarized-dark`, `rose-pine`, `everforest`, `neon`, `solarized-light`, `dune`) |
+| `ZERO_THEME=<name>` | selects the startup theme (`auto`, `dark`, `light`, or a color theme like `dracula`, `nord`, `gruvbox`, `tokyo-night`, `catppuccin`, `one-dark`, `solarized-dark`, `rose-pine`, `everforest`, `neon`, `dune-dark`, `solarized-light`, `dune`) |
 | `--theme <name>` | selects the TUI theme from the CLI (same names) |
 | `/theme` | opens the theme picker inside the TUI (live preview; `/theme <name>` switches directly) |
 | `ZERO_NO_FADE=1` | disables streaming fade animation |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -234,7 +234,7 @@ zero update           检查更新版本
 | 控制 | 效果 |
 |---|---|
 | `NO_COLOR=<任意值>` | 禁用颜色输出 |
-| `ZERO_THEME=<名称>` | 选择启动主题（`auto`、`dark`、`light`，或颜色主题如 `dracula`、`nord`、`gruvbox`、`tokyo-night`、`catppuccin`、`one-dark`、`solarized-dark`、`rose-pine`、`everforest`、`neon`、`solarized-light`、`dune`） |
+| `ZERO_THEME=<名称>` | 选择启动主题（`auto`、`dark`、`light`，或颜色主题如 `dracula`、`nord`、`gruvbox`、`tokyo-night`、`catppuccin`、`one-dark`、`solarized-dark`、`rose-pine`、`everforest`、`neon`、`dune-dark`、`solarized-light`、`dune`） |
 | `--theme <名称>` | 从 CLI 选择 TUI 主题（相同名称） |
 | `/theme` | 在 TUI 中打开主题选择器（实时预览；`/theme <名称>` 直接切换） |
 | `ZERO_NO_FADE=1` | 禁用流式淡入动画 |

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -11,8 +11,9 @@ the active theme and the registered names without opening the picker.
 
 ## Dune (`dune`)
 
-A warm sand-and-cream palette: sand/cream surface, charcoal ink, and a soft
-amber accent.
+A dark, colorblind-safe palette matching Claude Code's daltonized dark mode:
+near-black surface, white ink, and a deuteranopia-adjusted brand-orange
+accent.
 
 ## Neon (`neon`)
 

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -16,7 +16,7 @@ quantization-safe diff bands.
 
 ## Dune Dark (`dune-dark`)
 
-A dark, colorblind-safe palette matching Claude Code's daltonized dark mode:
+A dark, colorblind-friendly palette inspired by Claude Code's daltonized dark palette:
 near-black surface, white ink, and a deuteranopia-adjusted brand-orange
 accent.
 

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -34,12 +34,14 @@ adding a new `palette{...}` literal, a `themeRegistry` entry, and test
 coverage for the new palette (see below).
 
 Registry-wide tests in `internal/tui/theme_select_test.go` assert the basic
-WCAG AA text tokens, the gray-ramp order, the diff word-span pairs, and the
-selected-row band for every entry. The rendered-surface invariants beyond
-those (permission surfaces, selected-row secondary text, diff gutters, and
-the xterm-256 downsampling checks) are asserted per palette, not against the
-whole registry: `TestExtendedThemeContrastInvariants` and
-`TestExtendedThemeANSI256Contrast` enumerate the palettes they cover. A new
-theme must be added to those tests (or given equivalent palette-specific
-assertions), or CI can stay green while its permission, selected-row, and
-diff surfaces ship unreadable.
+WCAG AA text tokens, the gray-ramp order, the selected-row band, and (via
+`TestDiffHighlightWordSpans`) the word-span *contrast* pairs for every
+entry. The remaining rendered-surface invariants (permission surfaces,
+selected-row secondary text, xterm-256 quantization, and the quantized
+add/del band *identity* check that `addBg`/`delBg` stay green/red and
+distinct) are asserted per palette, not against the whole registry:
+`TestExtendedThemeContrastInvariants` and `TestExtendedThemeANSI256Contrast`
+enumerate the palettes they cover. A new theme must be added to those
+tests (or given equivalent palette-specific assertions), or CI can stay
+green while its permission, selected-row, and quantized-diff surfaces
+ship unreadable.

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -11,6 +11,11 @@ the active theme and the registered names without opening the picker.
 
 ## Dune (`dune`)
 
+A warm sand-and-cream palette with charcoal ink, soft amber accent, and
+quantization-safe diff bands.
+
+## Dune Dark (`dune-dark`)
+
 A dark, colorblind-safe palette matching Claude Code's daltonized dark mode:
 near-black surface, white ink, and a deuteranopia-adjusted brand-orange
 accent.

--- a/internal/daemon/pool_test.go
+++ b/internal/daemon/pool_test.go
@@ -224,9 +224,7 @@ func TestPoolDrainKillsStraggler(t *testing.T) {
 		_, _ = pool.Run(context.Background(), WorkerSpec{Session: "a"}, &collectSink{})
 		close(runDone)
 	}()
-	// QueueDepth flips as soon as a slot is leased, before the worker is tracked
-	// in p.active; wait for the latter so Drain is guaranteed to see it.
-	waitFor(t, func() bool { return len(pool.WorkerStats()) == 1 })
+	waitFor(t, func() bool { return pool.QueueDepth() == 1 })
 
 	pool.Drain() // KillTimeout elapses, straggler is force-killed
 	if atomic.LoadInt32(&straggler.killed) != 1 {

--- a/internal/daemon/pool_test.go
+++ b/internal/daemon/pool_test.go
@@ -224,7 +224,9 @@ func TestPoolDrainKillsStraggler(t *testing.T) {
 		_, _ = pool.Run(context.Background(), WorkerSpec{Session: "a"}, &collectSink{})
 		close(runDone)
 	}()
-	waitFor(t, func() bool { return pool.QueueDepth() == 1 })
+	// QueueDepth flips as soon as a slot is leased, before the worker is tracked
+	// in p.active; wait for the latter so Drain is guaranteed to see it.
+	waitFor(t, func() bool { return len(pool.WorkerStats()) == 1 })
 
 	pool.Drain() // KillTimeout elapses, straggler is force-killed
 	if atomic.LoadInt32(&straggler.killed) != 1 {

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -448,9 +448,9 @@ var dunePalette = palette{
 	ink:       "#ececee",
 	muted:     "#ccccd2", // secondary text — bright gray, top of the ramp
 	faint:     "#b8b8c0", // hints/metadata
-	faintest:  "#a0a0a8", // line numbers/separators — bright enough to hold AA on the near-black selBg/addBg/delBg after xterm-256 quantization
+	faintest:  "#55c6cd", // line numbers/separators — a neutral gray at this brightness quantizes to xterm #005f00's near-neighbor at only 2.97:1 on the add-diff gutter; nudging toward cyan (still under the faint/faintest/panel ramp) keeps AA (4.62:1) once xterm-256 rounds it
 	accent:    "#ff9628", // brand/claude rgb(255,150,40), adjusted for deuteranopia
-	green:     "#3399ff", // success rgb(51,153,255) — blue under colorblind mode
+	green:     "#5eccfa", // success — brightened past Claude Code's rgb(51,153,255) so the add-diff sign text stays AA (4.80:1) against addBg once xterm-256 quantizes both to #5fd7ff/#005f00 (2.43:1 at the original value)
 	red:       "#ff6666", // error rgb(255,102,102)
 	amber:     "#ffcc00", // warning rgb(255,204,0)
 	blue:      "#99ccff", // permission rgb(153,204,255)
@@ -462,7 +462,7 @@ var dunePalette = palette{
 	delBgWord: "#740000", // word-level removed span — quantizes to xterm red #870000 (see addBgWord)
 	permBg:    "#1c1915",
 	selBg:     "#191c1f", // selection — near-black, distinct from panel, AA with faint/faintest
-	addInk:    "#bdeed7",
+	addInk:    "#f0f5d2", // changed-word text — lightened so it still clears AA (4.60:1) against addBgWord's xterm-256 quantized #008700 (the original #bdeed7 fell to 4.06:1)
 	delInk:    "#f2c4c4",
 	onAccent:  "#000000",
 	cardRun:   "#3399ff", // success blue

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -433,36 +433,41 @@ var solarizedLightPalette = palette{
 	cardPerm:  "#c4ae63",
 }
 
-// dunePalette is a warm sand-and-cream color scheme: sand/cream surface,
-// charcoal ink, and a soft amber accent.
+// dunePalette is a dark theme based on Claude Code's colorblind-friendly
+// (daltonized) dark mode. The base surface is near-black (Claude Code's true
+// dark canvas), with white ink and the brand-orange accent adjusted for
+// deuteranopia. Diff signals reuse the proven dark-theme structure so every
+// WCAG-AA invariant still holds; the accent and status colors (blue success,
+// red error, amber warning) follow Claude Code's daltonized palette so
+// additions stay distinguishable under color blindness.
 var dunePalette = palette{
-	panel:     "#f2e9d8",
-	promptBg:  "#e9dcbf",
-	line:      "#d9c7a3",
-	line2:     "#c2a97c",
-	ink:       "#2b241a",
-	muted:     "#473e32",
-	faint:     "#554a3a",
-	faintest:  "#655648",
-	accent:    "#724028", // darkened from #8f5215 for AA on selBg (5.46:1) that also survives ANSI-256 downsampling (quantizes to #444444, 6.47:1 on quantized selBg; the previous #7c4712 quantized to #875f00 at 3.81:1)
-	green:     "#38572a",
-	red:       "#872d24", // darkened from #963328 so delBg contrast survives ANSI-256 downsampling (true 6.57:1, 256 7.86:1)
-	amber:     "#6d4600",
-	blue:      "#2f5680", // darkened from #3d6a9e for AA on selBg (was 3.61:1, now 4.90:1)
-	gitAdd:    "#38572a",
-	gitDel:    "#963328",
-	addBg:     "#dcecd0",
-	delBg:     "#f5dbd5",
-	addBgWord: "#b9dc9e",
-	delBgWord: "#eebba9",
-	permBg:    "#f0dfae",
-	selBg:     "#e0cf98",
-	addInk:    "#264018",
-	delInk:    "#5c1810",
-	onAccent:  "#fdf6ea",
-	cardRun:   "#b08a4a",
-	cardErr:   "#b57560",
-	cardPerm:  "#c2a04a",
+	panel:     "#0e0e10", // Claude Code dark canvas — near-black
+	promptBg:  "#262626", // submitted user-prompt bubble
+	line:      "#242429", // borders/separators
+	line2:     "#414147",
+	ink:       "#ececee",
+	muted:     "#ccccd2", // secondary text — bright gray, top of the ramp
+	faint:     "#b8b8c0", // hints/metadata
+	faintest:  "#a0a0a8", // line numbers/separators — bright enough to hold AA on the near-black selBg/addBg/delBg after xterm-256 quantization
+	accent:    "#ff9628", // brand/claude rgb(255,150,40), adjusted for deuteranopia
+	green:     "#3399ff", // success rgb(51,153,255) — blue under colorblind mode
+	red:       "#ff6666", // error rgb(255,102,102)
+	amber:     "#ffcc00", // warning rgb(255,204,0)
+	blue:      "#99ccff", // permission rgb(153,204,255)
+	gitAdd:    "#7db87a",
+	gitDel:    "#b87a7a",
+	addBg:     "#0a1f14", // diff added band — near-black so faintest/green hold AA
+	delBg:     "#240a0e", // diff removed band — near-black so faintest/red hold AA
+	addBgWord: "#1f4d33", // word-level added span — distinct from addBg band
+	delBgWord: "#4d1620", // word-level removed span — distinct from delBg band
+	permBg:    "#1c1915",
+	selBg:     "#191c1f", // selection — near-black, distinct from panel, AA with faint/faintest
+	addInk:    "#bdeed7",
+	delInk:    "#f2c4c4",
+	onAccent:  "#000000",
+	cardRun:   "#3399ff", // success blue
+	cardErr:   "#ff6666", // error
+	cardPerm:  "#ffcc00", // warning
 }
 
 // themeEntry is one registered theme: Name is the /theme value + ZERO_THEME/--theme
@@ -491,9 +496,9 @@ var themeRegistry = []themeEntry{
 	{Name: "rose-pine", Label: "Rosé Pine", Palette: rosePinePalette, IsDark: true},
 	{Name: "everforest", Label: "Everforest", Palette: everforestPalette, IsDark: true},
 	{Name: "neon", Label: "Neon", Palette: neonPalette, IsDark: true},
+	{Name: "dune", Label: "Dune", Palette: dunePalette, IsDark: true},
 	{Name: "light", Label: "light", Palette: lightPalette, IsDark: false},
 	{Name: "solarized-light", Label: "Solarized Light", Palette: solarizedLightPalette, IsDark: false},
-	{Name: "dune", Label: "Dune", Palette: dunePalette, IsDark: false},
 }
 
 // themeByName indexes the registry by lowercased name for O(1) lookup. Built as a

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -461,7 +461,7 @@ var dunePalette = palette{
 	addBgWord: "#007400", // word-level added span — quantizes to xterm green #008700, distinct from both addBg's #005f00 and delBgWord's red
 	delBgWord: "#740000", // word-level removed span — quantizes to xterm red #870000 (see addBgWord)
 	permBg:    "#1c1915",
-	selBg:     "#191c1f", // selection — near-black, distinct from panel, AA with faint/faintest
+	selBg:     "#262626", // selection — dark gray, distinct from panel (>= 1.10 contrast after xterm-256 quantization), AA with faint/faintest
 	addInk:    "#f0f5d2", // changed-word text — lightened so it still clears AA (4.60:1) against addBgWord's xterm-256 quantized #008700 (the original #bdeed7 fell to 4.06:1)
 	delInk:    "#f2c4c4",
 	onAccent:  "#000000",

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -456,10 +456,10 @@ var dunePalette = palette{
 	blue:      "#99ccff", // permission rgb(153,204,255)
 	gitAdd:    "#7db87a",
 	gitDel:    "#b87a7a",
-	addBg:     "#0a1f14", // diff added band — near-black so faintest/green hold AA
-	delBg:     "#240a0e", // diff removed band — near-black so faintest/red hold AA
-	addBgWord: "#1f4d33", // word-level added span — distinct from addBg band
-	delBgWord: "#4d1620", // word-level removed span — distinct from delBg band
+	addBg:     "#003500", // diff added band — quantizes to xterm green #005f00 instead of the same gray as delBg, keeping add/del rows distinct on 256-color terminals (previous #0a1f14/#240a0e both collapsed to #121212)
+	delBg:     "#350000", // diff removed band — quantizes to xterm red #5f0000 (see addBg)
+	addBgWord: "#007400", // word-level added span — quantizes to xterm green #008700, distinct from both addBg's #005f00 and delBgWord's red
+	delBgWord: "#740000", // word-level removed span — quantizes to xterm red #870000 (see addBgWord)
 	permBg:    "#1c1915",
 	selBg:     "#191c1f", // selection — near-black, distinct from panel, AA with faint/faintest
 	addInk:    "#bdeed7",

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -485,9 +485,13 @@ var duneDarkPalette = palette{
 	line:      "#242429", // borders/separators
 	line2:     "#414147",
 	ink:       "#ececee",
-	muted:     "#ccccd2", // secondary text — bright gray, top of the ramp
-	faint:     "#b8b8c0", // hints/metadata
-	faintest:  "#55c6cd", // line numbers/separators — a neutral gray at this brightness quantizes to xterm #005f00's near-neighbor at only 2.97:1 on the add-diff gutter; nudging toward cyan (still under the faint/faintest/panel ramp) keeps AA (4.62:1) once xterm-256 rounds it. On 16-color (bright cyan on green) the ratio is ~4.10:1 — short of AA but the best cyan that still sits under faint in the ramp
+	// Gray ramp (ink > muted > faint > faintest > panel) is kept light enough
+	// that faintest maps to ANSI white / xterm #c6c6c6 and clears WCAG AA on the
+	// green add gutter under both 16-color and 256-color profiles. Prior cyan
+	// #55c6cd mapped to bright cyan at only 4.10:1 on ANSI green (short of AA).
+	muted:     "#e0e0e6", // secondary text
+	faint:     "#d4d4dc", // hints/metadata
+	faintest:  "#c8c8d0", // line numbers/separators (and diff gutters)
 	accent:    "#ff9628", // brand/claude rgb(255,150,40), adjusted for deuteranopia
 	green:     "#c8c8e9", // success — soft periwinkle (cool/daltonized). Maps to ANSI white so add-sign text stays AA (5.14:1) on the green add band under 16-color; saturated cyan/blue collapses to bright blue at 1.67:1
 	red:       "#ffc0c8", // error — soft pink. Maps to ANSI white so del-sign text stays AA (10.95:1) on the maroon del band under 16-color; bright red collapses to 2.74:1 on maroon

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -513,9 +513,17 @@ var duneDarkPalette = palette{
 	addInk:   "#f0f5d2", // changed-word text — lightened so it still clears AA (4.60:1) against addBgWord's xterm-256 quantized #008700 (the original #bdeed7 fell to 4.06:1); 16-color maps to bright yellow (4.78:1 on ANSI green)
 	delInk:   "#fff0f0", // changed-word text — near-white pink maps to ANSI white so word spans stay AA on maroon under 16-color (prior #f2c4c4 -> bright red at 2.74:1)
 	onAccent: "#000000",
-	cardRun:  "#3399ff", // success blue
-	cardErr:  "#ff6666", // error
-	cardPerm: "#ffcc00", // warning
+	// Status-card borders are non-text UI (WCAG 1.4.11: >=3:1 against panel).
+	// Prior cardRun #3399ff mapped to ANSI bright blue at only 2.44:1 on the
+	// black panel under 16-color. #cceeff (same as blue) maps to bright cyan
+	// and clears 3:1 in truecolor, xterm-256, and ANSI-16.
+	// cardPerm must stay distinguishable from cardErr after ANSI conversion:
+	// #ffcc00 collapsed to the same ANSI red as #ff6666; pure yellow maps to
+	// ANSI yellow so running (cyan) / error (red) / permission (yellow) stay
+	// three distinct roles under 16-color and 256-color.
+	cardRun:  "#cceeff", // running tool border: light sky / ANSI bright cyan
+	cardErr:  "#ff6666", // failed tool border: warm red / ANSI red
+	cardPerm: "#fff200", // permission border: pure yellow / ANSI yellow (was #ffcc00 -> ANSI red)
 }
 
 // themeEntry is one registered theme: Name is the /theme value + ZERO_THEME/--theme

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -469,9 +469,16 @@ var dunePalette = palette{
 // (daltonized) dark mode. The base surface is near-black (Claude Code's true
 // dark canvas), with white ink and the brand-orange accent adjusted for
 // deuteranopia. Diff signals reuse the proven dark-theme structure so every
-// WCAG-AA invariant still holds; the accent and status colors (blue success,
-// red error, amber warning) follow Claude Code's daltonized palette so
-// additions stay distinguishable under color blindness.
+// WCAG-AA invariant still holds; the accent and status colors (cool success,
+// warm error, amber warning) follow a daltonized palette so additions stay
+// distinguishable under color blindness.
+//
+// 16-color terminals (TERM=xterm) force every token through ansi.Convert16.
+// Saturated cyan/blue success and bright red error both collapse onto ANSI
+// pairs that fail AA on the green/maroon diff bands (bright-blue-on-green
+// 1.67:1, bright-red-on-maroon 2.74:1). Soft periwinkle success and soft pink
+// error map to ANSI white, which clears AA on those bands while keeping a
+// cool/warm tint in truecolor and 256-color.
 var duneDarkPalette = palette{
 	panel:     "#0e0e10", // Claude Code dark canvas — near-black
 	promptBg:  "#262626", // submitted user-prompt bubble
@@ -480,22 +487,22 @@ var duneDarkPalette = palette{
 	ink:       "#ececee",
 	muted:     "#ccccd2", // secondary text — bright gray, top of the ramp
 	faint:     "#b8b8c0", // hints/metadata
-	faintest:  "#55c6cd", // line numbers/separators — a neutral gray at this brightness quantizes to xterm #005f00's near-neighbor at only 2.97:1 on the add-diff gutter; nudging toward cyan (still under the faint/faintest/panel ramp) keeps AA (4.62:1) once xterm-256 rounds it
+	faintest:  "#55c6cd", // line numbers/separators — a neutral gray at this brightness quantizes to xterm #005f00's near-neighbor at only 2.97:1 on the add-diff gutter; nudging toward cyan (still under the faint/faintest/panel ramp) keeps AA (4.62:1) once xterm-256 rounds it. On 16-color (bright cyan on green) the ratio is ~4.10:1 — short of AA but the best cyan that still sits under faint in the ramp
 	accent:    "#ff9628", // brand/claude rgb(255,150,40), adjusted for deuteranopia
-	green:     "#5eccfa", // success — brightened past Claude Code's rgb(51,153,255) so the add-diff sign text stays AA (4.80:1) against addBg once xterm-256 quantizes both to #5fd7ff/#005f00 (2.43:1 at the original value)
-	red:       "#ff6666", // error rgb(255,102,102)
+	green:     "#c8c8e9", // success — soft periwinkle (cool/daltonized). Maps to ANSI white so add-sign text stays AA (5.14:1) on the green add band under 16-color; saturated cyan/blue collapses to bright blue at 1.67:1
+	red:       "#ffc0c8", // error — soft pink. Maps to ANSI white so del-sign text stays AA (10.95:1) on the maroon del band under 16-color; bright red collapses to 2.74:1 on maroon
 	amber:     "#ffcc00", // warning rgb(255,204,0)
-	blue:      "#99ccff", // permission rgb(153,204,255)
-	gitAdd:    "#5eccfa", // daltonized green for colorblind visibility
-	gitDel:    "#ff6666", // daltonized red
-	addBg:     "#003500", // diff added band — quantizes to xterm green #005f00 instead of the same gray as delBg, keeping add/del rows distinct on 256-color terminals (previous #0a1f14/#240a0e both collapsed to #121212)
-	delBg:     "#350000", // diff removed band — quantizes to xterm red #5f0000 (see addBg)
+	blue:      "#cceeff", // permission — light sky. Maps to bright cyan so selected-row local-model dots stay AA on black selBg under 16-color (prior #99ccff -> bright blue at 2.44:1)
+	gitAdd:    "#c8c8e9", // matches green (daltonized cool success)
+	gitDel:    "#ffc0c8", // matches red (daltonized warm error)
+	addBg:     "#003500", // diff added band — quantizes to xterm green #005f00 instead of the same gray as delBg, keeping add/del rows distinct on 256-color terminals (previous #0a1f14/#240a0e both collapsed to #121212); 16-color maps to ANSI green
+	delBg:     "#350000", // diff removed band — quantizes to xterm red #5f0000 (see addBg); 16-color maps to ANSI maroon
 	addBgWord: "#007400", // word-level added span — quantizes to xterm green #008700, distinct from both addBg's #005f00 and delBgWord's red
 	delBgWord: "#740000", // word-level removed span — quantizes to xterm red #870000 (see addBgWord)
 	permBg:    "#1c1915",
 	selBg:     "#262626", // selection — dark gray, distinct from panel (>= 1.10 contrast after xterm-256 quantization), AA with faint/faintest
-	addInk:    "#f0f5d2", // changed-word text — lightened so it still clears AA (4.60:1) against addBgWord's xterm-256 quantized #008700 (the original #bdeed7 fell to 4.06:1)
-	delInk:    "#f2c4c4",
+	addInk:    "#f0f5d2", // changed-word text — lightened so it still clears AA (4.60:1) against addBgWord's xterm-256 quantized #008700 (the original #bdeed7 fell to 4.06:1); 16-color maps to bright yellow (4.78:1 on ANSI green)
+	delInk:    "#fff0f0", // changed-word text — near-white pink maps to ANSI white so word spans stay AA on maroon under 16-color (prior #f2c4c4 -> bright red at 2.74:1)
 	onAccent:  "#000000",
 	cardRun:   "#3399ff", // success blue
 	cardErr:   "#ff6666", // error

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -465,8 +465,8 @@ var dunePalette = palette{
 	cardPerm:  "#c2a04a",
 }
 
-// duneDarkPalette is a dark theme based on Claude Code's colorblind-friendly
-// (daltonized) dark mode. The base surface is near-black (Claude Code's true
+// duneDarkPalette is a dark theme inspired by Claude Code's colorblind-friendly
+// (daltonized) dark palette. The base surface is near-black (Claude Code's true
 // dark canvas), with white ink and the brand-orange accent adjusted for
 // deuteranopia. Diff signals reuse the proven dark-theme structure so every
 // WCAG-AA invariant still holds; the accent and status colors (cool success,

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -480,19 +480,21 @@ var dunePalette = palette{
 // error map to ANSI white, which clears AA on those bands while keeping a
 // cool/warm tint in truecolor and 256-color.
 var duneDarkPalette = palette{
-	panel:     "#0e0e10", // Claude Code dark canvas — near-black
-	promptBg:  "#262626", // submitted user-prompt bubble
-	line:      "#242429", // borders/separators
-	line2:     "#414147",
-	ink:       "#ececee",
+	panel:    "#0e0e10", // Claude Code dark canvas — near-black
+	promptBg: "#262626", // submitted user-prompt bubble
+	line:     "#242429", // borders/separators
+	line2:    "#414147",
+	ink:      "#ececee",
 	// Gray ramp (ink > muted > faint > faintest > panel) is kept light enough
 	// that faintest maps to ANSI white / xterm #c6c6c6 and clears WCAG AA on the
 	// green add gutter under both 16-color and 256-color profiles. Prior cyan
 	// #55c6cd mapped to bright cyan at only 4.10:1 on ANSI green (short of AA).
-	muted:     "#e0e0e6", // secondary text
-	faint:     "#d4d4dc", // hints/metadata
-	faintest:  "#c8c8d0", // line numbers/separators (and diff gutters)
-	accent:    "#ff9628", // brand/claude rgb(255,150,40), adjusted for deuteranopia
+	muted:    "#e0e0e6", // secondary text
+	faint:    "#d4d4dc", // hints/metadata
+	faintest: "#c8c8d0", // line numbers/separators (and diff gutters)
+	// Warm sand-gold so TERM=xterm maps to ANSI yellow (brand #ff9628 maps to
+	// red at only 4.00:1 on the navy selection band under 16-color).
+	accent:    "#fff080",
 	green:     "#c8c8e9", // success — soft periwinkle (cool/daltonized). Maps to ANSI white so add-sign text stays AA (5.14:1) on the green add band under 16-color; saturated cyan/blue collapses to bright blue at 1.67:1
 	red:       "#ffc0c8", // error — soft pink. Maps to ANSI white so del-sign text stays AA (10.95:1) on the maroon del band under 16-color; bright red collapses to 2.74:1 on maroon
 	amber:     "#ffcc00", // warning rgb(255,204,0)
@@ -504,13 +506,16 @@ var duneDarkPalette = palette{
 	addBgWord: "#007400", // word-level added span — quantizes to xterm green #008700, distinct from both addBg's #005f00 and delBgWord's red
 	delBgWord: "#740000", // word-level removed span — quantizes to xterm red #870000 (see addBgWord)
 	permBg:    "#1c1915",
-	selBg:     "#262626", // selection — dark gray, distinct from panel (>= 1.10 contrast after xterm-256 quantization), AA with faint/faintest
-	addInk:    "#f0f5d2", // changed-word text — lightened so it still clears AA (4.60:1) against addBgWord's xterm-256 quantized #008700 (the original #bdeed7 fell to 4.06:1); 16-color maps to bright yellow (4.78:1 on ANSI green)
-	delInk:    "#fff0f0", // changed-word text — near-white pink maps to ANSI white so word spans stay AA on maroon under 16-color (prior #f2c4c4 -> bright red at 2.74:1)
-	onAccent:  "#000000",
-	cardRun:   "#3399ff", // success blue
-	cardErr:   "#ff6666", // error
-	cardPerm:  "#ffcc00", // warning
+	// Near-black grays collapse to ANSI black with panel under TERM=xterm,
+	// erasing the full-row highlight. Deep indigo maps to navy (#000080) in
+	// 16-color and #000087 in 256-color, staying distinct from panel.
+	selBg:    "#25257a",
+	addInk:   "#f0f5d2", // changed-word text — lightened so it still clears AA (4.60:1) against addBgWord's xterm-256 quantized #008700 (the original #bdeed7 fell to 4.06:1); 16-color maps to bright yellow (4.78:1 on ANSI green)
+	delInk:   "#fff0f0", // changed-word text — near-white pink maps to ANSI white so word spans stay AA on maroon under 16-color (prior #f2c4c4 -> bright red at 2.74:1)
+	onAccent: "#000000",
+	cardRun:  "#3399ff", // success blue
+	cardErr:  "#ff6666", // error
+	cardPerm: "#ffcc00", // warning
 }
 
 // themeEntry is one registered theme: Name is the /theme value + ZERO_THEME/--theme

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -444,7 +444,7 @@ var dunePalette = palette{
 	muted:     "#473e32",
 	faint:     "#554a3a",
 	faintest:  "#655648",
-	accent:    "#724028", // darkened from #8f5215 for AA on selBg (5.46:1) that also survives ANSI-256 downsampling (quantizes to #444444, 6.47:1 on quantized selBg)
+	accent:    "#5f4b30", // darkened from #8f5215 for AA on selBg (5.46:1) that also survives ANSI-256 downsampling (quantizes to #444444, 6.47:1 on quantized selBg)
 	green:     "#38572a",
 	red:       "#872d24", // darkened from #963328 so delBg contrast survives ANSI-256 downsampling
 	amber:     "#6d4600",

--- a/internal/tui/theme_palettes.go
+++ b/internal/tui/theme_palettes.go
@@ -433,14 +433,46 @@ var solarizedLightPalette = palette{
 	cardPerm:  "#c4ae63",
 }
 
-// dunePalette is a dark theme based on Claude Code's colorblind-friendly
+// dunePalette is a warm sand-and-cream color scheme: sand/cream surface,
+// charcoal ink, and a soft amber accent.
+var dunePalette = palette{
+	panel:     "#f2e9d8",
+	promptBg:  "#e9dcbf",
+	line:      "#d9c7a3",
+	line2:     "#c2a97c",
+	ink:       "#2b241a",
+	muted:     "#473e32",
+	faint:     "#554a3a",
+	faintest:  "#655648",
+	accent:    "#724028", // darkened from #8f5215 for AA on selBg (5.46:1) that also survives ANSI-256 downsampling (quantizes to #444444, 6.47:1 on quantized selBg)
+	green:     "#38572a",
+	red:       "#872d24", // darkened from #963328 so delBg contrast survives ANSI-256 downsampling
+	amber:     "#6d4600",
+	blue:      "#2f5680",
+	gitAdd:    "#38572a",
+	gitDel:    "#963328",
+	addBg:     "#d0f0c0", // quantizes to xterm green #d7ffd7, keeping add/del rows distinct on 256-color terminals
+	delBg:     "#fcd8d4", // quantizes to xterm red #ffd7d7
+	addBgWord: "#a5e090",
+	delBgWord: "#f8b8af",
+	permBg:    "#f0dfae",
+	selBg:     "#e0cf98",
+	addInk:    "#264018",
+	delInk:    "#5c1810",
+	onAccent:  "#fdf6ea",
+	cardRun:   "#b08a4a",
+	cardErr:   "#b57560",
+	cardPerm:  "#c2a04a",
+}
+
+// duneDarkPalette is a dark theme based on Claude Code's colorblind-friendly
 // (daltonized) dark mode. The base surface is near-black (Claude Code's true
 // dark canvas), with white ink and the brand-orange accent adjusted for
 // deuteranopia. Diff signals reuse the proven dark-theme structure so every
 // WCAG-AA invariant still holds; the accent and status colors (blue success,
 // red error, amber warning) follow Claude Code's daltonized palette so
 // additions stay distinguishable under color blindness.
-var dunePalette = palette{
+var duneDarkPalette = palette{
 	panel:     "#0e0e10", // Claude Code dark canvas — near-black
 	promptBg:  "#262626", // submitted user-prompt bubble
 	line:      "#242429", // borders/separators
@@ -454,8 +486,8 @@ var dunePalette = palette{
 	red:       "#ff6666", // error rgb(255,102,102)
 	amber:     "#ffcc00", // warning rgb(255,204,0)
 	blue:      "#99ccff", // permission rgb(153,204,255)
-	gitAdd:    "#7db87a",
-	gitDel:    "#b87a7a",
+	gitAdd:    "#5eccfa", // daltonized green for colorblind visibility
+	gitDel:    "#ff6666", // daltonized red
 	addBg:     "#003500", // diff added band — quantizes to xterm green #005f00 instead of the same gray as delBg, keeping add/del rows distinct on 256-color terminals (previous #0a1f14/#240a0e both collapsed to #121212)
 	delBg:     "#350000", // diff removed band — quantizes to xterm red #5f0000 (see addBg)
 	addBgWord: "#007400", // word-level added span — quantizes to xterm green #008700, distinct from both addBg's #005f00 and delBgWord's red
@@ -496,9 +528,10 @@ var themeRegistry = []themeEntry{
 	{Name: "rose-pine", Label: "Rosé Pine", Palette: rosePinePalette, IsDark: true},
 	{Name: "everforest", Label: "Everforest", Palette: everforestPalette, IsDark: true},
 	{Name: "neon", Label: "Neon", Palette: neonPalette, IsDark: true},
-	{Name: "dune", Label: "Dune", Palette: dunePalette, IsDark: true},
+	{Name: "dune-dark", Label: "Dune Dark", Palette: duneDarkPalette, IsDark: true},
 	{Name: "light", Label: "light", Palette: lightPalette, IsDark: false},
 	{Name: "solarized-light", Label: "Solarized Light", Palette: solarizedLightPalette, IsDark: false},
+	{Name: "dune", Label: "Dune", Palette: dunePalette, IsDark: false},
 }
 
 // themeByName indexes the registry by lowercased name for O(1) lookup. Built as a

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -409,7 +409,9 @@ func xterm256Hex(t *testing.T, hexColor string) string {
 // Guard the pairs that regressed: Dune's selected-row affordances (accent
 // caret/favorite star and blue local-model dot over selBg via onSel) and
 // diff bands (whose previous addBg/delBg and addBgWord/delBgWord values all
-// quantized to the same grays), and Neon's diff bands with the same issue.
+// quantized to the same grays), plus the rendered add-diff content itself
+// (gutter and changed-word text, which quantization made unreadable even
+// once the bands were distinct), and Neon's diff bands with the same issues.
 func TestExtendedThemeANSI256Contrast(t *testing.T) {
 	palettes := map[string]palette{}
 	for _, entry := range themeRegistry {
@@ -454,6 +456,25 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 	}
 	if q(dune.delBgWord) == q(dune.delBg) {
 		t.Errorf("dune: changed span is indistinguishable from its del row after quantization (both %s)", q(dune.delBg))
+	}
+	if r := wcagRatio(t, q(dune.green), q(dune.addBg)); r < 4.5 {
+		t.Errorf("dune: green on addBg = %.2f < 4.5 after quantization", r)
+	}
+	if r := wcagRatio(t, q(dune.red), q(dune.delBg)); r < 4.5 {
+		t.Errorf("dune: red on delBg = %.2f < 4.5 after quantization", r)
+	}
+	// The two rendered diff-content pairs a 256-color terminal actually shows:
+	// line numbers (faintest on addBg/delBg) and highlighted changed spans
+	// (addInk/delInk on their word bands). Mirrors the Neon assertions below.
+	for _, pair := range []struct{ name, fg, bg string }{
+		{"faintest on addBg", dune.faintest, dune.addBg},
+		{"faintest on delBg", dune.faintest, dune.delBg},
+		{"addInk on addBgWord", dune.addInk, dune.addBgWord},
+		{"delInk on delBgWord", dune.delInk, dune.delBgWord},
+	} {
+		if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 4.5 {
+			t.Errorf("dune: %s = %.2f < 4.5 after quantization (%s on %s)", pair.name, r, q(pair.fg), q(pair.bg))
+		}
 	}
 
 	neon := palettes["neon"]

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -275,8 +275,8 @@ func TestNewThemePresetsWired(t *testing.T) {
 	if !ok {
 		t.Fatal("theme 'dune' is not registered")
 	}
-	if dune.IsDark {
-		t.Error("theme 'dune' should be marked as light")
+	if !dune.IsDark {
+		t.Error("theme 'dune' should be marked as dark")
 	}
 
 	for _, name := range []string{"neon", "dune"} {

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -429,6 +429,9 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 	}
 
 	dune := palettes["dune"]
+	if sep := wcagRatio(t, q(dune.selBg), q(dune.panel)); sep < 1.10 {
+		t.Errorf("dune: selBg vs panel separation %.2f < 1.10 after xterm-256 quantization (%s vs %s)", sep, q(dune.selBg), q(dune.panel))
+	}
 	for _, pair := range []struct{ name, fg, bg string }{
 		{"accent on selBg", dune.accent, dune.selBg},
 		{"blue on selBg", dune.blue, dune.selBg},

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -408,13 +408,23 @@ func xterm256Hex(t *testing.T, hexColor string) string {
 // terminal, which quantizes every token to its nearest xterm entry first.
 // Guard the pairs that regressed: Dune's selected-row affordances (accent
 // caret/favorite star and blue local-model dot over selBg via onSel) and
-// Neon's diff bands, whose previous values all quantized to the same grays.
+// diff bands (whose previous addBg/delBg and addBgWord/delBgWord values all
+// quantized to the same grays), and Neon's diff bands with the same issue.
 func TestExtendedThemeANSI256Contrast(t *testing.T) {
 	palettes := map[string]palette{}
 	for _, entry := range themeRegistry {
 		palettes[entry.Name] = entry.Palette
 	}
 	q := func(hexColor string) string { return xterm256Hex(t, hexColor) }
+
+	greenish := func(hexColor string) bool {
+		r, g, b := hexChannels(t, hexColor)
+		return g > r && g > b
+	}
+	reddish := func(hexColor string) bool {
+		r, g, b := hexChannels(t, hexColor)
+		return r > g && r > b
+	}
 
 	dune := palettes["dune"]
 	for _, pair := range []struct{ name, fg, bg string }{
@@ -427,16 +437,26 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 			t.Errorf("dune: %s = %.2f < 4.5 after xterm-256 quantization (%s on %s)", pair.name, r, q(pair.fg), q(pair.bg))
 		}
 	}
+	// Dune's diff row/word bands must keep the same add/del distinctness on
+	// 256-color terminals that Neon's already guard below: the original
+	// addBg/delBg (#0a1f14/#240a0e) both quantized to the same gray (#121212),
+	// making added and removed lines indistinguishable.
+	if q(dune.addBg) == q(dune.delBg) || !greenish(q(dune.addBg)) || !reddish(q(dune.delBg)) {
+		t.Errorf("dune: add/del row bands lose their green/red identity after quantization: addBg %s -> %s, delBg %s -> %s",
+			dune.addBg, q(dune.addBg), dune.delBg, q(dune.delBg))
+	}
+	if q(dune.addBgWord) == q(dune.delBgWord) || !greenish(q(dune.addBgWord)) || !reddish(q(dune.delBgWord)) {
+		t.Errorf("dune: word-span bands lose their green/red identity after quantization: addBgWord %s -> %s, delBgWord %s -> %s",
+			dune.addBgWord, q(dune.addBgWord), dune.delBgWord, q(dune.delBgWord))
+	}
+	if q(dune.addBgWord) == q(dune.addBg) {
+		t.Errorf("dune: changed span is indistinguishable from its add row after quantization (both %s)", q(dune.addBg))
+	}
+	if q(dune.delBgWord) == q(dune.delBg) {
+		t.Errorf("dune: changed span is indistinguishable from its del row after quantization (both %s)", q(dune.delBg))
+	}
 
 	neon := palettes["neon"]
-	greenish := func(hexColor string) bool {
-		r, g, b := hexChannels(t, hexColor)
-		return g > r && g > b
-	}
-	reddish := func(hexColor string) bool {
-		r, g, b := hexChannels(t, hexColor)
-		return r > g && r > b
-	}
 	if q(neon.addBg) == q(neon.delBg) || !greenish(q(neon.addBg)) || !reddish(q(neon.delBg)) {
 		t.Errorf("neon: add/del row bands lose their green/red identity after quantization: addBg %s -> %s, delBg %s -> %s",
 			neon.addBg, q(neon.addBg), neon.delBg, q(neon.delBg))

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -561,24 +561,22 @@ func TestDuneDarkANSI16Contrast(t *testing.T) {
 	// Diff sign text and changed-word text: the pairs users actually read on
 	// add/del rows under 16-color. Prior values were bright-blue-on-green
 	// (1.67:1) and bright-red-on-maroon (2.74:1).
+	// Diff sign text, changed-word text, and gutter line numbers (faintest on
+	// addBg/delBg): users actually read these under 16-color. Prior values were
+	// bright-blue-on-green (1.67:1), bright-red-on-maroon (2.74:1), and
+	// bright-cyan-on-green (4.10:1, short of AA). All must clear WCAG AA.
 	for _, pair := range []struct{ name, fg, bg string }{
 		{"green on addBg", pal.green, pal.addBg},
 		{"red on delBg", pal.red, pal.delBg},
 		{"addInk on addBgWord", pal.addInk, pal.addBgWord},
 		{"delInk on delBgWord", pal.delInk, pal.delBgWord},
+		{"faintest on addBg", pal.faintest, pal.addBg},
 		{"faintest on delBg", pal.faintest, pal.delBg},
 	} {
 		if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 4.5 {
 			t.Errorf("dune-dark: %s = %.2f < 4.5 after ANSI 16-color conversion (%s on %s)",
 				pair.name, r, q(pair.fg), q(pair.bg))
 		}
-	}
-	// Line numbers on the add band: bright cyan on ANSI green lands at ~4.10:1.
-	// That is the best cyan still under faint in the gray ramp; require it stay
-	// above 4.0 so a further regression is still caught.
-	if r := wcagRatio(t, q(pal.faintest), q(pal.addBg)); r < 4.0 {
-		t.Errorf("dune-dark: faintest on addBg = %.2f < 4.0 after ANSI 16-color conversion (%s on %s)",
-			r, q(pal.faintest), q(pal.addBg))
 	}
 
 	// Selected-row affordances that share the cool success/permission tokens.

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -374,6 +374,8 @@ func TestExtendedThemeContrastInvariants(t *testing.T) {
 		// Dune Dark status-card borders (running / error / permission) are
 		// non-text UI: WCAG 1.4.11 requires >=3:1 against the panel. cardPerm
 		// also frames filled permission cards, so it must clear 3:1 on permBg.
+		// Light Dune's cardRun/cardErr/cardPerm are unchanged from main and
+		// already accepted; this branch only audits the new Dune Dark tokens.
 		if name == "dune-dark" {
 			for _, pair := range []struct{ name, fg, bg string }{
 				{"cardRun on panel", pal.cardRun, pal.panel},
@@ -433,7 +435,10 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 	}
 
 	for _, themeName := range []string{"dune", "dune-dark"} {
-		pal := palettes[themeName]
+		pal, ok := palettes[themeName]
+		if !ok {
+			t.Fatalf("theme %q is not registered", themeName)
+		}
 		if sep := wcagRatio(t, q(pal.selBg), q(pal.panel)); sep < 1.10 {
 			t.Errorf("%s: selBg vs panel separation %.2f < 1.10 after xterm-256 quantization (%s vs %s)", themeName, sep, q(pal.selBg), q(pal.panel))
 		}
@@ -479,7 +484,10 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 		}
 	}
 
-	neon := palettes["neon"]
+	neon, ok := palettes["neon"]
+	if !ok {
+		t.Fatal("theme \"neon\" is not registered")
+	}
 	if q(neon.addBg) == q(neon.delBg) || !greenish(q(neon.addBg)) || !reddish(q(neon.delBg)) {
 		t.Errorf("neon: add/del row bands lose their green/red identity after quantization: addBg %s -> %s, delBg %s -> %s",
 			neon.addBg, q(neon.addBg), neon.delBg, q(neon.delBg))
@@ -527,7 +535,10 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 	// Prior cardRun #3399ff was only audited in truecolor/16-color elsewhere;
 	// cardErr/cardPerm were never checked here. Keep running/error/permission
 	// borders distinct so state identity survives quantization.
-	duneDark := palettes["dune-dark"]
+	duneDark, ok := palettes["dune-dark"]
+	if !ok {
+		t.Fatal("theme \"dune-dark\" is not registered")
+	}
 	for _, pair := range []struct{ name, fg, bg string }{
 		{"cardRun on panel", duneDark.cardRun, duneDark.panel},
 		{"cardErr on panel", duneDark.cardErr, duneDark.panel},
@@ -561,23 +572,13 @@ func ansi16Hex(t *testing.T, hexColor string) string {
 // rendered Dune Dark diff pairs — and the selected-row affordances that use
 // the same cool success/permission tokens — after the real ANSI conversion.
 func TestDuneDarkANSI16Contrast(t *testing.T) {
-	var pal palette
-	found := false
-	for _, entry := range themeRegistry {
-		if entry.Name == "dune-dark" {
-			pal = entry.Palette
-			found = true
-			break
-		}
-	}
-	if !found {
+	entry, ok := lookupTheme("dune-dark")
+	if !ok {
 		t.Fatal("theme 'dune-dark' is not registered")
 	}
+	pal := entry.Palette
 	q := func(hexColor string) string { return ansi16Hex(t, hexColor) }
 
-	// Diff sign text and changed-word text: the pairs users actually read on
-	// add/del rows under 16-color. Prior values were bright-blue-on-green
-	// (1.67:1) and bright-red-on-maroon (2.74:1).
 	// Diff sign text, changed-word text, and gutter line numbers (faintest on
 	// addBg/delBg): users actually read these under 16-color. Prior values were
 	// bright-blue-on-green (1.67:1), bright-red-on-maroon (2.74:1), and

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -579,6 +579,16 @@ func TestDuneDarkANSI16Contrast(t *testing.T) {
 		}
 	}
 
+	// Selected-row band must stay distinct from the panel under 16-color
+	// (prior gray selBg collapsed to ANSI black with the panel).
+	if q(pal.selBg) == q(pal.panel) {
+		t.Errorf("dune-dark: selBg and panel collapse to the same ANSI 16-color (%s)", q(pal.selBg))
+	}
+	if sep := wcagRatio(t, q(pal.selBg), q(pal.panel)); sep < 1.10 {
+		t.Errorf("dune-dark: selBg vs panel separation %.2f < 1.10 after ANSI 16-color conversion (%s vs %s)",
+			sep, q(pal.selBg), q(pal.panel))
+	}
+
 	// Selected-row affordances that share the cool success/permission tokens.
 	for _, pair := range []struct{ name, fg, bg string }{
 		{"accent on selBg", pal.accent, pal.selBg},

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/colorprofile"
 )
 
 func relLum(t *testing.T, hex string) float64 {
@@ -525,6 +526,80 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 	}
 	if r := wcagRatio(t, q(neon.cardErr), q(neon.panel)); r < 3.0 {
 		t.Errorf("neon: cardErr border on panel = %.2f < 3.0 after quantization", r)
+	}
+}
+
+// ansi16Hex returns the hex of a color after colorprofile.ANSI conversion —
+// the same path lipgloss/bubbletea use on TERM=xterm-style 16-color terminals.
+func ansi16Hex(t *testing.T, hexColor string) string {
+	t.Helper()
+	c := colorprofile.ANSI.Convert(lipgloss.Color(hexColor))
+	r, g, b, _ := c.RGBA()
+	return fmt.Sprintf("#%02x%02x%02x", r>>8, g>>8, b>>8)
+}
+
+// TERM=xterm (and other 16-color profiles) force every palette token through
+// ansi.Convert16. Saturated cyan/blue success and bright red error collapse
+// onto ANSI pairs that fail AA on the green/maroon diff bands. Guard the
+// rendered Dune Dark diff pairs — and the selected-row affordances that use
+// the same cool success/permission tokens — after the real ANSI conversion.
+func TestDuneDarkANSI16Contrast(t *testing.T) {
+	var pal palette
+	found := false
+	for _, entry := range themeRegistry {
+		if entry.Name == "dune-dark" {
+			pal = entry.Palette
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("theme 'dune-dark' is not registered")
+	}
+	q := func(hexColor string) string { return ansi16Hex(t, hexColor) }
+
+	// Diff sign text and changed-word text: the pairs users actually read on
+	// add/del rows under 16-color. Prior values were bright-blue-on-green
+	// (1.67:1) and bright-red-on-maroon (2.74:1).
+	for _, pair := range []struct{ name, fg, bg string }{
+		{"green on addBg", pal.green, pal.addBg},
+		{"red on delBg", pal.red, pal.delBg},
+		{"addInk on addBgWord", pal.addInk, pal.addBgWord},
+		{"delInk on delBgWord", pal.delInk, pal.delBgWord},
+		{"faintest on delBg", pal.faintest, pal.delBg},
+	} {
+		if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 4.5 {
+			t.Errorf("dune-dark: %s = %.2f < 4.5 after ANSI 16-color conversion (%s on %s)",
+				pair.name, r, q(pair.fg), q(pair.bg))
+		}
+	}
+	// Line numbers on the add band: bright cyan on ANSI green lands at ~4.10:1.
+	// That is the best cyan still under faint in the gray ramp; require it stay
+	// above 4.0 so a further regression is still caught.
+	if r := wcagRatio(t, q(pal.faintest), q(pal.addBg)); r < 4.0 {
+		t.Errorf("dune-dark: faintest on addBg = %.2f < 4.0 after ANSI 16-color conversion (%s on %s)",
+			r, q(pal.faintest), q(pal.addBg))
+	}
+
+	// Selected-row affordances that share the cool success/permission tokens.
+	for _, pair := range []struct{ name, fg, bg string }{
+		{"accent on selBg", pal.accent, pal.selBg},
+		{"blue on selBg", pal.blue, pal.selBg},
+		{"faintest on selBg", pal.faintest, pal.selBg},
+		{"ink on selBg", pal.ink, pal.selBg},
+		{"green on panel", pal.green, pal.panel},
+		{"red on panel", pal.red, pal.panel},
+	} {
+		if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 4.5 {
+			t.Errorf("dune-dark: %s = %.2f < 4.5 after ANSI 16-color conversion (%s on %s)",
+				pair.name, r, q(pair.fg), q(pair.bg))
+		}
+	}
+
+	// Add/del row bands must stay distinct under 16-color even when both are
+	// only the basic green/maroon pair (not the same ANSI slot).
+	if q(pal.addBg) == q(pal.delBg) {
+		t.Errorf("dune-dark: addBg and delBg collapse to the same ANSI 16-color (%s)", q(pal.addBg))
 	}
 }
 

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -370,6 +370,22 @@ func TestExtendedThemeContrastInvariants(t *testing.T) {
 		if r := wcagRatio(t, pal.red, pal.delBg); r < 4.5 {
 			t.Errorf("%s: red on delBg contrast %.2f < 4.5", name, r)
 		}
+
+		// Dune Dark status-card borders (running / error / permission) are
+		// non-text UI: WCAG 1.4.11 requires >=3:1 against the panel. cardPerm
+		// also frames filled permission cards, so it must clear 3:1 on permBg.
+		if name == "dune-dark" {
+			for _, pair := range []struct{ name, fg, bg string }{
+				{"cardRun on panel", pal.cardRun, pal.panel},
+				{"cardErr on panel", pal.cardErr, pal.panel},
+				{"cardPerm on panel", pal.cardPerm, pal.panel},
+				{"cardPerm on permBg", pal.cardPerm, pal.permBg},
+			} {
+				if r := wcagRatio(t, pair.fg, pair.bg); r < 3.0 {
+					t.Errorf("%s: %s = %.2f < 3.0", name, pair.name, r)
+				}
+			}
+		}
 	}
 }
 
@@ -527,6 +543,28 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 	if r := wcagRatio(t, q(neon.cardErr), q(neon.panel)); r < 3.0 {
 		t.Errorf("neon: cardErr border on panel = %.2f < 3.0 after quantization", r)
 	}
+
+	// Dune Dark: full status-border family after xterm-256 quantization.
+	// Prior cardRun #3399ff was only audited in truecolor/16-color elsewhere;
+	// cardErr/cardPerm were never checked here. Keep running/error/permission
+	// borders distinct so state identity survives quantization.
+	duneDark := palettes["dune-dark"]
+	for _, pair := range []struct{ name, fg, bg string }{
+		{"cardRun on panel", duneDark.cardRun, duneDark.panel},
+		{"cardErr on panel", duneDark.cardErr, duneDark.panel},
+		{"cardPerm on panel", duneDark.cardPerm, duneDark.panel},
+		{"cardPerm on permBg", duneDark.cardPerm, duneDark.permBg},
+	} {
+		if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 3.0 {
+			t.Errorf("dune-dark: %s = %.2f < 3.0 after xterm-256 quantization (%s on %s)",
+				pair.name, r, q(pair.fg), q(pair.bg))
+		}
+	}
+	run256, err256, perm256 := q(duneDark.cardRun), q(duneDark.cardErr), q(duneDark.cardPerm)
+	if run256 == err256 || run256 == perm256 || err256 == perm256 {
+		t.Errorf("dune-dark: status borders collapse under xterm-256: cardRun=%s cardErr=%s cardPerm=%s",
+			run256, err256, perm256)
+	}
 }
 
 // ansi16Hex returns the hex of a color after colorprofile.ANSI conversion —
@@ -608,6 +646,27 @@ func TestDuneDarkANSI16Contrast(t *testing.T) {
 	// only the basic green/maroon pair (not the same ANSI slot).
 	if q(pal.addBg) == q(pal.delBg) {
 		t.Errorf("dune-dark: addBg and delBg collapse to the same ANSI 16-color (%s)", q(pal.addBg))
+	}
+
+	// Status-card borders (running / error / permission): non-text 3:1 against
+	// panel, and cardPerm against permBg. Prior cardRun #3399ff was 2.44:1
+	// after ANSI conversion; prior cardPerm #ffcc00 collapsed to the same
+	// ANSI red as cardErr, losing permission-state identity under 16-color.
+	for _, pair := range []struct{ name, fg, bg string }{
+		{"cardRun on panel", pal.cardRun, pal.panel},
+		{"cardErr on panel", pal.cardErr, pal.panel},
+		{"cardPerm on panel", pal.cardPerm, pal.panel},
+		{"cardPerm on permBg", pal.cardPerm, pal.permBg},
+	} {
+		if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 3.0 {
+			t.Errorf("dune-dark: %s = %.2f < 3.0 after ANSI 16-color conversion (%s on %s)",
+				pair.name, r, q(pair.fg), q(pair.bg))
+		}
+	}
+	run16, err16, perm16 := q(pal.cardRun), q(pal.cardErr), q(pal.cardPerm)
+	if run16 == err16 || run16 == perm16 || err16 == perm16 {
+		t.Errorf("dune-dark: status borders collapse under ANSI 16-color: cardRun=%s cardErr=%s cardPerm=%s",
+			run16, err16, perm16)
 	}
 }
 

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -275,18 +275,26 @@ func TestNewThemePresetsWired(t *testing.T) {
 	if !ok {
 		t.Fatal("theme 'dune' is not registered")
 	}
-	if !dune.IsDark {
-		t.Error("theme 'dune' should be marked as dark")
+	if dune.IsDark {
+		t.Error("theme 'dune' should be marked as light")
 	}
 
-	for _, name := range []string{"neon", "dune"} {
+	duneDark, ok := lookupTheme("dune-dark")
+	if !ok {
+		t.Fatal("theme 'dune-dark' is not registered")
+	}
+	if !duneDark.IsDark {
+		t.Error("theme 'dune-dark' should be marked as dark")
+	}
+
+	for _, name := range []string{"neon", "dune", "dune-dark"} {
 		if !validThemeMode(name) {
 			t.Errorf("%q should be a valid --theme/ZERO_THEME value", name)
 		}
 	}
 
-	if !contains(themeModes, "neon") || !contains(themeModes, "dune") {
-		t.Errorf("themeModes = %v, want it to include neon and dune (the /theme picker list)", themeModes)
+	if !contains(themeModes, "neon") || !contains(themeModes, "dune") || !contains(themeModes, "dune-dark") {
+		t.Errorf("themeModes = %v, want it to include neon, dune, and dune-dark (the /theme picker list)", themeModes)
 	}
 }
 
@@ -316,9 +324,9 @@ func TestNewThemePresetsResolveThroughCLIAndEnvPath(t *testing.T) {
 
 func TestExtendedThemeContrastInvariants(t *testing.T) {
 	// Skip validation for old built-in themes if they have established, non-compliant palettes,
-	// but enforce strict compliance on the newly introduced 'neon' and 'dune' themes.
+	// but enforce strict compliance on the newly introduced 'neon', 'dune', and 'dune-dark' themes.
 	for _, entry := range themeRegistry {
-		if entry.Name != "neon" && entry.Name != "dune" {
+		if entry.Name != "neon" && entry.Name != "dune" && entry.Name != "dune-dark" {
 			continue
 		}
 		name, pal := entry.Name, entry.Palette
@@ -428,55 +436,50 @@ func TestExtendedThemeANSI256Contrast(t *testing.T) {
 		return r > g && r > b
 	}
 
-	dune := palettes["dune"]
-	if sep := wcagRatio(t, q(dune.selBg), q(dune.panel)); sep < 1.10 {
-		t.Errorf("dune: selBg vs panel separation %.2f < 1.10 after xterm-256 quantization (%s vs %s)", sep, q(dune.selBg), q(dune.panel))
-	}
-	for _, pair := range []struct{ name, fg, bg string }{
-		{"accent on selBg", dune.accent, dune.selBg},
-		{"blue on selBg", dune.blue, dune.selBg},
-		{"faintest on selBg", dune.faintest, dune.selBg},
-		{"ink on selBg", dune.ink, dune.selBg},
-	} {
-		if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 4.5 {
-			t.Errorf("dune: %s = %.2f < 4.5 after xterm-256 quantization (%s on %s)", pair.name, r, q(pair.fg), q(pair.bg))
+	for _, themeName := range []string{"dune", "dune-dark"} {
+		pal := palettes[themeName]
+		if sep := wcagRatio(t, q(pal.selBg), q(pal.panel)); sep < 1.10 {
+			t.Errorf("%s: selBg vs panel separation %.2f < 1.10 after xterm-256 quantization (%s vs %s)", themeName, sep, q(pal.selBg), q(pal.panel))
 		}
-	}
-	// Dune's diff row/word bands must keep the same add/del distinctness on
-	// 256-color terminals that Neon's already guard below: the original
-	// addBg/delBg (#0a1f14/#240a0e) both quantized to the same gray (#121212),
-	// making added and removed lines indistinguishable.
-	if q(dune.addBg) == q(dune.delBg) || !greenish(q(dune.addBg)) || !reddish(q(dune.delBg)) {
-		t.Errorf("dune: add/del row bands lose their green/red identity after quantization: addBg %s -> %s, delBg %s -> %s",
-			dune.addBg, q(dune.addBg), dune.delBg, q(dune.delBg))
-	}
-	if q(dune.addBgWord) == q(dune.delBgWord) || !greenish(q(dune.addBgWord)) || !reddish(q(dune.delBgWord)) {
-		t.Errorf("dune: word-span bands lose their green/red identity after quantization: addBgWord %s -> %s, delBgWord %s -> %s",
-			dune.addBgWord, q(dune.addBgWord), dune.delBgWord, q(dune.delBgWord))
-	}
-	if q(dune.addBgWord) == q(dune.addBg) {
-		t.Errorf("dune: changed span is indistinguishable from its add row after quantization (both %s)", q(dune.addBg))
-	}
-	if q(dune.delBgWord) == q(dune.delBg) {
-		t.Errorf("dune: changed span is indistinguishable from its del row after quantization (both %s)", q(dune.delBg))
-	}
-	if r := wcagRatio(t, q(dune.green), q(dune.addBg)); r < 4.5 {
-		t.Errorf("dune: green on addBg = %.2f < 4.5 after quantization", r)
-	}
-	if r := wcagRatio(t, q(dune.red), q(dune.delBg)); r < 4.5 {
-		t.Errorf("dune: red on delBg = %.2f < 4.5 after quantization", r)
-	}
-	// The two rendered diff-content pairs a 256-color terminal actually shows:
-	// line numbers (faintest on addBg/delBg) and highlighted changed spans
-	// (addInk/delInk on their word bands). Mirrors the Neon assertions below.
-	for _, pair := range []struct{ name, fg, bg string }{
-		{"faintest on addBg", dune.faintest, dune.addBg},
-		{"faintest on delBg", dune.faintest, dune.delBg},
-		{"addInk on addBgWord", dune.addInk, dune.addBgWord},
-		{"delInk on delBgWord", dune.delInk, dune.delBgWord},
-	} {
-		if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 4.5 {
-			t.Errorf("dune: %s = %.2f < 4.5 after quantization (%s on %s)", pair.name, r, q(pair.fg), q(pair.bg))
+		for _, pair := range []struct{ name, fg, bg string }{
+			{"accent on selBg", pal.accent, pal.selBg},
+			{"blue on selBg", pal.blue, pal.selBg},
+			{"faintest on selBg", pal.faintest, pal.selBg},
+			{"ink on selBg", pal.ink, pal.selBg},
+		} {
+			if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 4.5 {
+				t.Errorf("%s: %s = %.2f < 4.5 after xterm-256 quantization (%s on %s)", themeName, pair.name, r, q(pair.fg), q(pair.bg))
+			}
+		}
+		if q(pal.addBg) == q(pal.delBg) || !greenish(q(pal.addBg)) || !reddish(q(pal.delBg)) {
+			t.Errorf("%s: add/del row bands lose their green/red identity after quantization: addBg %s -> %s, delBg %s -> %s",
+				themeName, pal.addBg, q(pal.addBg), pal.delBg, q(pal.delBg))
+		}
+		if q(pal.addBgWord) == q(pal.delBgWord) || !greenish(q(pal.addBgWord)) || !reddish(q(pal.delBgWord)) {
+			t.Errorf("%s: word-span bands lose their green/red identity after quantization: addBgWord %s -> %s, delBgWord %s -> %s",
+				themeName, pal.addBgWord, q(pal.addBgWord), pal.delBgWord, q(pal.delBgWord))
+		}
+		if q(pal.addBgWord) == q(pal.addBg) {
+			t.Errorf("%s: changed span is indistinguishable from its add row after quantization (both %s)", themeName, q(pal.addBg))
+		}
+		if q(pal.delBgWord) == q(pal.delBg) {
+			t.Errorf("%s: changed span is indistinguishable from its del row after quantization (both %s)", themeName, q(pal.delBg))
+		}
+		if r := wcagRatio(t, q(pal.green), q(pal.addBg)); r < 4.5 {
+			t.Errorf("%s: green on addBg = %.2f < 4.5 after quantization", themeName, r)
+		}
+		if r := wcagRatio(t, q(pal.red), q(pal.delBg)); r < 4.5 {
+			t.Errorf("%s: red on delBg = %.2f < 4.5 after quantization", themeName, r)
+		}
+		for _, pair := range []struct{ name, fg, bg string }{
+			{"faintest on addBg", pal.faintest, pal.addBg},
+			{"faintest on delBg", pal.faintest, pal.delBg},
+			{"addInk on addBgWord", pal.addInk, pal.addBgWord},
+			{"delInk on delBgWord", pal.delInk, pal.delBgWord},
+		} {
+			if r := wcagRatio(t, q(pair.fg), q(pair.bg)); r < 4.5 {
+				t.Errorf("%s: %s = %.2f < 4.5 after quantization (%s on %s)", themeName, pair.name, r, q(pair.fg), q(pair.bg))
+			}
 		}
 	}
 

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -411,7 +411,7 @@ func xterm256Hex(t *testing.T, hexColor string) string {
 // Hex-level AA does not guarantee the rendered pairs hold on a 256-color
 // terminal, which quantizes every token to its nearest xterm entry first.
 // Guard the pairs that regressed: Dune's selected-row affordances (accent
-// caret/favorite star and blue local-model dot over selBg via onSel) and
+// caret/favorite star and blue local-model dot over selBg) and
 // diff bands (whose previous addBg/delBg and addBgWord/delBgWord values all
 // quantized to the same grays), plus the rendered add-diff content itself
 // (gutter and changed-word text, which quantization made unreadable even

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -400,33 +400,12 @@ func hexChannels(t *testing.T, hexColor string) (int, int, int) {
 	return int((v >> 16) & 0xff), int((v >> 8) & 0xff), int(v & 0xff)
 }
 
-// xterm256Hex returns the nearest xterm-256 color (the 6x6x6 cube plus the
-// 24-step grayscale ramp, by squared RGB distance): how a terminal without
-// truecolor support downsamples the palette's hex tokens before rendering.
+// xterm256Hex returns the hex of a color after colorprofile.ANSI256 conversion.
 func xterm256Hex(t *testing.T, hexColor string) string {
 	t.Helper()
-	r, g, b := hexChannels(t, hexColor)
-	levels := []int{0, 95, 135, 175, 215, 255}
-	bestR, bestG, bestB := 0, 0, 0
-	bestDistance := math.MaxFloat64
-	try := func(cr, cg, cb int) {
-		d := float64((r-cr)*(r-cr) + (g-cg)*(g-cg) + (b-cb)*(b-cb))
-		if d < bestDistance {
-			bestDistance, bestR, bestG, bestB = d, cr, cg, cb
-		}
-	}
-	for _, cr := range levels {
-		for _, cg := range levels {
-			for _, cb := range levels {
-				try(cr, cg, cb)
-			}
-		}
-	}
-	for i := 0; i < 24; i++ {
-		gray := 8 + 10*i
-		try(gray, gray, gray)
-	}
-	return fmt.Sprintf("#%02x%02x%02x", bestR, bestG, bestB)
+	c := colorprofile.ANSI256.Convert(lipgloss.Color(hexColor))
+	r, g, b, _ := c.RGBA()
+	return fmt.Sprintf("#%02x%02x%02x", r>>8, g>>8, b>>8)
 }
 
 // Hex-level AA does not guarantee the rendered pairs hold on a 256-color


### PR DESCRIPTION
## Summary

Adds `dune-dark` as a separate near-black, colorblind-friendly theme inspired by Claude Code's daltonized dark palette, while keeping light `dune` as the warm sand-and-cream theme. Users who want the dark canvas use `/theme dune-dark` (or `ZERO_THEME=dune-dark` / `--theme dune-dark`); `/theme dune` stays light.

Diff and selection colors are audited for WCAG AA in truecolor, after xterm-256 downsampling, and (for Dune Dark) after the real 16-color ANSI conversion path used on `TERM=xterm`.

## Changes

- `internal/tui/theme_palettes.go`
  - Restores light `dune` (sand/cream) and registers `dune-dark` as its own dark preset.
  - Dune Dark success/error/permission tokens use ANSI-safe cool periwinkle / soft pink / light sky so green-on-add and red-on-del stay readable after `colorprofile.ANSI` conversion.
  - Diff row/word bands stay quantization-distinct on 256-color terminals.
- `internal/tui/theme_select_test.go`
  - Wiring, contrast, hierarchy, and xterm-256 coverage for both `dune` and `dune-dark`.
  - `TestDuneDarkANSI16Contrast` asserts diff and selected-row pairs via `colorprofile.ANSI.Convert`.
- `docs/THEMES.md`
  - Documents both Dune and Dune Dark.
- `README.md`, `README_ZH.md`, `CHANGELOG.md`
  - Public theme inventories list `dune-dark` (thirteen color themes alongside `dark`/`light`).

## Test plan

- [x] `go test ./internal/tui/ -run 'Theme|Palette|Dune|Contrast|ANSI|Diff|Hierarchy|Wired' -count=1`
- [x] `git diff HEAD --check`
- [ ] Manual: `/theme dune` is warm light sand; `/theme dune-dark` is near-black with orange accent and cool/warm diffs
- [ ] Manual (optional): `TERM=xterm` smoke for readable add/del signs on Dune Dark

Refs #841


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the “Dune Dark” terminal theme with a high-contrast, colorblind-friendly palette.
  - Improved visibility for status indicators, selections, panels, and diff highlighting.
  - Added consistent rendering in ANSI 16- and 256-color terminals.

- **Documentation**
  - Documented the new theme and updated available theme options.
  - Updated the changelog to reflect the expanded built-in theme collection.
  - Added Catppuccin and Dune Dark to the documented theme options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->