### PR TITLE
perf(providers): provider capabilities and default turn-session adapter (PR7)

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -737,23 +737,35 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		// of the run. At most one switch per turn (first request wins). A switcher
 		// error is NON-FATAL — record a brief note and continue on the current
 		// model. nil switcher ⇒ requests are ignored entirely (escalation off).
-		if turnRequestedModel != "" && options.ModelSwitcher != nil {
-			newProvider, switchErr := options.ModelSwitcher(ctx, turnRequestedModel)
+		if turnRequestedModel != "" && (options.ModelSessionSwitcher != nil || options.ModelSwitcher != nil) {
+			// Resolve the escalated model's session source. The target-aware
+			// ModelSessionSwitcher is preferred: its TurnSessionProvider carries an
+			// optimized session (and capabilities) across the swap. The legacy
+			// ModelSwitcher fallback returns a bare Provider, wrapped in the
+			// default no-op session — identical to pre-seam behavior.
+			var newSessions zeroruntime.TurnSessionProvider
+			var switchErr error
+			if options.ModelSessionSwitcher != nil {
+				newSessions, switchErr = options.ModelSessionSwitcher(ctx, turnRequestedModel)
+			} else {
+				var newProvider Provider
+				newProvider, switchErr = options.ModelSwitcher(ctx, turnRequestedModel)
+				if switchErr == nil && newProvider != nil {
+					newSessions = zeroruntime.NewProviderTurnSessionProvider(newProvider, zeroruntime.ProviderCapabilities{})
+				}
+			}
 			if switchErr != nil {
 				messages = append(messages, zeroruntime.Message{
 					Role:    zeroruntime.MessageRoleUser,
 					Content: escalationFailedNoticePrefix + " (" + turnRequestedModel + "): " + switchErr.Error() + ". Continuing on " + options.Model + ".",
 				})
-			} else if newProvider != nil {
-				// Open a fresh default session over the escalated provider and close
-				// the old one, so the next turn's streams and compaction use the new
-				// model. The default open never errors and its Close is a no-op, so
-				// this stays byte-identical to the old direct reassignment; the
-				// guarded open matters once a session holds real state. Note the
-				// switcher returns a bare Provider, so an optimized session is not
-				// carried across a swap — acceptable for the same reason as the
-				// context-window limitation below (a switcher contract change).
-				newSession, openErr := zeroruntime.NewProviderTurnSessionProvider(newProvider, zeroruntime.ProviderCapabilities{}).OpenTurnSession(ctx)
+			} else if newSessions != nil {
+				// Open the new session and close the old one, so the next turn's
+				// streams and compaction use the new model. For the default adapter
+				// the open never errors and Close is a no-op, so this stays
+				// byte-identical to a direct provider reassignment; the guarded open
+				// and prewarm matter once a session holds real state.
+				newSession, openErr := newSessions.OpenTurnSession(ctx)
 				if openErr != nil {
 					messages = append(messages, zeroruntime.Message{
 						Role:    zeroruntime.MessageRoleUser,
@@ -769,8 +781,8 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 					// KNOWN LIMITATION (deferred): the compactor's context-window budget
 					// is fixed at run start from options.ContextWindow and is NOT updated
 					// here, so a switch to a model with a different window keeps compacting
-					// against the original budget. Fixing it needs a ModelSwitcher contract
-					// change (return the new window) — out of scope for this change.
+					// against the original budget. Fixing it needs the switcher to also
+					// report the new window — out of scope for this change.
 				}
 			}
 		}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -136,6 +136,33 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		}
 	}
 
+	// Establish the run's turn session — the seam an optimized provider session
+	// (connection reuse, prewarm, native compaction) plugs into without touching
+	// this loop. Default: wrap the passed provider so the session's Stream IS
+	// provider.StreamCompletion, byte-identical to calling it directly. Opened
+	// before dispatchSessionStart so a failed open is a clean run-start error
+	// with no session hooks fired and nothing to unwind.
+	turnSessions := options.TurnSessionProvider
+	if turnSessions == nil {
+		turnSessions = zeroruntime.NewProviderTurnSessionProvider(provider, zeroruntime.ProviderCapabilities{})
+	}
+	session, sessionErr := turnSessions.OpenTurnSession(ctx)
+	if sessionErr != nil {
+		return Result{}, fmt.Errorf("agent: open turn session: %w", sessionErr)
+	}
+	// Closed via closure (not `defer session.Close()`) so after a mid-run model
+	// swap the CURRENT session is the one closed at teardown — the swap closes
+	// the old one inline. Close errors are advisory and never fail the run.
+	defer func() { _ = session.Close() }()
+	// Best-effort prewarm: the default adapter no-ops; a real session may prime
+	// a connection. Failure is ignored by contract (never fatal).
+	_ = session.Prewarm(ctx)
+	// Route ALL provider I/O — per-turn streams, mid-stream retries, the
+	// compaction summarizer, and the final-answer request — through the session
+	// by reassigning the loop's provider local. Every existing call site reads
+	// this local, so no signatures change anywhere downstream.
+	provider = sessionProvider{session: session}
+
 	maxTurns := options.MaxTurns
 	if maxTurns <= 0 {
 		maxTurns = 12
@@ -718,17 +745,33 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 					Content: escalationFailedNoticePrefix + " (" + turnRequestedModel + "): " + switchErr.Error() + ". Continuing on " + options.Model + ".",
 				})
 			} else if newProvider != nil {
-				// Reassign the local provider so the next turn's StreamCompletion and
-				// compaction use it; update options.Model so subsequent RunOptions.Model,
-				// context-window sizing, and usage attribution follow the new model.
-				provider = newProvider
-				options.Model = turnRequestedModel
-				options.Trace.Counter(trace.CounterModelSwitches, 1)
-				// KNOWN LIMITATION (deferred): the compactor's context-window budget
-				// is fixed at run start from options.ContextWindow and is NOT updated
-				// here, so a switch to a model with a different window keeps compacting
-				// against the original budget. Fixing it needs a ModelSwitcher contract
-				// change (return the new window) — out of scope for this change.
+				// Open a fresh default session over the escalated provider and close
+				// the old one, so the next turn's streams and compaction use the new
+				// model. The default open never errors and its Close is a no-op, so
+				// this stays byte-identical to the old direct reassignment; the
+				// guarded open matters once a session holds real state. Note the
+				// switcher returns a bare Provider, so an optimized session is not
+				// carried across a swap — acceptable for the same reason as the
+				// context-window limitation below (a switcher contract change).
+				newSession, openErr := zeroruntime.NewProviderTurnSessionProvider(newProvider, zeroruntime.ProviderCapabilities{}).OpenTurnSession(ctx)
+				if openErr != nil {
+					messages = append(messages, zeroruntime.Message{
+						Role:    zeroruntime.MessageRoleUser,
+						Content: escalationFailedNoticePrefix + " (" + turnRequestedModel + "): " + openErr.Error() + ". Continuing on " + options.Model + ".",
+					})
+				} else {
+					_ = session.Close()
+					session = newSession
+					_ = session.Prewarm(ctx)
+					provider = sessionProvider{session: session}
+					options.Model = turnRequestedModel
+					options.Trace.Counter(trace.CounterModelSwitches, 1)
+					// KNOWN LIMITATION (deferred): the compactor's context-window budget
+					// is fixed at run start from options.ContextWindow and is NOT updated
+					// here, so a switch to a model with a different window keeps compacting
+					// against the original budget. Fixing it needs a ModelSwitcher contract
+					// change (return the new window) — out of scope for this change.
+				}
 			}
 		}
 

--- a/internal/agent/turn_session.go
+++ b/internal/agent/turn_session.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// sessionProvider adapts a TurnSession back to the Provider interface so the
+// loop's existing Provider-shaped call sites (streamWithReconnect, the
+// compaction summarizer, finalAnswerAfterMaxTurns) route their stream I/O
+// through the session without any signature change. For the default adapter
+// this reduces to the wrapped provider's StreamCompletion, so behavior is
+// byte-identical; an optimized session (PR8) takes effect here transparently.
+type sessionProvider struct {
+	session zeroruntime.TurnSession
+}
+
+func (s sessionProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	return s.session.Stream(ctx, request)
+}

--- a/internal/agent/turn_session_test.go
+++ b/internal/agent/turn_session_test.go
@@ -280,6 +280,52 @@ func TestRunModelSessionSwitcherCarriesOptimizedSession(t *testing.T) {
 	}
 }
 
+// TestRunModelSessionSwitcherOpenFailureIsNonFatal verifies the swap-time open
+// failure: the switcher returns a TurnSessionProvider whose OpenTurnSession
+// fails. The run stays non-fatal on the ORIGINAL session (closed only at
+// teardown), and the switch-failure note reaches the next request.
+func TestRunModelSessionSwitcherOpenFailureIsNonFatal(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	inner := &mockProvider{turns: escalateThenAnswerTurns("recovered after failed open")}
+	session := &fakeTurnSession{inner: inner}
+	failingOpen := &fakeTurnSessionProvider{openErr: errors.New("switched handshake refused")}
+
+	result, err := Run(context.Background(), "go", inner, Options{
+		Registry:            registry,
+		Model:               "claude-sonnet-4.5",
+		MaxTurns:            4,
+		TurnSessionProvider: &fakeTurnSessionProvider{session: session},
+		ModelSessionSwitcher: func(_ context.Context, _ string) (zeroruntime.TurnSessionProvider, error) {
+			return failingOpen, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected a failed swap open to be non-fatal, got %v", err)
+	}
+	if result.FinalAnswer != "recovered after failed open" {
+		t.Fatalf("expected the run to recover on the original session, got %q", result.FinalAnswer)
+	}
+	if failingOpen.opens != 1 {
+		t.Fatalf("expected exactly one open attempt on the switched provider, got %d", failingOpen.opens)
+	}
+	// The original session serves both turns and is closed only at teardown —
+	// never by the failed swap.
+	if session.streams != 2 || session.closes != 1 {
+		t.Fatalf("expected the original session to serve both turns and close once (streams=%d closes=%d)", session.streams, session.closes)
+	}
+	var sawNote bool
+	for _, message := range inner.requests[1].Messages {
+		if message.Role == zeroruntime.MessageRoleUser && strings.Contains(strings.ToLower(message.Content), "could not switch") {
+			sawNote = true
+		}
+	}
+	if !sawNote {
+		t.Fatalf("expected a switch-failure note on the next turn, messages: %+v", inner.requests[1].Messages)
+	}
+}
+
 // TestRunModelSessionSwitcherErrorIsNonFatal verifies a ModelSessionSwitcher
 // error keeps the run on the current session with a transcript note — the same
 // non-fatal contract as ModelSwitcher.

--- a/internal/agent/turn_session_test.go
+++ b/internal/agent/turn_session_test.go
@@ -1,0 +1,216 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// fakeTurnSession wraps an inner provider for streaming while counting the
+// session lifecycle, so tests can observe exactly how the loop drives it.
+type fakeTurnSession struct {
+	inner    Provider
+	prewarms int
+	streams  int
+	closes   int
+	closeErr error
+}
+
+func (s *fakeTurnSession) Prewarm(context.Context) error { s.prewarms++; return nil }
+
+func (s *fakeTurnSession) Stream(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	s.streams++
+	return s.inner.StreamCompletion(ctx, request)
+}
+
+func (s *fakeTurnSession) Compact(context.Context, zeroruntime.CompletionRequest) ([]zeroruntime.Message, error) {
+	return nil, zeroruntime.ErrCompactionUnsupported
+}
+
+func (s *fakeTurnSession) Close() error { s.closes++; return s.closeErr }
+
+// fakeTurnSessionProvider opens a scripted session (or fails to).
+type fakeTurnSessionProvider struct {
+	session *fakeTurnSession
+	openErr error
+	opens   int
+}
+
+func (p *fakeTurnSessionProvider) OpenTurnSession(context.Context) (zeroruntime.TurnSession, error) {
+	p.opens++
+	if p.openErr != nil {
+		return nil, p.openErr
+	}
+	return p.session, nil
+}
+
+func (p *fakeTurnSessionProvider) Capabilities() zeroruntime.ProviderCapabilities {
+	return zeroruntime.ProviderCapabilities{}
+}
+
+func singleAnswerTurns(answer string) [][]zeroruntime.StreamEvent {
+	return [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventText, Content: answer},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+}
+
+// TestRunOpenTurnSessionFailureSurfaces verifies a failed session open is a
+// clean run-start error: no panic, no stream ever issued, nothing to close.
+func TestRunOpenTurnSessionFailureSurfaces(t *testing.T) {
+	positional := &mockProvider{turns: singleAnswerTurns("never reached")}
+	tsp := &fakeTurnSessionProvider{openErr: errors.New("handshake refused")}
+
+	_, err := Run(context.Background(), "go", positional, Options{
+		MaxTurns:            2,
+		TurnSessionProvider: tsp,
+	})
+	if err == nil {
+		t.Fatal("expected an error from a failed session open")
+	}
+	if !strings.Contains(err.Error(), "open turn session") || !strings.Contains(err.Error(), "handshake refused") {
+		t.Fatalf("expected a wrapped open-turn-session error, got %v", err)
+	}
+	if len(positional.requests) != 0 {
+		t.Fatalf("expected no provider request after a failed open, got %d", len(positional.requests))
+	}
+	if tsp.opens != 1 {
+		t.Fatalf("expected exactly one open attempt, got %d", tsp.opens)
+	}
+}
+
+// TestRunCloseFailureIsSafe verifies a Close error at teardown is swallowed:
+// the run still returns its normal result.
+func TestRunCloseFailureIsSafe(t *testing.T) {
+	inner := &mockProvider{turns: singleAnswerTurns("done")}
+	session := &fakeTurnSession{inner: inner, closeErr: errors.New("close blew up")}
+	tsp := &fakeTurnSessionProvider{session: session}
+
+	result, err := Run(context.Background(), "go", inner, Options{
+		MaxTurns:            2,
+		TurnSessionProvider: tsp,
+	})
+	if err != nil {
+		t.Fatalf("expected Close failure to be swallowed, got %v", err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("expected normal result despite Close error, got %q", result.FinalAnswer)
+	}
+	if session.closes != 1 {
+		t.Fatalf("expected exactly one Close at teardown, got %d", session.closes)
+	}
+}
+
+// TestRunStreamsThroughTurnSession verifies that when a TurnSessionProvider is
+// wired, every model request of the run flows through the session (and the
+// session is prewarmed once and closed once).
+func TestRunStreamsThroughTurnSession(t *testing.T) {
+	inner := &mockProvider{turns: singleAnswerTurns("via session")}
+	session := &fakeTurnSession{inner: inner}
+	tsp := &fakeTurnSessionProvider{session: session}
+
+	// The positional provider is a DIFFERENT mock: it must stay untouched,
+	// proving the session (not the positional provider) carried the run.
+	positional := &mockProvider{turns: singleAnswerTurns("wrong path")}
+
+	result, err := Run(context.Background(), "go", positional, Options{
+		MaxTurns:            2,
+		TurnSessionProvider: tsp,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "via session" {
+		t.Fatalf("expected the session-backed answer, got %q", result.FinalAnswer)
+	}
+	if len(positional.requests) != 0 {
+		t.Fatalf("expected the positional provider to be bypassed, got %d requests", len(positional.requests))
+	}
+	if session.streams == 0 || session.streams != len(inner.requests) {
+		t.Fatalf("expected every request to flow through the session: streams=%d inner=%d", session.streams, len(inner.requests))
+	}
+	if session.prewarms != 1 {
+		t.Fatalf("expected exactly one prewarm, got %d", session.prewarms)
+	}
+	if session.closes != 1 {
+		t.Fatalf("expected exactly one close, got %d", session.closes)
+	}
+}
+
+// TestRunDefaultTurnSessionMatchesRawProvider verifies the default (nil
+// TurnSessionProvider) path is behavior-identical to passing an explicit
+// default adapter over the same provider: same result, same request count.
+func TestRunDefaultTurnSessionMatchesRawProvider(t *testing.T) {
+	run := func(explicit bool) (Result, *mockProvider) {
+		provider := &mockProvider{turns: escalateThenAnswerTurns("identical")}
+		registry := tools.NewRegistry()
+		registry.Register(escalatingTool{target: ""})
+		options := Options{Registry: registry, MaxTurns: 4}
+		if explicit {
+			options.TurnSessionProvider = zeroruntime.NewProviderTurnSessionProvider(provider, zeroruntime.ProviderCapabilities{})
+		}
+		result, err := Run(context.Background(), "go", provider, options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result, provider
+	}
+
+	defaultResult, defaultProvider := run(false)
+	explicitResult, explicitProvider := run(true)
+
+	if defaultResult.FinalAnswer != explicitResult.FinalAnswer {
+		t.Fatalf("final answers diverged: default=%q explicit=%q", defaultResult.FinalAnswer, explicitResult.FinalAnswer)
+	}
+	if defaultResult.Turns != explicitResult.Turns {
+		t.Fatalf("turn counts diverged: default=%d explicit=%d", defaultResult.Turns, explicitResult.Turns)
+	}
+	if len(defaultProvider.requests) != len(explicitProvider.requests) {
+		t.Fatalf("request counts diverged: default=%d explicit=%d", len(defaultProvider.requests), len(explicitProvider.requests))
+	}
+}
+
+// TestRunModelSwitchClosesSessionAndContinues verifies a mid-run model switch
+// closes the active session exactly once and streams the rest of the run on
+// the new provider.
+func TestRunModelSwitchClosesSessionAndContinues(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	firstInner := &mockProvider{turns: escalateThenAnswerTurns("unused")}
+	firstSession := &fakeTurnSession{inner: firstInner}
+	tsp := &fakeTurnSessionProvider{session: firstSession}
+
+	secondProvider := &mockProvider{turns: singleAnswerTurns("answered after switch")}
+
+	result, err := Run(context.Background(), "go", firstInner, Options{
+		Registry:            registry,
+		Model:               "claude-sonnet-4.5",
+		MaxTurns:            4,
+		TurnSessionProvider: tsp,
+		ModelSwitcher: func(_ context.Context, _ string) (Provider, error) {
+			return secondProvider, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "answered after switch" {
+		t.Fatalf("expected the post-switch answer, got %q", result.FinalAnswer)
+	}
+	// The original session handled exactly the escalation turn, then was closed
+	// once by the swap (the teardown defer closes the NEW session, not this one).
+	if firstSession.streams != 1 {
+		t.Fatalf("expected the original session to stream exactly the escalation turn, got %d", firstSession.streams)
+	}
+	if firstSession.closes != 1 {
+		t.Fatalf("expected the swap to close the original session exactly once, got %d", firstSession.closes)
+	}
+	if len(secondProvider.requests) != 1 {
+		t.Fatalf("expected the post-switch turn on the new provider, got %d requests", len(secondProvider.requests))
+	}
+}

--- a/internal/agent/turn_session_test.go
+++ b/internal/agent/turn_session_test.go
@@ -214,3 +214,108 @@ func TestRunModelSwitchClosesSessionAndContinues(t *testing.T) {
 		t.Fatalf("expected the post-switch turn on the new provider, got %d requests", len(secondProvider.requests))
 	}
 }
+
+// TestRunModelSessionSwitcherCarriesOptimizedSession verifies the target-aware
+// switcher: the switched-to TurnSessionProvider's DISTINCT session receives the
+// post-switch streams, is prewarmed exactly once, and is closed exactly once at
+// teardown — and the legacy ModelSwitcher is never consulted when both are set.
+func TestRunModelSessionSwitcherCarriesOptimizedSession(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	firstInner := &mockProvider{turns: escalateThenAnswerTurns("unused")}
+	firstSession := &fakeTurnSession{inner: firstInner}
+	initial := &fakeTurnSessionProvider{session: firstSession}
+
+	switchedInner := &mockProvider{turns: singleAnswerTurns("answered on the switched session")}
+	switchedSession := &fakeTurnSession{inner: switchedInner}
+	switched := &fakeTurnSessionProvider{session: switchedSession}
+
+	var switchedTo string
+	legacyCalled := false
+	result, err := Run(context.Background(), "go", firstInner, Options{
+		Registry:            registry,
+		Model:               "claude-sonnet-4.5",
+		MaxTurns:            4,
+		TurnSessionProvider: initial,
+		ModelSessionSwitcher: func(_ context.Context, modelID string) (zeroruntime.TurnSessionProvider, error) {
+			switchedTo = modelID
+			return switched, nil
+		},
+		ModelSwitcher: func(_ context.Context, _ string) (Provider, error) {
+			legacyCalled = true
+			return nil, errors.New("legacy switcher must not be consulted")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "answered on the switched session" {
+		t.Fatalf("expected the switched session's answer, got %q", result.FinalAnswer)
+	}
+	if switchedTo != "claude-opus-4.1" {
+		t.Fatalf("expected switch to claude-opus-4.1, got %q", switchedTo)
+	}
+	if legacyCalled {
+		t.Fatal("legacy ModelSwitcher was consulted despite ModelSessionSwitcher being set")
+	}
+	if switched.opens != 1 {
+		t.Fatalf("expected exactly one open of the switched provider, got %d", switched.opens)
+	}
+	// The switched session carries the rest of the run: it streams the answer
+	// turn, is prewarmed exactly once at the swap, and is closed exactly once by
+	// the teardown defer.
+	if switchedSession.streams != 1 || len(switchedInner.requests) != 1 {
+		t.Fatalf("expected the switched session to stream the post-switch turn, streams=%d inner=%d", switchedSession.streams, len(switchedInner.requests))
+	}
+	if switchedSession.prewarms != 1 {
+		t.Fatalf("expected the switched session to be prewarmed exactly once, got %d", switchedSession.prewarms)
+	}
+	if switchedSession.closes != 1 {
+		t.Fatalf("expected the switched session to be closed exactly once at teardown, got %d", switchedSession.closes)
+	}
+	// The original session ends with the swap: one stream, one close.
+	if firstSession.streams != 1 || firstSession.closes != 1 {
+		t.Fatalf("expected the original session to end at the swap (streams=%d closes=%d)", firstSession.streams, firstSession.closes)
+	}
+}
+
+// TestRunModelSessionSwitcherErrorIsNonFatal verifies a ModelSessionSwitcher
+// error keeps the run on the current session with a transcript note — the same
+// non-fatal contract as ModelSwitcher.
+func TestRunModelSessionSwitcherErrorIsNonFatal(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	inner := &mockProvider{turns: escalateThenAnswerTurns("recovered on original session")}
+	session := &fakeTurnSession{inner: inner}
+
+	result, err := Run(context.Background(), "go", inner, Options{
+		Registry:            registry,
+		Model:               "claude-sonnet-4.5",
+		MaxTurns:            4,
+		TurnSessionProvider: &fakeTurnSessionProvider{session: session},
+		ModelSessionSwitcher: func(_ context.Context, _ string) (zeroruntime.TurnSessionProvider, error) {
+			return nil, errors.New("session build blew up")
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected session-switcher error to be non-fatal, got %v", err)
+	}
+	if result.FinalAnswer != "recovered on original session" {
+		t.Fatalf("expected the run to recover on the original session, got %q", result.FinalAnswer)
+	}
+	// Both turns stream through the original session; it closes once at teardown.
+	if session.streams != 2 || session.closes != 1 {
+		t.Fatalf("expected the original session to serve both turns and close once (streams=%d closes=%d)", session.streams, session.closes)
+	}
+	var sawNote bool
+	for _, request := range inner.requests[1].Messages {
+		if request.Role == zeroruntime.MessageRoleUser && strings.Contains(strings.ToLower(request.Content), "could not switch") {
+			sawNote = true
+		}
+	}
+	if !sawNote {
+		t.Fatalf("expected a non-fatal switch-failure note on the next turn, messages: %+v", inner.requests[1].Messages)
+	}
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -290,6 +290,14 @@ type Options struct {
 	// whose Stream IS provider.StreamCompletion, so behavior is byte-identical
 	// and every existing caller is unaffected.
 	TurnSessionProvider zeroruntime.TurnSessionProvider
+	// ModelSessionSwitcher, when set, is the target-aware escalation hook: the
+	// loop prefers it over ModelSwitcher, and its TurnSessionProvider keeps an
+	// optimized session (and its capabilities) across a mid-run model switch.
+	// nil falls back to ModelSwitcher, whose bare Provider is wrapped in the
+	// default no-op session — today's behavior, unchanged. Same non-fatal error
+	// contract as ModelSwitcher: a returned error records a note and the run
+	// continues on the current model and session.
+	ModelSessionSwitcher func(ctx context.Context, modelID string) (zeroruntime.TurnSessionProvider, error)
 	// Trace, when set, records per-turn timing for the run: the loop stamps
 	// spans (prompt build, generation, tool execution, permission wait,
 	// compaction, provider connect) and counters (model requests, tool calls,

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -283,6 +283,13 @@ type Options struct {
 	// request), so every existing caller is unaffected. A returned error is
 	// non-fatal: the run continues on the current model.
 	ModelSwitcher func(ctx context.Context, modelID string) (Provider, error)
+	// TurnSessionProvider, when set, supplies the turn session the run streams
+	// through — the seam an optimized provider session (connection reuse,
+	// prewarm, native compaction) plugs into without touching the loop. nil
+	// keeps the default: the loop wraps the passed provider in a no-op session
+	// whose Stream IS provider.StreamCompletion, so behavior is byte-identical
+	// and every existing caller is unaffected.
+	TurnSessionProvider zeroruntime.TurnSessionProvider
 	// Trace, when set, records per-turn timing for the run: the loop stamps
 	// spans (prompt build, generation, tool execution, permission wait,
 	// compaction, provider connect) and counters (model requests, tool calls,

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -148,7 +148,11 @@ func resolveCapabilities(profile config.ProviderProfile, options Options) (zeror
 		caps.SupportsVision = entry.Supports(modelregistry.ModelCapabilityVision)
 		caps.SupportsReasoning = entry.Supports(modelregistry.ModelCapabilityReasoning)
 		caps.SupportsPromptCache = entry.Supports(modelregistry.ModelCapabilityPromptCache)
-		for _, effort := range entry.ReasoningEfforts {
+		// Read efforts through Registry.ReasoningEfforts (not the raw entry) so
+		// the projection matches what the /effort picker and the run-time
+		// resolver advertise — including the name-based fallback for catalog
+		// entries that enumerate no efforts of their own.
+		for _, effort := range registry.ReasoningEfforts(entry.ID) {
 			caps.ReasoningEfforts = append(caps.ReasoningEfforts, string(effort))
 		}
 	}

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -108,6 +108,53 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 	}
 }
 
+// NewTurnSessionProvider builds the default TurnSessionProvider for a resolved
+// profile: it constructs the provider exactly as New does, then wraps it with a
+// ProviderCapabilities projection computed from the same model-registry entry
+// New already resolves. The default session's Stream is the provider's
+// StreamCompletion, so runtime behavior is identical to using New directly.
+func NewTurnSessionProvider(profile config.ProviderProfile, options Options) (zeroruntime.TurnSessionProvider, error) {
+	provider, err := New(profile, options)
+	if err != nil {
+		return nil, err
+	}
+	caps, err := resolveCapabilities(profile, options)
+	if err != nil {
+		return nil, err
+	}
+	return zeroruntime.NewProviderTurnSessionProvider(provider, caps), nil
+}
+
+// resolveCapabilities projects the resolved profile's model-registry entry into
+// the flat zeroruntime.ProviderCapabilities (zeroruntime cannot reference
+// modelregistry types — modelregistry imports zeroruntime, so a typed field
+// would form an import cycle). A model absent from the registry yields only the
+// resolved API model id and max-output tokens; the rest stays zero (unknown).
+func resolveCapabilities(profile config.ProviderProfile, options Options) (zeroruntime.ProviderCapabilities, error) {
+	resolved, err := resolveProfile(profile, options)
+	if err != nil {
+		return zeroruntime.ProviderCapabilities{}, err
+	}
+	caps := zeroruntime.ProviderCapabilities{
+		Model:           resolved.apiModel,
+		MaxOutputTokens: resolved.maxOutputTokens,
+	}
+	registry, err := defaultRegistry(options.ModelRegistry)
+	if err != nil {
+		return zeroruntime.ProviderCapabilities{}, err
+	}
+	if entry, ok := registry.Get(strings.TrimSpace(profile.Model)); ok {
+		caps.ContextWindow = entry.ContextLimits.ContextWindow
+		caps.SupportsVision = entry.Supports(modelregistry.ModelCapabilityVision)
+		caps.SupportsReasoning = entry.Supports(modelregistry.ModelCapabilityReasoning)
+		caps.SupportsPromptCache = entry.Supports(modelregistry.ModelCapabilityPromptCache)
+		for _, effort := range entry.ReasoningEfforts {
+			caps.ReasoningEfforts = append(caps.ReasoningEfforts, string(effort))
+		}
+	}
+	return caps, nil
+}
+
 func parseThinkTagsForProfile(profile config.ProviderProfile, resolved resolvedProfile) bool {
 	if profile.ParseThinkTags != nil {
 		return *profile.ParseThinkTags

--- a/internal/providers/factory_turn_session_test.go
+++ b/internal/providers/factory_turn_session_test.go
@@ -131,3 +131,64 @@ func TestNewTurnSessionProviderProjectsRegistryCapabilities(t *testing.T) {
 		t.Fatal("NativeCompaction = true, want false for the default adapter")
 	}
 }
+
+// TestNewTurnSessionProviderUsesEffectiveReasoningEfforts asserts the
+// projection reads efforts through Registry.ReasoningEfforts, so a catalog
+// entry that enumerates no efforts of its own still reports the name-inferred
+// effective tiers the /effort picker and run-time resolver advertise.
+func TestNewTurnSessionProviderUsesEffectiveReasoningEfforts(t *testing.T) {
+	registry, err := modelregistry.NewRegistry([]modelregistry.ModelEntry{{
+		// A gpt-5-family id with NO ReasoningEfforts listed: the effective
+		// efforts come from name inference, differing from the raw entry.
+		ID:          "gpt-5-pr7-probe",
+		DisplayName: "PR7 Effective Efforts Probe",
+		APIModel:    "gpt-5-pr7-probe-api",
+		Provider:    modelregistry.ProviderOpenAI,
+		ContextLimits: modelregistry.ContextLimits{
+			ContextWindow:   400_000,
+			MaxOutputTokens: 128_000,
+		},
+		Capabilities: modelregistry.ModelCapabilities{
+			modelregistry.ModelCapabilityChat,
+			modelregistry.ModelCapabilityReasoning,
+		},
+		Cost: modelregistry.ModelCost{
+			Currency:           "USD",
+			Unit:               "per_1m_tokens",
+			InputPerMillion:    1,
+			OutputPerMillion:   2,
+			Source:             "https://provider.example/pricing (test fixture)",
+			SourceLastVerified: "2026-07-18",
+		},
+		Status:  modelregistry.ModelStatusActive,
+		Aliases: []string{"pr7-effective-efforts"},
+	}})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	tsp, err := NewTurnSessionProvider(config.ProviderProfile{
+		Name:         "pr7-effective",
+		ProviderKind: config.ProviderKindOpenAI,
+		BaseURL:      "https://provider.example/v1",
+		APIKey:       "sk-turn-session-test",
+		Model:        "gpt-5-pr7-probe",
+	}, Options{
+		UserAgent:     "zero-turn-session-test",
+		ModelRegistry: &registry,
+	})
+	if err != nil {
+		t.Fatalf("NewTurnSessionProvider: %v", err)
+	}
+
+	got := tsp.Capabilities().ReasoningEfforts
+	want := []string{"minimal", "low", "medium", "high"}
+	if len(got) != len(want) {
+		t.Fatalf("ReasoningEfforts = %v, want %v (name-inferred fallback)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ReasoningEfforts[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/providers/factory_turn_session_test.go
+++ b/internal/providers/factory_turn_session_test.go
@@ -1,0 +1,133 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// TestNewTurnSessionProviderForEveryKind asserts every current provider kind
+// wraps into the default TurnSessionProvider: construction succeeds, a session
+// opens, and Compact reports unsupported (the default adapter contract).
+func TestNewTurnSessionProviderForEveryKind(t *testing.T) {
+	kinds := []config.ProviderKind{
+		config.ProviderKindOpenAI,
+		config.ProviderKindOpenAICompatible,
+		config.ProviderKindAnthropic,
+		config.ProviderKindAnthropicCompat,
+		config.ProviderKindGoogle,
+	}
+	for _, kind := range kinds {
+		t.Run(string(kind), func(t *testing.T) {
+			tsp, err := NewTurnSessionProvider(config.ProviderProfile{
+				Name:         "pr7-" + string(kind),
+				ProviderKind: kind,
+				BaseURL:      "https://provider.example/v1",
+				APIKey:       "sk-turn-session-test",
+				// A model absent from the registry: resolution falls back to the
+				// raw id, so this test stays hermetic across catalog changes.
+				Model: "pr7-unregistered-model",
+			}, Options{UserAgent: "zero-turn-session-test"})
+			if err != nil {
+				t.Fatalf("NewTurnSessionProvider(%s): %v", kind, err)
+			}
+			session, err := tsp.OpenTurnSession(context.Background())
+			if err != nil {
+				t.Fatalf("OpenTurnSession(%s): %v", kind, err)
+			}
+			defer func() {
+				if closeErr := session.Close(); closeErr != nil {
+					t.Fatalf("Close(%s): %v", kind, closeErr)
+				}
+			}()
+			if err := session.Prewarm(context.Background()); err != nil {
+				t.Fatalf("Prewarm(%s): %v", kind, err)
+			}
+			if _, compactErr := session.Compact(context.Background(), zeroruntime.CompletionRequest{}); !errors.Is(compactErr, zeroruntime.ErrCompactionUnsupported) {
+				t.Fatalf("Compact(%s) = %v, want ErrCompactionUnsupported", kind, compactErr)
+			}
+			caps := tsp.Capabilities()
+			if caps.Model != "pr7-unregistered-model" {
+				t.Fatalf("Capabilities(%s).Model = %q, want the resolved api model", kind, caps.Model)
+			}
+			if caps.NativeCompaction {
+				t.Fatalf("Capabilities(%s).NativeCompaction = true, want false for the default adapter", kind)
+			}
+		})
+	}
+}
+
+// TestNewTurnSessionProviderProjectsRegistryCapabilities asserts the factory
+// projects the model-registry entry (context limits, capability flags,
+// reasoning efforts) into the flat ProviderCapabilities.
+func TestNewTurnSessionProviderProjectsRegistryCapabilities(t *testing.T) {
+	registry, err := modelregistry.NewRegistry([]modelregistry.ModelEntry{{
+		ID:          "pr7-caps-model",
+		DisplayName: "PR7 Capability Probe",
+		APIModel:    "pr7-caps-api-model",
+		Provider:    modelregistry.ProviderOpenAI,
+		ContextLimits: modelregistry.ContextLimits{
+			ContextWindow:   200_000,
+			MaxOutputTokens: 64_000,
+		},
+		ReasoningEfforts: []modelregistry.ReasoningEffort{
+			modelregistry.ReasoningEffortLow,
+			modelregistry.ReasoningEffortMedium,
+			modelregistry.ReasoningEffortHigh,
+		},
+		Capabilities: modelregistry.ModelCapabilities{
+			modelregistry.ModelCapabilityChat,
+			modelregistry.ModelCapabilityVision,
+			modelregistry.ModelCapabilityReasoning,
+			modelregistry.ModelCapabilityPromptCache,
+		},
+		Cost: modelregistry.ModelCost{
+			Currency:           "USD",
+			Unit:               "per_1m_tokens",
+			InputPerMillion:    1,
+			OutputPerMillion:   2,
+			Source:             "https://provider.example/pricing (test fixture)",
+			SourceLastVerified: "2026-07-18",
+		},
+		Status:  modelregistry.ModelStatusActive,
+		Aliases: []string{"pr7-caps"},
+	}})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	tsp, err := NewTurnSessionProvider(config.ProviderProfile{
+		Name:         "pr7-caps",
+		ProviderKind: config.ProviderKindOpenAI,
+		BaseURL:      "https://provider.example/v1",
+		APIKey:       "sk-turn-session-test",
+		Model:        "pr7-caps-model",
+	}, Options{
+		UserAgent:     "zero-turn-session-test",
+		ModelRegistry: &registry,
+	})
+	if err != nil {
+		t.Fatalf("NewTurnSessionProvider: %v", err)
+	}
+
+	caps := tsp.Capabilities()
+	if caps.Model != "pr7-caps-api-model" {
+		t.Fatalf("Model = %q, want the registry APIModel", caps.Model)
+	}
+	if caps.ContextWindow != 200_000 || caps.MaxOutputTokens != 64_000 {
+		t.Fatalf("limits = (%d, %d), want (200000, 64000)", caps.ContextWindow, caps.MaxOutputTokens)
+	}
+	if !caps.SupportsVision || !caps.SupportsReasoning || !caps.SupportsPromptCache {
+		t.Fatalf("capability flags = %+v, want vision/reasoning/prompt-cache all true", caps)
+	}
+	if len(caps.ReasoningEfforts) != 3 || caps.ReasoningEfforts[0] != "low" || caps.ReasoningEfforts[2] != "high" {
+		t.Fatalf("ReasoningEfforts = %v, want [low medium high]", caps.ReasoningEfforts)
+	}
+	if caps.NativeCompaction {
+		t.Fatal("NativeCompaction = true, want false for the default adapter")
+	}
+}

--- a/internal/zeroruntime/session.go
+++ b/internal/zeroruntime/session.go
@@ -1,0 +1,125 @@
+package zeroruntime
+
+import (
+	"context"
+	"errors"
+)
+
+// ProviderCapabilities is a flat, provider-agnostic projection of a resolved
+// model's static capabilities. It is deliberately plain data — no modelregistry
+// or reasoning types — because modelregistry imports zeroruntime, so a typed
+// reference here would form an import cycle. The providers factory populates it
+// from the model-registry entry it already resolves; a zero value means the
+// capabilities are unknown, which every consumer must treat as "assume nothing".
+type ProviderCapabilities struct {
+	// Model is the resolved API model id (informational; may be empty).
+	Model string
+	// ContextWindow is the model's max input context in tokens; 0 = unknown.
+	ContextWindow int
+	// MaxOutputTokens is the model's max output tokens per turn; 0 = unknown.
+	MaxOutputTokens int
+	// SupportsVision mirrors the registry's vision capability.
+	SupportsVision bool
+	// SupportsReasoning mirrors the registry's reasoning capability.
+	SupportsReasoning bool
+	// SupportsPromptCache mirrors the registry's prompt-cache capability.
+	SupportsPromptCache bool
+	// ReasoningEfforts lists the accepted effort tiers, weakest to strongest.
+	// nil/empty means the model exposes no effort control.
+	ReasoningEfforts []string
+	// NativeCompaction reports server-side compaction support. Always false for
+	// the default adapter; a future native-compaction session sets it, and the
+	// loop branches on it to call TurnSession.Compact instead of the local
+	// summarizer.
+	NativeCompaction bool
+}
+
+// ErrCompactionUnsupported is returned by TurnSession.Compact when the provider
+// has no native server-side compaction (every default adapter). Callers treat
+// it as "use the local summarizer path", not as a run failure.
+var ErrCompactionUnsupported = errors.New("zeroruntime: native compaction unsupported")
+
+// TurnSession is one provider conversation for the lifetime of a single agent
+// run: many turns, compaction summaries, and any mid-run model swaps each open
+// a fresh session. It owns whatever per-run provider state an optimized
+// implementation keeps warm (a pooled connection, a cached-prefix handle). The
+// default adapter holds nothing and every method degrades to today's one-shot
+// request path.
+type TurnSession interface {
+	// Prewarm optionally primes provider-side state before the first Stream.
+	// It must be safe to skip entirely: the default adapter no-ops and returns
+	// nil. A non-nil error is advisory — callers proceed without prewarming
+	// (best-effort, never fatal).
+	Prewarm(ctx context.Context) error
+
+	// Stream issues one completion request. The signature is identical to
+	// Provider.StreamCompletion so the default adapter forwards verbatim and
+	// callers' stream handling stays byte-for-byte unchanged.
+	Stream(ctx context.Context, request CompletionRequest) (<-chan StreamEvent, error)
+
+	// Compact asks the provider to compact the conversation server-side and
+	// returns the replacement messages. The default adapter returns
+	// ErrCompactionUnsupported; callers then keep their local summarizer path.
+	Compact(ctx context.Context, request CompletionRequest) ([]Message, error)
+
+	// Close releases per-run provider state. It must be idempotent and safe to
+	// call after a mid-run swap as well as at run teardown. Default: no-op.
+	Close() error
+}
+
+// TurnSessionProvider opens a TurnSession for one run and exposes the resolved
+// model's static capabilities. The providers factory builds the default
+// implementation by wrapping an existing Provider.
+type TurnSessionProvider interface {
+	// OpenTurnSession starts a session for one run. Everything a session needs
+	// per request (messages, tools, reasoning effort, prompt-cache key) already
+	// arrives on Stream, so nothing beyond ctx is passed here — keeping the
+	// seam narrow. The default adapter never errors; a real implementation may
+	// fail a handshake, which callers surface as a clean run-start error.
+	OpenTurnSession(ctx context.Context) (TurnSession, error)
+
+	// Capabilities returns the resolved model's static capability projection.
+	Capabilities() ProviderCapabilities
+}
+
+// NewProviderTurnSessionProvider wraps an existing Provider as a default
+// TurnSessionProvider. caps may be the zero value (unknown) for callers that
+// only need streaming behavior; the providers factory supplies a populated
+// projection.
+func NewProviderTurnSessionProvider(provider Provider, caps ProviderCapabilities) TurnSessionProvider {
+	return providerTurnSessionProvider{provider: provider, caps: caps}
+}
+
+// providerTurnSessionProvider is the default TurnSessionProvider: it wraps a
+// Provider so every current provider plugs into the session seam unchanged.
+type providerTurnSessionProvider struct {
+	provider Provider
+	caps     ProviderCapabilities
+}
+
+func (d providerTurnSessionProvider) OpenTurnSession(context.Context) (TurnSession, error) {
+	return providerTurnSession{provider: d.provider}, nil
+}
+
+func (d providerTurnSessionProvider) Capabilities() ProviderCapabilities {
+	return d.caps
+}
+
+// providerTurnSession forwards Stream to the wrapped Provider; Prewarm and
+// Close are no-ops and Compact is unsupported. The value receiver keeps it
+// stateless, so double-Close and post-Close Stream are inherently safe.
+type providerTurnSession struct {
+	provider Provider
+}
+
+func (s providerTurnSession) Prewarm(context.Context) error { return nil }
+
+func (s providerTurnSession) Stream(ctx context.Context, request CompletionRequest) (<-chan StreamEvent, error) {
+	return s.provider.StreamCompletion(ctx, request)
+}
+
+func (s providerTurnSession) Compact(context.Context, CompletionRequest) ([]Message, error) {
+	return nil, ErrCompactionUnsupported
+}
+
+func (s providerTurnSession) Close() error { return nil }

--- a/internal/zeroruntime/session_test.go
+++ b/internal/zeroruntime/session_test.go
@@ -1,0 +1,126 @@
+package zeroruntime
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// recordingProvider captures every request and replays a scripted event stream,
+// so tests can assert the default session forwards verbatim.
+type recordingProvider struct {
+	requests []CompletionRequest
+	events   []StreamEvent
+	err      error
+}
+
+func (p *recordingProvider) StreamCompletion(_ context.Context, request CompletionRequest) (<-chan StreamEvent, error) {
+	p.requests = append(p.requests, request)
+	if p.err != nil {
+		return nil, p.err
+	}
+	ch := make(chan StreamEvent, len(p.events))
+	for _, event := range p.events {
+		ch <- event
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestDefaultTurnSessionStreamForwardsVerbatim(t *testing.T) {
+	provider := &recordingProvider{events: []StreamEvent{
+		{Type: StreamEventText, Content: "hello"},
+		{Type: StreamEventDone, FinishReason: "stop"},
+	}}
+	session, err := NewProviderTurnSessionProvider(provider, ProviderCapabilities{}).OpenTurnSession(context.Background())
+	if err != nil {
+		t.Fatalf("OpenTurnSession: %v", err)
+	}
+
+	request := CompletionRequest{
+		Messages:        []Message{{Role: MessageRoleUser, Content: "hi"}},
+		ReasoningEffort: "high",
+		PromptCacheKey:  "session-123",
+	}
+	stream, err := session.Stream(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var got []StreamEvent
+	for event := range stream {
+		got = append(got, event)
+	}
+	if len(got) != 2 || got[0].Content != "hello" || got[1].FinishReason != "stop" {
+		t.Fatalf("stream events not forwarded verbatim: %#v", got)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("provider saw %d requests, want 1", len(provider.requests))
+	}
+	recorded := provider.requests[0]
+	if recorded.PromptCacheKey != request.PromptCacheKey ||
+		recorded.ReasoningEffort != request.ReasoningEffort ||
+		len(recorded.Messages) != 1 || recorded.Messages[0].Content != "hi" {
+		t.Fatalf("request not forwarded verbatim: %#v", recorded)
+	}
+}
+
+func TestDefaultTurnSessionStreamPropagatesError(t *testing.T) {
+	wantErr := errors.New("provider unavailable")
+	provider := &recordingProvider{err: wantErr}
+	session, err := NewProviderTurnSessionProvider(provider, ProviderCapabilities{}).OpenTurnSession(context.Background())
+	if err != nil {
+		t.Fatalf("OpenTurnSession: %v", err)
+	}
+	if _, streamErr := session.Stream(context.Background(), CompletionRequest{}); !errors.Is(streamErr, wantErr) {
+		t.Fatalf("Stream error = %v, want %v", streamErr, wantErr)
+	}
+}
+
+func TestDefaultTurnSessionPrewarmCloseNoop(t *testing.T) {
+	session, err := NewProviderTurnSessionProvider(&recordingProvider{}, ProviderCapabilities{}).OpenTurnSession(context.Background())
+	if err != nil {
+		t.Fatalf("OpenTurnSession: %v", err)
+	}
+	if err := session.Prewarm(context.Background()); err != nil {
+		t.Fatalf("Prewarm: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Idempotent: a second Close (e.g. after a mid-run swap already closed it)
+	// must also succeed.
+	if err := session.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestDefaultTurnSessionCompactUnsupported(t *testing.T) {
+	session, err := NewProviderTurnSessionProvider(&recordingProvider{}, ProviderCapabilities{}).OpenTurnSession(context.Background())
+	if err != nil {
+		t.Fatalf("OpenTurnSession: %v", err)
+	}
+	if _, compactErr := session.Compact(context.Background(), CompletionRequest{}); !errors.Is(compactErr, ErrCompactionUnsupported) {
+		t.Fatalf("Compact error = %v, want ErrCompactionUnsupported", compactErr)
+	}
+}
+
+func TestDefaultTurnSessionProviderCapabilities(t *testing.T) {
+	caps := ProviderCapabilities{
+		Model:               "test-model",
+		ContextWindow:       200_000,
+		MaxOutputTokens:     64_000,
+		SupportsVision:      true,
+		SupportsReasoning:   true,
+		SupportsPromptCache: true,
+		ReasoningEfforts:    []string{"low", "medium", "high"},
+	}
+	tsp := NewProviderTurnSessionProvider(&recordingProvider{}, caps)
+	got := tsp.Capabilities()
+	if got.Model != caps.Model || got.ContextWindow != caps.ContextWindow ||
+		got.MaxOutputTokens != caps.MaxOutputTokens || !got.SupportsVision ||
+		!got.SupportsReasoning || !got.SupportsPromptCache ||
+		len(got.ReasoningEfforts) != 3 || got.NativeCompaction {
+		t.Fatalf("Capabilities() = %#v, want %#v", got, caps)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **PR7 of the Zero Agent Performance Program**: provider capabilities and the default turn-session adapter — the architecture seam that PR8 (one optimized provider session) and a future native-compaction session plug into without touching the agent loop again.

### Added

- `zeroruntime.TurnSession` — one provider conversation per run: `Prewarm` (best-effort, no-op by default), `Stream` (signature-identical to `Provider.StreamCompletion`), `Compact` (returns `ErrCompactionUnsupported` on the default adapter; dormant until a native-compaction session exists), `Close` (idempotent no-op by default).
- `zeroruntime.TurnSessionProvider` — opens a session for a run and exposes `ProviderCapabilities`.
- `zeroruntime.ProviderCapabilities` — a flat projection of the resolved model's static capabilities (context window, max output tokens, vision/reasoning/prompt-cache flags, reasoning efforts). Deliberately plain data: `modelregistry` imports `zeroruntime`, so typed registry fields here would form an import cycle. `providers.NewTurnSessionProvider` does the projection instead.
- `providers.NewTurnSessionProvider` — builds the default adapter for **every current provider kind** (openai, openai-compatible, anthropic, anthropic-compatible, google, and the chatgpt path via `New`), populating capabilities from the same registry entry `New` already resolves.
- Loop integration: `agent.Run` opens a session at run start (before session hooks, so a failed open is a clean run-start error with nothing to unwind), routes **all** provider I/O through it via a one-line `Provider` shim — per-turn streams, mid-stream retries, the compaction summarizer, and the final-answer request — and closes it at teardown. A mid-run model switch closes the old session and opens a fresh one over the escalated provider.
- `Options.TurnSessionProvider` (optional): nil keeps the default wrapper over the passed provider, so **every existing caller is unaffected** — no signature changes anywhere.

## No performance change expected

This PR is a pure extension point. The default session's `Stream` *is* `provider.StreamCompletion`; `Prewarm`/`Close` are no-ops; no extra network round-trips, no hot-path allocation beyond a value-typed shim. Behavior identity is asserted by tests, not claimed: the same scripted run with the default path and an explicit adapter produces identical results and request counts.

## Safety properties

Preserves permissions, sandboxing, secret scrubbing, output ceilings, transcript ordering, exactly one result per tool call, reconnect/stall-retry behavior (`streamWithReconnect` is unchanged and still wraps every stream), and cancellation semantics. A `TurnSession.Close` failure never fails the run; a `Prewarm` failure is ignored by contract.

## Scope boundaries

No connection reuse, prewarm implementation, request-prefix fingerprint reuse, provider-specific sessions, or native compaction — those are PR8 and later, behind this seam. The `ModelSwitcher` contract still returns a bare `Provider`, so an optimized session is not carried across a mid-run swap (documented next to the existing context-window limitation; fixing both needs the same switcher contract change).

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test ./internal/zeroruntime/ ./internal/providers/... ./internal/agent/ ./internal/cli/ ./internal/tui/` green
- New tests: default-adapter forwarding is verbatim (request and events), `Prewarm`/`Close` no-op + idempotent, `Compact` unsupported; fault injection — a failed `OpenTurnSession` surfaces as a wrapped run-start error with zero provider requests, a failing `Close` is swallowed; every request of a run flows through the session (prewarmed once, closed once); the default path is behavior-identical to an explicit adapter; a mid-run model switch closes the old session exactly once and continues on the new provider; every provider kind wraps; registry capabilities project correctly.
- Existing escalation, completion-gate, and reconnect test suites pass unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-run turn sessions to centralize streaming and lifecycle handling.
  * Introduced `TurnSessionProvider` and `ModelSessionSwitcher` options for target-aware mid-run escalation.
  * Added capability projection for sessions (limits, support flags, reasoning tiers).
* **Reliability**
  * Turn session open failures surface cleanly; teardown close errors no longer fail runs.
  * Mid-run model/session switching continues on errors and records a user-visible notice.
* **Tests**
  * Expanded coverage for session routing, lifecycle safety, capability projection, and escalation switching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->