### PR TITLE
Clarify saved and effective provider selection

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Gitlawb/zero/internal/localcontrol"
 	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/observability"
 	"github.com/Gitlawb/zero/internal/peermsg"
 	"github.com/Gitlawb/zero/internal/plugins"
@@ -69,6 +70,7 @@ type appDeps struct {
 	discoverProviderModels func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	detectLocalRuntimes    func(context.Context, provideronboarding.LocalDetectOptions) []provideronboarding.DetectedLocalRuntime
 	openRouterLogin        func(context.Context, provideroauth.OpenRouterOptions) (string, error)
+	chatGPTLogin           func(context.Context, provideroauth.ChatGPTOptions) (oauth.Token, error)
 	newSessionStore        func() *sessions.Store
 	loadPlugins            func(plugins.LoadOptions) (plugins.LoadResult, error)
 	loadHooks              func(hooks.LoadOptions) (hooks.LoadResult, error)
@@ -157,6 +159,7 @@ func defaultAppDeps() appDeps {
 		discoverProviderModels: defaultDiscoverProviderModels,
 		detectLocalRuntimes:    provideronboarding.DetectLocalRuntimes,
 		openRouterLogin:        provideroauth.OpenRouterLogin,
+		chatGPTLogin:           provideroauth.ChatGPTLogin,
 		newSessionStore: func() *sessions.Store {
 			return sessions.NewStore(sessions.StoreOptions{})
 		},
@@ -495,6 +498,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.openRouterLogin == nil {
 		deps.openRouterLogin = defaults.openRouterLogin
+	}
+	if deps.chatGPTLogin == nil {
+		deps.chatGPTLogin = defaults.chatGPTLogin
 	}
 	if deps.newSessionStore == nil {
 		deps.newSessionStore = defaults.newSessionStore

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,7 +40,7 @@ func ensureLoginProviderProfile(deps appDeps, provider string) string {
 	if err != nil {
 		return "warning: login saved, but no provider profile was written: " + err.Error()
 	}
-	active := strings.EqualFold(strings.TrimSpace(ensured.Active), strings.TrimSpace(ensured.Name))
+	active := config.SameProviderIdentity(ensured.Active, ensured.Name)
 	switch {
 	case ensured.Created && active:
 		return fmt.Sprintf("Added provider %q to your config and set it active.", ensured.Name)
@@ -99,6 +100,16 @@ func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, deps a
 	if len(args) > 0 {
 		return writeExecUsageError(stderr, fmt.Sprintf("zero auth openrouter takes no arguments (got %q)", args[0]))
 	}
+	// Check the config BEFORE the browser flow, as every other auth entry point
+	// does. Finding out the file is unusable only after the user has completed a
+	// PKCE round trip wastes their work and mints a key Zero then cannot store.
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if err := config.PreflightCatalogProviderLogin(configPath, "openrouter"); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
 	key, err := deps.openRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
 		Out:        stdout,
 		HTTPClient: &http.Client{Timeout: 30 * time.Second},
@@ -111,10 +122,14 @@ func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, deps a
 	key = strings.TrimSpace(key)
 	line, err := saveOpenRouterProviderKey(deps, key)
 	if err != nil {
-		if _, writeErr := fmt.Fprintf(stdout, "\nOpenRouter login complete — new API key minted, but Zero could not save it: %s\nUse it manually, e.g.:\n  export OPENROUTER_API_KEY=%s\n", err, key); writeErr != nil {
+		// The key is real and the user paid for it with a browser round trip, so
+		// print it rather than losing it. But nothing was persisted, so this is a
+		// failure: exiting 0 here reported success for a command that left the
+		// provider unusable, and a script would have carried on.
+		if _, writeErr := fmt.Fprintf(stdout, "\nOpenRouter login complete — new API key minted, but Zero could not save it.\nUse it manually, e.g.:\n  export OPENROUTER_API_KEY=%s\n", key); writeErr != nil {
 			return exitCrash
 		}
-		return exitSuccess
+		return writeAppError(stderr, "could not save the OpenRouter API key: "+err.Error(), exitCrash)
 	}
 	if _, err := fmt.Fprintf(stdout, "\nOpenRouter login complete — new API key saved.\n%s\n", line); err != nil {
 		return exitCrash
@@ -129,6 +144,9 @@ func saveOpenRouterProviderKey(deps appDeps, key string) (string, error) {
 	}
 	configPath, err := deps.userConfigPath()
 	if err != nil {
+		return "", err
+	}
+	if err := config.PreflightUserConfig(configPath); err != nil {
 		return "", err
 	}
 	ensured, err := config.EnsureCatalogProvider(configPath, "openrouter")
@@ -148,7 +166,7 @@ func saveOpenRouterProviderKey(deps appDeps, key string) (string, error) {
 		_, _ = store.Delete(ensured.Name)
 		return "", err
 	}
-	active := strings.EqualFold(strings.TrimSpace(ensured.Active), strings.TrimSpace(ensured.Name))
+	active := config.SameProviderIdentity(ensured.Active, ensured.Name)
 	switch {
 	case ensured.Created && active:
 		return fmt.Sprintf("Added provider %q to your config and set it active.", ensured.Name), nil
@@ -176,6 +194,14 @@ func runAuthChatGPT(args []string, stdout io.Writer, stderr io.Writer, deps appD
 	if len(args) > 0 {
 		return writeExecUsageError(stderr, fmt.Sprintf("zero auth chatgpt takes no arguments (got %q)", args[0]))
 	}
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	const provider = "chatgpt"
+	if err := config.PreflightCatalogProviderLogin(configPath, provider); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
 
 	// Build the same env map the oauth engine reads so the chatgpt preset is
 	// opted into (the preset is off by default to keep third-party OAuth
@@ -189,7 +215,7 @@ func runAuthChatGPT(args []string, stdout io.Writer, stderr io.Writer, deps appD
 	}
 	env["ZERO_OAUTH_ALLOW_PRESETS"] = "1"
 
-	token, err := provideroauth.ChatGPTLogin(context.Background(), provideroauth.ChatGPTOptions{
+	token, err := deps.chatGPTLogin(context.Background(), provideroauth.ChatGPTOptions{
 		Env:        env,
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
 		Out:        stdout,
@@ -212,7 +238,10 @@ func runAuthChatGPT(args []string, stdout io.Writer, stderr io.Writer, deps appD
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
-	if err := store.Save(oauth.ProviderKey("chatgpt"), token); err != nil {
+	if err := config.PreflightCatalogProviderLogin(configPath, provider); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if err := store.Save(oauth.ProviderKey(provider), token); err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
 	statuses, err := oauthFormatChatGPTStatus(token)
@@ -343,7 +372,7 @@ func validateAuthFlags(sub string, a authArgs) error {
 // ZERO_OAUTH_TOKENS_PATH (env), so callers/tests can redirect it. Setting
 // ZERO_OAUTH_STORAGE=encrypted-file selects the AES-256-GCM encrypted-at-rest
 // backend (a per-user secret is created beside the token file).
-func newAuthManager(deps appDeps, out io.Writer) (*oauth.Manager, error) {
+func newAuthManager(deps appDeps, out io.Writer, beforeSave func() error) (*oauth.Manager, error) {
 	// Validate ZERO_OAUTH_STORAGE up front: a mistyped value must fail fast rather
 	// than silently change the backend. Empty = default (plaintext 0600 file);
 	// "encrypted-file" = AES-256-GCM; "keyring" = the OS keyring.
@@ -372,6 +401,7 @@ func newAuthManager(deps appDeps, out io.Writer) (*oauth.Manager, error) {
 		// `zero auth login <preset>` (e.g. xai) should resolve the baked-in preset
 		// without the operator exporting ZERO_OAUTH_ALLOW_PRESETS first.
 		AllowPresets: true,
+		BeforeSave:   beforeSave,
 	})
 }
 
@@ -387,7 +417,7 @@ func runAuthLogin(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 	if len(parsed.positional) != 1 {
 		return writeExecUsageError(stderr, "usage: zero auth login <provider> [--device] [--scope <scope>]")
 	}
-	provider := parsed.positional[0]
+	provider := strings.ToLower(strings.TrimSpace(parsed.positional[0]))
 	// ChatGPT (Codex) requires a fixed redirect_uri (http://localhost:1455/
 	// auth/callback) and mandatory authorize params (id_token_add_organizations,
 	// codex_cli_simplified_flow, originator) that the generic loopback flow
@@ -402,7 +432,16 @@ func runAuthLogin(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 		}
 		return runAuthChatGPT(nil, stdout, stderr, deps)
 	}
-	manager, err := newAuthManager(deps, stdout)
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if err := config.PreflightCatalogProviderLogin(configPath, provider); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	manager, err := newAuthManager(deps, stdout, func() error {
+		return config.PreflightCatalogProviderLogin(configPath, provider)
+	})
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
@@ -438,25 +477,98 @@ func runAuthLogout(args []string, stdout io.Writer, stderr io.Writer, deps appDe
 		return writeExecUsageError(stderr, "usage: zero auth logout <provider>")
 	}
 	provider := parsed.positional[0]
-	manager, err := newAuthManager(deps, stdout)
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	configErr := config.PreflightUserConfig(configPath)
+	// Resolve the target the way login does. Login accepts a catalog id or a case
+	// variant and stores its token under the catalog id, and the TUI tells users
+	// to run `zero auth logout <catalog id>` — so refusing that spelling here left
+	// the OAuth token and any stored API key in place for exactly the command the
+	// UI documents. The credential store keys stay on what the user typed (that is
+	// where login put them); only the config mutation below needs the persisted
+	// spelling, because those mutators match a row exactly.
+	//
+	// Identity resolution and candidate expansion run regardless of configErr:
+	// PersistedProviderIdentity/ProviderRow only read+parse the raw JSON, they
+	// never call ValidatePersistedProviderNames, so an unrelated ambiguous
+	// case-duplicate row elsewhere in the file must not suppress deleting every
+	// credential this logout can find for the requested provider. Only the
+	// config WRITE below (clearing the apiKeyStored marker) needs a valid config
+	// and is gated on configErr.
+	//
+	// Identity resolution prefers an exact name over a case variant, and a name
+	// over a catalog id (config.ResolvePersistedProviderIdentity). Taking the
+	// first row that matched either field let `logout xai` retarget a
+	// {name:"work-xai", catalogId:"xai"} row — a different profile, with
+	// different credentials, than the one named.
+	credentialCandidates, configProvider, identityErr := config.ProviderCredentialCandidates(configPath, provider)
+	if identityErr != nil {
+		if configErr == nil {
+			configErr = identityErr
+		}
+	}
+	manager, err := newAuthManager(deps, stdout, nil)
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
-	removed, err := manager.Logout(provider)
-	if err != nil {
-		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	// Delete every candidate the runtime bearer resolver would have tried
+	// (ProviderProfile.OAuthLoginCandidates: profile name, then catalog id) —
+	// not just the spelling the user typed. A profile saved as
+	// {name:"my-xai", catalogId:"xai"} logged in via `zero auth login xai`
+	// stores its token under "xai"; `zero auth logout my-xai` must delete that
+	// too, or the login silently survives. The same candidate set is used below
+	// for the API key store, which has the identical asymmetry.
+	//
+	// The catalog id joins that set only when the resolved profile is the ONLY
+	// row claiming it. Catalog ids are shared by design — stored-key "work-xai",
+	// stored-key "xai", and keyless "personal-xai" can all carry catalogId
+	// "xai" — so expanding unconditionally made `logout work-xai` delete the
+	// "xai" token and the "xai" profile's API key while clearing only
+	// work-xai's marker. When the id is shared, the user has to name the
+	// profile whose credential they mean.
+	removed := false
+	for _, candidate := range credentialCandidates {
+		candidateRemoved, err := manager.Logout(candidate)
+		if err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+		removed = removed || candidateRemoved
 	}
 	// Also drop any stored API key and its marker so `auth logout` clears the whole
 	// credential (OAuth token AND key), not just the OAuth side. Surface deletion
 	// failures rather than reporting success while a credential remains.
-	keyRemoved, keyErr := config.ForgetProviderKey(provider)
+	//
+	// The key store is asked for every OAuth candidate spelling too: a key
+	// captured by provider setup lives under the persisted row's name, while one
+	// captured by a catalog login lives under the catalog id. Clearing only the
+	// spelling the user typed would leave the others behind.
+	keyStore, keyErr := config.ProviderKeyStoreAt(filepath.Dir(configPath))
 	if keyErr != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(keyErr, redaction.Options{}), exitCrash)
 	}
-	if configPath, perr := deps.userConfigPath(); perr == nil {
-		if _, clearErr := config.ClearProviderKeyStored(configPath, provider); clearErr != nil {
-			return writeAppError(stderr, redaction.ErrorMessage(clearErr, redaction.Options{}), exitCrash)
+	keyRemoved := false
+	for _, candidate := range credentialCandidates {
+		candidateRemoved, candidateErr := keyStore.Delete(candidate)
+		if candidateErr != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(candidateErr, redaction.Options{}), exitCrash)
 		}
+		keyRemoved = keyRemoved || candidateRemoved
+	}
+	if configErr != nil {
+		// Credentials are already gone at this point, but an invalid persisted
+		// config (e.g. ambiguous case-duplicate rows) blocks every config write,
+		// including clearing a stale apiKeyStored marker — writeConfigFile
+		// re-validates on every call, so nothing here could succeed either.
+		// Say so explicitly rather than leaving the marker silently stale.
+		return writeAppError(stderr, redaction.ErrorMessage(configErr, redaction.Options{})+"; any stale apiKeyStored marker in config.json must be corrected by hand alongside this", exitCrash)
+	}
+	// Clear the marker on every case-variant row, not just configProvider's exact
+	// spelling: the credential store keys secrets case-folded, so a sibling row
+	// could have pointed at the same now-deleted secret.
+	if _, clearErr := config.ClearProviderKeyStoredCaseVariants(configPath, configProvider); clearErr != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(clearErr, redaction.Options{}), exitCrash)
 	}
 	removed = removed || keyRemoved
 	if parsed.json {
@@ -491,7 +603,18 @@ func runAuthStatus(args []string, stdout io.Writer, stderr io.Writer, deps appDe
 	if len(parsed.positional) > 1 {
 		return writeExecUsageError(stderr, "usage: zero auth status [provider]")
 	}
-	manager, err := newAuthManager(deps, stdout)
+	var credentialCandidates []string
+	if len(parsed.positional) == 1 {
+		configPath, err := deps.userConfigPath()
+		if err != nil {
+			return writeAppError(stderr, err.Error(), exitCrash)
+		}
+		credentialCandidates, _, err = config.ProviderCredentialCandidates(configPath, parsed.positional[0])
+		if err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+	}
+	manager, err := newAuthManager(deps, stdout, nil)
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
@@ -500,7 +623,7 @@ func runAuthStatus(args []string, stdout io.Writer, stderr io.Writer, deps appDe
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
 	if len(parsed.positional) == 1 {
-		statuses = filterAuthStatuses(statuses, parsed.positional[0])
+		statuses = filterAuthStatuses(statuses, credentialCandidates)
 	}
 	if parsed.json {
 		payload := struct {
@@ -530,16 +653,33 @@ func runAuthRefresh(args []string, stdout io.Writer, stderr io.Writer, deps appD
 		return writeExecUsageError(stderr, "usage: zero auth refresh <provider>")
 	}
 	provider := parsed.positional[0]
-	manager, err := newAuthManager(deps, stdout)
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	credentialCandidates, _, err := config.ProviderCredentialCandidates(configPath, provider)
 	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
-	key := oauth.ProviderKey(provider)
-	if parsed.watch {
-		return runAuthRefreshWatch(manager, key, provider, stdout, stderr)
-	}
-	if _, err := manager.Handle401(context.Background(), key); err != nil {
+	manager, err := newAuthManager(deps, stdout, nil)
+	if err != nil {
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if parsed.watch {
+		return runAuthRefreshWatch(manager, credentialCandidates, provider, stdout, stderr)
+	}
+	var refreshErr error
+	for _, candidate := range credentialCandidates {
+		_, refreshErr = manager.Handle401(context.Background(), oauth.ProviderKey(candidate))
+		if refreshErr == nil {
+			break
+		}
+		if !errors.Is(refreshErr, oauth.ErrNoToken) {
+			break
+		}
+	}
+	if refreshErr != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(refreshErr, redaction.Options{}), exitCrash)
 	}
 	if _, err := fmt.Fprintf(stdout, "Refreshed OAuth token for %s.\n", provider); err != nil {
 		return exitCrash
@@ -551,13 +691,26 @@ func runAuthRefresh(args []string, stdout io.Writer, stderr io.Writer, deps appD
 // interrupted. This is the opt-in proactive-refresh scheduler surface (for a
 // long-running external process that reads the token file). It validates a
 // refreshable token exists first, then schedules refreshes before each expiry.
-func runAuthRefreshWatch(manager *oauth.Manager, key, provider string, stdout io.Writer, stderr io.Writer) int {
+func runAuthRefreshWatch(manager *oauth.Manager, candidates []string, provider string, stdout io.Writer, stderr io.Writer) int {
 	ctx, stop := signalContext()
 	defer stop()
 	// Validate (and refresh-if-needed) once up front so a missing/non-refreshable
 	// token fails fast instead of silently watching nothing.
-	if _, err := manager.GetFresh(ctx, key); err != nil {
-		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	key := ""
+	var freshErr error
+	for _, candidate := range candidates {
+		candidateKey := oauth.ProviderKey(candidate)
+		_, freshErr = manager.GetFresh(ctx, candidateKey)
+		if freshErr == nil {
+			key = candidateKey
+			break
+		}
+		if !errors.Is(freshErr, oauth.ErrNoToken) {
+			break
+		}
+	}
+	if freshErr != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(freshErr, redaction.Options{}), exitCrash)
 	}
 	scheduler := oauth.NewRefreshScheduler()
 	scheduler.Start(ctx, manager, key)
@@ -569,11 +722,14 @@ func runAuthRefreshWatch(manager *oauth.Manager, key, provider string, stdout io
 	return exitSuccess
 }
 
-func filterAuthStatuses(statuses []oauth.Status, provider string) []oauth.Status {
-	want := oauth.ProviderKey(provider)
-	filtered := make([]oauth.Status, 0, 1)
+func filterAuthStatuses(statuses []oauth.Status, candidates []string) []oauth.Status {
+	wanted := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		wanted[oauth.ProviderKey(candidate)] = struct{}{}
+	}
+	filtered := make([]oauth.Status, 0, len(candidates))
 	for _, st := range statuses {
-		if st.Key == want {
+		if _, ok := wanted[st.Key]; ok {
 			filtered = append(filtered, st)
 		}
 	}

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -4,10 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/oauth"
@@ -74,6 +79,31 @@ func TestRunAuthStatusReportsLoginWithoutSecret(t *testing.T) {
 	}
 }
 
+func TestRunAuthStatusResolvesCatalogLoginCandidates(t *testing.T) {
+	storePath := withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"my-xai","catalogId":"xai"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("xai"), oauth.Token{AccessToken: "secret", Account: "catalog-account"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "status", "my-xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	}); code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "catalog-account") || !strings.Contains(stdout.String(), "xai") {
+		t.Fatalf("status did not find the catalog-addressed login: %q", stdout.String())
+	}
+}
+
 func TestRunAuthLogoutNothing(t *testing.T) {
 	withAuthStore(t)
 	var stdout, stderr bytes.Buffer
@@ -111,12 +141,204 @@ func TestRunAuthLoginUnknownProvider(t *testing.T) {
 	}
 }
 
+func TestRunAuthLoginRevalidatesConfigImmediatelyBeforeSave(t *testing.T) {
+	storePath := withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	initial := `{"providers":[{"name":"demo"}]}`
+	ambiguous := `{"providers":[{"name":"demo"},{"name":"DEMO"}]}`
+	if err := os.WriteFile(configPath, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("demo"), oauth.Token{AccessToken: "unchanged"}); err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	mux.HandleFunc("/device", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"device_code":"dc","user_code":"code","verification_uri":"https://example.test","expires_in":60,"interval":1}`)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		if err := os.WriteFile(configPath, []byte(ambiguous), 0o600); err != nil {
+			t.Errorf("mutate config: %v", err)
+		}
+		_, _ = io.WriteString(w, `{"access_token":"replacement","token_type":"Bearer"}`)
+	})
+	t.Setenv("ZERO_OAUTH_DEMO_CLIENT_ID", "client")
+	t.Setenv("ZERO_OAUTH_DEMO_TOKEN_URL", server.URL+"/token")
+	t.Setenv("ZERO_OAUTH_DEMO_DEVICE_URL", server.URL+"/device")
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "login", "demo", "--device"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if code == exitSuccess || !strings.Contains(stderr.String(), "ambiguous persisted provider names") {
+		t.Fatalf("exit = %d, stderr = %q; want ambiguous-config failure", code, stderr.String())
+	}
+	token, ok, err := store.Load(oauth.ProviderKey("demo"))
+	if err != nil || !ok || token.AccessToken != "unchanged" {
+		t.Fatalf("stored token = %+v, %v, %v; want unchanged", token, ok, err)
+	}
+}
+
+func TestRunAuthChatGPTRevalidatesConfigImmediatelyBeforeSave(t *testing.T) {
+	storePath := withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"chatgpt","catalogId":"chatgpt"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("chatgpt"), oauth.Token{AccessToken: "unchanged"}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "chatgpt"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+		chatGPTLogin: func(context.Context, provideroauth.ChatGPTOptions) (oauth.Token, error) {
+			ambiguous := `{"providers":[{"name":"chatgpt"},{"name":"ChatGPT"}]}`
+			if err := os.WriteFile(configPath, []byte(ambiguous), 0o600); err != nil {
+				return oauth.Token{}, err
+			}
+			return oauth.Token{AccessToken: "replacement"}, nil
+		},
+	})
+	if code == exitSuccess || !strings.Contains(stderr.String(), "ambiguous persisted provider names") {
+		t.Fatalf("exit = %d, stderr = %q; want ambiguous-config failure", code, stderr.String())
+	}
+	token, ok, err := store.Load(oauth.ProviderKey("chatgpt"))
+	if err != nil || !ok || token.AccessToken != "unchanged" {
+		t.Fatalf("stored token = %+v, %v, %v; want unchanged", token, ok, err)
+	}
+}
+
+// TestRunAuthChatGPTAllowsCaseVariantPersistedProfile is the regression test for
+// jatmn's #725 finding: preflighting a login as if it were a new provider write
+// rejected the very row it was logging into. A config whose sole ChatGPT profile
+// is spelled "ChatGPT" made `zero auth chatgpt` fail before the browser flow with
+// `provider "chatgpt" already exists as "ChatGPT"` — while the TUI, which only
+// validates the file, completed the same login. A login mints no new spelling,
+// but reuse still requires the row's catalogId to prove catalog ownership.
+func TestRunAuthChatGPTAllowsCaseVariantPersistedProfile(t *testing.T) {
+	storePath := withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"ChatGPT","catalogId":"chatgpt"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "chatgpt"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+		chatGPTLogin: func(context.Context, provideroauth.ChatGPTOptions) (oauth.Token, error) {
+			return oauth.Token{AccessToken: "fresh"}, nil
+		},
+	})
+	if code != exitSuccess {
+		t.Fatalf("exit = %d, want success; stderr = %q", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "already exists as") {
+		t.Fatalf("a case-variant re-login must not be treated as a colliding new provider: %q", stderr.String())
+	}
+	token, ok, err := store.Load(oauth.ProviderKey("chatgpt"))
+	if err != nil || !ok || token.AccessToken != "fresh" {
+		t.Fatalf("stored token = %+v, %v, %v; want the fresh login saved", token, ok, err)
+	}
+	// The ambiguous-config guard is unchanged: a login still refuses to run
+	// against a file with two case-duplicate rows.
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"chatgpt"},{"name":"ChatGPT"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = runWithDeps([]string{"auth", "chatgpt"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+		chatGPTLogin: func(context.Context, provideroauth.ChatGPTOptions) (oauth.Token, error) {
+			return oauth.Token{AccessToken: "should-not-save"}, nil
+		},
+	})
+	if code == exitSuccess || !strings.Contains(stderr.String(), "ambiguous persisted provider names") {
+		t.Fatalf("exit = %d, stderr = %q; want the ambiguous-config failure preserved", code, stderr.String())
+	}
+}
+
 func TestRunAuthRefreshNoToken(t *testing.T) {
 	withAuthStore(t)
 	t.Setenv("ZERO_OAUTH_DEMO_CLIENT_ID", "client") // so config resolves; refresh still fails (no token)
 	var stdout, stderr bytes.Buffer
 	if code := runWithDeps([]string{"auth", "refresh", "demo"}, &stdout, &stderr, appDeps{}); code == exitSuccess {
 		t.Fatal("refresh with no stored token should fail")
+	}
+}
+
+func TestRunAuthRefreshResolvesCatalogLoginCandidates(t *testing.T) {
+	storePath := withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"my-xai","catalogId":"xai"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("xai"), oauth.Token{
+		AccessToken: "old", RefreshToken: "refresh", ExpiresAt: time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"access_token":"fresh","token_type":"Bearer","expires_in":3600}`)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("ZERO_OAUTH_XAI_TOKEN_URL", server.URL)
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "refresh", "my-xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	}); code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	token, ok, err := store.Load(oauth.ProviderKey("xai"))
+	if err != nil || !ok || token.AccessToken != "fresh" {
+		t.Fatalf("refreshed token = %+v, ok = %v, err = %v", token, ok, err)
+	}
+}
+
+func TestAuthReadCommandsRejectAmbiguousCatalogAddress(t *testing.T) {
+	withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"work-xai","catalogId":"xai"},{"name":"personal-xai","catalogId":"xai"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"auth", "status", "xai"}, {"auth", "refresh", "xai"}} {
+		var stdout, stderr bytes.Buffer
+		if code := runWithDeps(args, &stdout, &stderr, appDeps{
+			userConfigPath: func() (string, error) { return configPath, nil },
+		}); code == exitSuccess || !strings.Contains(stderr.String(), "ambiguous") {
+			t.Fatalf("args %v: exit = %d, stdout = %q, stderr = %q; want ambiguity", args, code, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestRunAuthLoginRejectsAmbiguousCatalogAddress(t *testing.T) {
+	withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"work-xai","catalogId":"xai"},{"name":"personal-xai","catalogId":"xai"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "login", "xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	}); code == exitSuccess || !strings.Contains(stderr.String(), "ambiguous") {
+		t.Fatalf("exit = %d, stdout = %q, stderr = %q; want pre-login ambiguity", code, stdout.String(), stderr.String())
 	}
 }
 
@@ -135,6 +357,356 @@ func TestRunAuthRejectsWrongFlags(t *testing.T) {
 		if code := runWithDeps(args, &stdout, &stderr, appDeps{}); code == exitSuccess {
 			t.Errorf("args %v should be rejected, got success", args)
 		}
+	}
+}
+
+// TestRunAuthLogoutResolvesCatalogIdentity covers jatmn's #725 finding: login
+// accepts a catalog id and stores its token under that key, and the TUI tells
+// users to run `zero auth logout chatgpt` — but logout hard-stopped whenever a
+// persisted row matched case-insensitively without matching exactly, so the
+// documented command left the token and any stored key in place.
+func TestRunAuthLogoutResolvesCatalogIdentity(t *testing.T) {
+	storePath := withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"ChatGPT","catalogId":"chatgpt"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("chatgpt"), oauth.Token{AccessToken: "stored"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "logout", "chatgpt"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "capitalization") {
+		t.Fatalf("logout refused the spelling the UI documents: %q", stderr.String())
+	}
+	if _, ok, err := store.Load(oauth.ProviderKey("chatgpt")); err != nil || ok {
+		t.Fatalf("stored token survived logout: ok=%v err=%v", ok, err)
+	}
+	if !strings.Contains(stdout.String(), "Logged out") {
+		t.Fatalf("stdout = %q, want a logout confirmation", stdout.String())
+	}
+}
+
+// TestRunAuthLogoutDeletesCatalogIDToken covers jatmn's #725 follow-up
+// finding: a profile addressed by its own name but logged in under its
+// catalog id (e.g. {name:"my-xai", catalogId:"xai"} via `zero auth login
+// xai`) left the "xai" OAuth token behind when logged out as "my-xai",
+// because logout only ever deleted the exact spelling the user typed.
+func TestRunAuthLogoutDeletesCatalogIDToken(t *testing.T) {
+	storePath := withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"my-xai","catalogId":"xai"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("xai"), oauth.Token{AccessToken: "stored"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "logout", "my-xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if _, ok, err := store.Load(oauth.ProviderKey("xai")); err != nil || ok {
+		t.Fatalf("catalog-id OAuth token survived logout: ok=%v err=%v", ok, err)
+	}
+	if !strings.Contains(stdout.String(), "Logged out") {
+		t.Fatalf("stdout = %q, want a logout confirmation", stdout.String())
+	}
+}
+
+// TestRunAuthLogoutDeletesCatalogIDAPIKey covers jatmn's second #725 follow-up
+// finding: logout's OAuth-token deletion covers the profile name, canonical
+// persisted name, and catalog id, but API-key deletion only covered the first
+// two — a key stored under the catalog id (e.g. captured via `zero auth
+// openrouter`-style catalog flows) survived `zero auth logout my-xai`.
+func TestRunAuthLogoutDeletesCatalogIDAPIKey(t *testing.T) {
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"my-xai","catalogId":"xai","apiKeyStored":true}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keyStore, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("xai", "catalog-id-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "logout", "my-xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if _, ok, err := keyStore.Get("xai"); err != nil || ok {
+		t.Fatalf("catalog-id API key survived logout: ok=%v err=%v", ok, err)
+	}
+	if !strings.Contains(stdout.String(), "Logged out") {
+		t.Fatalf("stdout = %q, want a logout confirmation", stdout.String())
+	}
+}
+
+// TestRunAuthLogoutKeepsDistinctUnicodeCredentials pins the end-to-end
+// guarantee behind jatmn's #725 finding that destructive candidate expansion
+// used strings.EqualFold as authority for credential ownership: a saved "s"
+// profile with its own token and key must survive `zero auth logout ſ`, which
+// names a provider the config never saved (the credential store defines
+// identity with credstore.NormalizeProvider, under which "s" and Unicode
+// long-s "ſ" are separate entries).
+//
+// Two independent layers now enforce that, and this test deliberately asserts
+// the outcome rather than either mechanism. The one that fires first is
+// oauth.ValidateKey, which rejects the non-ASCII spelling before any deletion
+// runs — so the folded-name adoption itself is pinned where it is reachable, in
+// TestPersistedProviderIdentityRulesMatchTheCredentialStore (internal/config).
+func TestRunAuthLogoutKeepsDistinctUnicodeCredentials(t *testing.T) {
+	const longS = "ſ"
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	storePath := withAuthStore(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"s","apiKeyStored":true}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tokens, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tokens.Save(oauth.ProviderKey("s"), oauth.Token{AccessToken: "stored"}); err != nil {
+		t.Fatal(err)
+	}
+	keyStore, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("s", "long-s-is-not-s"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	runWithDeps([]string{"auth", "logout", longS}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if _, ok, err := tokens.Load(oauth.ProviderKey("s")); err != nil || !ok {
+		t.Fatalf("logging out of a distinct identity deleted the saved token: ok=%v err=%v", ok, err)
+	}
+	if key, ok, err := keyStore.Get("s"); err != nil || !ok || key != "long-s-is-not-s" {
+		t.Fatalf("stored API key = %q, %v, %v; want the unrelated profile untouched", key, ok, err)
+	}
+	saved := readCLIConfigFixture(t, configPath).Providers
+	if len(saved) != 1 || saved[0].Name != "s" || !saved[0].APIKeyStored {
+		t.Fatalf("providers = %+v, want the saved profile keeping its stored-key marker", saved)
+	}
+}
+
+// TestRunAuthLogoutResolvesCandidatesDespiteUnrelatedAmbiguousConfig covers
+// jatmn's third #725 follow-up finding: identity resolution and OAuth/API-key
+// candidate expansion were gated on PreflightUserConfig succeeding, even
+// though PersistedProviderIdentity/ProviderRow only read+parse raw JSON and
+// never validate case-duplicate names. An unrelated ambiguous pair elsewhere
+// in the file (demo/DEMO) must not suppress deleting every credential for the
+// unambiguous profile actually being logged out — only the final marker-write
+// should fail on that unrelated validation error.
+func TestRunAuthLogoutResolvesCandidatesDespiteUnrelatedAmbiguousConfig(t *testing.T) {
+	storePath := withAuthStore(t)
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configData := []byte(`{"providers":[{"name":"demo"},{"name":"DEMO"},{"name":"my-xai","catalogId":"xai","apiKeyStored":true}]}`)
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("xai"), oauth.Token{AccessToken: "stored"}); err != nil {
+		t.Fatal(err)
+	}
+	keyStore, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("xai", "catalog-id-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "logout", "my-xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if code == exitSuccess || !strings.Contains(stderr.String(), "ambiguous persisted provider names") {
+		t.Fatalf("exit = %d stderr = %q, want the unrelated ambiguity surfaced as a truthful marker-update failure", code, stderr.String())
+	}
+	if _, ok, err := store.Load(oauth.ProviderKey("xai")); err != nil || ok {
+		t.Fatalf("catalog-id OAuth token survived logout despite the unrelated ambiguous config: ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := keyStore.Get("xai"); err != nil || ok {
+		t.Fatalf("catalog-id API key survived logout despite the unrelated ambiguous config: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestRunAuthLogoutCleansCredentialsWhenConfigIsAmbiguous(t *testing.T) {
+	storePath := withAuthStore(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(configHome, "zero", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configData := []byte(`{"providers":[{"name":"demo"},{"name":"DEMO","apiKeyStored":true}]}`)
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("demo"), oauth.Token{AccessToken: "stored"}); err != nil {
+		t.Fatal(err)
+	}
+	keyStore, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("demo", "stored-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "logout", "demo"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if code == exitSuccess || !strings.Contains(stderr.String(), "ambiguous persisted provider names") {
+		t.Fatalf("exit = %d stderr = %q, want truthful marker-update failure", code, stderr.String())
+	}
+	if _, ok, err := store.Load(oauth.ProviderKey("demo")); err != nil || ok {
+		t.Fatalf("OAuth credential survived recovery logout: ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := keyStore.Get("demo"); err != nil || ok {
+		t.Fatalf("API key survived recovery logout: ok=%v err=%v", ok, err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil || !bytes.Equal(after, configData) {
+		t.Fatalf("invalid config changed during recovery logout: err=%v content=%s", err, after)
+	}
+}
+
+// TestRunAuthOpenRouterPreflightsBeforeTheBrowserFlow covers the second half of
+// the same finding: every other auth entry point validates the config before
+// opening a browser, and this one minted a key first and only discovered the
+// config was unusable when trying to save it.
+func TestRunAuthOpenRouterPreflightsBeforeTheBrowserFlow(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"work"},{"name":"WORK"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loginCalled := false
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "openrouter"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+		openRouterLogin: func(context.Context, provideroauth.OpenRouterOptions) (string, error) {
+			loginCalled = true
+			return "sk-should-not-be-minted", nil
+		},
+	})
+	if code == exitSuccess {
+		t.Fatalf("an unusable config must fail before login; stdout = %q", stdout.String())
+	}
+	if loginCalled {
+		t.Fatal("the browser flow ran before the config was validated")
+	}
+	if !strings.Contains(stderr.String(), "ambiguous persisted provider names") {
+		t.Fatalf("stderr = %q, want the config error", stderr.String())
+	}
+}
+
+// TestRunAuthOpenRouterFailsWhenTheKeyCannotBeSaved pins the exit code: the
+// minted key is still printed so the user does not lose it, but nothing was
+// persisted, and reporting success left a script believing the provider was
+// configured.
+func TestRunAuthOpenRouterFailsWhenTheKeyCannotBeSaved(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "openrouter"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) {
+			calls++
+			if calls > 1 {
+				// The preflight passed; break the path only for the save that follows.
+				return "", errors.New("config path unavailable")
+			}
+			return configPath, nil
+		},
+		openRouterLogin: func(context.Context, provideroauth.OpenRouterOptions) (string, error) {
+			return "sk-openrouter-test", nil
+		},
+	})
+	if code == exitSuccess {
+		t.Fatal("a failed save must not report success")
+	}
+	if !strings.Contains(stdout.String(), "sk-openrouter-test") {
+		t.Fatalf("stdout = %q, want the minted key printed so it is not lost", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "could not save") {
+		t.Fatalf("stderr = %q, want the save failure reported", stderr.String())
+	}
+}
+
+// TestProviderSetupAdoptsPersistedCatalogRowCasing covers the third: catalog
+// OAuth reused an existing row through EnsureCatalogProvider while setup and the
+// wizard still collided with it on write, so re-running setup for a provider
+// saved as "OpenRouter" failed after a successful capture.
+func TestProviderSetupAdoptsPersistedCatalogRowCasing(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"OpenRouter","catalogId":"openrouter","model":"x"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profile := config.ProviderProfile{Name: "openrouter", CatalogID: "openrouter", Model: "y"}
+
+	adopted, err := config.AdoptPersistedCatalogProviderName(configPath, profile)
+	if err != nil {
+		t.Fatalf("AdoptPersistedCatalogProviderName: %v", err)
+	}
+	if adopted.Name != "OpenRouter" {
+		t.Fatalf("adopted name = %q, want the persisted row's spelling", adopted.Name)
+	}
+	if err := config.PreflightProviderWrite(configPath, adopted.Name); err != nil {
+		t.Fatalf("write preflight rejected the adopted name: %v", err)
+	}
+
+	// A user-chosen name is left alone: colliding with an existing row there is a
+	// real collision, and silently overwriting it would be worse than the error.
+	custom := config.ProviderProfile{Name: "openrouter", CatalogID: "anthropic"}
+	kept, err := config.AdoptPersistedCatalogProviderName(configPath, custom)
+	if err != nil {
+		t.Fatalf("AdoptPersistedCatalogProviderName: %v", err)
+	}
+	if kept.Name != "openrouter" {
+		t.Fatalf("name = %q, want a non-catalog-default name left untouched", kept.Name)
 	}
 }
 
@@ -320,4 +892,145 @@ func readCLIConfigFixture(t *testing.T, path string) config.FileConfig {
 		t.Fatalf("decode config: %v", err)
 	}
 	return cfg
+}
+
+// TestRunAuthLogoutLeavesSharedCatalogCredentialsAlone covers jatmn's #725
+// finding that logout cleanup was scoped by catalog id rather than by proven
+// profile ownership. Catalog ids are shared by design: stored-key "work-xai",
+// stored-key "xai", and keyless "personal-xai" can all carry catalogId "xai".
+// Logging out "work-xai" deleted the shared "xai" OAuth token and the "xai"
+// profile's API key — another profile's credentials — while clearing only
+// work-xai's own marker.
+func TestRunAuthLogoutLeavesSharedCatalogCredentialsAlone(t *testing.T) {
+	storePath := withAuthStore(t)
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configData := []byte(`{"providers":[` +
+		`{"name":"work-xai","catalogId":"xai","apiKeyStored":true},` +
+		`{"name":"xai","catalogId":"xai","apiKeyStored":true},` +
+		`{"name":"personal-xai","catalogId":"xai"}]}`)
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(oauth.ProviderKey("xai"), oauth.Token{AccessToken: "shared"}); err != nil {
+		t.Fatal(err)
+	}
+	keyStore, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("xai", "sibling-key"); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("work-xai", "own-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runWithDeps([]string{"auth", "logout", "work-xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if _, ok, err := keyStore.Get("work-xai"); err != nil || ok {
+		t.Fatalf("the profile's own API key must be deleted: ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := store.Load(oauth.ProviderKey("xai")); err != nil || !ok {
+		t.Fatalf("a catalog token three profiles can use must survive one profile's logout: ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := keyStore.Get("xai"); err != nil || !ok {
+		t.Fatalf("the sibling xai profile's API key must survive: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestRunAuthLogoutRejectsAmbiguousCatalogAddress(t *testing.T) {
+	storePath := withAuthStore(t)
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configData := []byte(`{"providers":[` +
+		`{"name":"work-xai","catalogId":"xai"},` +
+		`{"name":"personal-xai","catalogId":"xai"}]}`)
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tokenStore, err := oauth.NewStore(oauth.StoreOptions{FilePath: storePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tokenStore.Save(oauth.ProviderKey("xai"), oauth.Token{AccessToken: "shared"}); err != nil {
+		t.Fatal(err)
+	}
+	keyStore, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("xai", "shared-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "logout", "xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	}); code == exitSuccess || !strings.Contains(stderr.String(), "ambiguous") {
+		t.Fatalf("exit succeeded or ambiguity was not reported: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if _, ok, err := tokenStore.Load(oauth.ProviderKey("xai")); err != nil || !ok {
+		t.Fatalf("ambiguous catalog token was deleted: ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := keyStore.Get("xai"); err != nil || !ok {
+		t.Fatalf("ambiguous catalog key was deleted: ok=%v err=%v", ok, err)
+	}
+}
+
+// TestRunAuthLogoutPrefersTheExactlyNamedProfile is the other half of the same
+// finding: identity resolution took the first row matching name OR catalog id,
+// so `zero auth logout xai` retargeted an earlier {name:"work-xai",
+// catalogId:"xai"} row and cleared that profile's marker instead.
+func TestRunAuthLogoutPrefersTheExactlyNamedProfile(t *testing.T) {
+	withAuthStore(t)
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configData := []byte(`{"providers":[` +
+		`{"name":"work-xai","catalogId":"xai","apiKeyStored":true},` +
+		`{"name":"xai","catalogId":"xai","apiKeyStored":true}]}`)
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keyStore, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("work-xai", "work-key"); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyStore.Set("xai", "own-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"auth", "logout", "xai"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	}); code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if _, ok, err := keyStore.Get("xai"); err != nil || ok {
+		t.Fatalf("the exactly named profile's key must be deleted: ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := keyStore.Get("work-xai"); err != nil || !ok {
+		t.Fatalf("an earlier catalog sibling must not be logged out instead: ok=%v err=%v", ok, err)
+	}
+	cfg := readFileConfig(t, configPath)
+	for _, provider := range cfg.Providers {
+		if provider.Name == "xai" && provider.APIKeyStored {
+			t.Fatal("the named profile's apiKeyStored marker must be cleared")
+		}
+		if provider.Name == "work-xai" && !provider.APIKeyStored {
+			t.Fatal("the sibling profile's apiKeyStored marker must be left alone")
+		}
+	}
 }

--- a/internal/cli/command_center.go
+++ b/internal/cli/command_center.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -24,6 +26,24 @@ type configSummary = zerocommands.ConfigSnapshot
 type providerSummary = zerocommands.ProviderSnapshot
 type modelSummary = zerocommands.ModelSnapshot
 type providerCatalogSummary = zerocommands.ProviderCatalogSnapshot
+
+// providerSourceUserConfig marks a profile saved in the user config file — the
+// only place `zero providers use` can switch, since it writes that file.
+// providerSourceResolved covers every other way a profile reaches the resolved
+// config: project config, a provider command, or a profile synthesized from an
+// ambient env var. Those are deliberately NOT called "runtime": some of them are
+// persisted, just not where `providers use` writes, so the only guarantee the
+// label carries is that the entry cannot be selected with that command.
+const (
+	providerSourceUserConfig = "user-config"
+	providerSourceResolved   = "resolved"
+)
+
+type providerCLISummary struct {
+	providerSummary
+	Selectable bool   `json:"selectable"`
+	Source     string `json:"source"`
+}
 
 func runConfig(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
 	options, help, err := parseCommandCenterArgs(args, false, false)
@@ -125,15 +145,34 @@ func runProviders(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 		return exitCode
 	}
 	summary := summarizeConfig(resolved)
-	providers := summary.Providers
+	userProviderNames, err := loadUserProviderNames(deps)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	providers := make([]providerCLISummary, 0, len(summary.Providers))
+	for _, provider := range summary.Providers {
+		// Resolution merges provider names case-sensitively (a project config
+		// or provider command can add a "WORK" entry alongside a persisted
+		// "work"), and `providers use` only ever matches config.json rows by
+		// their exact stored casing (see config.SetActiveProvider's Resolve()
+		// path). Folding case here would label a case-variant resolved entry
+		// selectable even though `providers use` cannot actually select it.
+		_, selectable := userProviderNames[strings.TrimSpace(provider.Name)]
+		source := providerSourceResolved
+		if selectable {
+			source = providerSourceUserConfig
+		}
+		providers = append(providers, providerCLISummary{providerSummary: provider, Selectable: selectable, Source: source})
+	}
 	if command == "current" {
-		providers = []providerSummary{}
-		for _, provider := range summary.Providers {
+		current := []providerCLISummary{}
+		for _, provider := range providers {
 			if provider.Active {
-				providers = append(providers, provider)
+				current = append(current, provider)
 				break
 			}
 		}
+		providers = current
 	}
 	if options.json {
 		if command == "current" {
@@ -151,10 +190,33 @@ func runProviders(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 		}
 		return exitSuccess
 	}
-	if _, err := fmt.Fprintln(stdout, formatProviderSummaries(command, providers)); err != nil {
+	if _, err := fmt.Fprintln(stdout, formatProviderCLISummaries(command, providers)); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
+}
+
+func loadUserProviderNames(deps appDeps) (map[string]struct{}, error) {
+	names := map[string]struct{}{}
+	path, err := deps.userConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return names, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg config.FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	for _, provider := range cfg.Providers {
+		names[strings.TrimSpace(provider.Name)] = struct{}{}
+	}
+	return names, nil
 }
 
 func runModels(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -325,7 +387,18 @@ func formatConfigSummary(summary configSummary) string {
 	return strings.Join(lines, "\n")
 }
 
+// formatProviderSummaries renders a list whose selectability was not computed
+// (the `zero config` summary and tests), so every entry reads as an ordinary
+// saved profile and no misleading marker appears.
 func formatProviderSummaries(command string, providers []providerSummary) string {
+	cliProviders := make([]providerCLISummary, 0, len(providers))
+	for _, provider := range providers {
+		cliProviders = append(cliProviders, providerCLISummary{providerSummary: provider, Selectable: true, Source: providerSourceUserConfig})
+	}
+	return formatProviderCLISummaries(command, cliProviders)
+}
+
+func formatProviderCLISummaries(command string, providers []providerCLISummary) string {
 	title := "Providers"
 	if command == "current" {
 		title = "Provider"
@@ -343,24 +416,32 @@ func formatProviderSummaries(command string, providers []providerSummary) string
 				"model: "+displayCLIValue(provider.Model, "none"),
 				"api model: "+displayCLIValue(provider.APIModel, "unknown"),
 				"base url: "+displayCLIValue(provider.BaseURL, "default"),
-				"api key: "+providerCredentialState(provider),
+				"api key: "+providerCredentialState(provider.providerSummary),
+				fmt.Sprintf("selectable: %t (source: %s)", provider.Selectable, provider.Source),
 			)
 			if provider.Message != "" {
 				lines = append(lines, "status: "+provider.Status+" - "+provider.Message)
 			}
 			continue
 		}
-		lines = append(lines, "  "+formatProviderLine(provider))
+		lines = append(lines, "  "+formatProviderCLILine(provider))
 	}
 	return strings.Join(lines, "\n")
 }
 
 func formatProviderLine(provider providerSummary) string {
+	return formatProviderCLILine(providerCLISummary{providerSummary: provider, Selectable: true, Source: providerSourceUserConfig})
+}
+
+func formatProviderCLILine(provider providerCLISummary) string {
 	marker := " "
 	if provider.Active {
 		marker = "*"
 	}
-	line := fmt.Sprintf("%s %s [%s] model=%s apiModel=%s api key: %s", marker, displayCLIValue(provider.Name, "none"), displayCLIValue(provider.ProviderKind, "unknown"), displayCLIValue(provider.Model, "none"), displayCLIValue(provider.APIModel, "unknown"), providerCredentialState(provider))
+	line := fmt.Sprintf("%s %s [%s] model=%s apiModel=%s api key: %s", marker, displayCLIValue(provider.Name, "none"), displayCLIValue(provider.ProviderKind, "unknown"), displayCLIValue(provider.Model, "none"), displayCLIValue(provider.APIModel, "unknown"), providerCredentialState(provider.providerSummary))
+	if !provider.Selectable {
+		line += fmt.Sprintf(" (not selectable via providers use; source: %s)", provider.Source)
+	}
 	if provider.Message != "" {
 		line += " (" + provider.Status + ": " + provider.Message + ")"
 	}

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -191,6 +191,96 @@ func TestRunProvidersCurrentJSONIncludesRuntimeMetadata(t *testing.T) {
 	}
 }
 
+func TestRunProvidersListMarksUserAndRuntimeProfiles(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	writeProviderOnboardingConfig(t, configPath, config.FileConfig{Providers: []config.ProviderProfile{{Name: "saved"}}})
+	deps := commandCenterDeps(t)
+	deps.userConfigPath = func() (string, error) { return configPath, nil }
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profiles := []config.ProviderProfile{{Name: "saved", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"}, {Name: "runtime", ProviderKind: config.ProviderKindOpenAICompatible, Model: "runtime-model"}}
+		return config.ResolvedConfig{ActiveProvider: "runtime", Provider: profiles[1], Providers: profiles}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"providers", "list", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	var payload struct {
+		Providers []struct {
+			Name       string `json:"name"`
+			Selectable bool   `json:"selectable"`
+			Source     string `json:"source"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Providers) != 2 || payload.Providers[0].Name != "runtime" || payload.Providers[0].Selectable || payload.Providers[0].Source != "resolved" || !payload.Providers[1].Selectable || payload.Providers[1].Source != "user-config" {
+		t.Fatalf("unexpected providers: %#v", payload.Providers)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runWithDeps([]string{"providers", "list"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not selectable via providers use") {
+		t.Fatalf("non-selectable marker missing: %s", stdout.String())
+	}
+}
+
+// Resolution merges provider names case-sensitively (internal/config/resolver.go
+// mergeProvider), so a project config or provider command can add a "WORK" entry
+// alongside a persisted "work" as two distinct resolved profiles. `providers use`
+// only ever matches config.json rows by their exact stored casing, so it can
+// select "work" but has no way to select the case-variant "WORK" entry. Folding
+// case when deriving selectable/source would mislabel "WORK" as selectable too.
+func TestRunProvidersListDoesNotFoldCaseForSelectability(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	writeProviderOnboardingConfig(t, configPath, config.FileConfig{Providers: []config.ProviderProfile{{Name: "work"}}})
+	deps := commandCenterDeps(t)
+	deps.userConfigPath = func() (string, error) { return configPath, nil }
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profiles := []config.ProviderProfile{
+			{Name: "work", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"},
+			{Name: "WORK", ProviderKind: config.ProviderKindOpenAICompatible, Model: "other-model"},
+		}
+		return config.ResolvedConfig{ActiveProvider: "work", Provider: profiles[0], Providers: profiles}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"providers", "list", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	var payload struct {
+		Providers []struct {
+			Name       string `json:"name"`
+			Selectable bool   `json:"selectable"`
+			Source     string `json:"source"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Providers) != 2 {
+		t.Fatalf("unexpected providers: %#v", payload.Providers)
+	}
+	for _, provider := range payload.Providers {
+		switch provider.Name {
+		case "work":
+			if !provider.Selectable || provider.Source != "user-config" {
+				t.Fatalf("exact-case persisted entry should be selectable: %#v", provider)
+			}
+		case "WORK":
+			if provider.Selectable || provider.Source != "resolved" {
+				t.Fatalf("case-variant resolved entry must not be marked selectable: %#v", provider)
+			}
+		default:
+			t.Fatalf("unexpected provider name: %#v", provider)
+		}
+	}
+}
+
 func TestRunProvidersCatalogListsDescriptors(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -345,6 +435,34 @@ func TestRunProvidersAddWritesCatalogProfile(t *testing.T) {
 	output := stdout.String()
 	if !strings.Contains(output, "Added provider fast") || !strings.Contains(output, configPath) {
 		t.Fatalf("unexpected add output: %q", output)
+	}
+}
+
+func TestRunProvidersAddRejectsExactNameWithoutCatalogOwnership(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	original := config.FileConfig{Providers: []config.ProviderProfile{{
+		Name: "openrouter", CatalogID: "custom-openai-compatible",
+		ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://corp.example/v1",
+		Model: "corp-model", APIKeyStored: true,
+	}}}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"providers", "add", "openrouter"}, &stdout, &stderr, providerSetupDeps(configPath)); code == exitSuccess || !strings.Contains(stderr.String(), "does not prove ownership") {
+		t.Fatalf("exit succeeded or ownership error missing: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	after := readFileConfig(t, configPath)
+	if len(after.Providers) != 1 || after.Providers[0].CatalogID != "custom-openai-compatible" || after.Providers[0].BaseURL != "https://corp.example/v1" || after.Providers[0].Model != "corp-model" || !after.Providers[0].APIKeyStored {
+		t.Fatalf("foreign exact-name profile changed: %+v", after.Providers)
 	}
 }
 

--- a/internal/cli/provider_onboarding.go
+++ b/internal/cli/provider_onboarding.go
@@ -1,14 +1,17 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/credstore"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/provideronboarding"
 )
@@ -71,10 +74,23 @@ func runProvidersUse(args []string, stdout io.Writer, stderr io.Writer, deps app
 	}
 	cfg, err := config.SetActiveProvider(configPath, options.name)
 	if err != nil {
-		return writeAppError(stderr, err.Error(), exitCrash)
+		return writeAppError(stderr, providerMutationError(configPath, options.name, err), exitCrash)
 	}
-
 	override := activeProviderEnvOverride(deps.getenv, cfg.ActiveProvider)
+	// A case-only difference is only harmless when it demonstrably selects the
+	// row just written; a separate exact-case profile from project config makes
+	// it a real override of a real, different provider.
+	if override != "" && config.SameProviderIdentity(override, cfg.ActiveProvider) &&
+		activeProviderEnvOverrideSelectsSaved(deps, configPath, cfg.ActiveProvider) {
+		override = ""
+	}
+	// An override only becomes the effective provider if Zero can actually
+	// resolve it; a stale value names nothing and fails the next resolution.
+	overrideResolution := activeProviderOverrideAbsent
+	var overrideResolutionErr error
+	if override != "" {
+		overrideResolution, overrideResolutionErr = activeProviderEnvOverrideResolution(deps, configPath, override)
+	}
 	if options.json {
 		payload := map[string]any{
 			"activeProvider": cfg.ActiveProvider,
@@ -82,8 +98,19 @@ func runProvidersUse(args []string, stdout io.Writer, stderr io.Writer, deps app
 		}
 		if override != "" {
 			// A JSON consumer must not read this as an effective switch either.
-			payload["effectiveProvider"] = override
 			payload["overriddenByEnv"] = config.ActiveProviderEnv
+			payload["envProvider"] = override
+			payload["envProviderResolves"] = overrideResolution.resolves()
+			if overrideResolution == activeProviderOverrideDeferred {
+				payload["envProviderResolution"] = "deferred"
+			}
+			if overrideResolution == activeProviderOverrideConfigError {
+				payload["envProviderResolution"] = "config-error"
+				payload["envProviderResolutionError"] = overrideResolutionErr.Error()
+			}
+			if overrideResolution == activeProviderOverrideResolved {
+				payload["effectiveProvider"] = override
+			}
 		}
 		if err := writePrettyJSON(stdout, payload); err != nil {
 			return exitCrash
@@ -94,29 +121,135 @@ func runProvidersUse(args []string, stdout io.Writer, stderr io.Writer, deps app
 		return exitCrash
 	}
 	if override != "" {
-		if _, err := fmt.Fprintf(stderr, "Note: %s=%s is set and overrides config.json, so %s stays the active provider until you unset %s.\n", config.ActiveProviderEnv, override, override, config.ActiveProviderEnv); err != nil {
+		note := fmt.Sprintf("Note: %s=%s is set and overrides config.json, so %s stays the active provider until you unset %s.\n", config.ActiveProviderEnv, override, override, config.ActiveProviderEnv)
+		if overrideResolution == activeProviderOverrideDeferred {
+			note = fmt.Sprintf("Note: %s=%s is set and overrides config.json; %s is also set, so the effective provider will be determined when Zero next resolves configuration.\n", config.ActiveProviderEnv, override, config.ProviderCommandEnv)
+		} else if overrideResolution == activeProviderOverrideConfigError {
+			note = fmt.Sprintf("Note: %s=%s is set and overrides config.json, but the effective provider cannot be verified because configuration is invalid: %v\n", config.ActiveProviderEnv, override, overrideResolutionErr)
+		} else if overrideResolution != activeProviderOverrideResolved {
+			// Naming it "effective" would be wrong: nothing resolves under that
+			// name, so the next command fails rather than using it.
+			note = fmt.Sprintf("Note: %s=%s is set and overrides config.json, but no provider named %s can be resolved, so Zero cannot start until you unset %s or point it at a saved provider.\n", config.ActiveProviderEnv, override, override, config.ActiveProviderEnv)
+		}
+		if _, err := fmt.Fprint(stderr, note); err != nil {
 			return exitCrash
 		}
 	}
 	return exitSuccess
 }
 
+type activeProviderOverrideResolution uint8
+
+const (
+	activeProviderOverrideAbsent activeProviderOverrideResolution = iota
+	activeProviderOverrideResolved
+	activeProviderOverrideUnresolved
+	activeProviderOverrideDeferred
+	activeProviderOverrideConfigError
+)
+
+func (resolution activeProviderOverrideResolution) resolves() any {
+	switch resolution {
+	case activeProviderOverrideResolved:
+		return true
+	case activeProviderOverrideUnresolved:
+		return false
+	default:
+		return nil
+	}
+}
+
 // activeProviderEnvOverride returns the ZERO_PROVIDER value when it is set and
-// names a DIFFERENT provider than the one just selected, meaning the saved
-// `providers use` selection will NOT be the effective active provider until the
+// names a DIFFERENT spelling than the one just selected, meaning the saved
+// `providers use` selection may NOT be the effective active provider until the
 // env var is unset. applyEnv (resolver.go) makes ZERO_PROVIDER win over
 // config.json unconditionally, so reporting the write as a plain success reads as
 // a switch that silently has no effect (issue #721). Empty when nothing overrides
 // (including when getenv is nil, e.g. a test that did not inject the environment).
+//
+// A case-only difference is NOT assumed here to name the same provider — see
+// activeProviderEnvOverrideSelectsSaved, which resolves that question instead of
+// guessing at it.
 func activeProviderEnvOverride(getenv func(string) string, selected string) string {
 	if getenv == nil {
 		return ""
 	}
 	override := strings.TrimSpace(getenv(config.ActiveProviderEnv))
-	if override == "" || strings.EqualFold(override, strings.TrimSpace(selected)) {
+	if override == "" || override == strings.TrimSpace(selected) {
 		return ""
 	}
 	return override
+}
+
+// activeProviderEnvOverrideSelectsSaved reports whether a case-only ZERO_PROVIDER
+// difference actually lands on the row `providers use` just wrote.
+//
+// Folding the comparison outright was wrong: user config resolves the active row
+// case-insensitively, but project config and provider commands contribute their
+// own rows, and resolution then selects an exact-case match. With a workspace
+// profile literally named "WORK", ZERO_PROVIDER=WORK selects THAT row — different
+// credentials, different endpoint — while `zero providers use work` reported a
+// clean switch with no override at all. So the suppression is granted only when
+// resolution proves the env value produces the very spelling just selected.
+func activeProviderEnvOverrideSelectsSaved(deps appDeps, configPath string, selected string) bool {
+	resolved, err := resolveActiveProviderWithoutProviderCommand(deps, configPath)
+	if err != nil {
+		return false
+	}
+	return resolved == strings.TrimSpace(selected)
+}
+
+// resolveActiveProviderWithoutProviderCommand resolves the effective active
+// provider name without running ZERO_PROVIDER_COMMAND. Provider commands are
+// arbitrary external programs and `providers use` must remain a config-only
+// operation, so a configured one makes the answer unknowable here (false).
+func resolveActiveProviderWithoutProviderCommand(deps appDeps, configPath string) (string, error) {
+	if deps.getenv != nil && strings.TrimSpace(deps.getenv(config.ProviderCommandEnv)) != "" {
+		return "", fmt.Errorf("provider command resolution is deferred")
+	}
+	workspaceRoot, err := resolveWorkspaceRoot("", deps)
+	if err != nil {
+		return "", err
+	}
+	options, err := config.DefaultResolveOptions(workspaceRoot)
+	if err != nil {
+		return "", err
+	}
+	options.UserConfigPath = configPath
+	options.ProviderCommand = ""
+	resolved, err := config.Resolve(options)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(resolved.ActiveProvider), nil
+}
+
+// activeProviderEnvOverrideResolution checks whether ZERO_PROVIDER resolves
+// without running ZERO_PROVIDER_COMMAND. Provider commands are arbitrary
+// external programs and `providers use` must remain a config-only operation;
+// when one is configured, the final provider is therefore explicitly deferred
+// until the next normal resolution instead of being guessed here.
+func activeProviderEnvOverrideResolution(deps appDeps, configPath string, override string) (activeProviderOverrideResolution, error) {
+	if deps.getenv != nil && strings.TrimSpace(deps.getenv(config.ProviderCommandEnv)) != "" {
+		return activeProviderOverrideDeferred, nil
+	}
+	resolved, err := resolveActiveProviderWithoutProviderCommand(deps, configPath)
+	if err != nil {
+		if errors.Is(err, config.ErrNoActiveProvider) || errors.Is(err, config.ErrProviderRequiresModel) {
+			return activeProviderOverrideUnresolved, nil
+		}
+		return activeProviderOverrideConfigError, err
+	}
+	// Fold case: resolution selects the active row case-insensitively and reports
+	// the row's canonical persisted spelling, so ZERO_PROVIDER=openrouter against
+	// a saved "OpenRouter" resolves to "OpenRouter". Comparing exactly called that
+	// a failed override and told the user Zero could not start with it, which was
+	// the opposite of true. A fold cannot report a false success here: if the
+	// active row folds to the override, the override is what selected it.
+	if !config.SameProviderIdentity(resolved, override) {
+		return activeProviderOverrideUnresolved, nil
+	}
+	return activeProviderOverrideResolved, nil
 }
 
 func runProvidersSetup(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -414,14 +547,62 @@ func runProvidersRemove(args []string, stdout io.Writer, stderr io.Writer, deps 
 			return exit
 		}
 	}
-	cfg, err := config.RemoveProvider(configPath, name)
+	// Read the row BEFORE removal so we know whether it owned the stored-key
+	// marker — RemoveProvider's returned cfg no longer has it, and the
+	// credential store's secret is keyed case-folded, so removing a keyed row
+	// while a case-variant sibling survives must carry the marker over
+	// instead of silently orphaning the still-shared secret.
+	before, hadBefore, err := config.ProviderRow(configPath, name)
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
+	credentialCandidates, _, err := config.ProviderCredentialCandidates(configPath, name)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	// Decide up front whether a sibling row will survive this removal holding
+	// the SAME credential-store identity, because that decides what happens to
+	// the shared secret: hand the marker over, or delete the key outright.
+	survivor, survivorSurvives, err := survivingCaseVariantProviderName(configPath, name)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	cfg, err := config.RemoveProvider(configPath, name)
+	if err != nil {
+		return writeAppError(stderr, providerMutationError(configPath, name, err), exitCrash)
+	}
+	// The marker handoff can only run AFTER the removal, not as a transaction
+	// around it: while both case-variant rows are present the config is
+	// ambiguous, and writeConfigFile rejects every write against it — removing
+	// one row is precisely the repair. So the window is real, and the command
+	// reports it as a partial failure (nonzero below) instead of success.
+	//
 	// Delete the key from the store BESIDE the config being edited — the same
 	// store setup/rename write to — not the default-path store, so a
-	// non-default config path cannot leave the encrypted key behind.
-	keyRemoved, keyErr := removeStoredProviderKeyAt(configPath, name)
+	// non-default config path cannot leave the encrypted key behind. Skipped
+	// when a case variant survives: that row keeps reading the shared entry.
+	keyRemoved := false
+	var keyErr error
+	markerTransferFailed := false
+	if survivorSurvives {
+		if hadBefore && before.APIKeyStored {
+			if _, err := config.TransferProviderAPIKeyStoredMarker(configPath, survivor); err != nil {
+				keyErr = err
+				markerTransferFailed = true
+			}
+		}
+		credentialCandidates = slices.DeleteFunc(credentialCandidates, func(candidate string) bool {
+			return config.SameProviderIdentity(candidate, name)
+		})
+	}
+	keyRemoved, cleanupErr := removeStoredProviderKeysAt(configPath, credentialCandidates)
+	if cleanupErr != nil {
+		if keyErr != nil {
+			keyErr = fmt.Errorf("%v; credential cleanup: %w", keyErr, cleanupErr)
+		} else {
+			keyErr = cleanupErr
+		}
+	}
 	if options.json {
 		payload := map[string]any{
 			"removed":        name,
@@ -436,13 +617,22 @@ func runProvidersRemove(args []string, stdout io.Writer, stderr io.Writer, deps 
 		if err := writePrettyJSON(stdout, payload); err != nil {
 			return exitCrash
 		}
+		// A failed handoff left the survivor unable to reach the shared key.
+		// Scripts must not read that as a completed removal.
+		if markerTransferFailed {
+			return exitCrash
+		}
 		return exitSuccess
 	}
 	if _, err := fmt.Fprintf(stdout, "Removed provider %s\n", name); err != nil {
 		return exitCrash
 	}
 	if keyErr != nil {
-		if _, err := fmt.Fprintf(stderr, "warning: its stored API key could not be deleted and remains in the credential store: %v\n", keyErr); err != nil {
+		warning := "its stored API key could not be deleted and remains in the credential store"
+		if markerTransferFailed {
+			warning = fmt.Sprintf("the stored API key marker could not be handed to %s, which shares its credential entry, so the shared key is now unreachable", survivor)
+		}
+		if _, err := fmt.Fprintf(stderr, "warning: %s: %v\n", warning, keyErr); err != nil {
 			return exitCrash
 		}
 	} else if keyRemoved {
@@ -459,18 +649,59 @@ func runProvidersRemove(args []string, stdout io.Writer, stderr io.Writer, deps 
 			return exitCrash
 		}
 	}
+	if markerTransferFailed {
+		return exitCrash
+	}
 	return exitSuccess
 }
 
-// removeStoredProviderKeyAt deletes a provider's API key from the credential
+// removeStoredProviderKeysAt deletes provider API keys from the credential
 // store co-located with configPath (the store SecureProviderProfile captured
-// it into and RenameProvider migrates within).
-func removeStoredProviderKeyAt(configPath string, provider string) (bool, error) {
+// them into and RenameProvider migrates within).
+func removeStoredProviderKeysAt(configPath string, providers []string) (bool, error) {
 	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
 	if err != nil {
 		return false, err
 	}
-	return store.Delete(provider)
+	removed := false
+	for _, provider := range providers {
+		candidateRemoved, err := store.Delete(provider)
+		if err != nil {
+			return removed, err
+		}
+		removed = removed || candidateRemoved
+	}
+	return removed, nil
+}
+
+// survivingCaseVariantProviderName returns the exact name of another persisted
+// row that shares name's CREDENTIAL-STORE identity — a case-only variant that
+// will still read the same stored secret once name's row is gone — and whether
+// one was found. config.RemoveProvider matches its row exactly, so any row with
+// a different exact spelling survives.
+//
+// The comparison is credstore.NormalizeProvider, not strings.EqualFold, because
+// only the former is the store's own equivalence rule. Unicode case folding
+// equates "s" and "ſ" while strings.ToLower does not, so EqualFold would let
+// `providers remove s` skip deleting the key and hand the marker to "ſ", whose
+// lookup uses a different store entry — orphaning the secret and leaving the
+// survivor with a marker pointing at nothing.
+func survivingCaseVariantProviderName(configPath string, name string) (string, bool, error) {
+	names, err := config.PersistedProviderNames(configPath)
+	if err != nil {
+		return "", false, err
+	}
+	removed := strings.TrimSpace(name)
+	target := credstore.NormalizeProvider(removed)
+	for _, candidate := range names {
+		if candidate == removed {
+			continue
+		}
+		if credstore.NormalizeProvider(candidate) == target {
+			return candidate, true, nil
+		}
+	}
+	return "", false, nil
 }
 
 // runProvidersRename renames a saved provider profile, migrating its stored
@@ -502,7 +733,7 @@ func runProvidersRename(args []string, stdout io.Writer, stderr io.Writer, deps 
 	}
 	cfg, err := config.RenameProvider(configPath, options.names[0], options.names[1])
 	if err != nil {
-		return writeAppError(stderr, err.Error(), exitCrash)
+		return writeAppError(stderr, providerMutationError(configPath, options.names[0], err), exitCrash)
 	}
 	if options.json {
 		if err := writePrettyJSON(stdout, map[string]any{
@@ -525,12 +756,54 @@ func runProvidersRename(args []string, stdout io.Writer, stderr io.Writer, deps 
 // apart from a real, env-derived provider that just has no config.json row.
 func providerResolvedByName(providers []config.ProviderProfile, name string) bool {
 	name = strings.TrimSpace(name)
+	matches := 0
 	for _, provider := range providers {
-		if strings.EqualFold(strings.TrimSpace(provider.Name), name) {
-			return true
+		if config.SameProviderIdentity(provider.Name, name) || config.SameProviderIdentity(provider.CatalogID, name) {
+			matches++
 		}
 	}
-	return false
+	return matches == 1
+}
+
+// providerMutationError renders a provider mutator's failure, naming the saved
+// profile when the config owns what the user asked for under another spelling.
+// The mutators match exactly on purpose — one credential identity, one row — so
+// `zero providers use SAVED` against a saved "saved", or a catalog id against a
+// row saved under a different name, correctly fails not-found. Saying only that
+// leaves the user to guess what they got wrong, and `zero auth logout` already
+// explains the same situation; this keeps the provider commands consistent with
+// it, and goes one better by naming the spelling that works.
+func providerMutationError(configPath, name string, err error) string {
+	message := err.Error()
+	if !strings.Contains(message, "not found") {
+		return message
+	}
+	canonical, owned, lookupErr := config.PersistedProviderIdentity(configPath, name)
+	if lookupErr != nil || !owned || canonical == strings.TrimSpace(name) {
+		return message
+	}
+	return fmt.Sprintf("%s; the saved profile is named %q and provider names are matched exactly", message, canonical)
+}
+
+// configOwnsProviderIdentity reports whether a persisted row already owns name —
+// under any capitalization, or as the catalog id of a row saved under a
+// different name. Every runtime-only report below must consult it first: its
+// message claims the provider exists only because an environment variable is
+// set, and that is simply false for a provider the config owns. The caller falls
+// through to the command's own not-found handling instead, which is the right
+// answer for a mis-addressed saved profile — `zero providers use openrouter`
+// against a saved {name: "my-router", catalogId: "openrouter"} is the wrong name
+// for a real profile, not an env-derived provider.
+//
+// failed reports that reading the config failed; the error is already on stderr
+// and exit carries the code. owned is meaningful only when failed is false.
+func configOwnsProviderIdentity(stderr io.Writer, configPath, name string) (owned bool, exit int, failed bool) {
+	if _, ok, err := config.PersistedProviderIdentity(configPath, name); err != nil {
+		return false, writeAppError(stderr, err.Error(), exitCrash), true
+	} else if ok {
+		return true, exitSuccess, false
+	}
+	return false, exitSuccess, false
 }
 
 // reportUnpersistedProviderUse handles `zero providers use <name>` for a
@@ -542,6 +815,11 @@ func providerResolvedByName(providers []config.ProviderProfile, name string) boo
 // reports the situation plainly instead of that confusing error (issue
 // #707).
 func reportUnpersistedProviderUse(stdout, stderr io.Writer, deps appDeps, options providerUseOptions, configPath string) (int, bool) {
+	if owned, exit, failed := configOwnsProviderIdentity(stderr, configPath, options.name); failed {
+		return exit, true
+	} else if owned {
+		return exitSuccess, false
+	}
 	resolved, exitCode := resolveCommandCenterConfig(stderr, deps)
 	if exitCode != exitSuccess {
 		// resolveCommandCenterConfig already wrote its own error to stderr;
@@ -578,6 +856,11 @@ func reportUnpersistedProviderUse(stdout, stderr io.Writer, deps appDeps, option
 // name isn't resolvable at all, it returns handled=false so the caller falls
 // through to RemoveProvider's real "not found" error.
 func reportUnpersistedProviderRemove(stdout, stderr io.Writer, deps appDeps, name string, jsonOutput bool, configPath string) (int, bool) {
+	if owned, exit, failed := configOwnsProviderIdentity(stderr, configPath, name); failed {
+		return exit, true
+	} else if owned {
+		return exitSuccess, false
+	}
 	resolved, exitCode := resolveCommandCenterConfig(stderr, deps)
 	if exitCode != exitSuccess {
 		return exitCode, true
@@ -609,6 +892,11 @@ func reportUnpersistedProviderRemove(stdout, stderr io.Writer, deps appDeps, nam
 }
 
 func reportUnpersistedProviderRename(stdout, stderr io.Writer, deps appDeps, name string, jsonOutput bool, configPath string) (int, bool) {
+	if owned, exit, failed := configOwnsProviderIdentity(stderr, configPath, name); failed {
+		return exit, true
+	} else if owned {
+		return exitSuccess, false
+	}
 	resolved, exitCode := resolveCommandCenterConfig(stderr, deps)
 	if exitCode != exitSuccess {
 		return exitCode, true

--- a/internal/cli/provider_onboarding_test.go
+++ b/internal/cli/provider_onboarding_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -12,6 +14,7 @@ import (
 )
 
 func TestRunProvidersUseSetsActiveProvider(t *testing.T) {
+	t.Setenv(config.ActiveProviderEnv, "")
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
@@ -75,6 +78,44 @@ func TestRunProvidersUseJSONIncludesActiveProviderAndConfigPath(t *testing.T) {
 	}
 }
 
+func TestRunProvidersUseExplainsRuntimeOnlyProfilesAreNotSelectable(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	writeProviderOnboardingConfig(t, configPath, config.FileConfig{Providers: []config.ProviderProfile{{Name: "saved", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"}}})
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"providers", "use", "runtime"}, &stdout, &stderr, providerSetupDeps(configPath)); code != exitCrash {
+		t.Fatalf("unexpected code %d", code)
+	}
+	if !strings.Contains(stderr.String(), `provider "runtime" not found`) {
+		t.Fatalf("error missing plain not-found: %s", stderr.String())
+	}
+}
+
+func TestRunProvidersUseRejectsCaseVariantOfPersistedProvider(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	writeProviderOnboardingConfig(t, configPath, config.FileConfig{
+		ActiveProvider: "saved",
+		Providers: []config.ProviderProfile{
+			{Name: "saved", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"},
+		},
+	})
+
+	var stdout, stderr bytes.Buffer
+	deps := providerSetupDeps(configPath)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{Name: "saved", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"}
+		return config.ResolvedConfig{ActiveProvider: "saved", Provider: profile, Providers: []config.ProviderProfile{profile}}, nil
+	}
+	if code := runWithDeps([]string{"providers", "use", "SAVED"}, &stdout, &stderr, deps); code != exitCrash {
+		t.Fatalf("exit = %d, want %d", code, exitCrash)
+	}
+	if !strings.Contains(stderr.String(), `provider "SAVED" not found`) {
+		t.Fatalf("case-variant error was not plain not-found: %q", stderr.String())
+	}
+	if cfg := readFileConfig(t, configPath); cfg.ActiveProvider != "saved" {
+		t.Fatalf("ActiveProvider = %q, want saved", cfg.ActiveProvider)
+	}
+}
+
 func providersUseOverrideConfig(t *testing.T) string {
 	t.Helper()
 	configPath := filepath.Join(t.TempDir(), "config.json")
@@ -86,6 +127,158 @@ func providersUseOverrideConfig(t *testing.T) string {
 		},
 	})
 	return configPath
+}
+
+// providersUseOverrideConfigAtDefaultUserPath is providersUseOverrideConfig,
+// but written to the exact path config.DefaultUserConfigPath() resolves to via
+// a redirected APPDATA/XDG_CONFIG_HOME.
+func providersUseOverrideConfigAtDefaultUserPath(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", root)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", root)
+	}
+	configPath := filepath.Join(root, "zero", "config.json")
+	writeProviderOnboardingConfig(t, configPath, config.FileConfig{
+		ActiveProvider: "work",
+		Providers: []config.ProviderProfile{
+			{Name: "work", ProviderKind: config.ProviderKindOpenAI, BaseURL: config.OpenAIBaseURL, Model: "gpt-4.1"},
+			{Name: "fast", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://api.groq.com/openai/v1", Model: "llama-3.3-70b-versatile"},
+		},
+	})
+	return configPath
+}
+
+// TestRunProvidersUseResolvesCaseVariantEnvOverride is the regression test for
+// jatmn's #725 review: the override check ran the real resolver but compared its
+// result to the raw env string exactly. Resolution matches the active row
+// case-insensitively and reports the row's persisted spelling, so
+// ZERO_PROVIDER=WORK against a saved "work" resolves fine at runtime yet was
+// reported as unresolvable — telling the user Zero could not start on an
+// override that works.
+func TestRunProvidersUseResolvesCaseVariantEnvOverride(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	// As in TestRunProvidersUseJSONFlagsEnvOverride: the resolver reads the real
+	// process environment, so the override has to be set for real.
+	t.Setenv(config.ActiveProviderEnv, "WORK")
+	deps := providerSetupDeps(providersUseOverrideConfigAtDefaultUserPath(t))
+	deps.getenv = func(key string) string {
+		if key == config.ActiveProviderEnv {
+			return "WORK"
+		}
+		return ""
+	}
+
+	if code := runWithDeps([]string{"providers", "use", "fast", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if resolves, ok := payload["envProviderResolves"].(bool); !ok || !resolves {
+		t.Fatalf("envProviderResolves = %#v, want true for a case-variant override of a saved profile", payload["envProviderResolves"])
+	}
+	if payload["effectiveProvider"] != "WORK" {
+		t.Fatalf("effectiveProvider = %#v, want the override reported as effective", payload["effectiveProvider"])
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	textDeps := providerSetupDeps(providersUseOverrideConfigAtDefaultUserPath(t))
+	textDeps.getenv = deps.getenv
+	if code := runWithDeps([]string{"providers", "use", "fast"}, &stdout, &stderr, textDeps); code != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+	}
+	if note := stderr.String(); strings.Contains(note, "can be resolved") {
+		t.Fatalf("a resolvable case-variant override must not be reported as broken: %q", note)
+	}
+}
+
+// TestRunProvidersUseRejectsCatalogIDOfSavedProfile covers jatmn's #725 finding
+// that catalog-id addressing of a SAVED row took the runtime-only path: the row
+// is not persisted under that name, but the config plainly owns the identity, so
+// the env-derived explanation is false and exiting 0 hides a failed switch.
+func TestRunProvidersUseRejectsCatalogIDOfSavedProfile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	writeProviderOnboardingConfig(t, configPath, config.FileConfig{
+		ActiveProvider: "work",
+		Providers: []config.ProviderProfile{
+			{Name: "work", ProviderKind: config.ProviderKindOpenAI, BaseURL: config.OpenAIBaseURL, Model: "gpt-4.1"},
+			{Name: "my-router", ProviderKind: config.ProviderKindOpenAICompatible, CatalogID: "openrouter", BaseURL: "https://openrouter.ai/api/v1", Model: "x"},
+		},
+	})
+
+	var stdout, stderr bytes.Buffer
+	deps := providerSetupDeps(configPath)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		saved := config.ProviderProfile{Name: "my-router", ProviderKind: config.ProviderKindOpenAICompatible, CatalogID: "openrouter", Model: "x"}
+		return config.ResolvedConfig{ActiveProvider: "work", Provider: saved, Providers: []config.ProviderProfile{saved}}, nil
+	}
+	if code := runWithDeps([]string{"providers", "use", "openrouter"}, &stdout, &stderr, deps); code != exitCrash {
+		t.Fatalf("exit = %d, want %d (stdout %q, stderr %q)", code, exitCrash, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "environment variable") {
+		t.Fatalf("a saved profile addressed by catalog id must not be described as environment-derived: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `provider "openrouter" not found`) {
+		t.Fatalf("stderr = %q, want the real not-found error", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `"my-router"`) {
+		t.Fatalf("stderr = %q, want the saved profile's name named in the hint", stderr.String())
+	}
+	if cfg := readFileConfig(t, configPath); cfg.ActiveProvider != "work" {
+		t.Fatalf("ActiveProvider = %q, want work (nothing should have switched)", cfg.ActiveProvider)
+	}
+}
+
+// TestRunProvidersRemoveRenameRejectCaseVariantOfPersistedProvider extends the
+// guard `providers use` already had to remove and rename, which jatmn found had
+// been left behind: `zero providers remove SAVED` against a saved "saved" exited
+// 0 with the environment-variable explanation instead of failing not-found.
+func TestRunProvidersRemoveRenameRejectCaseVariantOfPersistedProvider(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "remove", args: []string{"providers", "remove", "SAVED"}},
+		{name: "rename", args: []string{"providers", "rename", "SAVED", "renamed"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.json")
+			writeProviderOnboardingConfig(t, configPath, config.FileConfig{
+				ActiveProvider: "saved",
+				Providers: []config.ProviderProfile{
+					{Name: "saved", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"},
+				},
+			})
+
+			var stdout, stderr bytes.Buffer
+			deps := providerSetupDeps(configPath)
+			deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+				profile := config.ProviderProfile{Name: "saved", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"}
+				return config.ResolvedConfig{ActiveProvider: "saved", Provider: profile, Providers: []config.ProviderProfile{profile}}, nil
+			}
+			if code := runWithDeps(tc.args, &stdout, &stderr, deps); code != exitCrash {
+				t.Fatalf("exit = %d, want %d (stdout %q, stderr %q)", code, exitCrash, stdout.String(), stderr.String())
+			}
+			if strings.Contains(stdout.String(), "environment variable") {
+				t.Fatalf("a case variant of a saved profile must not be described as environment-derived: %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), `provider "SAVED" not found`) {
+				t.Fatalf("stderr = %q, want the real not-found error", stderr.String())
+			}
+			if !strings.Contains(stderr.String(), `"saved"`) {
+				t.Fatalf("stderr = %q, want the persisted spelling named in the hint", stderr.String())
+			}
+			cfg := readFileConfig(t, configPath)
+			if len(cfg.Providers) != 1 || cfg.Providers[0].Name != "saved" {
+				t.Fatalf("config was mutated by a rejected command: %#v", cfg.Providers)
+			}
+		})
+	}
 }
 
 // The write to config.json still succeeds, but when ZERO_PROVIDER names a
@@ -121,7 +314,14 @@ func TestRunProvidersUseWarnsWhenEnvOverrides(t *testing.T) {
 
 func TestRunProvidersUseJSONFlagsEnvOverride(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	deps := providerSetupDeps(providersUseOverrideConfig(t))
+	// activeProviderEnvOverrideResolution runs the resolver to prove the override
+	// is genuinely effective, and the resolver reads the real process
+	// environment (config.Resolve falls back to os.Getenv when no Env map is
+	// injected) — so the override must be set for real, not just mocked via
+	// deps.getenv, which only feeds the separate "is this an override at all"
+	// check.
+	t.Setenv(config.ActiveProviderEnv, "work")
+	deps := providerSetupDeps(providersUseOverrideConfigAtDefaultUserPath(t))
 	deps.getenv = func(key string) string {
 		if key == config.ActiveProviderEnv {
 			return "work"
@@ -142,6 +342,203 @@ func TestRunProvidersUseJSONFlagsEnvOverride(t *testing.T) {
 	}
 	if payload.ActiveProvider != "fast" || payload.EffectiveProvider != "work" || payload.OverriddenByEnv != config.ActiveProviderEnv {
 		t.Fatalf("JSON must flag the env override, got %#v", payload)
+	}
+}
+
+// A ZERO_PROVIDER value that names nothing resolvable must not be reported as
+// the effective provider: the next resolution fails on it, so the note has to say
+// the override is broken rather than send the user to check a provider that does
+// not exist.
+func TestRunProvidersUseFlagsUnresolvableEnvOverride(t *testing.T) {
+	configPath := providersUseOverrideConfig(t)
+	getenv := func(key string) string {
+		if key == config.ActiveProviderEnv {
+			return "removed-profile"
+		}
+		return ""
+	}
+
+	var stdout, stderr bytes.Buffer
+	deps := providerSetupDeps(configPath)
+	deps.getenv = getenv
+	if code := runWithDeps([]string{"providers", "use", "fast"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+	}
+	note := stderr.String()
+	for _, want := range []string{config.ActiveProviderEnv, "removed-profile", "can be resolved"} {
+		if !strings.Contains(note, want) {
+			t.Fatalf("unresolvable-override note missing %q, got %q", want, note)
+		}
+	}
+	if strings.Contains(note, "stays the active provider") {
+		t.Fatalf("an unresolvable override must not be called the active provider: %q", note)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	jsonDeps := providerSetupDeps(configPath)
+	jsonDeps.getenv = getenv
+	if code := runWithDeps([]string{"providers", "use", "fast", "--json"}, &stdout, &stderr, jsonDeps); code != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if _, reported := payload["effectiveProvider"]; reported {
+		t.Fatalf("an unresolvable override must not be reported as effective: %#v", payload)
+	}
+	if payload["envProvider"] != "removed-profile" || payload["overriddenByEnv"] != config.ActiveProviderEnv {
+		t.Fatalf("JSON must still name the override, got %#v", payload)
+	}
+	if resolves, ok := payload["envProviderResolves"].(bool); !ok || resolves {
+		t.Fatalf("envProviderResolves = %#v, want false", payload["envProviderResolves"])
+	}
+}
+
+// A ZERO_PROVIDER override that names a persisted profile is still not proof
+// the next resolution succeeds: an OpenAI-compatible profile saved without a
+// model fails normalization (config.Resolve requires one), so the override
+// must not be reported as effective just because a config.json row exists.
+func TestRunProvidersUseFlagsBrokenPersistedEnvOverride(t *testing.T) {
+	root := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", root)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", root)
+	}
+	configPath := filepath.Join(root, "zero", "config.json")
+	writeProviderOnboardingConfig(t, configPath, config.FileConfig{
+		ActiveProvider: "work",
+		Providers: []config.ProviderProfile{
+			{Name: "work", ProviderKind: config.ProviderKindOpenAI, BaseURL: config.OpenAIBaseURL, Model: "gpt-4.1"},
+			{Name: "fast", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://api.groq.com/openai/v1", Model: "llama-3.3-70b-versatile"},
+			{Name: "broken", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://api.example.com/v1"},
+		},
+	})
+	t.Setenv(config.ActiveProviderEnv, "broken")
+	deps := providerSetupDeps(configPath)
+	deps.getenv = func(key string) string {
+		if key == config.ActiveProviderEnv {
+			return "broken"
+		}
+		return ""
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"providers", "use", "fast", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if _, reported := payload["effectiveProvider"]; reported {
+		t.Fatalf("a persisted-but-unresolvable override must not be reported as effective: %#v", payload)
+	}
+	if resolves, ok := payload["envProviderResolves"].(bool); !ok || resolves {
+		t.Fatalf("envProviderResolves = %#v, want false", payload["envProviderResolves"])
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runWithDeps([]string{"providers", "use", "fast"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "stays the active provider") {
+		t.Fatalf("a persisted-but-unresolvable override must not be called the active provider: %q", stderr.String())
+	}
+}
+
+func TestRunProvidersUseDoesNotBlameOverrideForInvalidProjectConfig(t *testing.T) {
+	t.Setenv(config.ActiveProviderEnv, "work")
+	configPath := providersUseOverrideConfigAtDefaultUserPath(t)
+	workspace := t.TempDir()
+	projectPath := filepath.Join(workspace, ".zero", "config.json")
+	if err := os.MkdirAll(filepath.Dir(projectPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectPath, []byte(`{"tools":{"deferThreshold":-1}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps := providerSetupDeps(configPath)
+	deps.getwd = func() (string, error) { return workspace, nil }
+	deps.getenv = func(key string) string {
+		if key == config.ActiveProviderEnv {
+			return "work"
+		}
+		return ""
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"providers", "use", "fast"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	note := stderr.String()
+	if !strings.Contains(note, "configuration is invalid") || !strings.Contains(note, "deferThreshold") {
+		t.Fatalf("note did not report the actual config error: %q", note)
+	}
+	if strings.Contains(note, "no provider named work") {
+		t.Fatalf("unrelated config failure was blamed on ZERO_PROVIDER: %q", note)
+	}
+}
+
+func TestRunProvidersUseDefersOverrideResolutionWhenProviderCommandIsSet(t *testing.T) {
+	configPath := providersUseOverrideConfig(t)
+	marker := filepath.Join(t.TempDir(), "provider-command-ran")
+	t.Setenv(config.ActiveProviderEnv, "work")
+	t.Setenv("ZERO_TEST_PROVIDER_COMMAND_MARKER", marker)
+	providerCommand := strconv.Quote(os.Args[0]) + " -test.run=^TestProviderCommandSentinel$"
+	t.Setenv(config.ProviderCommandEnv, providerCommand)
+	deps := providerSetupDeps(configPath)
+	deps.getenv = func(key string) string {
+		switch key {
+		case config.ActiveProviderEnv:
+			return "work"
+		case config.ProviderCommandEnv:
+			return providerCommand
+		default:
+			return ""
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"providers", "use", "fast", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if payload["envProviderResolution"] != "deferred" || payload["envProviderResolves"] != nil {
+		t.Fatalf("provider-command override resolution must be deferred: %#v", payload)
+	}
+	if _, reported := payload["effectiveProvider"]; reported {
+		t.Fatalf("deferred override must not be reported as effective: %#v", payload)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("provider command ran during override reporting: stat error = %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runWithDeps([]string{"providers", "use", "fast"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+	}
+	for _, want := range []string{config.ProviderCommandEnv, "determined", "next resolves configuration"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("deferred override note missing %q: %q", want, stderr.String())
+		}
+	}
+}
+
+func TestProviderCommandSentinel(t *testing.T) {
+	marker := os.Getenv("ZERO_TEST_PROVIDER_COMMAND_MARKER")
+	if marker == "" {
+		return
+	}
+	if err := os.WriteFile(marker, []byte("ran"), 0o600); err != nil {
+		t.Fatalf("write provider-command marker: %v", err)
 	}
 }
 
@@ -169,6 +566,83 @@ func TestRunProvidersUseNoWarnWithoutEnvOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestActiveProviderEnvOverrideReportsEveryDistinctSpelling pins the pure
+// function's contract after jatmn's #725 round: a case-only difference is no
+// longer silently treated as "the same provider". Deciding that needs the
+// resolver (see TestRunProvidersUseCaseVariantEnvOverrideFollowsResolution),
+// so this layer reports every spelling that is not literally the selection.
+func TestActiveProviderEnvOverrideReportsEveryDistinctSpelling(t *testing.T) {
+	getenv := func(value string) func(string) string {
+		return func(key string) string {
+			if key == config.ActiveProviderEnv {
+				return value
+			}
+			return ""
+		}
+	}
+	if override := activeProviderEnvOverride(getenv("work"), "work"); override != "" {
+		t.Fatalf("activeProviderEnvOverride() = %q, want no override when the env names the selection exactly", override)
+	}
+	if override := activeProviderEnvOverride(getenv("WORK"), "work"); override != "WORK" {
+		t.Fatalf("activeProviderEnvOverride() = %q, want the case-distinct spelling reported to the resolver", override)
+	}
+	if override := activeProviderEnvOverride(getenv("fast"), "work"); override != "fast" {
+		t.Fatalf("activeProviderEnvOverride() = %q, want the genuinely different provider reported", override)
+	}
+}
+
+// TestRunProvidersUseCaseVariantEnvOverrideFollowsResolution is the regression
+// test for jatmn's #725 finding that a case-distinct ZERO_PROVIDER was hidden
+// unconditionally. Folding is right only when the env value lands on the row
+// `providers use` just wrote; a project config contributing a separate
+// exact-case "WORK" profile makes it a real override of a different provider,
+// with different credentials, and that must still be reported.
+func TestRunProvidersUseCaseVariantEnvOverrideFollowsResolution(t *testing.T) {
+	run := func(t *testing.T, projectProviders []config.ProviderProfile) string {
+		t.Helper()
+		// The resolver reads the real process environment, so the override has
+		// to be set for real, and the user config has to sit at the default path.
+		t.Setenv(config.ActiveProviderEnv, "WORK")
+		configPath := providersUseOverrideConfigAtDefaultUserPath(t)
+		workspace := t.TempDir()
+		if len(projectProviders) > 0 {
+			projectPath := filepath.Join(workspace, ".zero", "config.json")
+			writeProviderOnboardingConfig(t, projectPath, config.FileConfig{Providers: projectProviders})
+		}
+		deps := providerSetupDeps(configPath)
+		deps.getwd = func() (string, error) { return workspace, nil }
+		deps.getenv = func(key string) string {
+			if key == config.ActiveProviderEnv {
+				return "WORK"
+			}
+			return ""
+		}
+		var stdout, stderr bytes.Buffer
+		if code := runWithDeps([]string{"providers", "use", "work"}, &stdout, &stderr, deps); code != exitSuccess {
+			t.Fatalf("exit = %d, want %d: %s", code, exitSuccess, stderr.String())
+		}
+		return stderr.String()
+	}
+
+	t.Run("case variant of the selection", func(t *testing.T) {
+		if note := run(t, nil); note != "" {
+			t.Fatalf("an override that resolves to the selected row must not warn: %q", note)
+		}
+	})
+
+	t.Run("case-distinct project profile", func(t *testing.T) {
+		note := run(t, []config.ProviderProfile{{
+			Name:         "WORK",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			Model:        "example-model",
+		}})
+		if !strings.Contains(note, "WORK") || !strings.Contains(note, config.ActiveProviderEnv) {
+			t.Fatalf("a separate exact-case profile must be reported as an override: %q", note)
+		}
+	})
 }
 
 func TestRunProvidersUseSurfacesMalformedConfig(t *testing.T) {
@@ -443,7 +917,7 @@ func TestRunProvidersRemoveDeletesKeyBesideConfig(t *testing.T) {
 	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
-	seed := `{"activeProvider":"gw","providers":[{"name":"gw","provider_kind":"openai-compatible","baseURL":"https://gw.example.com/v1","apiKeyStored":true,"model":"m1"},{"name":"other","provider_kind":"openai-compatible","baseURL":"https://o.example.com/v1","model":"m2"}]}`
+	seed := `{"activeProvider":"gw","providers":[{"name":"gw","catalogId":"catalog-gw","provider_kind":"openai-compatible","baseURL":"https://gw.example.com/v1","apiKeyStored":true,"model":"m1"},{"name":"other","provider_kind":"openai-compatible","baseURL":"https://o.example.com/v1","model":"m2"}]}`
 	if err := os.WriteFile(configPath, []byte(seed), 0o600); err != nil {
 		t.Fatalf("seed config: %v", err)
 	}
@@ -451,7 +925,7 @@ func TestRunProvidersRemoveDeletesKeyBesideConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
-	if err := store.Set("gw", "sk-secret"); err != nil {
+	if err := store.Set("catalog-gw", "sk-secret"); err != nil {
 		t.Fatalf("seed key: %v", err)
 	}
 
@@ -476,7 +950,156 @@ func TestRunProvidersRemoveDeletesKeyBesideConfig(t *testing.T) {
 	if payload.ActiveProvider != "other" {
 		t.Fatalf("active must hand off, got %q", payload.ActiveProvider)
 	}
-	if _, ok, _ := store.Get("gw"); ok {
-		t.Fatalf("stored key must be deleted from the store beside the config")
+	if _, ok, _ := store.Get("catalog-gw"); ok {
+		t.Fatalf("stored key under the catalog alias must be deleted from the store beside the config")
+	}
+}
+
+func TestProviderResolvedByNameRequiresOneCredentialStoreIdentity(t *testing.T) {
+	providers := []config.ProviderProfile{
+		{Name: "work-xai", CatalogID: "xai"},
+		{Name: "personal-xai", CatalogID: "xai"},
+	}
+	if providerResolvedByName(providers, "xai") {
+		t.Fatal("a shared catalog id must not be attributed to the first resolved provider")
+	}
+	if providerResolvedByName([]config.ProviderProfile{{Name: "s"}}, "ſ") {
+		t.Fatal("Unicode long-s is distinct from the credential store identity s")
+	}
+	if !providerResolvedByName([]config.ProviderProfile{{Name: "work"}}, "WORK") {
+		t.Fatal("ASCII case variants should resolve to the same credential-store identity")
+	}
+}
+
+func TestRunProvidersRemoveCaseDuplicateKeepsSurvivorKey(t *testing.T) {
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	seed := `{"activeProvider":"work","providers":[{"name":"work","apiKeyStored":true},{"name":"WORK"}]}`
+	if err := os.WriteFile(configPath, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := config.ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("work", "survivor-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	deps := appDeps{userConfigPath: func() (string, error) { return configPath, nil }}
+	if code := runWithDeps([]string{"providers", "remove", "WORK", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("remove failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if key, ok, err := store.Get("work"); err != nil || !ok || key != "survivor-key" {
+		t.Fatalf("surviving provider key = %q, %v, %v; want retained", key, ok, err)
+	}
+	var payload struct {
+		KeyRemoved bool `json:"keyRemoved"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil || payload.KeyRemoved {
+		t.Fatalf("payload = %s, err = %v; shared key must not be reported removed", stdout.String(), err)
+	}
+}
+
+// TestRunProvidersRemoveTransfersKeyMarkerToSurvivingCaseVariant covers the
+// inverse of TestRunProvidersRemoveCaseDuplicateKeepsSurvivorKey: the removed
+// row (not the survivor) owns apiKeyStored. Without transferring the marker,
+// the still-shared credential-store secret becomes unreachable through the
+// surviving row even though it was never deleted.
+func TestRunProvidersRemoveTransfersKeyMarkerToSurvivingCaseVariant(t *testing.T) {
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	seed := `{"activeProvider":"WORK","providers":[{"name":"work","catalogId":"xai","apiKeyStored":true},{"name":"WORK"}]}`
+	if err := os.WriteFile(configPath, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := config.ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("work", "shared-key"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("xai", "alias-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	deps := appDeps{userConfigPath: func() (string, error) { return configPath, nil }}
+	if code := runWithDeps([]string{"providers", "remove", "work", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("remove failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if key, ok, err := store.Get("work"); err != nil || !ok || key != "shared-key" {
+		t.Fatalf("shared provider key = %q, %v, %v; want retained", key, ok, err)
+	}
+	if _, ok, err := store.Get("xai"); err != nil || ok {
+		t.Fatalf("exclusive catalog-alias key survived removal: ok=%v err=%v", ok, err)
+	}
+	var payload struct {
+		KeyRemoved bool `json:"keyRemoved"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil || !payload.KeyRemoved {
+		t.Fatalf("payload = %s, err = %v; deleted catalog-alias key must be reported removed", stdout.String(), err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg config.FileConfig
+	if err := json.Unmarshal(after, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Providers) != 1 || cfg.Providers[0].Name != "WORK" || !cfg.Providers[0].APIKeyStored {
+		t.Fatalf("survivor must inherit apiKeyStored marker, got %+v", cfg.Providers)
+	}
+}
+
+// TestRunProvidersRemoveUsesCredentialStoreEquivalenceForSurvivors covers
+// jatmn's #725 finding that survivor detection compared with strings.EqualFold
+// while the credential store keys entries with trimmed strings.ToLower. The two
+// relations differ: Unicode case folding equates "s" and "ſ", ToLower does not.
+// Both spellings therefore pass persisted-name validation as separate rows with
+// separate store entries, but the EqualFold check called "ſ" a survivor of
+// removing "s" — skipping the key deletion (orphaning the secret) and handing
+// the marker to a row whose lookup uses a different entry entirely.
+func TestRunProvidersRemoveUsesCredentialStoreEquivalenceForSurvivors(t *testing.T) {
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	seed := `{"activeProvider":"s","providers":[{"name":"s","apiKeyStored":true},{"name":"\u017f"}]}`
+	if err := os.WriteFile(configPath, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := config.ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("s", "long-s-is-not-s"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	deps := appDeps{userConfigPath: func() (string, error) { return configPath, nil }}
+	if code := runWithDeps([]string{"providers", "remove", "s", "--json"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("remove failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, ok, err := store.Get("s"); err != nil || ok {
+		t.Fatalf("key = ok:%v err:%v; the removed row owned its own store entry, which must be deleted", ok, err)
+	}
+	var payload struct {
+		KeyRemoved bool `json:"keyRemoved"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil || !payload.KeyRemoved {
+		t.Fatalf("payload = %s, err = %v; want keyRemoved true", stdout.String(), err)
+	}
+	cfg := readFileConfig(t, configPath)
+	if len(cfg.Providers) != 1 || cfg.Providers[0].Name != "\u017f" {
+		t.Fatalf("providers = %+v, want only the distinct long-s row", cfg.Providers)
+	}
+	if cfg.Providers[0].APIKeyStored {
+		t.Fatal("a row with its own credential-store identity must not inherit another row's marker")
 	}
 }

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -53,6 +53,16 @@ func runProvidersAdd(args []string, stdout io.Writer, stderr io.Writer, deps app
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
+	// Retarget a catalog-default name at the row that already owns that catalog
+	// identity, so re-running setup for a provider saved under different casing
+	// updates it instead of failing the collision check.
+	profile, err = config.AdoptPersistedCatalogProviderName(configPath, profile)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if err := config.PreflightProviderWrite(configPath, profile.Name); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
 	// Persist with the key moved into the encrypted credential store (capture flip);
 	// the local profile keeps the key for the verification build below.
 	cfg, err := config.UpsertProvider(configPath, config.SecureProviderProfile(profile, configPath), options.setActive)

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -53,22 +53,20 @@ func runProvidersAdd(args []string, stdout io.Writer, stderr io.Writer, deps app
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
-	// Retarget a catalog-default name at the row that already owns that catalog
-	// identity, so re-running setup for a provider saved under different casing
-	// updates it instead of failing the collision check.
-	profile, err = config.AdoptPersistedCatalogProviderName(configPath, profile)
+	// One serialized transaction: retarget a catalog-default name at the row that
+	// already owns that catalog identity (so re-running setup for a provider saved
+	// under different casing updates it instead of colliding), reject a colliding
+	// spelling, move the key into the encrypted credential store, and persist. The
+	// local profile keeps the key for this run's immediate use.
+	committed, err := config.CommitProviderProfile(configPath, config.ProviderCommit{
+		Profile:   profile,
+		SetActive: options.setActive,
+	})
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
-	if err := config.PreflightProviderWrite(configPath, profile.Name); err != nil {
-		return writeAppError(stderr, err.Error(), exitCrash)
-	}
-	// Persist with the key moved into the encrypted credential store (capture flip);
-	// the local profile keeps the key for the verification build below.
-	cfg, err := config.UpsertProvider(configPath, config.SecureProviderProfile(profile, configPath), options.setActive)
-	if err != nil {
-		return writeAppError(stderr, err.Error(), exitCrash)
-	}
+	cfg := committed.Config
+	profile.Name = committed.Persisted.Name
 
 	if options.json {
 		if err := writePrettyJSON(stdout, map[string]any{

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -264,6 +264,15 @@ func saveSetupProvider(deps appDeps, selection tui.SetupSelection, options setup
 	if err != nil {
 		return tui.SetupResult{}, err
 	}
+	// Same identity resolution the login path uses: a catalog-default name yields
+	// to the row already saved for that catalog provider.
+	profile, err = config.AdoptPersistedCatalogProviderName(configPath, profile)
+	if err != nil {
+		return tui.SetupResult{}, err
+	}
+	if err := config.PreflightProviderWrite(configPath, profile.Name); err != nil {
+		return tui.SetupResult{}, err
+	}
 	// Persist with the key moved into the encrypted credential store (capture flip);
 	// the returned profile keeps the key for this run's immediate use.
 	if _, err := config.UpsertProvider(configPath, config.SecureProviderProfile(profile, configPath), true); err != nil {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -264,20 +264,19 @@ func saveSetupProvider(deps appDeps, selection tui.SetupSelection, options setup
 	if err != nil {
 		return tui.SetupResult{}, err
 	}
-	// Same identity resolution the login path uses: a catalog-default name yields
-	// to the row already saved for that catalog provider.
-	profile, err = config.AdoptPersistedCatalogProviderName(configPath, profile)
+	// Same identity resolution the login path uses, as one serialized transaction:
+	// a catalog-default name yields to the row already saved for that catalog
+	// provider, a colliding spelling is rejected, and the key moves into the
+	// encrypted credential store as the row is persisted. The returned profile
+	// keeps the key for this run's immediate use.
+	committed, err := config.CommitProviderProfile(configPath, config.ProviderCommit{
+		Profile:   profile,
+		SetActive: true,
+	})
 	if err != nil {
 		return tui.SetupResult{}, err
 	}
-	if err := config.PreflightProviderWrite(configPath, profile.Name); err != nil {
-		return tui.SetupResult{}, err
-	}
-	// Persist with the key moved into the encrypted credential store (capture flip);
-	// the returned profile keeps the key for this run's immediate use.
-	if _, err := config.UpsertProvider(configPath, config.SecureProviderProfile(profile, configPath), true); err != nil {
-		return tui.SetupResult{}, err
-	}
+	profile.Name = committed.Persisted.Name
 	return tui.SetupResult{ConfigPath: configPath, Provider: profile}, nil
 }
 

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -197,6 +199,35 @@ func TestSaveSetupProviderStoresPastedAPIKey(t *testing.T) {
 	}
 	if key, ok, _ := store.Get("ollama-cloud"); !ok || key != "sk-pasted-secret" {
 		t.Fatalf("stored key = %q,%v; want sk-pasted-secret in the credential store", key, ok)
+	}
+}
+
+func TestSaveSetupProviderRejectsExactNameWithoutCatalogOwnership(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	original := config.FileConfig{Providers: []config.ProviderProfile{{
+		Name: "openrouter", ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL: "https://corp.example/v1", Model: "corp-model", APIKeyStored: true,
+	}}}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = saveSetupProvider(appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	}, tui.SetupSelection{CatalogID: "openrouter", Model: "openai/gpt-4.1"}, setupSaveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "does not prove ownership") {
+		t.Fatalf("saveSetupProvider error = %v, want ownership rejection", err)
+	}
+	after := readFileConfig(t, configPath)
+	if len(after.Providers) != 1 || after.Providers[0].CatalogID != "" || after.Providers[0].BaseURL != "https://corp.example/v1" || after.Providers[0].Model != "corp-model" || !after.Providers[0].APIKeyStored {
+		t.Fatalf("name-only exact profile changed: %+v", after.Providers)
 	}
 }
 

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -99,7 +99,44 @@ func ClearProviderKeyStored(path, provider string) (bool, error) {
 	}
 	changed := false
 	for index := range cfg.Providers {
-		if strings.EqualFold(strings.TrimSpace(cfg.Providers[index].Name), provider) && cfg.Providers[index].APIKeyStored {
+		if strings.TrimSpace(cfg.Providers[index].Name) == provider && cfg.Providers[index].APIKeyStored {
+			cfg.Providers[index].APIKeyStored = false
+			changed = true
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	return true, writeConfigFile(path, cfg)
+}
+
+// ClearProviderKeyStoredCaseVariants unsets the APIKeyStored marker on every
+// row whose name normalizes to the same credential-store identity as provider,
+// not just an exact-spelling match. Deleting the shared secret for one
+// case-variant row (e.g. "WORK") must also clear the marker on any sibling row
+// ("work") that pointed at the same now-gone entry — leaving it set would claim
+// a key is available when ApplyStoredAPIKey's store lookup will always miss.
+func ClearProviderKeyStoredCaseVariants(path, provider string) (bool, error) {
+	path = strings.TrimSpace(path)
+	provider = strings.TrimSpace(provider)
+	if path == "" || provider == "" {
+		return false, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false, fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	changed := false
+	providerIdentity := credstore.NormalizeProvider(provider)
+	for index := range cfg.Providers {
+		if credstore.NormalizeProvider(cfg.Providers[index].Name) == providerIdentity && cfg.Providers[index].APIKeyStored {
 			cfg.Providers[index].APIKeyStored = false
 			changed = true
 		}
@@ -268,9 +305,9 @@ func firstNonEmptyTrimmed(values ...string) string {
 // profile name is unambiguously yours), then the catalog ID as a FALLBACK (so a
 // profile renamed away from its catalog ID — e.g. {name:"codex",
 // catalogID:"chatgpt"} — still finds a `zero auth login chatgpt` token).
-// Candidates are trimmed, blank-skipped, and de-duplicated CASE-SENSITIVELY — the
-// OAuth token store is a case-sensitive map, so "ChatGPT" and "chatgpt" are
-// distinct keys and both must survive.
+// Candidates are trimmed, blank-skipped, and de-duplicated before ProviderKey
+// applies the token store's lowercase key normalization. Keeping their persisted
+// spellings here preserves deterministic profile-name-first lookup order.
 func (profile ProviderProfile) OAuthLoginCandidates() []string {
 	if profile.HasConfiguredCredential() {
 		return nil

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -157,6 +157,36 @@ func TestClearProviderKeyStored(t *testing.T) {
 	if cleared, _ := ClearProviderKeyStored(path, "nope"); cleared {
 		t.Fatal("unknown provider should report no change")
 	}
+	if err := os.WriteFile(path, []byte(`{"providers":[{"name":"work","apiKeyStored":true}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cleared, err := ClearProviderKeyStored(path, "WORK"); err != nil || cleared {
+		t.Fatalf("case-variant clear = %v,%v; want false,nil", cleared, err)
+	}
+	cfg = readConfigFixture(t, path)
+	if !cfg.Providers[0].APIKeyStored {
+		t.Fatalf("clear must require exact provider identity: %+v", cfg.Providers)
+	}
+}
+
+func TestClearProviderKeyStoredCaseVariantsPreservesDistinctUnicodeIdentity(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"providers":[{"name":"s","apiKeyStored":true},{"name":"ſ","apiKeyStored":true}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleared, err := ClearProviderKeyStoredCaseVariants(path, "s")
+	if err != nil || !cleared {
+		t.Fatalf("clear = %v,%v; want true,nil", cleared, err)
+	}
+	cfg := readConfigFixture(t, path)
+	if cfg.Providers[0].APIKeyStored {
+		t.Fatal("s marker should be cleared")
+	}
+	if !cfg.Providers[1].APIKeyStored {
+		t.Fatal("long-s marker belongs to a distinct credential-store identity and must remain set")
+	}
 }
 
 func TestProviderProfileAPIKeyStoredRoundTrips(t *testing.T) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const ProviderCommandEnv = "ZERO_PROVIDER_COMMAND"
+
 // DefaultResolveOptions builds config resolution inputs from the local process
 // environment and workspace.
 func DefaultResolveOptions(workspaceRoot string) (ResolveOptions, error) {
@@ -29,7 +31,7 @@ func DefaultResolveOptions(workspaceRoot string) (ResolveOptions, error) {
 	return ResolveOptions{
 		UserConfigPath:    userConfigPath,
 		ProjectConfigPath: projectConfigPath,
-		ProviderCommand:   strings.TrimSpace(os.Getenv("ZERO_PROVIDER_COMMAND")),
+		ProviderCommand:   strings.TrimSpace(os.Getenv(ProviderCommandEnv)),
 	}, nil
 }
 

--- a/internal/config/provider_commit.go
+++ b/internal/config/provider_commit.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/lockutil"
+)
+
+// ProviderCommit is one provider write: resolve the name against what is
+// already saved, reject a colliding spelling, capture the inline key into the
+// credential store, and persist the row.
+type ProviderCommit struct {
+	Profile   ProviderProfile
+	SetActive bool
+	// KeepStoredKey leaves the credential store untouched instead of capturing
+	// Profile.APIKey — the case where the profile already references a stored
+	// credential that this write must not replace.
+	KeepStoredKey bool
+}
+
+// ProviderCommitResult reports the config as written and the profile exactly as
+// it was persisted: the adopted name, and the key moved into the credential
+// store (APIKey cleared, APIKeyStored set) unless KeepStoredKey was requested.
+type ProviderCommitResult struct {
+	Config    FileConfig
+	Persisted ProviderProfile
+}
+
+// CommitProviderProfile runs name adoption, the case-variant collision check,
+// credential capture, and the config write as one serialized transaction.
+//
+// Splitting those steps is what made the credential store and config disagree.
+// The capture writes under the credential store's NORMALIZED identity while the
+// collision check reads config's EXACT names, so two concurrent writers for
+// `foo` and `FOO` could both pass the check against an empty config; the loser
+// then overwrote the winner's `foo` credential entry on its way to being
+// correctly rejected by the config write, destroying a working profile's API
+// key. A cross-process lock keeps a second writer out for the whole sequence,
+// and a rejected write restores the credential entry it displaced, so a failed
+// mutation cannot leave another profile's secret behind.
+func CommitProviderProfile(path string, commit ProviderCommit) (ProviderCommitResult, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ProviderCommitResult{}, fmt.Errorf("config path is required")
+	}
+	release, err := lockProviderWrite(path)
+	if err != nil {
+		return ProviderCommitResult{}, err
+	}
+	defer release()
+
+	profile, err := AdoptPersistedCatalogProviderName(path, commit.Profile)
+	if err != nil {
+		return ProviderCommitResult{}, err
+	}
+	if err := PreflightProviderWrite(path, profile.Name); err != nil {
+		return ProviderCommitResult{}, err
+	}
+
+	persisted := profile
+	restore := func() {}
+	if !commit.KeepStoredKey {
+		persisted, restore = secureProviderProfileWithRestore(profile, path)
+	}
+	cfg, err := UpsertProvider(path, persisted, commit.SetActive)
+	if err != nil {
+		restore()
+		return ProviderCommitResult{}, err
+	}
+	return ProviderCommitResult{Config: cfg, Persisted: persisted}, nil
+}
+
+// secureProviderProfileWithRestore captures the profile's inline key like
+// SecureProviderProfile and additionally returns a function that puts the
+// credential store back the way it was — restoring a displaced key, or removing
+// the entry this capture created. The caller runs it when the config write that
+// justified the capture is rejected.
+func secureProviderProfileWithRestore(profile ProviderProfile, configPath string) (ProviderProfile, func()) {
+	noRestore := func() {}
+	if strings.TrimSpace(profile.APIKey) == "" || strings.TrimSpace(profile.Name) == "" {
+		return profile, noRestore
+	}
+	store, err := ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		return profile, noRestore
+	}
+	// Read the displaced value before overwriting it. A store that cannot be read
+	// cannot be rolled back either, so leave it alone rather than capture a key
+	// this call would not be able to undo.
+	previous, hadPrevious, err := store.Get(profile.Name)
+	if err != nil {
+		return profile, noRestore
+	}
+	if err := store.Set(profile.Name, profile.APIKey); err != nil {
+		return profile, noRestore
+	}
+	secured := profile
+	secured.APIKey = ""
+	secured.APIKeyStored = true
+	return secured, func() {
+		if hadPrevious {
+			_ = store.Set(profile.Name, previous)
+			return
+		}
+		_, _ = store.Delete(profile.Name)
+	}
+}
+
+const (
+	providerWriteLockTimeout    = 5 * time.Second
+	providerWriteLockStaleAfter = 30 * time.Second
+)
+
+var providerWriteLockSeq atomic.Uint64
+
+// lockProviderWrite takes a cross-process exclusive lock covering the provider
+// rows of the config at path and the credential store beside it, which are one
+// unit of state written by two files. It mirrors the O_EXCL lock used by the
+// oauth token store: a bounded wait, a stale-holder reclaim so a crashed writer
+// cannot deadlock the next one, and an ownership-checked release.
+//
+// Failing to take the lock does not fail the write. This lock removes a
+// concurrency window; treating a locking problem as a reason to refuse a
+// provider write would turn a rare race into a routine outage.
+func lockProviderWrite(configPath string) (func(), error) {
+	lockPath := filepath.Join(filepath.Dir(configPath), ".zero-provider-write.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return func() {}, nil
+	}
+	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), time.Now().UnixNano(), providerWriteLockSeq.Add(1))
+	deadline := time.Now().Add(providerWriteLockTimeout)
+	for {
+		file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			if _, werr := file.WriteString(token); werr != nil {
+				_ = file.Close()
+				_ = lockutil.RemoveLockFile(lockPath)
+				return func() {}, nil
+			}
+			if cerr := file.Close(); cerr != nil {
+				_ = lockutil.RemoveLockFile(lockPath)
+				return func() {}, nil
+			}
+			released := false
+			return func() {
+				if released {
+					return
+				}
+				released = true
+				if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == token {
+					_ = lockutil.RemoveLockFile(lockPath)
+				}
+			}, nil
+		}
+		// On Windows a concurrent holder's remove leaves the file delete-pending, so
+		// an O_EXCL create races it with ERROR_ACCESS_DENIED rather than ErrExist.
+		// Both mean contention.
+		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
+			return func() {}, nil
+		}
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > providerWriteLockStaleAfter {
+			cleared, rerr := lockutil.ReclaimStaleLock(lockPath, token, func(reclaimedPath string) bool {
+				info, err := os.Stat(reclaimedPath)
+				return err == nil && time.Since(info.ModTime()) <= providerWriteLockStaleAfter
+			})
+			if rerr == nil && cleared {
+				continue
+			}
+		}
+		if time.Now().After(deadline) {
+			return func() {}, nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/config/provider_commit_test.go
+++ b/internal/config/provider_commit_test.go
@@ -1,0 +1,266 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// A rejected case-variant write must not take the accepted profile's secret with
+// it. The credential store is keyed case-insensitively while the config
+// collision check compares exact names, so the capture and the check must happen
+// as one transaction: capturing first and rejecting afterwards overwrote the
+// working `foo` key with the rejected `FOO` write's key.
+func TestCommitProviderProfileRejectedCollisionKeepsExistingKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	path := filepath.Join(dir, "config.json")
+	writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "foo",
+		Providers: []ProviderProfile{
+			{Name: "foo", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://a.example.com/v1", APIKeyStored: true, Model: "m1"},
+		},
+	}, 0o600)
+	store, err := ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.Set("foo", "sk-original"); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	_, err = CommitProviderProfile(path, ProviderCommit{Profile: ProviderProfile{
+		Name:         "FOO",
+		ProviderKind: ProviderKindOpenAICompatible,
+		BaseURL:      "https://b.example.com/v1",
+		APIKey:       "sk-replacement",
+		Model:        "m2",
+	}})
+	if err == nil {
+		t.Fatal("CommitProviderProfile must reject a case-variant collision")
+	}
+	if !strings.Contains(err.Error(), "already exists as") {
+		t.Fatalf("CommitProviderProfile error = %v, want a collision report", err)
+	}
+
+	key, ok, err := store.Get("foo")
+	if err != nil || !ok {
+		t.Fatalf("existing key must survive a rejected write, got ok=%v err=%v", ok, err)
+	}
+	if key != "sk-original" {
+		t.Fatalf("rejected write replaced the existing profile's key: got %q", key)
+	}
+}
+
+// The same guarantee for a name that had no stored key before: a rejected write
+// must not leave its captured secret behind under the shared identity.
+func TestCommitProviderProfileRejectedCollisionRemovesCapturedKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	path := filepath.Join(dir, "config.json")
+	writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "work",
+		Providers: []ProviderProfile{
+			{Name: "work", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://a.example.com/v1", Model: "m1"},
+		},
+	}, 0o600)
+
+	if _, err := CommitProviderProfile(path, ProviderCommit{Profile: ProviderProfile{
+		Name:         "WORK",
+		ProviderKind: ProviderKindOpenAICompatible,
+		BaseURL:      "https://b.example.com/v1",
+		APIKey:       "sk-replacement",
+	}}); err == nil {
+		t.Fatal("CommitProviderProfile must reject a case-variant collision")
+	}
+
+	store, err := ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if key, ok, err := store.Get("work"); err != nil || ok {
+		t.Fatalf("rejected write left a captured key behind: key=%q ok=%v err=%v", key, ok, err)
+	}
+}
+
+func TestCommitProviderProfileCapturesKeyAndPersistsRow(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	path := filepath.Join(dir, "config.json")
+
+	result, err := CommitProviderProfile(path, ProviderCommit{
+		Profile: ProviderProfile{
+			Name:         "work",
+			ProviderKind: ProviderKindOpenAICompatible,
+			BaseURL:      "https://a.example.com/v1",
+			APIKey:       "sk-secret",
+			Model:        "m1",
+		},
+		SetActive: true,
+	})
+	if err != nil {
+		t.Fatalf("CommitProviderProfile() error = %v", err)
+	}
+	if result.Persisted.APIKey != "" || !result.Persisted.APIKeyStored {
+		t.Fatalf("persisted profile must carry the capture flip, got %+v", result.Persisted)
+	}
+	if result.Config.ActiveProvider != "work" {
+		t.Fatalf("active provider = %q, want work", result.Config.ActiveProvider)
+	}
+	store, err := ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if key, ok, err := store.Get("work"); err != nil || !ok || key != "sk-secret" {
+		t.Fatalf("captured key = %q ok=%v err=%v, want the secret in the store", key, ok, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(data), "sk-secret") {
+		t.Fatal("config.json must never hold the cleartext key")
+	}
+}
+
+// KeepStoredKey is the path that must not touch the store at all: the profile
+// already references a credential this write is not replacing.
+func TestCommitProviderProfileKeepStoredKeyLeavesStoreUntouched(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	path := filepath.Join(dir, "config.json")
+	store, err := ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.Set("work", "sk-existing"); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	if _, err := CommitProviderProfile(path, ProviderCommit{
+		Profile: ProviderProfile{
+			Name:         "work",
+			ProviderKind: ProviderKindOpenAICompatible,
+			BaseURL:      "https://a.example.com/v1",
+			APIKeyStored: true,
+			Model:        "m1",
+		},
+		SetActive:     true,
+		KeepStoredKey: true,
+	}); err != nil {
+		t.Fatalf("CommitProviderProfile() error = %v", err)
+	}
+	if key, ok, err := store.Get("work"); err != nil || !ok || key != "sk-existing" {
+		t.Fatalf("stored key = %q ok=%v err=%v, want it untouched", key, ok, err)
+	}
+}
+
+// The restore half of the capture, exercised directly: inside the lock the
+// collision is caught before any capture, so this covers the remaining case —
+// the config write failing after the key has already moved into the store
+// (a full disk, a permission error) — where the credential store must not keep
+// a secret no config row refers to.
+func TestSecureProviderProfileRestoreUndoesCapture(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	path := filepath.Join(dir, "config.json")
+	store, err := ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	// No previous entry: restore removes what the capture created.
+	secured, restore := secureProviderProfileWithRestore(ProviderProfile{Name: "work", APIKey: "sk-new"}, path)
+	if secured.APIKey != "" || !secured.APIKeyStored {
+		t.Fatalf("capture must flip the profile, got %+v", secured)
+	}
+	if key, ok, err := store.Get("work"); err != nil || !ok || key != "sk-new" {
+		t.Fatalf("captured key = %q ok=%v err=%v, want sk-new", key, ok, err)
+	}
+	restore()
+	if key, ok, err := store.Get("work"); err != nil || ok {
+		t.Fatalf("restore must remove the captured key, got %q ok=%v err=%v", key, ok, err)
+	}
+
+	// Previous entry: restore puts the displaced secret back.
+	if err := store.Set("work", "sk-original"); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	_, restore = secureProviderProfileWithRestore(ProviderProfile{Name: "WORK", APIKey: "sk-new"}, path)
+	if key, _, _ := store.Get("work"); key != "sk-new" {
+		t.Fatalf("capture must overwrite the normalized entry, got %q", key)
+	}
+	restore()
+	if key, ok, err := store.Get("work"); err != nil || !ok || key != "sk-original" {
+		t.Fatalf("restore must put the displaced key back, got %q ok=%v err=%v", key, ok, err)
+	}
+}
+
+// Concurrent writers for the same case-insensitive identity must not both
+// commit, and whichever loses must leave the winner's key intact. This is the
+// race the transaction exists for; the lock also has to be released so the
+// loser's attempt completes rather than hanging.
+func TestCommitProviderProfileConcurrentCaseVariantsKeepOneKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	path := filepath.Join(dir, "config.json")
+
+	names := []string{"foo", "FOO"}
+	keys := map[string]string{"foo": "sk-lower", "FOO": "sk-upper"}
+	errs := make([]error, len(names))
+	var wait sync.WaitGroup
+	start := make(chan struct{})
+	for index, name := range names {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			_, errs[index] = CommitProviderProfile(path, ProviderCommit{
+				Profile: ProviderProfile{
+					Name:         name,
+					ProviderKind: ProviderKindOpenAICompatible,
+					BaseURL:      "https://a.example.com/v1",
+					APIKey:       keys[name],
+					Model:        "m1",
+				},
+				SetActive: true,
+			})
+		}()
+	}
+	close(start)
+	wait.Wait()
+
+	committed := ""
+	for index, err := range errs {
+		if err == nil {
+			if committed != "" {
+				t.Fatalf("both %q and %q committed; case variants must collide", committed, names[index])
+			}
+			committed = names[index]
+		}
+	}
+	if committed == "" {
+		t.Fatalf("neither write committed: %v", errs)
+	}
+
+	store, err := ProviderKeyStoreAt(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	key, ok, err := store.Get(committed)
+	if err != nil || !ok {
+		t.Fatalf("committed profile lost its key: ok=%v err=%v", ok, err)
+	}
+	if key != keys[committed] {
+		t.Fatalf("stored key = %q, want %q — the rejected write replaced it", key, keys[committed])
+	}
+	names, err = PersistedProviderNames(path)
+	if err != nil {
+		t.Fatalf("PersistedProviderNames() error = %v", err)
+	}
+	if len(names) != 1 || names[0] != committed {
+		t.Fatalf("persisted rows = %v, want only %q", names, committed)
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -74,6 +74,9 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		if err != nil {
 			return ResolvedConfig{}, err
 		}
+		if err := ValidatePersistedProviderNames(fileConfig); err != nil {
+			return ResolvedConfig{}, err
+		}
 		mergeConfig(&cfg, fileConfig)
 	}
 	if options.ProjectConfigPath != "" {
@@ -953,26 +956,51 @@ func normalizeProvidersWithOptions(providers []ProviderProfile, activeName strin
 	}
 
 	if activeName == "" && len(providers) == 1 {
-		activeName = providers[0].Name
+		activeName = strings.TrimSpace(providers[0].Name)
+	}
+
+	// Select the active source row before normalizing anything. An exact name
+	// always wins; credential-store identity is only a fallback when it identifies
+	// one row. This prevents an invalid case-variant sibling from making an exact
+	// target fail while keeping distinct identities such as "s" and "ſ" separate.
+	activeIndex := -1
+	if activeName != "" {
+		for index := range providers {
+			if strings.TrimSpace(providers[index].Name) == activeName {
+				activeIndex = index
+				break
+			}
+		}
+		if activeIndex < 0 {
+			for index := range providers {
+				if !sameProviderIdentity(providers[index].Name, activeName) {
+					continue
+				}
+				if activeIndex >= 0 {
+					return nil, ProviderProfile{}, fmt.Errorf("ambiguous active provider %q: multiple provider names differ only by case", activeName)
+				}
+				activeIndex = index
+			}
+		}
 	}
 
 	normalized := make([]ProviderProfile, 0, len(providers))
 	var active ProviderProfile
 	activeFound := false
-	for _, provider := range providers {
+	for index, provider := range providers {
 		next, err := normalizeProvider(provider, env, options)
 		if err != nil {
 			// One unresolvable provider (e.g. a profile referencing a provider preset
 			// this build doesn't ship) must NOT brick the whole app — drop it and keep
 			// the rest. Only the ACTIVE provider failing is fatal, since the run can't
 			// proceed without it.
-			if strings.TrimSpace(provider.Name) == activeName {
+			if index == activeIndex {
 				return nil, ProviderProfile{}, err
 			}
 			continue
 		}
 		normalized = append(normalized, next)
-		if next.Name == activeName {
+		if index == activeIndex {
 			active = next
 			activeFound = true
 		}

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -396,6 +397,107 @@ func TestResolveAPIKeyEnvLooksUpEnvOnlyWhenAPIKeyMissing(t *testing.T) {
 	direct := providerByName(t, resolved.Providers, "direct")
 	if direct.APIKey != "sk-direct" {
 		t.Fatalf("direct APIKey = %q, want direct apiKey to win over apiKeyEnv", direct.APIKey)
+	}
+}
+
+func TestNormalizeProvidersMatchesResolvedActiveNameCaseInsensitively(t *testing.T) {
+	providers, active, err := normalizeProviders([]ProviderProfile{{
+		Name:         "EnvProvider",
+		ProviderKind: ProviderKindOpenAI,
+		Model:        "gpt-4.1",
+	}}, "envprovider")
+	if err != nil {
+		t.Fatalf("normalizeProviders() error = %v", err)
+	}
+	if len(providers) != 1 || active.Name != "EnvProvider" {
+		t.Fatalf("resolved active = %+v from %+v, want EnvProvider", active, providers)
+	}
+}
+
+func TestNormalizeProvidersSelectsActiveSourceBeforeNormalization(t *testing.T) {
+	valid := func(name string) ProviderProfile {
+		return ProviderProfile{Name: name, ProviderKind: ProviderKindOpenAI, Model: "gpt-4.1"}
+	}
+	t.Run("exact wins over folded invalid sibling", func(t *testing.T) {
+		providers, active, err := normalizeProviders([]ProviderProfile{
+			valid("Target"),
+			{Name: "target", ProviderKind: "invalid", Model: "broken"},
+		}, " Target ")
+		if err != nil {
+			t.Fatalf("normalizeProviders() error = %v", err)
+		}
+		if active.Name != "Target" || len(providers) != 1 {
+			t.Fatalf("active = %+v, providers = %+v; want exact Target only", active, providers)
+		}
+	})
+
+	t.Run("unique folded fallback", func(t *testing.T) {
+		_, active, err := normalizeProviders([]ProviderProfile{valid("Target")}, "target")
+		if err != nil {
+			t.Fatalf("normalizeProviders() error = %v", err)
+		}
+		if active.Name != "Target" {
+			t.Fatalf("active.Name = %q, want Target", active.Name)
+		}
+	})
+
+	t.Run("multiple folded matches are ambiguous", func(t *testing.T) {
+		_, _, err := normalizeProviders([]ProviderProfile{valid("Target"), valid("TARGET")}, "target")
+		const want = `ambiguous active provider "target": multiple provider names differ only by case`
+		if err == nil || err.Error() != want {
+			t.Fatalf("error = %v, want %q", err, want)
+		}
+	})
+}
+
+func TestNormalizeProvidersActiveFallbackUsesCredentialIdentity(t *testing.T) {
+	providers, active, err := normalizeProviders([]ProviderProfile{
+		{Name: "s", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://s.example/v1", Model: "s-model"},
+		{Name: "ſ", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://long-s.example/v1", Model: "long-s-model"},
+	}, "S")
+	if err != nil {
+		t.Fatalf("normalizeProviders() error = %v", err)
+	}
+	if len(providers) != 2 || active.Name != "s" || active.Model != "s-model" {
+		t.Fatalf("providers=%#v active=%#v, want credential identity s selected", providers, active)
+	}
+}
+
+func TestResolveCrossLayerActiveProviderCaseMatching(t *testing.T) {
+	valid := func(name string) string {
+		return fmt.Sprintf(`{"providers":[{"name":%q,"providerKind":"openai","model":"gpt-4.1"}]}`, name)
+	}
+	t.Run("exact user active wins over project case variant", func(t *testing.T) {
+		userPath := writeConfig(t, `{"activeProvider":"Target","providers":[{"name":"Target","providerKind":"openai","model":"gpt-4.1"}]}`)
+		projectPath := writeConfig(t, valid("target"))
+		resolved, err := Resolve(ResolveOptions{UserConfigPath: userPath, ProjectConfigPath: projectPath, Env: map[string]string{}})
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+		if resolved.ActiveProvider != "Target" {
+			t.Fatalf("active provider = %q, want exact Target", resolved.ActiveProvider)
+		}
+	})
+
+	t.Run("folded cross-layer target is ambiguous", func(t *testing.T) {
+		userPath := writeConfig(t, `{"activeProvider":"target","providers":[{"name":"Target","providerKind":"openai","model":"gpt-4.1"}]}`)
+		projectPath := writeConfig(t, valid("TARGET"))
+		_, err := Resolve(ResolveOptions{UserConfigPath: userPath, ProjectConfigPath: projectPath, Env: map[string]string{}})
+		const want = `ambiguous active provider "target": multiple provider names differ only by case`
+		if err == nil || err.Error() != want {
+			t.Fatalf("Resolve() error = %v, want %q", err, want)
+		}
+	})
+}
+
+func TestResolvePreservesSoleOpenRouterCaseVariant(t *testing.T) {
+	path := writeConfig(t, `{"activeProvider":"openrouter","providers":[{"name":"OpenRouter","catalogId":"openrouter","providerKind":"openai-compatible","baseURL":"https://openrouter.ai/api/v1","model":"openai/gpt-4.1"}]}`)
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.ActiveProvider != "OpenRouter" {
+		t.Fatalf("active provider name = %q, want preserved OpenRouter", resolved.ActiveProvider)
 	}
 }
 

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -5,11 +5,462 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/credstore"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 )
+
+// ValidatePersistedProviderNames rejects user-config rows that share the same
+// case-insensitive identity. Credential-store keys are case-insensitive, so
+// allowing both rows would make writes and deletes affect a shared secret.
+// This validator intentionally applies only to raw persisted user config, not
+// to profiles merged from project, environment, or provider-command layers.
+//
+// A repeated folded identity is rejected whether or not the spellings differ.
+// Exact duplicates are just as broken as case variants: resolver merging
+// silently coalesces the rows, and plaintext-key migration writes both values
+// into the same normalized credential-store entry, so the second row's key
+// overwrites the first.
+func ValidatePersistedProviderNames(cfg FileConfig) error {
+	seen := make(map[string]string, len(cfg.Providers))
+	for _, provider := range cfg.Providers {
+		name := strings.TrimSpace(provider.Name)
+		folded := credstore.NormalizeProvider(name)
+		previous, ok := seen[folded]
+		if ok && previous == name {
+			return fmt.Errorf("duplicate persisted provider name %q; remove one of the rows in config.json", name)
+		}
+		if ok {
+			return fmt.Errorf("ambiguous persisted provider names %q and %q differ only by case; rename or remove one row in config.json", previous, name)
+		}
+		seen[folded] = name
+	}
+	return nil
+}
+
+// sameProviderIdentity reports whether two persisted spellings name the same
+// provider identity. It is credstore.NormalizeProvider — the credential store's
+// own rule — rather than strings.EqualFold, because the two disagree and the
+// store is the authority: EqualFold folds "s" and Unicode long-s "ſ" together,
+// while the store keeps separate entries for them. Treating them as one identity
+// let a mutation of one profile reach the other's row and its secret, which is
+// precisely what ValidatePersistedProviderNames permits as a distinct pair.
+func sameProviderIdentity(a string, b string) bool {
+	return credstore.NormalizeProvider(a) == credstore.NormalizeProvider(b)
+}
+
+// SameProviderIdentity exposes the credential store's provider-name identity
+// rule to UI and CLI list operations. It deliberately differs from
+// strings.EqualFold for Unicode spellings such as "s" and long-s.
+func SameProviderIdentity(a string, b string) bool {
+	return sameProviderIdentity(strings.TrimSpace(a), strings.TrimSpace(b))
+}
+
+// PreflightUserConfig validates existing user config before any command makes
+// credential-store side effects.
+func PreflightUserConfig(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("config path is required")
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	return ValidatePersistedProviderNames(cfg)
+}
+
+// PreflightCatalogProviderLogin is the preflight for a credential login against
+// a catalog provider. A login does not mint a new spelling, so a case-variant
+// persisted row may be reused only when its catalogId positively proves that it
+// owns the requested catalog identity. A matching display name alone is not
+// ownership: custom profiles may use catalog-like names for unrelated endpoints.
+//
+// The collision check still runs when nothing owns the identity, because that is
+// the case where a row WILL be created. It is unreachable today given
+// EnsureCatalogProvider's own matching, and kept so that if that matching ever
+// narrows, this fails fast before the browser flow instead of after it.
+func PreflightCatalogProviderLogin(path, catalogID string) error {
+	if err := PreflightUserConfig(path); err != nil {
+		return err
+	}
+	descriptor, catalogProvider := providercatalog.Get(catalogID)
+	if catalogProvider {
+		providers, err := persistedProviders(path)
+		if err != nil {
+			return err
+		}
+		if _, owned, err := catalogProviderOwner(providers, descriptor.ID); err != nil {
+			return err
+		} else if owned {
+			return nil
+		}
+		return PreflightProviderWrite(path, descriptor.ID)
+	}
+	if _, owned, err := PersistedProviderIdentity(path, catalogID); err != nil {
+		return err
+	} else if owned {
+		return nil
+	}
+	return PreflightProviderWrite(path, catalogID)
+}
+
+// providerOwnsCatalog is the positive ownership test for catalog login and
+// persistence. A matching display/name spelling is not ownership: custom
+// profiles may legitimately use names such as "OpenRouter" while pointing at a
+// different catalog provider or carrying no catalog id at all.
+func providerOwnsCatalog(provider ProviderProfile, catalogID string) bool {
+	rowCatalogID := strings.TrimSpace(provider.CatalogID)
+	return rowCatalogID != "" && sameProviderIdentity(rowCatalogID, catalogID)
+}
+
+// catalogProviderOwner resolves the one persisted row that positively owns a
+// catalog identity. Catalog ids may normally be shared by named profiles, but a
+// catalog-addressed login cannot choose among them: it would store one shared
+// provider:<catalog-id> token that logout/status/refresh cannot attribute safely.
+// A different row owning the catalog spelling as its NAME is equally ambiguous.
+func catalogProviderOwner(providers []ProviderProfile, catalogID string) (ProviderProfile, bool, error) {
+	catalogID = strings.TrimSpace(catalogID)
+	ownerIndex := -1
+	owners := 0
+	for index, provider := range providers {
+		if providerOwnsCatalog(provider, catalogID) {
+			ownerIndex = index
+			owners++
+		}
+	}
+	if owners > 1 {
+		return ProviderProfile{}, false, fmt.Errorf("provider identity %q is ambiguous: %d saved profiles use it as a catalog id", catalogID, owners)
+	}
+	if owners == 1 {
+		for index, provider := range providers {
+			if index != ownerIndex && sameProviderIdentity(provider.Name, catalogID) {
+				return ProviderProfile{}, false, fmt.Errorf("provider identity %q is ambiguous: saved profile %q uses it as a name while %q uses it as a catalog id", catalogID, strings.TrimSpace(provider.Name), strings.TrimSpace(providers[ownerIndex].Name))
+			}
+		}
+		return providers[ownerIndex], true, nil
+	}
+	for _, provider := range providers {
+		if sameProviderIdentity(provider.Name, catalogID) {
+			return ProviderProfile{}, false, fmt.Errorf("saved profile %q does not prove ownership of catalog provider %q (catalogId is %q)", strings.TrimSpace(provider.Name), catalogID, strings.TrimSpace(provider.CatalogID))
+		}
+	}
+	return ProviderProfile{}, false, nil
+}
+
+// AdoptPersistedCatalogProviderName retargets a catalog-named profile at the row
+// that already owns its catalog identity, so persisting it UPDATES that row
+// instead of colliding with it.
+//
+// It applies only when the caller took the catalog's own default name (profile
+// name == catalog id) AND a persisted row owns that very NAME under a different
+// spelling. That is the case where the two spellings are the same provider by
+// construction — a re-setup or re-login of, say, openrouter against a row saved
+// as "OpenRouter" — and where EnsureCatalogProvider already reuses the row on
+// the login path. A user-chosen name is left alone on purpose: there, a case
+// collision with an existing row is a real collision, and silently overwriting
+// the other row would be worse than the error.
+//
+// Adoption deliberately does NOT follow the catalog id of an arbitrary row.
+// Several profiles may legitimately share one catalog provider — {name:
+// "work-xai", catalogId: "xai"} alongside a plain "xai" — so retargeting the
+// default "xai" profile at whichever row happened to list catalogId "xai" would
+// silently overwrite that row's endpoint, model, and stored key. An exactly
+// spelled row short-circuits only after the same positive-ownership check: there
+// is nothing to adopt when the caller's spelling and catalog identity already
+// match the persisted profile.
+//
+// Nor is a matching NAME on its own proof of ownership. A custom profile is free
+// to be called {name: "OpenRouter", catalogId: "custom-openai-compatible",
+// baseURL: "https://corp.example/v1"}; adopting it for `zero providers add
+// openrouter` would hand that row to UpsertProvider, whose merge overwrites the
+// catalog id, endpoint, model, transport and headers with OpenRouter's defaults
+// while a stored-key marker survives the rewrite. So the row's non-empty catalog
+// identity must agree too; a missing catalog id is absence of ownership evidence,
+// not proof that the row belongs to the requested descriptor. Anything else keeps
+// the requested name and lets the write report the collision instead of mutating
+// a different profile.
+func AdoptPersistedCatalogProviderName(path string, profile ProviderProfile) (ProviderProfile, error) {
+	catalogID := strings.TrimSpace(profile.CatalogID)
+	name := strings.TrimSpace(profile.Name)
+	if catalogID == "" || !sameProviderIdentity(name, catalogID) {
+		return profile, nil
+	}
+	providers, err := persistedProviders(path)
+	if err != nil {
+		return profile, err
+	}
+	canonical := ""
+	variants := 0
+	for _, row := range providers {
+		rowName := strings.TrimSpace(row.Name)
+		if !sameProviderIdentity(rowName, name) {
+			continue
+		}
+		if !providerOwnsCatalog(row, catalogID) {
+			// A differently-cased collision is left for PreflightProviderWrite to
+			// report. An exact collision needs an error here because exact-name
+			// writes are otherwise valid updates and would rewrite this foreign
+			// profile with catalog defaults while preserving its stored-key marker.
+			if rowName == name {
+				return profile, fmt.Errorf("saved profile %q does not prove ownership of catalog provider %q (catalogId is %q)", rowName, catalogID, strings.TrimSpace(row.CatalogID))
+			}
+			return profile, nil
+		}
+		if rowName == name {
+			return profile, nil
+		}
+		canonical = rowName
+		variants++
+	}
+	if variants == 1 {
+		profile.Name = canonical
+	}
+	return profile, nil
+}
+
+// PersistedProviderNames returns the exact name of every row in the persisted
+// user config, in file order. Callers that must reason about the SET of saved
+// rows — e.g. deciding whether removing one row leaves a case variant behind
+// that still reads the same credential-store entry — get the raw names here
+// rather than re-implementing FileConfig parsing.
+func PersistedProviderNames(path string) ([]string, error) {
+	providers, err := persistedProviders(path)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		names = append(names, strings.TrimSpace(provider.Name))
+	}
+	return names, nil
+}
+
+// persistedProviders reads the provider rows out of the user config at path.
+// A missing file is an empty list, not an error: every caller here asks "what
+// is already saved?", and "nothing yet" is a legitimate answer.
+func persistedProviders(path string) ([]ProviderProfile, error) {
+	data, err := os.ReadFile(strings.TrimSpace(path))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	return cfg.Providers, nil
+}
+
+// PersistedProviderIdentity reports whether a persisted user-config row already
+// owns identity — as its name (case-insensitively) or as its catalog id — and
+// returns that row's exact name.
+//
+// Callers use it to answer "is this the config's provider, however it was
+// spelled or addressed?", which is a different question from ProviderPersisted's
+// "is this the exact key a mutator will match". A row saved as
+// {name: "my-router", catalogId: "openrouter"} is owned by both spellings here,
+// so `zero providers use openrouter` is a wrong way to address a saved profile
+// rather than an environment-derived provider.
+func PersistedProviderIdentity(path, identity string) (string, bool, error) {
+	row, match, err := ResolvePersistedProviderIdentity(path, identity)
+	if err != nil || match == PersistedIdentityNone {
+		return "", false, err
+	}
+	return strings.TrimSpace(row.Name), true, nil
+}
+
+// PersistedIdentityMatch says HOW a persisted row was addressed, because the
+// two ways carry different authority. A name match identifies exactly one
+// profile. A catalog-id match identifies "some profile of this kind" — several
+// profiles may legitimately share one catalog provider — so callers that go on
+// to delete credentials must not treat it as proof of ownership.
+type PersistedIdentityMatch uint8
+
+const (
+	// PersistedIdentityNone means no row owns the identity, or a catalog id was
+	// given that more than one row claims (an ambiguous request this package
+	// refuses to guess at).
+	PersistedIdentityNone PersistedIdentityMatch = iota
+	// PersistedIdentityName means a row's own name matched, exactly or as a
+	// case variant.
+	PersistedIdentityName
+	// PersistedIdentityCatalog means the identity matched only the catalog id of
+	// exactly one row.
+	PersistedIdentityCatalog
+)
+
+// ResolvePersistedProviderIdentity finds the persisted user-config row that
+// owns identity and reports how it was addressed.
+//
+// Names win over catalog ids, and an exact name wins over a case variant.
+// Scanning in file order and accepting the first name-OR-catalog hit picked
+// whichever row came first, so `zero auth logout xai` against
+// [{name:"work-xai", catalogId:"xai"}, {name:"xai"}] resolved to "work-xai" —
+// a different profile, with different credentials, than the one named.
+//
+// A catalog id claimed by more than one row resolves to nothing rather than to
+// an arbitrary winner: the caller asked for something the config does not
+// uniquely identify, and guessing there is what let one profile's logout delete
+// a sibling's shared token.
+func ResolvePersistedProviderIdentity(path, identity string) (ProviderProfile, PersistedIdentityMatch, error) {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return ProviderProfile{}, PersistedIdentityNone, nil
+	}
+	providers, err := persistedProviders(path)
+	if err != nil {
+		return ProviderProfile{}, PersistedIdentityNone, err
+	}
+	var foldedName *ProviderProfile
+	var catalogRow *ProviderProfile
+	catalogMatches := 0
+	for index := range providers {
+		row := providers[index]
+		name := strings.TrimSpace(row.Name)
+		if name == identity {
+			return row, PersistedIdentityName, nil
+		}
+		if foldedName == nil && sameProviderIdentity(name, identity) {
+			match := row
+			foldedName = &match
+		}
+		if sameProviderIdentity(row.CatalogID, identity) {
+			catalogMatches++
+			if catalogRow == nil {
+				match := row
+				catalogRow = &match
+			}
+		}
+	}
+	if foldedName != nil {
+		return *foldedName, PersistedIdentityName, nil
+	}
+	if catalogMatches == 1 {
+		return *catalogRow, PersistedIdentityCatalog, nil
+	}
+	return ProviderProfile{}, PersistedIdentityNone, nil
+}
+
+// CatalogIdentityExclusive reports whether catalogID is claimed by the row
+// named owner and by nothing else in the persisted config — neither as another
+// row's name nor as another row's catalog id.
+//
+// Credential cleanup uses this before treating the catalog id as one of the
+// target profile's own credential keys. With stored-key "work-xai",
+// stored-key "xai", and keyless "personal-xai" all carrying catalogId "xai",
+// the "xai" token and key belong to whoever logged in under that spelling —
+// deleting them while logging out of "work-xai" takes down a sibling's login.
+func CatalogIdentityExclusive(path, catalogID, owner string) (bool, error) {
+	catalogID = strings.TrimSpace(catalogID)
+	owner = strings.TrimSpace(owner)
+	if catalogID == "" || owner == "" {
+		return false, nil
+	}
+	providers, err := persistedProviders(path)
+	if err != nil {
+		return false, err
+	}
+	for _, row := range providers {
+		name := strings.TrimSpace(row.Name)
+		if name == owner {
+			continue
+		}
+		if sameProviderIdentity(name, catalogID) || sameProviderIdentity(row.CatalogID, catalogID) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// ProviderCredentialCandidates returns every credential-store key that can
+// belong exclusively to the addressed persisted profile. The requested spelling
+// and canonical row name are always included; a catalog id is included only when
+// no sibling row can own credentials under it. Auth status, refresh, and logout
+// share this resolver so each command addresses the same stored login.
+//
+// The canonical name is returned separately for marker mutations. On a config
+// read error, callers still receive the requested spelling so logout can delete
+// the credential it was explicitly asked to clear before reporting the error.
+func ProviderCredentialCandidates(path, addressedName string) (candidates []string, canonicalName string, err error) {
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate != "" && !slices.Contains(candidates, candidate) {
+			candidates = append(candidates, candidate)
+		}
+	}
+	canonicalName = strings.TrimSpace(addressedName)
+	add(canonicalName)
+	row, match, err := ResolvePersistedProviderIdentity(path, addressedName)
+	if err != nil {
+		return candidates, canonicalName, err
+	}
+	if match == PersistedIdentityNone {
+		providers, err := persistedProviders(path)
+		if err != nil {
+			return candidates, canonicalName, err
+		}
+		catalogMatches := 0
+		for _, provider := range providers {
+			if sameProviderIdentity(provider.CatalogID, addressedName) {
+				catalogMatches++
+			}
+		}
+		if catalogMatches > 1 {
+			return nil, canonicalName, fmt.Errorf("provider identity %q is ambiguous: %d saved profiles use it as a catalog id", addressedName, catalogMatches)
+		}
+		return candidates, canonicalName, nil
+	}
+	canonicalName = strings.TrimSpace(row.Name)
+	add(canonicalName)
+	exclusive, err := CatalogIdentityExclusive(path, row.CatalogID, canonicalName)
+	if err != nil {
+		return candidates, canonicalName, err
+	}
+	if exclusive {
+		add(row.CatalogID)
+	}
+	return candidates, canonicalName, nil
+}
+
+// PreflightProviderWrite also rejects a new spelling that would share a
+// case-insensitive credential key with an existing persisted row.
+func PreflightProviderWrite(path, name string) error {
+	if err := PreflightUserConfig(path); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	name = strings.TrimSpace(name)
+	for _, provider := range cfg.Providers {
+		existing := strings.TrimSpace(provider.Name)
+		if sameProviderIdentity(existing, name) && existing != name {
+			return fmt.Errorf("provider %q already exists as %q; provider names must be unique case-insensitively", name, existing)
+		}
+	}
+	return nil
+}
 
 func UpsertProvider(path string, profile ProviderProfile, setActive bool) (FileConfig, error) {
 	path = strings.TrimSpace(path)
@@ -28,6 +479,14 @@ func UpsertProvider(path string, profile ProviderProfile, setActive bool) (FileC
 		}
 	} else if !os.IsNotExist(err) {
 		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+	if err := ValidatePersistedProviderNames(cfg); err != nil {
+		return FileConfig{}, err
+	}
+	for _, existing := range cfg.Providers {
+		if sameProviderIdentity(existing.Name, profile.Name) && strings.TrimSpace(existing.Name) != profile.Name {
+			return FileConfig{}, fmt.Errorf("provider %q already exists as %q; provider names must be unique case-insensitively", profile.Name, existing.Name)
+		}
 	}
 
 	mergeProvider(&cfg, profile)
@@ -90,11 +549,13 @@ func EnsureCatalogProvider(path string, catalogID string) (EnsuredProvider, erro
 	} else if !os.IsNotExist(err) {
 		return EnsuredProvider{}, fmt.Errorf("read config %s: %w", path, err)
 	}
-	for _, provider := range cfg.Providers {
-		if strings.EqualFold(strings.TrimSpace(provider.CatalogID), descriptor.ID) ||
-			strings.EqualFold(strings.TrimSpace(provider.Name), descriptor.ID) {
-			return EnsuredProvider{Name: provider.Name, Active: cfg.ActiveProvider}, nil
-		}
+	if err := ValidatePersistedProviderNames(cfg); err != nil {
+		return EnsuredProvider{}, err
+	}
+	if owner, owned, err := catalogProviderOwner(cfg.Providers, descriptor.ID); err != nil {
+		return EnsuredProvider{}, err
+	} else if owned {
+		return EnsuredProvider{Name: owner.Name, Active: cfg.ActiveProvider}, nil
 	}
 
 	profile := ProviderProfile{
@@ -133,8 +594,11 @@ func MarkProviderAPIKeyStored(path string, provider string) error {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return fmt.Errorf("invalid config JSON %s: %w", path, err)
 	}
+	if err := ValidatePersistedProviderNames(cfg); err != nil {
+		return err
+	}
 	for index := range cfg.Providers {
-		if strings.EqualFold(strings.TrimSpace(cfg.Providers[index].Name), provider) {
+		if strings.TrimSpace(cfg.Providers[index].Name) == provider {
 			cfg.Providers[index].APIKey = ""
 			cfg.Providers[index].APIKeyEnv = ""
 			cfg.Providers[index].APIKeyStored = true
@@ -165,7 +629,7 @@ func SetActiveProvider(path string, name string) (FileConfig, error) {
 	}
 
 	for _, provider := range cfg.Providers {
-		if strings.EqualFold(provider.Name, name) {
+		if strings.TrimSpace(provider.Name) == name {
 			cfg.ActiveProvider = provider.Name
 			if err := writeConfigFile(path, cfg); err != nil {
 				return FileConfig{}, err
@@ -192,16 +656,78 @@ func ProviderPersisted(path string, name string) (bool, error) {
 	if path == "" || name == "" {
 		return false, nil
 	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("stat config %s: %w", path, err)
+	}
 	cfg, err := loadConfigFile(path)
 	if err != nil {
 		return false, err
 	}
 	for _, provider := range cfg.Providers {
-		if strings.EqualFold(strings.TrimSpace(provider.Name), name) {
+		if strings.TrimSpace(provider.Name) == name {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+// ProviderRow returns the persisted user-config row whose Name matches name
+// exactly, and whether one was found. Unlike ProviderPersisted's yes/no, this
+// hands back the row itself (CatalogID, APIKeyStored, ...) so callers that
+// need more than presence — e.g. deciding whether a stored key marker must be
+// carried over to a surviving case-variant row before it is removed — don't
+// each re-implement FileConfig parsing.
+func ProviderRow(path string, name string) (ProviderProfile, bool, error) {
+	path = strings.TrimSpace(path)
+	name = strings.TrimSpace(name)
+	if path == "" || name == "" {
+		return ProviderProfile{}, false, nil
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ProviderProfile{}, false, nil
+	} else if err != nil {
+		return ProviderProfile{}, false, fmt.Errorf("stat config %s: %w", path, err)
+	}
+	cfg, err := loadConfigFile(path)
+	if err != nil {
+		return ProviderProfile{}, false, err
+	}
+	for _, provider := range cfg.Providers {
+		if strings.TrimSpace(provider.Name) == name {
+			return provider, true, nil
+		}
+	}
+	return ProviderProfile{}, false, nil
+}
+
+// TransferProviderAPIKeyStoredMarker sets the APIKeyStored marker on the row
+// named to, without touching any other field on it. The credential store keys
+// its secrets case-folded, so removing a case-variant row that owned the
+// marker leaves the shared secret orphaned unless a surviving case-variant
+// row is marked to take over reading it. No-op (false, nil) when to isn't
+// found or already carries the marker.
+func TransferProviderAPIKeyStoredMarker(path string, to string) (bool, error) {
+	path = strings.TrimSpace(path)
+	to = strings.TrimSpace(to)
+	if path == "" || to == "" {
+		return false, nil
+	}
+	cfg, err := loadConfigFile(path)
+	if err != nil {
+		return false, err
+	}
+	for index := range cfg.Providers {
+		if strings.TrimSpace(cfg.Providers[index].Name) == to {
+			if cfg.Providers[index].APIKeyStored {
+				return false, nil
+			}
+			cfg.Providers[index].APIKeyStored = true
+			return true, writeConfigFile(path, cfg)
+		}
+	}
+	return false, fmt.Errorf("provider %q not found", to)
 }
 
 // RemoveProvider deletes the named provider profile from the config at path.
@@ -229,9 +755,13 @@ func RemoveProvider(path string, name string) (FileConfig, error) {
 		return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
 	}
 
+	// Persisted provider identity is exact. Resolution may fold names from
+	// runtime sources, but config mutations must target the requested row. This
+	// lookup intentionally precedes validation so an exact removal can repair a
+	// case-duplicate config; writeConfigFile validates the resulting config.
 	index := -1
 	for i, provider := range cfg.Providers {
-		if strings.EqualFold(strings.TrimSpace(provider.Name), name) {
+		if strings.TrimSpace(provider.Name) == name {
 			index = i
 			break
 		}
@@ -239,9 +769,22 @@ func RemoveProvider(path string, name string) (FileConfig, error) {
 	if index < 0 {
 		return FileConfig{}, fmt.Errorf("provider %q not found", name)
 	}
-	removed := cfg.Providers[index]
+	activeIndex := -1
+	activeFoldedIndex := -1
+	activeFoldedMatches := 0
+	for i, provider := range cfg.Providers {
+		providerName := strings.TrimSpace(provider.Name)
+		if providerName == strings.TrimSpace(cfg.ActiveProvider) {
+			activeIndex = i
+		}
+		if sameProviderIdentity(providerName, cfg.ActiveProvider) {
+			activeFoldedIndex = i
+			activeFoldedMatches++
+		}
+	}
+	removedWasActive := activeIndex == index || (activeIndex < 0 && activeFoldedMatches == 1 && activeFoldedIndex == index)
 	cfg.Providers = append(cfg.Providers[:index], cfg.Providers[index+1:]...)
-	if strings.EqualFold(strings.TrimSpace(cfg.ActiveProvider), strings.TrimSpace(removed.Name)) {
+	if removedWasActive {
 		cfg.ActiveProvider = ""
 		if len(cfg.Providers) > 0 {
 			cfg.ActiveProvider = cfg.Providers[0].Name
@@ -280,22 +823,28 @@ func RenameProvider(path string, oldName string, newName string) (FileConfig, er
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
 	}
+	if err := ValidatePersistedProviderNames(cfg); err != nil {
+		return FileConfig{}, err
+	}
 
+	// oldName is matched exactly, like ProviderPersisted/SetActiveProvider.
+	// newName collides case-insensitively because the credential store retains
+	// legacy case-insensitive keys.
 	index := -1
 	for i, provider := range cfg.Providers {
 		providerName := strings.TrimSpace(provider.Name)
-		if strings.EqualFold(providerName, oldName) {
+		if providerName == oldName {
 			index = i
 			continue
 		}
-		if strings.EqualFold(providerName, newName) {
+		if sameProviderIdentity(providerName, newName) {
 			return FileConfig{}, fmt.Errorf("provider %q already exists", newName)
 		}
 	}
 	if index < 0 {
 		return FileConfig{}, fmt.Errorf("provider %q not found", oldName)
 	}
-	if strings.EqualFold(oldName, newName) && cfg.Providers[index].Name == newName {
+	if sameProviderIdentity(oldName, newName) && cfg.Providers[index].Name == newName {
 		return cfg, nil
 	}
 
@@ -307,7 +856,7 @@ func RenameProvider(path string, oldName string, newName string) (FileConfig, er
 		}
 		keyMigrated = true
 	}
-	if strings.EqualFold(strings.TrimSpace(cfg.ActiveProvider), strings.TrimSpace(previousName)) {
+	if sameProviderIdentity(cfg.ActiveProvider, previousName) {
 		cfg.ActiveProvider = newName
 	}
 	cfg.Providers[index].Name = newName
@@ -325,7 +874,7 @@ func RenameProvider(path string, oldName string, newName string) (FileConfig, er
 
 // ProviderEdit is a field-level edit of one saved provider, applied by
 // EditProvider in a single atomic write. Name is the CURRENT profile name
-// (matched case-insensitively); NewName renames (case-only renames included).
+// (matched exactly); NewName renames (case-only renames included).
 // Empty BaseURL/Model/APIKey mean "leave unchanged"; Description is applied
 // VERBATIM (the editor always knows the full desired text, so clearing works).
 type ProviderEdit struct {
@@ -344,8 +893,7 @@ type ProviderEdit struct {
 // verbatim description. A single write keeps the operation atomic — the
 // previous rename+upsert+describe sequence could fail halfway and leave
 // config.json renamed while every in-memory consumer still held the old name —
-// and, unlike UpsertProvider's exact-name merge, the case-insensitive match
-// here makes a case-only rename (groq -> Groq) an in-place update instead of
+// and a case-only rename (groq -> Groq) remains an in-place update instead of
 // an appended duplicate profile.
 func EditProvider(path string, edit ProviderEdit) (FileConfig, error) {
 	path = strings.TrimSpace(path)
@@ -369,15 +917,19 @@ func EditProvider(path string, edit ProviderEdit) (FileConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
 	}
+	if err := ValidatePersistedProviderNames(cfg); err != nil {
+		return FileConfig{}, err
+	}
 
 	index := -1
+	newIdentity := credstore.NormalizeProvider(newName)
 	for i, provider := range cfg.Providers {
 		providerName := strings.TrimSpace(provider.Name)
-		if strings.EqualFold(providerName, oldName) {
+		if providerName == oldName {
 			index = i
 			continue
 		}
-		if strings.EqualFold(providerName, newName) {
+		if credstore.NormalizeProvider(providerName) == newIdentity {
 			return FileConfig{}, fmt.Errorf("provider %q already exists", newName)
 		}
 	}
@@ -400,7 +952,7 @@ func EditProvider(path string, edit ProviderEdit) (FileConfig, error) {
 		}
 		keyMigrated = true
 	}
-	if renamed && strings.EqualFold(strings.TrimSpace(cfg.ActiveProvider), strings.TrimSpace(previousName)) {
+	if renamed && sameProviderIdentity(cfg.ActiveProvider, previousName) {
 		cfg.ActiveProvider = newName
 	}
 
@@ -440,7 +992,7 @@ func migrateStoredProviderKey(configPath string, oldName string, newName string)
 	// (groq -> Groq) targets ONE entry: Set(new) rewrites it in place and
 	// Delete(old) would then remove the key that was just "moved". Nothing to
 	// migrate — the existing entry already serves the new name.
-	if strings.EqualFold(strings.TrimSpace(oldName), strings.TrimSpace(newName)) {
+	if sameProviderIdentity(oldName, newName) {
 		return nil
 	}
 	store, err := ProviderKeyStoreAt(filepath.Dir(configPath))
@@ -485,8 +1037,10 @@ func SetProviderModel(path string, name string, model string) (FileConfig, error
 		return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
 	}
 
+	// Persisted provider identity is exact. Resolution may fold names from
+	// runtime sources, but config mutations must target the requested row.
 	for index := range cfg.Providers {
-		if strings.EqualFold(cfg.Providers[index].Name, name) {
+		if strings.TrimSpace(cfg.Providers[index].Name) == name {
 			cfg.Providers[index].Model = model
 			if err := writeConfigFile(path, cfg); err != nil {
 				return FileConfig{}, err
@@ -765,6 +1319,9 @@ func NormalizeRecentModels(entries []RecentModelEntry) []RecentModelEntry {
 }
 
 func writeConfigFile(path string, cfg FileConfig) error {
+	if err := ValidatePersistedProviderNames(cfg); err != nil {
+		return err
+	}
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode config JSON: %w", err)

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -1,14 +1,17 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -31,7 +34,7 @@ func TestSetActiveProviderSwitchesConfiguredProvider(t *testing.T) {
 		},
 	}, 0o600)
 
-	cfg, err := SetActiveProvider(path, "  anthropic  ")
+	cfg, err := SetActiveProvider(path, "  Anthropic  ")
 	if err != nil {
 		t.Fatalf("SetActiveProvider() error = %v", err)
 	}
@@ -43,6 +46,56 @@ func TestSetActiveProviderSwitchesConfiguredProvider(t *testing.T) {
 	persisted := readConfigFixture(t, path)
 	if persisted.ActiveProvider != "Anthropic" {
 		t.Fatalf("persisted ActiveProvider = %q, want Anthropic", persisted.ActiveProvider)
+	}
+}
+
+func TestSetActiveProviderRequiresExactProviderIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	before := writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "work",
+		Providers: []ProviderProfile{
+			{Name: "work", ProviderKind: ProviderKindOpenAI, Model: "gpt-4.1"},
+		},
+	}, 0o600)
+
+	_, err := SetActiveProvider(path, "WORK")
+	if err == nil || !strings.Contains(err.Error(), `provider "WORK" not found`) {
+		t.Fatalf("SetActiveProvider() error = %v, want exact-case not-found error", err)
+	}
+	after, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read config: %v", readErr)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("config was rewritten for case-variant provider\nbefore: %s\nafter: %s", before, after)
+	}
+}
+
+func TestMarkProviderAPIKeyStoredRequiresExactProviderIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	before := writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{{Name: "work", APIKeyEnv: "WORK_KEY"}}}, 0o600)
+	if err := MarkProviderAPIKeyStored(path, "WORK"); err == nil || !strings.Contains(err.Error(), `provider "WORK" not found`) {
+		t.Fatalf("MarkProviderAPIKeyStored() error = %v, want exact-case not-found", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("case-variant mark rewrote config")
+	}
+}
+
+func TestProviderPersistedRequiresExactProviderIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{{Name: "work"}}}, 0o600)
+
+	persisted, err := ProviderPersisted(path, "WORK")
+	if err != nil {
+		t.Fatalf("ProviderPersisted() error = %v", err)
+	}
+	if persisted {
+		t.Fatal("ProviderPersisted() = true for case-variant identity, want false")
 	}
 }
 
@@ -170,7 +223,7 @@ func TestSetProviderModelUpdatesConfiguredProvider(t *testing.T) {
 		},
 	}, 0o600)
 
-	cfg, err := SetProviderModel(path, " OpenAI ", " gpt-4.1-mini ")
+	cfg, err := SetProviderModel(path, " openai ", " gpt-4.1-mini ")
 	if err != nil {
 		t.Fatalf("SetProviderModel() error = %v", err)
 	}
@@ -215,6 +268,22 @@ func TestSetProviderModelRejectsUnknownProviderWithoutRewriting(t *testing.T) {
 	if string(after) != string(before) {
 		t.Fatalf("config was rewritten for unknown provider\nbefore: %s\nafter: %s", before, after)
 	}
+}
+
+// Same scenario as RemoveProvider/RenameProvider: two rows differing only by
+// case must not let SetProviderModel update the wrong one.
+func TestSetProviderModelRequiresExactProviderIdentityAmongCaseVariants(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	before := writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "work",
+		Providers: []ProviderProfile{
+			{Name: "work", ProviderKind: ProviderKindOpenAICompatible, Model: "m1"},
+			{Name: "WORK", ProviderKind: ProviderKindOpenAICompatible, Model: "m2"},
+		},
+	}, 0o600)
+
+	_, err := SetProviderModel(path, "WORK", "m2-updated")
+	assertAmbiguousConfigUnchanged(t, path, before, err, "work", "WORK")
 }
 
 func TestUpsertProviderTightensExistingConfigFilePermissions(t *testing.T) {
@@ -529,6 +598,54 @@ func TestEnsureCatalogProviderLeavesExistingProfileUntouched(t *testing.T) {
 	}
 }
 
+func TestEnsureCatalogProviderRequiresPositiveCatalogOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		catalogID string
+	}{
+		{name: "foreign catalog", catalogID: "custom-openai-compatible"},
+		{name: "missing catalog", catalogID: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "zero.json")
+			before := writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{{
+				Name:         "OpenRouter",
+				CatalogID:    tc.catalogID,
+				ProviderKind: ProviderKindOpenAICompatible,
+				BaseURL:      "https://corp.example/v1",
+				Model:        "corp-model",
+				APIKeyStored: true,
+			}}}, 0o600)
+
+			if _, err := EnsureCatalogProvider(path, "openrouter"); err == nil || !strings.Contains(err.Error(), "does not prove ownership") {
+				t.Fatalf("EnsureCatalogProvider error = %v, want ownership rejection", err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("foreign profile was rewritten:\nbefore: %s\nafter: %s", before, after)
+			}
+		})
+	}
+}
+
+func TestEnsureCatalogProviderRejectsAmbiguousCatalogOwner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{
+		{Name: "work-xai", CatalogID: "xai"},
+		{Name: "personal-xai", CatalogID: "xai"},
+	}}, 0o600)
+
+	if _, err := EnsureCatalogProvider(path, "xai"); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("EnsureCatalogProvider error = %v, want shared-catalog ambiguity", err)
+	}
+	if err := PreflightCatalogProviderLogin(path, "xai"); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("PreflightCatalogProviderLogin error = %v, want the same ambiguity", err)
+	}
+}
+
 func TestEnsureCatalogProviderActivatesOnEmptyConfig(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "zero.json")
 
@@ -594,7 +711,7 @@ func TestRemoveProviderDeletesAndHandsOffActive(t *testing.T) {
 		},
 	}, 0o600)
 
-	cfg, err := RemoveProvider(path, " BETA ")
+	cfg, err := RemoveProvider(path, " beta ")
 	if err != nil {
 		t.Fatalf("RemoveProvider() error = %v", err)
 	}
@@ -636,6 +753,105 @@ func TestRemoveProviderKeepsActiveWhenOtherRemoved(t *testing.T) {
 	}
 	if cfg.ActiveProvider != "alpha" {
 		t.Fatalf("active provider must be untouched, got %q", cfg.ActiveProvider)
+	}
+}
+
+func TestProviderMutatorsHandOffCaseVariantActiveProvider(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(string) (FileConfig, error)
+		wantActive string
+		wantName   string
+	}{
+		{name: "remove", mutate: func(path string) (FileConfig, error) { return RemoveProvider(path, "work") }},
+		{name: "rename", mutate: func(path string) (FileConfig, error) { return RenameProvider(path, "work", "office") }, wantActive: "office", wantName: "office"},
+		{name: "edit", mutate: func(path string) (FileConfig, error) {
+			return EditProvider(path, ProviderEdit{Name: "work", NewName: "office", Model: "updated"})
+		}, wantActive: "office", wantName: "office"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.json")
+			writeConfigFixture(t, path, FileConfig{ActiveProvider: "WORK", Providers: []ProviderProfile{{Name: "work", Model: "old"}}}, 0o600)
+			cfg, err := test.mutate(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.ActiveProvider != test.wantActive {
+				t.Fatalf("activeProvider = %q, want %q", cfg.ActiveProvider, test.wantActive)
+			}
+			if test.wantName == "" && len(cfg.Providers) != 0 {
+				t.Fatalf("providers = %+v, want none", cfg.Providers)
+			}
+			if test.wantName != "" && (len(cfg.Providers) != 1 || cfg.Providers[0].Name != test.wantName) {
+				t.Fatalf("providers = %+v, want canonical name %q", cfg.Providers, test.wantName)
+			}
+		})
+	}
+}
+
+// UpsertProvider merges by exact name, so a config file can end up with two
+// rows that differ only by case (e.g. one saved as "work", another later
+// saved as "WORK"). RemoveProvider must delete the exact row the caller
+// named, not whichever case-variant sorts first.
+func TestRemoveProviderRequiresExactProviderIdentityAmongCaseVariants(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "work",
+		Providers: []ProviderProfile{
+			{Name: "work", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://a.example.com/v1", Model: "m1"},
+			{Name: "WORK", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://b.example.com/v1", Model: "m2"},
+		},
+	}, 0o600)
+
+	cfg, err := RemoveProvider(path, "WORK")
+	if err != nil {
+		t.Fatalf("exact removal should repair case duplicates: %v", err)
+	}
+	if len(cfg.Providers) != 1 || cfg.Providers[0].Name != "work" || cfg.ActiveProvider != "work" {
+		t.Fatalf("repaired config = %+v", cfg)
+	}
+}
+
+func TestRemoveProviderRejectsNonExactCaseDuplicateTarget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	before := writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{{Name: "work"}, {Name: "WORK"}}}, 0o600)
+	_, err := RemoveProvider(path, "WoRk")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %v, want exact-target not-found error", err)
+	}
+	after, readErr := os.ReadFile(path)
+	if readErr != nil || !bytes.Equal(after, before) {
+		t.Fatalf("rejected removal rewrote config: readErr=%v", readErr)
+	}
+}
+
+func TestRemoveProviderRejectsRepairThatRemainsAmbiguous(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	before := writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{{Name: "work"}, {Name: "WORK"}, {Name: "Work"}}}, 0o600)
+	_, err := RemoveProvider(path, "Work")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous persisted provider names") {
+		t.Fatalf("error = %v, want resulting-config validation error", err)
+	}
+	after, readErr := os.ReadFile(path)
+	if readErr != nil || !bytes.Equal(after, before) {
+		t.Fatalf("invalid repair rewrote config: readErr=%v", readErr)
+	}
+}
+
+func TestRemoveProviderKeepsExactActiveCaseVariant(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "work",
+		Providers:      []ProviderProfile{{Name: "alpha"}, {Name: "work"}, {Name: "WORK"}},
+	}, 0o600)
+
+	cfg, err := RemoveProvider(path, "WORK")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ActiveProvider != "work" {
+		t.Fatalf("activeProvider = %q, want exact surviving row work", cfg.ActiveProvider)
 	}
 }
 
@@ -725,6 +941,22 @@ func TestRenameProviderRejectsCollisionAndUnknown(t *testing.T) {
 	if string(after) != string(before) {
 		t.Fatalf("config was rewritten by a rejected rename")
 	}
+}
+
+// Same scenario as RemoveProvider: two rows differing only by case must not
+// let RenameProvider act on the wrong one.
+func TestRenameProviderRequiresExactProviderIdentityAmongCaseVariants(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	before := writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "work",
+		Providers: []ProviderProfile{
+			{Name: "work", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://a.example.com/v1", Model: "m1"},
+			{Name: "WORK", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://b.example.com/v1", Model: "m2"},
+		},
+	}, 0o600)
+
+	_, err := RenameProvider(path, "WORK", "renamed")
+	assertAmbiguousConfigUnchanged(t, path, before, err, "work", "WORK")
 }
 
 func TestUpsertProviderPreservesStoredKeyMarkerOnExistingProfile(t *testing.T) {
@@ -915,11 +1147,40 @@ func TestEditProviderAppliesRenameFieldsAndDescriptionAtomically(t *testing.T) {
 	}
 }
 
+func TestEditProviderRequiresExactProviderIdentityAmongCaseVariants(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	before := writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "work",
+		Providers: []ProviderProfile{
+			{Name: "WORK", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://upper.example.com/v1", Model: "upper"},
+			{Name: "work", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://lower.example.com/v1", Model: "lower"},
+		},
+	}, 0o600)
+
+	_, err := EditProvider(path, ProviderEdit{Name: "WORK", NewName: "renamed", Model: "updated"})
+	assertAmbiguousConfigUnchanged(t, path, before, err, "WORK", "work")
+}
+
+func assertAmbiguousConfigUnchanged(t *testing.T, path string, before []byte, err error, first, second string) {
+	t.Helper()
+	want := fmt.Sprintf("ambiguous persisted provider names %q and %q differ only by case; rename or remove one row in config.json", first, second)
+	if err == nil || err.Error() != want {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+	after, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("ambiguous mutation rewrote config\nbefore: %s\nafter: %s", before, after)
+	}
+}
+
 // TestEditProviderCaseOnlyRenameUpdatesInPlace: the manager previously skipped
 // RenameProvider on case-insensitively-equal names and fell into UpsertProvider,
-// whose case-SENSITIVE merge appended a duplicate profile. EditProvider matches
-// case-insensitively, so a case-only rename is an in-place update and the store
-// entry (case-normalized) survives.
+// whose case-SENSITIVE merge appended a duplicate profile. EditProvider applies
+// NewName to the exact current profile, so a case-only rename is an in-place
+// update and the store entry (case-normalized) survives.
 func TestEditProviderCaseOnlyRenameUpdatesInPlace(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
@@ -1020,4 +1281,323 @@ func TestEditProviderRejectsCollisionAndUnknown(t *testing.T) {
 	if string(after) != string(before) {
 		t.Fatalf("config was rewritten by a rejected edit")
 	}
+}
+
+// TestValidatePersistedProviderNamesRejectsExactDuplicates covers jatmn's #725
+// finding: the validator only rejected a repeated folded name when the
+// SPELLINGS differed, so two rows literally named "work" passed. That breaks
+// the same one-credential-per-folded-name invariant the case check protects —
+// resolver merging coalesces the rows, and plaintext-key migration writes both
+// values into one normalized credential-store entry, overwriting the first key.
+func TestValidatePersistedProviderNamesRejectsExactDuplicates(t *testing.T) {
+	for name, providers := range map[string][]ProviderProfile{
+		"identical spellings": {{Name: "work"}, {Name: "work"}},
+		"same after trimming": {{Name: "work"}, {Name: "  work  "}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := ValidatePersistedProviderNames(FileConfig{Providers: providers})
+			if err == nil {
+				t.Fatal("a repeated folded provider identity must be rejected")
+			}
+			if want := `duplicate persisted provider name "work"`; !strings.Contains(err.Error(), want) {
+				t.Fatalf("error = %v, want it to contain %q", err, want)
+			}
+		})
+	}
+	if err := ValidatePersistedProviderNames(FileConfig{Providers: []ProviderProfile{{Name: "work"}, {Name: "fast"}}}); err != nil {
+		t.Fatalf("distinct names must validate: %v", err)
+	}
+}
+
+// TestAdoptPersistedCatalogProviderNameIgnoresCatalogSiblings covers jatmn's
+// #725 finding: adoption followed PersistedProviderIdentity, which returned the
+// first row sharing the catalog id. Several profiles may legitimately use one
+// catalog provider, so adding the default "xai" profile silently retargeted an
+// existing {name:"work-xai", catalogId:"xai"} row and would have overwritten its
+// endpoint, model, and stored key.
+func TestAdoptPersistedCatalogProviderNameIgnoresCatalogSiblings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	writeConfigFixture(t, path, FileConfig{
+		Providers: []ProviderProfile{
+			{Name: "work-xai", CatalogID: "xai", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://work.example.com/v1", Model: "m"},
+		},
+	}, 0o600)
+
+	adopted, err := AdoptPersistedCatalogProviderName(path, ProviderProfile{Name: "xai", CatalogID: "xai"})
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if adopted.Name != "xai" {
+		t.Fatalf("Name = %q, want the default spelling kept — a catalog sibling is not the same profile", adopted.Name)
+	}
+}
+
+// TestAdoptPersistedCatalogProviderNameFollowsCaseVariantOfTheDefaultName is the
+// behaviour adoption exists for: a re-setup of "openrouter" against a row the
+// user saved as "OpenRouter" must UPDATE that row instead of colliding with it.
+func TestAdoptPersistedCatalogProviderNameFollowsCaseVariantOfTheDefaultName(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	writeConfigFixture(t, path, FileConfig{
+		Providers: []ProviderProfile{
+			{Name: "OpenRouter", CatalogID: "openrouter", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://openrouter.ai/api/v1", Model: "m"},
+		},
+	}, 0o600)
+
+	adopted, err := AdoptPersistedCatalogProviderName(path, ProviderProfile{Name: "openrouter", CatalogID: "openrouter"})
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if adopted.Name != "OpenRouter" {
+		t.Fatalf("Name = %q, want the persisted case variant adopted", adopted.Name)
+	}
+}
+
+// TestAdoptPersistedCatalogProviderNameIgnoresForeignCatalogRow covers jatmn's
+// #725 finding that a case-folded NAME match was taken as proof of ownership.
+// A custom profile may legitimately be called "OpenRouter" while pointing at a
+// different provider entirely; adopting it for `zero providers add openrouter`
+// handed that row to UpsertProvider, whose merge overwrites the catalog id,
+// endpoint, model and transport with OpenRouter's defaults while a stored-key
+// marker survives the rewrite.
+func TestAdoptPersistedCatalogProviderNameIgnoresForeignCatalogRow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	writeConfigFixture(t, path, FileConfig{
+		Providers: []ProviderProfile{
+			{Name: "OpenRouter", CatalogID: "custom-openai-compatible", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://corp.example/v1", Model: "corp-model", APIKeyStored: true},
+		},
+	}, 0o600)
+
+	adopted, err := AdoptPersistedCatalogProviderName(path, ProviderProfile{Name: "openrouter", CatalogID: "openrouter"})
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if adopted.Name != "openrouter" {
+		t.Fatalf("Name = %q, want the requested spelling kept — a differently-catalogued row is another provider", adopted.Name)
+	}
+	// And the write that follows must report the collision rather than rewriting
+	// the custom row in place.
+	if err := PreflightProviderWrite(path, adopted.Name); err == nil {
+		t.Fatal("PreflightProviderWrite accepted a name that collides with the custom row; want a reported collision")
+	}
+}
+
+// TestAdoptPersistedCatalogProviderNameIgnoresNameOnlyRow pins that a matching
+// display name is not proof that a custom profile belongs to a catalog provider.
+func TestAdoptPersistedCatalogProviderNameIgnoresNameOnlyRow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	writeConfigFixture(t, path, FileConfig{
+		Providers: []ProviderProfile{
+			{Name: "OpenRouter", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://openrouter.ai/api/v1", Model: "m"},
+		},
+	}, 0o600)
+
+	adopted, err := AdoptPersistedCatalogProviderName(path, ProviderProfile{Name: "openrouter", CatalogID: "openrouter"})
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if adopted.Name != "openrouter" {
+		t.Fatalf("Name = %q, want the requested spelling kept without positive catalog ownership", adopted.Name)
+	}
+	if err := PreflightProviderWrite(path, adopted.Name); err == nil {
+		t.Fatal("PreflightProviderWrite accepted a name-only collision; want the custom row preserved")
+	}
+}
+
+func TestAdoptPersistedCatalogProviderNameRejectsExactForeignOrNameOnlyRow(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		catalogID string
+	}{
+		{name: "foreign catalog", catalogID: "custom-openai-compatible"},
+		{name: "missing catalog ownership"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.json")
+			original := ProviderProfile{
+				Name: "openrouter", CatalogID: tt.catalogID, ProviderKind: ProviderKindOpenAICompatible,
+				BaseURL: "https://corp.example/v1", Model: "corp-model", APIKeyStored: true,
+			}
+			writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{original}}, 0o600)
+
+			if _, err := AdoptPersistedCatalogProviderName(path, ProviderProfile{Name: "openrouter", CatalogID: "openrouter"}); err == nil || !strings.Contains(err.Error(), "does not prove ownership") {
+				t.Fatalf("AdoptPersistedCatalogProviderName error = %v, want ownership rejection", err)
+			}
+			cfg, err := loadConfigFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(cfg.Providers) != 1 || cfg.Providers[0].CatalogID != original.CatalogID || cfg.Providers[0].BaseURL != original.BaseURL || cfg.Providers[0].Model != original.Model || !cfg.Providers[0].APIKeyStored {
+				t.Fatalf("foreign exact-name row changed: %+v", cfg.Providers)
+			}
+		})
+	}
+}
+
+// TestPersistedProviderIdentityRulesMatchTheCredentialStore pins the identity
+// contract this PR introduced across every persisted-config path at once.
+// strings.EqualFold folds "s" and Unicode long-s "ſ" together while
+// credstore.NormalizeProvider (the store's own rule, and the rule
+// ValidatePersistedProviderNames enforces) keeps them apart, so the two
+// spellings are separate profiles with separate secrets. Mixing the two
+// comparisons made one profile's mutation reach the other's row: destructive
+// logout expansion adopted the unrelated row, while ordinary writes rejected
+// the pair as a collision.
+func TestPersistedProviderIdentityRulesMatchTheCredentialStore(t *testing.T) {
+	const longS = "ſ"
+	path := filepath.Join(t.TempDir(), "config.json")
+	writeConfigFixture(t, path, FileConfig{
+		Providers: []ProviderProfile{
+			{Name: "s", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://s.example/v1", Model: "m", APIKeyStored: true},
+		},
+	}, 0o600)
+
+	t.Run("identity resolution does not adopt the distinct spelling", func(t *testing.T) {
+		if _, match, err := ResolvePersistedProviderIdentity(path, longS); err != nil || match != PersistedIdentityNone {
+			t.Fatalf("ResolvePersistedProviderIdentity(%q) = %v, %v; want no match", longS, match, err)
+		}
+	})
+
+	t.Run("a distinct spelling is writable, not a collision", func(t *testing.T) {
+		if err := PreflightProviderWrite(path, longS); err != nil {
+			t.Fatalf("PreflightProviderWrite(%q) = %v; want the distinct identity accepted", longS, err)
+		}
+		cfg, err := UpsertProvider(path, ProviderProfile{Name: longS, ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://long-s.example/v1", Model: "m"}, false)
+		if err != nil {
+			t.Fatalf("UpsertProvider(%q) = %v; want the distinct identity accepted", longS, err)
+		}
+		if len(cfg.Providers) != 2 {
+			t.Fatalf("providers = %+v, want both distinct rows saved", cfg.Providers)
+		}
+	})
+
+	t.Run("a case variant is still a collision", func(t *testing.T) {
+		if err := PreflightProviderWrite(path, "S"); err == nil {
+			t.Fatal("PreflightProviderWrite(\"S\") accepted a case variant of a saved row")
+		}
+	})
+}
+
+// TestResolvePersistedProviderIdentityPrefersNames covers jatmn's #725 finding
+// that identity resolution took the first row matching EITHER field, so a
+// catalog id on an earlier row outranked a later row with the exact name.
+func TestResolvePersistedProviderIdentityPrefersNames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	writeConfigFixture(t, path, FileConfig{
+		Providers: []ProviderProfile{
+			{Name: "work-xai", CatalogID: "xai"},
+			{Name: "xai", CatalogID: "xai"},
+		},
+	}, 0o600)
+
+	t.Run("exact name beats an earlier catalog id", func(t *testing.T) {
+		row, match, err := ResolvePersistedProviderIdentity(path, "xai")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if match != PersistedIdentityName || row.Name != "xai" {
+			t.Fatalf("row = %q match = %v, want the exactly named row", row.Name, match)
+		}
+	})
+
+	t.Run("a shared catalog id resolves to nothing", func(t *testing.T) {
+		_, match, err := ResolvePersistedProviderIdentity(path, "XAI")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		// "XAI" folds to the "xai" row's NAME, so that wins; the point of the
+		// exclusivity rule shows on a catalog id nothing is named after.
+		if match != PersistedIdentityName {
+			t.Fatalf("match = %v, want the case-variant name match", match)
+		}
+	})
+
+	t.Run("unique catalog id still resolves", func(t *testing.T) {
+		unique := filepath.Join(t.TempDir(), "config.json")
+		writeConfigFixture(t, unique, FileConfig{
+			Providers: []ProviderProfile{{Name: "my-router", CatalogID: "openrouter"}},
+		}, 0o600)
+		row, match, err := ResolvePersistedProviderIdentity(unique, "openrouter")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if match != PersistedIdentityCatalog || row.Name != "my-router" {
+			t.Fatalf("row = %q match = %v, want the sole catalog owner", row.Name, match)
+		}
+	})
+
+	t.Run("an ambiguous catalog id resolves to nothing", func(t *testing.T) {
+		shared := filepath.Join(t.TempDir(), "config.json")
+		writeConfigFixture(t, shared, FileConfig{
+			Providers: []ProviderProfile{
+				{Name: "work-xai", CatalogID: "xai"},
+				{Name: "personal-xai", CatalogID: "xai"},
+			},
+		}, 0o600)
+		if _, match, err := ResolvePersistedProviderIdentity(shared, "xai"); err != nil || match != PersistedIdentityNone {
+			t.Fatalf("match = %v err = %v, want no guess at a shared catalog id", match, err)
+		}
+	})
+}
+
+// TestCatalogIdentityExclusive guards the rule credential cleanup depends on:
+// a catalog id claimed by any other row is not the target profile's own key.
+func TestCatalogIdentityExclusive(t *testing.T) {
+	shared := filepath.Join(t.TempDir(), "config.json")
+	writeConfigFixture(t, shared, FileConfig{
+		Providers: []ProviderProfile{
+			{Name: "work-xai", CatalogID: "xai"},
+			{Name: "xai", CatalogID: "xai"},
+			{Name: "personal-xai", CatalogID: "xai"},
+		},
+	}, 0o600)
+	if exclusive, err := CatalogIdentityExclusive(shared, "xai", "work-xai"); err != nil || exclusive {
+		t.Fatalf("exclusive = %v err = %v, want false for a catalog id three rows claim", exclusive, err)
+	}
+
+	sole := filepath.Join(t.TempDir(), "config.json")
+	writeConfigFixture(t, sole, FileConfig{
+		Providers: []ProviderProfile{
+			{Name: "my-router", CatalogID: "openrouter"},
+			{Name: "work", CatalogID: "xai"},
+		},
+	}, 0o600)
+	if exclusive, err := CatalogIdentityExclusive(sole, "openrouter", "my-router"); err != nil || !exclusive {
+		t.Fatalf("exclusive = %v err = %v, want true when only the owner claims the id", exclusive, err)
+	}
+}
+
+func TestProviderCredentialCandidates(t *testing.T) {
+	t.Run("includes the persisted name and exclusive catalog alias", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.json")
+		writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{
+			{Name: "my-router", CatalogID: "openrouter"},
+		}}, 0o600)
+		candidates, canonical, err := ProviderCredentialCandidates(path, "MY-ROUTER")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"MY-ROUTER", "my-router", "openrouter"}
+		if !slices.Equal(candidates, want) || canonical != "my-router" {
+			t.Fatalf("candidates = %q canonical = %q, want %q and my-router", candidates, canonical, want)
+		}
+	})
+
+	t.Run("does not claim a shared catalog alias", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.json")
+		writeConfigFixture(t, path, FileConfig{Providers: []ProviderProfile{
+			{Name: "work-xai", CatalogID: "xai"},
+			{Name: "personal-xai", CatalogID: "xai"},
+		}}, 0o600)
+		candidates, canonical, err := ProviderCredentialCandidates(path, "work-xai")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := []string{"work-xai"}; !slices.Equal(candidates, want) || canonical != "work-xai" {
+			t.Fatalf("candidates = %q canonical = %q, want %q and work-xai", candidates, canonical, want)
+		}
+		candidates, _, err = ProviderCredentialCandidates(path, "xai")
+		if err == nil || len(candidates) != 0 {
+			t.Fatalf("ambiguous alias candidates = %q err = %v, want no destructive candidates and an error", candidates, err)
+		}
+	})
 }

--- a/internal/credstore/credstore.go
+++ b/internal/credstore/credstore.go
@@ -265,5 +265,16 @@ func (s *Store) write(data map[string]string) error {
 }
 
 func normalizeProvider(provider string) string {
+	return NormalizeProvider(provider)
+}
+
+// NormalizeProvider is the credential-store's provider-name equivalence rule:
+// entries are keyed by the trimmed, lowercased name. Callers that decide
+// whether two provider spellings share one stored secret (e.g. removing a
+// case-variant row while a sibling survives) must compare with THIS function
+// rather than strings.EqualFold — the two relations are not the same. Unicode
+// case folding equates "s" and "ſ", strings.ToLower does not, so an EqualFold
+// comparison can promise a survivor access to a key it cannot look up.
+func NormalizeProvider(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
 }

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -35,6 +35,7 @@ type Manager struct {
 	// openBrowser is invoked with the authorization URL for loopback logins.
 	// Tests inject a function that drives the loopback redirect.
 	openBrowser func(authURL string) error
+	beforeSave  func() error
 	// refreshLocks serializes concurrent refreshes per key so parallel callers
 	// don't each spend the single-use refresh token; the loser reuses the rotated
 	// token. refreshMu guards the map (M7).
@@ -59,6 +60,10 @@ type ManagerOptions struct {
 	RefreshBuffer time.Duration
 	Out           io.Writer
 	OpenBrowser   func(authURL string) error
+	// BeforeSave runs after interactive authorization succeeds and immediately
+	// before credential mutation. Interactive callers use it to revalidate
+	// state that may have changed while a browser or device flow was pending.
+	BeforeSave func() error
 }
 
 // NewManager builds a Manager, filling defaults.
@@ -97,6 +102,7 @@ func NewManager(opts ManagerOptions) (*Manager, error) {
 	return &Manager{
 		store: opts.Store, registry: registry, client: client,
 		env: env, now: now, buffer: buffer, out: out, openBrowser: open,
+		beforeSave: opts.BeforeSave,
 	}, nil
 }
 
@@ -143,6 +149,11 @@ func (m *Manager) Login(ctx context.Context, opts LoginOptions) (Status, error) 
 	}
 
 	key := ProviderKey(opts.Provider)
+	if m.beforeSave != nil {
+		if err := m.beforeSave(); err != nil {
+			return Status{}, err
+		}
+	}
 	if err := m.store.Save(key, token); err != nil {
 		return Status{}, err
 	}
@@ -199,6 +210,11 @@ func (m *Manager) CompleteDeviceLogin(ctx context.Context, provider string, cfg 
 		return Status{}, err
 	}
 	key := ProviderKey(provider)
+	if m.beforeSave != nil {
+		if err := m.beforeSave(); err != nil {
+			return Status{}, err
+		}
+	}
 	if err := m.store.Save(key, token); err != nil {
 		return Status{}, err
 	}

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -674,11 +674,16 @@ func oauthLoginName(profile config.ProviderProfile) (string, bool) {
 func (m model) savedProviderByName(name string) (config.ProviderProfile, bool) {
 	name = strings.TrimSpace(name)
 	for _, profile := range m.savedProviders {
-		if strings.EqualFold(strings.TrimSpace(profile.Name), name) {
+		if strings.TrimSpace(profile.Name) == name {
 			return profile, true
 		}
 	}
-	if strings.EqualFold(strings.TrimSpace(m.providerProfile.Name), name) {
+	for _, profile := range m.savedProviders {
+		if config.SameProviderIdentity(profile.Name, name) {
+			return profile, true
+		}
+	}
+	if strings.TrimSpace(m.providerProfile.Name) == name || config.SameProviderIdentity(m.providerProfile.Name, name) {
 		return m.providerProfile, true
 	}
 	return config.ProviderProfile{}, false

--- a/internal/tui/oauth_device.go
+++ b/internal/tui/oauth_device.go
@@ -59,7 +59,11 @@ func oauthDevicePrepare(name string) (oauth.DeviceAuth, oauth.Config, error) {
 // oauthDeviceComplete polls for the token authorized via oauthDevicePrepare and
 // stores it under provider:<name> (phase 2). The runtime resolver then attaches
 // the refreshable token to model calls.
-func oauthDeviceComplete(name string, cfg oauth.Config, auth oauth.DeviceAuth) error {
+func oauthDeviceComplete(name string, cfg oauth.Config, auth oauth.DeviceAuth, configPath ...string) error {
+	path := firstString(configPath)
+	if err := preflightOAuthProviderConfig(path, name); err != nil {
+		return err
+	}
 	store, err := oauth.NewStore(oauth.StoreOptions{})
 	if err != nil {
 		return err
@@ -68,6 +72,7 @@ func oauthDeviceComplete(name string, cfg oauth.Config, auth oauth.DeviceAuth) e
 		Store:        store,
 		HTTPClient:   &http.Client{Timeout: 60 * time.Second},
 		AllowPresets: true, // preset config is needed to poll/exchange the device token
+		BeforeSave:   func() error { return preflightOAuthProviderConfig(path, name) },
 	})
 	if err != nil {
 		return err

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -537,10 +537,14 @@ func (m *model) moveSetupMethod(delta int) {
 
 // setupOAuthCmd runs the chosen provider's browser OAuth login off the UI
 // goroutine for first-run setup. Mirrors the /provider wizard's flow.
-func setupOAuthCmd(provider providercatalog.Descriptor) tea.Cmd {
+func setupOAuthCmd(provider providercatalog.Descriptor, configPath ...string) tea.Cmd {
+	path := firstString(configPath)
 	switch {
 	case provider.OAuthMintsKey:
 		return func() tea.Msg {
+			if err := preflightOAuthProviderConfig(path, provider.ID); err != nil {
+				return setupOAuthMsg{providerID: provider.ID, err: err}
+			}
 			key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
 				OpenBrowser: browser.OpenURL,
 				Timeout:     3 * time.Minute,
@@ -549,13 +553,13 @@ func setupOAuthCmd(provider providercatalog.Descriptor) tea.Cmd {
 		}
 	case provider.ID == "chatgpt":
 		return func() tea.Msg {
-			err := runProviderChatGPTLogin()
+			err := runProviderChatGPTLogin(path)
 			return setupOAuthMsg{tokenLogin: true, providerID: provider.ID, err: err}
 		}
 	default:
 		name := provider.ID
 		return func() tea.Msg {
-			return setupOAuthMsg{tokenLogin: true, providerID: name, err: runProviderTokenLogin(name)}
+			return setupOAuthMsg{tokenLogin: true, providerID: name, err: runProviderTokenLogin(name, path)}
 		}
 	}
 }
@@ -571,8 +575,11 @@ type setupOAuthDeviceMsg struct {
 	err        error
 }
 
-func setupDevicePrepareCmd(name string) tea.Cmd {
+func setupDevicePrepareCmd(name string, configPath ...string) tea.Cmd {
 	return func() tea.Msg {
+		if err := preflightOAuthProviderConfig(firstString(configPath), name); err != nil {
+			return setupOAuthDeviceMsg{providerID: name, err: err}
+		}
 		auth, cfg, err := oauthDevicePrepare(name)
 		if err != nil {
 			return setupOAuthDeviceMsg{providerID: name, err: err}
@@ -587,9 +594,13 @@ func setupDevicePrepareCmd(name string) tea.Cmd {
 	}
 }
 
-func setupDevicePollCmd(name string, cfg oauth.Config, auth oauth.DeviceAuth) tea.Cmd {
+func setupDevicePollCmd(name string, cfg oauth.Config, auth oauth.DeviceAuth, configPath ...string) tea.Cmd {
 	return func() tea.Msg {
-		return setupOAuthMsg{tokenLogin: true, providerID: name, err: oauthDeviceComplete(name, cfg, auth)}
+		path := firstString(configPath)
+		if err := preflightOAuthProviderConfig(path, name); err != nil {
+			return setupOAuthMsg{tokenLogin: true, providerID: name, err: err}
+		}
+		return setupOAuthMsg{tokenLogin: true, providerID: name, err: oauthDeviceComplete(name, cfg, auth, path)}
 	}
 }
 
@@ -604,7 +615,7 @@ func (m model) startSetupDeviceLogin(descriptor providercatalog.Descriptor) (tea
 	m.setup.oauthErr = ""
 	m.setup.deviceUserCode = ""
 	m.setup.deviceVerificationURI = ""
-	return m, setupDevicePrepareCmd(descriptor.ID)
+	return m, setupDevicePrepareCmd(descriptor.ID, m.setup.configPath)
 }
 
 // applySetupOAuthDeviceCode handles phase 1 of device-code login: show the code,
@@ -626,7 +637,7 @@ func (m model) applySetupOAuthDeviceCode(msg setupOAuthDeviceMsg) (tea.Model, te
 	}
 	m.setup.deviceUserCode = msg.userCode
 	m.setup.deviceVerificationURI = msg.verifyURL
-	return m, setupDevicePollCmd(msg.providerID, msg.cfg, msg.auth)
+	return m, setupDevicePollCmd(msg.providerID, msg.cfg, msg.auth, m.setup.configPath)
 }
 
 // applySetupOAuth folds an OAuth login result into the first-run setup: on success
@@ -652,9 +663,12 @@ func (m model) applySetupOAuth(msg setupOAuthMsg) (tea.Model, tea.Cmd) {
 	if msg.tokenLogin {
 		// Early persist on the Update goroutine (see persistOAuthLoginProvider's
 		// threading contract) so quitting setup after the login doesn't lose it;
-		// completeSetup persists the full profile with the chosen model anyway,
-		// so a failure here is recoverable and not fatal to setup.
-		_ = persistOAuthLoginProvider(m.setup.configPath, msg.providerID)
+		// do not advance when that write fails or the stored token would have no
+		// reachable provider profile after setup exits.
+		if err := persistOAuthLoginProvider(m.setup.configPath, msg.providerID); err != nil {
+			m.setup.oauthErr = "Signed in, but the provider profile could not be saved: " + redaction.ErrorMessage(err, redaction.Options{})
+			return m, nil
+		}
 	}
 	m.setup.oauthErr = ""
 	m.setup.err = ""
@@ -790,7 +804,7 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 				m.setup.oauthPending = true
 				m.setup.oauthDevice = false
 				m.setup.oauthErr = ""
-				return m, setupOAuthCmd(descriptor)
+				return m, setupOAuthCmd(descriptor, m.setup.configPath)
 			}
 		}
 		if m.setup.stage == setupStageProvider {
@@ -874,6 +888,9 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 	})
 	if err != nil {
 		m.setup.err = err.Error()
+		if m.setup.oauthMode && m.setupProviderDescriptor().OAuthMintsKey && strings.TrimSpace(apiKey) != "" {
+			m.setup.err = oauthMintedKeySaveError(m.setup.err, apiKey)
+		}
 		return m, nil
 	}
 
@@ -901,6 +918,10 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 	}
 
 	return m.exitSetupToChat()
+}
+
+func oauthMintedKeySaveError(message, apiKey string) string {
+	return fmt.Sprintf("%s\nThe minted API key was not saved. Copy it now before leaving Zero:\n%s", message, apiKey)
 }
 
 func (m *model) resetSetupModels() {

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -2066,6 +2066,61 @@ func TestApplySetupOAuthSuccessAdvancesToModel(t *testing.T) {
 	}
 }
 
+func TestApplySetupOAuthTokenPersistFailureStaysOnProvider(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{Visible: true, Providers: []SetupProviderOption{
+			{ID: "xai", Name: "xAI", RequiresAuth: true},
+		}},
+	})
+	m.setup.stage = setupStageProvider
+	m.setup.oauthPending = true
+	m.setup.oauthMode = true
+	m.setup.configPath = t.TempDir() // A directory cannot be read as config.json.
+
+	updated, cmd := m.applySetupOAuth(setupOAuthMsg{tokenLogin: true, providerID: "xai"})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("failed profile persistence should not start model discovery")
+	}
+	if next.setup.stage != setupStageProvider {
+		t.Fatalf("stage = %v, want provider", next.setup.stage)
+	}
+	if next.setup.oauthErr == "" || !strings.Contains(next.setup.oauthErr, "could not be saved") {
+		t.Fatalf("oauthErr = %q, want profile-save failure", next.setup.oauthErr)
+	}
+}
+
+func TestCompleteSetupSurfacesMintedOpenRouterKeyWhenSaveFails(t *testing.T) {
+	const mintedKey = "sk-or-minted-recovery"
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openrouter", Name: "OpenRouter", RequiresAuth: true},
+			},
+			Save: func(SetupSelection) (SetupResult, error) {
+				return SetupResult{}, errors.New("config write failed")
+			},
+		},
+	})
+	m.setup.oauthMode = true
+	m.setup.stage = setupStageReady
+	m.setup.apiKey.SetValue(mintedKey)
+
+	updated, _ := m.completeSetup()
+	next := updated.(model)
+	if !strings.Contains(next.setup.err, mintedKey) || !strings.Contains(next.setup.err, "was not saved") {
+		t.Fatalf("setup error = %q, want minted-key recovery", next.setup.err)
+	}
+}
+
+func TestSetupDevicePreparePreflightsConfigBeforeRequestingCode(t *testing.T) {
+	msg := setupDevicePrepareCmd("xai", t.TempDir())().(setupOAuthDeviceMsg)
+	if msg.err == nil {
+		t.Fatal("device-code preparation should reject an unreadable config before requesting a code")
+	}
+}
+
 func pressSetupContinue(m model) model {
 	m = pressSetupContinueOnce(m)
 	// Transparently skip the connect-method chooser via the API-key/browse path so

--- a/internal/tui/provider_manager.go
+++ b/internal/tui/provider_manager.go
@@ -10,12 +10,14 @@ package tui
 
 import (
 	"os"
+	"slices"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/credstore"
 	"github.com/Gitlawb/zero/internal/oauth"
 )
 
@@ -105,9 +107,13 @@ func (m model) reloadProviderManagerRows() (model, tea.Cmd) {
 	}
 	m.providerWizard.manageRows = rows
 	m.providerWizard.manageCursor = clampInt(m.providerWizard.manageCursor, 0, maxInt(0, len(rows)-1))
-	// The session's live provider is the truth the user cares about (config's
-	// activeProvider follows it on every switch).
-	m.providerWizard.manageActiveName = m.providerName
+	// Use the live profile's canonical exact spelling. Resolved project config
+	// can legitimately contribute "WORK" beside persisted "work"; folding here
+	// would mark both rows active and let edits to one retarget the other.
+	m.providerWizard.manageActiveName = strings.TrimSpace(m.providerProfile.Name)
+	if m.providerWizard.manageActiveName == "" {
+		m.providerWizard.manageActiveName = strings.TrimSpace(m.providerName)
+	}
 	m.providerWizard.manageCredGen++
 	return m, providerManagerCredsCmd(m.providerWizard.manageCredGen, rows, m.userConfigPath)
 }
@@ -328,6 +334,13 @@ func (m model) activateManagerSelection() (model, tea.Cmd) {
 	return next, cmd
 }
 
+// transferProviderAPIKeyStoredMarker is a package var so a test can drive the
+// partial-failure path: the handoff runs AFTER RemoveProvider has committed
+// (while both case-variant rows are present the config is ambiguous and every
+// write against it is rejected), so its failure is a real state the UI must
+// report rather than an unreachable branch.
+var transferProviderAPIKeyStoredMarker = config.TransferProviderAPIKeyStoredMarker
+
 // deleteManagerSelection removes the confirmed provider: the config write runs
 // synchronously (the list must reflect the config the instant the confirm
 // resolves), while the stored-key delete and the OAuth-login lookup — a
@@ -357,6 +370,11 @@ func (m model) deleteManagerSelection() (model, tea.Cmd) {
 	var activeAfter string
 	var cleanup tea.Cmd
 	if persisted {
+		credentialCandidates, _, err := config.ProviderCredentialCandidates(m.userConfigPath, name)
+		if err != nil {
+			wizard.manageStatus = "Delete failed: " + err.Error()
+			return m, nil
+		}
 		cfg, err := config.RemoveProvider(m.userConfigPath, name)
 		if err != nil {
 			wizard.manageStatus = "Delete failed: " + err.Error()
@@ -364,7 +382,58 @@ func (m model) deleteManagerSelection() (model, tea.Cmd) {
 		}
 		activeAfter = cfg.ActiveProvider
 		notes = []string{"Deleted " + name + "."}
-		cleanup = providerManagerCleanupCmd(m.userConfigPath, row.profile)
+		retainStoredKey := false
+		markerTransferredTo := ""
+		if survivor, ok := caseVariantProviderNameAfterRemoval(cfg, name); ok {
+			// A surviving case variant reads the same credential-store entry, so
+			// the shared key must not be deleted — provided that row can still
+			// REACH it. ApplyStoredAPIKey consults the store only for a row
+			// carrying apiKeyStored, so retention is only safe once the marker
+			// is where the survivor can use it.
+			retainStoredKey = true
+			// The removed row owned the shared secret's marker; carry it over to
+			// the surviving case-variant so it stays reachable, mirroring the CLI
+			// (`zero providers remove`) fix for the same case.
+			if row.profile.APIKeyStored {
+				if survivorRow, foundSurvivor, err := config.ProviderRow(m.userConfigPath, survivor); err == nil && foundSurvivor && !survivorRow.APIKeyStored {
+					if _, err := transferProviderAPIKeyStoredMarker(m.userConfigPath, survivor); err != nil {
+						// The row is already gone and the handoff failed, so the
+						// key is in the store with no profile marked to read it.
+						// Keep it rather than destroying a secret because a config
+						// write failed — but say so, and do not report this as a
+						// completed delete. Re-saving a key for the survivor (or
+						// restoring its apiKeyStored marker) makes it reachable again.
+						retainStoredKey = true
+						notes = []string{
+							"Removed " + name + ", but the delete is incomplete: its stored API key marker could not be handed to " + survivor + " (" + err.Error() + ").",
+							"The shared key is still in the credential store and " + survivor + " cannot reach it until you set a key for it again.",
+						}
+					} else {
+						markerTransferredTo = survivor
+					}
+				}
+			}
+		}
+		if retainStoredKey {
+			credentialCandidates = slices.DeleteFunc(credentialCandidates, func(candidate string) bool {
+				return config.SameProviderIdentity(candidate, name)
+			})
+		}
+		cleanup = providerManagerCleanupCmd(m.userConfigPath, row.profile, credentialCandidates)
+		// reloadProviderManagerRows (below, via the caller) rebuilds the manager
+		// list from savedProviders, so the on-disk marker transfer above must be
+		// mirrored here too — otherwise the survivor reads APIKeyStored: false in
+		// memory until the process restarts, and providerManagerCredState (which
+		// gates store lookups on that field) reports "no credential" for a
+		// profile whose key is actually reachable.
+		if markerTransferredTo != "" {
+			for index := range m.savedProviders {
+				if strings.TrimSpace(m.savedProviders[index].Name) == markerTransferredTo {
+					m.savedProviders[index].APIKeyStored = true
+					break
+				}
+			}
+		}
 	} else {
 		// Env-derived providers have no persisted profile or credential to
 		// delete. Keep this path session-only.
@@ -378,9 +447,9 @@ func (m model) deleteManagerSelection() (model, tea.Cmd) {
 	// must not replace the resolved/filtered savedProviders wholesale.
 	m.savedProviders = removeSavedProvider(m.savedProviders, name)
 
-	if strings.EqualFold(strings.TrimSpace(m.providerName), strings.TrimSpace(name)) {
+	if config.SameProviderIdentity(m.providerName, name) {
 		notes = append(notes, "This session keeps running on it until you switch.")
-	} else if activeAfter != "" && !strings.EqualFold(activeAfter, name) {
+	} else if activeAfter != "" && !config.SameProviderIdentity(activeAfter, name) {
 		notes = append(notes, "Active provider: "+activeAfter+".")
 	}
 
@@ -394,16 +463,39 @@ func (m model) deleteManagerSelection() (model, tea.Cmd) {
 	return next, tea.Batch(cmd, cleanup)
 }
 
-// removeSavedProvider drops one profile from the in-memory saved list.
+// removeSavedProvider drops one profile from the in-memory saved list. Uses
+// exact-name matching to agree with config.RemoveProvider, which the caller
+// just invoked: with case-variant rows now a supported layout (e.g. "work"
+// and "WORK"), a fold-based match here could evict the surviving row from the
+// UI list while it remains in config.json.
 func removeSavedProvider(saved []config.ProviderProfile, name string) []config.ProviderProfile {
 	kept := saved[:0]
 	for _, profile := range saved {
-		if strings.EqualFold(strings.TrimSpace(profile.Name), strings.TrimSpace(name)) {
+		if strings.TrimSpace(profile.Name) == strings.TrimSpace(name) {
 			continue
 		}
 		kept = append(kept, profile)
 	}
 	return kept
+}
+
+// caseVariantProviderNameAfterRemoval returns the exact name of a row in cfg
+// that shares name's CREDENTIAL-STORE identity (a case-only variant surviving
+// the removal that reads the same stored secret), and whether one was found.
+//
+// Matching uses credstore.NormalizeProvider, the store's own equivalence rule,
+// for the reason spelled out on the CLI twin (caseVariantProviderName in
+// internal/cli/provider_onboarding.go): strings.EqualFold is a strictly wider
+// relation and would promise a survivor a key it cannot look up.
+func caseVariantProviderNameAfterRemoval(cfg config.FileConfig, name string) (string, bool) {
+	target := credstore.NormalizeProvider(name)
+	for _, provider := range cfg.Providers {
+		providerName := strings.TrimSpace(provider.Name)
+		if credstore.NormalizeProvider(providerName) == target {
+			return providerName, true
+		}
+	}
+	return "", false
 }
 
 // providerManagerCleanupMsg reports the off-thread half of a delete: the
@@ -417,17 +509,23 @@ type providerManagerCleanupMsg struct {
 // reads the token store — blocking work the confirm keypress must not wait on.
 // A failed key delete is surfaced rather than letting a lingering secret read
 // as a clean removal.
-func providerManagerCleanupCmd(configPath string, profile config.ProviderProfile) tea.Cmd {
+func providerManagerCleanupCmd(configPath string, profile config.ProviderProfile, credentialCandidates []string) tea.Cmd {
 	name := profile.Name
 	catalogID := profile.CatalogID
 	return func() tea.Msg {
 		notes := []string{}
-		keyStore, storeErr := providerKeyStoreForPath(configPath)
-		if storeErr == nil {
-			_, storeErr = keyStore.Delete(name)
-		}
-		if storeErr != nil {
-			notes = append(notes, "Warning: its stored API key could not be deleted ("+storeErr.Error()+").")
+		if len(credentialCandidates) > 0 {
+			keyStore, storeErr := providerKeyStoreForPath(configPath)
+			if storeErr == nil {
+				for _, candidate := range credentialCandidates {
+					if _, storeErr = keyStore.Delete(candidate); storeErr != nil {
+						break
+					}
+				}
+			}
+			if storeErr != nil {
+				notes = append(notes, "Warning: its stored API key could not be deleted ("+storeErr.Error()+").")
+			}
 		}
 		if login, ok := oauthLoginName(config.ProviderProfile{Name: name, CatalogID: catalogID}); ok {
 			notes = append(notes, "OAuth login kept — remove with `zero auth logout "+login+"`.")
@@ -604,6 +702,16 @@ func (m model) saveManagerEdit() (model, tea.Cmd) {
 		wizard.err = "name cannot be empty"
 		return m, nil
 	}
+	if !config.SameProviderIdentity(newName, oldName) {
+		if err := config.PreflightProviderWrite(m.userConfigPath, newName); err != nil {
+			wizard.err = err.Error()
+			return m, nil
+		}
+	}
+	if err := config.PreflightUserConfig(m.userConfigPath); err != nil {
+		wizard.err = err.Error()
+		return m, nil
+	}
 	edit := config.ProviderEdit{
 		Name:        oldName,
 		NewName:     newName,
@@ -629,9 +737,11 @@ func (m model) saveManagerEdit() (model, tea.Cmd) {
 	// project-contributed providers and resurrect filtered stubs for the session.
 	m.savedProviders = applySavedProviderEdit(m.savedProviders, oldName, edit)
 
-	// Keep the live session's identity in sync with a rename of the provider it
-	// is running on: the exported ZERO_PROVIDER must resolve for spawned children.
-	if strings.EqualFold(strings.TrimSpace(m.providerName), oldName) {
+	// Keep the live session's identity in sync only when its canonical profile is
+	// the exact persisted row being edited. m.providerName alone is insufficient:
+	// a project profile "WORK" can be live beside the persisted row "work".
+	liveProfileEdited := strings.TrimSpace(m.providerProfile.Name) == oldName
+	if liveProfileEdited {
 		m.providerName = newName
 		m.providerProfile.Name = newName
 		config.SetActiveProviderEnv(newName)
@@ -639,17 +749,15 @@ func (m model) saveManagerEdit() (model, tea.Cmd) {
 
 	wizard.step = providerWizardStepManage
 	next, cmd := m.reloadProviderManagerRows()
-	next.providerWizard.manageStatus = "Updated " + newName + "." + providerEditRestartNote(next.providerName, newName)
+	next.providerWizard.manageStatus = "Updated " + newName + "." + providerEditRestartNote(liveProfileEdited)
 	return next, cmd
 }
 
 // providerEditRestartNote reminds the user when the edited provider is the one
 // this session is running on — endpoint/model/key changes only apply to the
 // built client after a switch (Enter on the row re-activates and rebuilds).
-// liveName is the session's provider AFTER any rename sync, so a single
-// comparison against the edited profile's final name suffices.
-func providerEditRestartNote(liveName string, editedName string) string {
-	if strings.EqualFold(strings.TrimSpace(liveName), strings.TrimSpace(editedName)) {
+func providerEditRestartNote(liveProfileEdited bool) string {
+	if liveProfileEdited {
 		return " Press Enter on it to apply the changes to this session."
 	}
 	return ""
@@ -658,8 +766,9 @@ func providerEditRestartNote(liveName string, editedName string) string {
 // applySavedProviderEdit mirrors a persisted config.EditProvider into the
 // in-memory saved list without wholesale replacement (see saveManagerEdit).
 func applySavedProviderEdit(saved []config.ProviderProfile, oldName string, edit config.ProviderEdit) []config.ProviderProfile {
+	oldName = strings.TrimSpace(oldName)
 	for index := range saved {
-		if !strings.EqualFold(strings.TrimSpace(saved[index].Name), strings.TrimSpace(oldName)) {
+		if strings.TrimSpace(saved[index].Name) != oldName {
 			continue
 		}
 		profile := &saved[index]
@@ -691,7 +800,7 @@ func applySavedProviderEdit(saved []config.ProviderProfile, oldName string, edit
 // in-memory saved list (replace by name, else append).
 func upsertSavedProviderProfile(saved []config.ProviderProfile, profile config.ProviderProfile) []config.ProviderProfile {
 	for index := range saved {
-		if strings.EqualFold(strings.TrimSpace(saved[index].Name), strings.TrimSpace(profile.Name)) {
+		if strings.TrimSpace(saved[index].Name) == strings.TrimSpace(profile.Name) {
 			saved[index] = profile
 			return saved
 		}
@@ -727,7 +836,7 @@ func (wizard *providerWizardState) renderManageStep(width int) []string {
 			marker = surface(zeroTheme.accent).Render("❯ ")
 		}
 		active := ""
-		if strings.EqualFold(strings.TrimSpace(row.profile.Name), strings.TrimSpace(wizard.manageActiveName)) {
+		if strings.TrimSpace(row.profile.Name) == strings.TrimSpace(wizard.manageActiveName) {
 			active = surface(zeroTheme.accent).Render(" ● active")
 		}
 		name := padProviderManagerCell(row.profile.Name, nameWidth)
@@ -767,7 +876,7 @@ func providerManagerRowMeta(profile config.ProviderProfile) string {
 	if kind == "" {
 		kind = strings.TrimSpace(profile.Provider)
 	}
-	if catalog := strings.TrimSpace(profile.CatalogID); catalog != "" && !strings.EqualFold(catalog, profile.Name) {
+	if catalog := strings.TrimSpace(profile.CatalogID); catalog != "" && !config.SameProviderIdentity(catalog, profile.Name) {
 		kind = catalog
 	}
 	model := strings.TrimSpace(profile.Model)

--- a/internal/tui/provider_manager_test.go
+++ b/internal/tui/provider_manager_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,6 +153,173 @@ func TestProviderManagerDeleteConfirmsAndRemoves(t *testing.T) {
 	}
 }
 
+func TestProviderManagerIdentityListsKeepLongSDistinct(t *testing.T) {
+	saved := []config.ProviderProfile{{Name: "s", Model: "ascii"}}
+	saved = upsertSavedProviderProfile(saved, config.ProviderProfile{Name: "ſ", Model: "long-s"})
+	if len(saved) != 2 {
+		t.Fatalf("upsert merged distinct credential-store identities: %+v", saved)
+	}
+	m := model{savedProviders: saved[:1]}
+	if profile, ok := m.savedProviderByName("ſ"); ok {
+		t.Fatalf("lookup returned unrelated ASCII profile: %+v", profile)
+	}
+}
+
+// TestProviderManagerDeleteTransfersKeyMarkerToSurvivingCaseVariant mirrors
+// the CLI's TestRunProvidersRemoveTransfersKeyMarkerToSurvivingCaseVariant:
+// deleting the case-variant row that owns apiKeyStored must carry the marker
+// to the surviving sibling, since the credential store's secret is keyed
+// case-folded and stays put either way.
+func TestProviderManagerDeleteTransfersKeyMarkerToSurvivingCaseVariant(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", home)
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", filepath.Join(home, "oauth-tokens.json"))
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	seed := config.FileConfig{
+		ActiveProvider: "WORK",
+		Providers: []config.ProviderProfile{
+			{Name: "work", CatalogID: "xai", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://work.example.com/v1", APIKeyStored: true, Model: "work-model"},
+			{Name: "WORK", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://work.example.com/v2", Model: "work-model-2"},
+		},
+	}
+	data, err := json.MarshalIndent(seed, "", "  ")
+	if err != nil {
+		t.Fatalf("encode seed config: %v", err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatalf("write seed config: %v", err)
+	}
+	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("work", "shared-key"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("xai", "alias-key"); err != nil {
+		t.Fatal(err)
+	}
+	m := newModel(context.Background(), Options{
+		ProviderName:    "WORK",
+		ModelName:       "work-model-2",
+		Provider:        &fakeProvider{},
+		ProviderProfile: seed.Providers[1],
+		SavedProviders:  seed.Providers,
+		UserConfigPath:  configPath,
+		NewProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return &fakeProvider{}, nil
+		},
+	})
+	m.width = 120
+	m.height = 40
+	m, _ = m.openProviderManager()
+
+	m = managerKey(t, m, testKeyText("d")) // select "work" (row 0)
+	next, cleanup := m.handleProviderWizardKey(testKeyText("y"))
+	if cleanup == nil {
+		t.Fatal("delete did not schedule credential cleanup")
+	}
+	next = drainProviderManagerCmds(t, next, cleanup)
+
+	persisted := readManagerConfig(t, next.userConfigPath)
+	if len(persisted.Providers) != 1 || persisted.Providers[0].Name != "WORK" || !persisted.Providers[0].APIKeyStored {
+		t.Fatalf("survivor must inherit apiKeyStored marker, got %+v", persisted.Providers)
+	}
+	if key, ok, err := store.Get("work"); err != nil || !ok || key != "shared-key" {
+		t.Fatalf("shared provider key = %q, %v, %v; want retained", key, ok, err)
+	}
+	if _, ok, err := store.Get("xai"); err != nil || ok {
+		t.Fatalf("exclusive catalog-alias key survived removal: ok=%v err=%v", ok, err)
+	}
+	// The marker transfer must be mirrored into the in-memory savedProviders
+	// too — reloadProviderManagerRows rebuilds the manager list from it, and
+	// providerManagerCredState gates store lookups on APIKeyStored, so a stale
+	// false here would show "no credential" for the survivor until restart
+	// even though config.json and the credstore both already agree.
+	if len(next.savedProviders) != 1 || next.savedProviders[0].Name != "WORK" || !next.savedProviders[0].APIKeyStored {
+		t.Fatalf("in-memory savedProviders must inherit apiKeyStored too, got %+v", next.savedProviders)
+	}
+}
+
+// TestProviderManagerDeleteReportsFailedKeyMarkerHandoff covers jatmn's #725
+// finding that the manager committed the retain-the-key decision before it knew
+// the handoff had worked. The marker transfer can only run AFTER RemoveProvider
+// (while both case-variant rows exist the config is ambiguous and every write
+// against it is rejected), so its failure is reachable: the shared secret then
+// sits in the store with no row marked to read it, while the UI had already
+// reported a completed "Deleted <name>."
+func TestProviderManagerDeleteReportsFailedKeyMarkerHandoff(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", home)
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", filepath.Join(home, "oauth-tokens.json"))
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	seed := config.FileConfig{
+		ActiveProvider: "WORK",
+		Providers: []config.ProviderProfile{
+			{Name: "work", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://work.example.com/v1", APIKeyStored: true, Model: "work-model"},
+			{Name: "WORK", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://work.example.com/v2", Model: "work-model-2"},
+		},
+	}
+	data, err := json.MarshalIndent(seed, "", "  ")
+	if err != nil {
+		t.Fatalf("encode seed config: %v", err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatalf("write seed config: %v", err)
+	}
+	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("work", "shared-key"); err != nil {
+		t.Fatal(err)
+	}
+	original := transferProviderAPIKeyStoredMarker
+	transferProviderAPIKeyStoredMarker = func(string, string) (bool, error) {
+		return false, errors.New("injected marker write failure")
+	}
+	t.Cleanup(func() { transferProviderAPIKeyStoredMarker = original })
+
+	m := newModel(context.Background(), Options{
+		ProviderName:    "WORK",
+		ModelName:       "work-model-2",
+		Provider:        &fakeProvider{},
+		ProviderProfile: seed.Providers[1],
+		SavedProviders:  seed.Providers,
+		UserConfigPath:  configPath,
+		NewProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return &fakeProvider{}, nil
+		},
+	})
+	m.width = 120
+	m.height = 40
+	m, _ = m.openProviderManager()
+
+	m = managerKey(t, m, testKeyText("d")) // select "work" (row 0)
+	next, cmd := m.handleProviderWizardKey(testKeyText("y"))
+	next = drainProviderManagerCmds(t, next, cmd)
+
+	status := next.providerWizard.manageStatus
+	if strings.Contains(status, "Deleted work.") {
+		t.Fatalf("status = %q, must not report a completed delete while the shared key is unreachable", status)
+	}
+	if !strings.Contains(status, "incomplete") || !strings.Contains(status, "WORK") {
+		t.Fatalf("status = %q, want it to name the incomplete handoff and the survivor", status)
+	}
+	// The secret is kept rather than destroyed by a failed config write: it is
+	// recoverable by setting a key for the survivor again, whereas deleting it
+	// is not.
+	if key, ok, err := store.Get("work"); err != nil || !ok || key != "shared-key" {
+		t.Fatalf("shared provider key = %q, %v, %v; want it preserved for recovery", key, ok, err)
+	}
+	persisted := readManagerConfig(t, next.userConfigPath)
+	if len(persisted.Providers) != 1 || persisted.Providers[0].Name != "WORK" {
+		t.Fatalf("providers = %+v, want only the survivor", persisted.Providers)
+	}
+}
+
 func TestProviderManagerEditModelPersists(t *testing.T) {
 	m := managerTestModel(t)
 	m = managerKey(t, m, testKeyText("e"))
@@ -214,6 +382,137 @@ func TestProviderManagerRenameFollowsLiveSession(t *testing.T) {
 	}
 	if len(persisted.Providers) != 2 || persisted.Providers[0].Name != "gateway-main" {
 		t.Fatalf("rename not persisted, providers: %v", names)
+	}
+}
+
+func TestProviderManagerCaseOnlyRenameFollowsNormalizedLiveSession(t *testing.T) {
+	m := managerTestModel(t)
+	t.Setenv(config.ActiveProviderEnv, "OPENGATEWAY")
+	m.providerName = "OPENGATEWAY"
+	m.providerWizard = &providerWizardState{
+		step:         providerWizardStepEditMenu,
+		editOriginal: m.savedProviders[0],
+		editDraft:    m.savedProviders[0],
+	}
+	m.providerWizard.editDraft.Name = "OpenGateway"
+
+	next, _ := m.saveManagerEdit()
+	if next.providerName != "OpenGateway" || next.providerProfile.Name != "OpenGateway" {
+		t.Fatalf("live session did not follow the case-only rename: provider=%q profile=%q", next.providerName, next.providerProfile.Name)
+	}
+	if got := os.Getenv(config.ActiveProviderEnv); got != "OpenGateway" {
+		t.Fatalf("%s = %q, want OpenGateway", config.ActiveProviderEnv, got)
+	}
+	if !strings.Contains(next.providerWizard.manageStatus, "Press Enter") {
+		t.Fatalf("active-profile edit omitted restart guidance: %q", next.providerWizard.manageStatus)
+	}
+	persisted := readManagerConfig(t, next.userConfigPath)
+	if persisted.Providers[0].Name != "OpenGateway" {
+		t.Fatalf("exact persisted row was not renamed: %+v", persisted.Providers)
+	}
+}
+
+func TestProviderManagerEditDoesNotRetargetCaseVariantProjectSession(t *testing.T) {
+	t.Setenv(config.ActiveProviderEnv, "WORK")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	persisted := config.ProviderProfile{
+		Name: "work", ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL: "https://user.example.com/v1", Model: "user-model",
+	}
+	project := config.ProviderProfile{
+		Name: "WORK", ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL: "https://project.example.com/v1", Model: "project-model",
+	}
+	data, err := json.Marshal(config.FileConfig{ActiveProvider: persisted.Name, Providers: []config.ProviderProfile{persisted}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := newModel(context.Background(), Options{
+		ProviderName: "WORK", ModelName: project.Model, Provider: &fakeProvider{},
+		ProviderProfile: project, SavedProviders: []config.ProviderProfile{persisted, project},
+		UserConfigPath: configPath,
+	})
+	m.providerWizard = &providerWizardState{
+		step: providerWizardStepEditMenu, editOriginal: persisted, editDraft: persisted,
+	}
+	m.providerWizard.editDraft.Name = "Work"
+
+	next, _ := m.saveManagerEdit()
+	if next.providerName != "WORK" || next.providerProfile.Name != "WORK" {
+		t.Fatalf("project live session was retargeted: provider=%q profile=%q", next.providerName, next.providerProfile.Name)
+	}
+	if got := os.Getenv(config.ActiveProviderEnv); got != "WORK" {
+		t.Fatalf("%s = %q, want the live project provider unchanged", config.ActiveProviderEnv, got)
+	}
+	if strings.Contains(next.providerWizard.manageStatus, "Press Enter") {
+		t.Fatalf("unrelated project session received restart guidance: %q", next.providerWizard.manageStatus)
+	}
+	if next.providerWizard.manageActiveName != "WORK" {
+		t.Fatalf("manager active identity = %q, want exact live project profile", next.providerWizard.manageActiveName)
+	}
+	cfg := readManagerConfig(t, configPath)
+	if len(cfg.Providers) != 1 || cfg.Providers[0].Name != "Work" {
+		t.Fatalf("persisted user profile was not renamed exactly: %+v", cfg.Providers)
+	}
+}
+
+func TestProviderManagerEditKeepsDistinctUnicodeIdentityOutOfLiveSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", home)
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", filepath.Join(home, "oauth-tokens.json"))
+	t.Setenv("ZERO_CRED_STORAGE", "encrypted-file")
+	t.Setenv(config.ActiveProviderEnv, "s")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	seed := config.FileConfig{
+		ActiveProvider: "s",
+		Providers: []config.ProviderProfile{
+			{Name: "s", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://s.example.com/v1", Model: "s-model"},
+			{Name: "ſ", ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://long-s.example.com/v1", Model: "long-s-model"},
+		},
+	}
+	data, err := json.MarshalIndent(seed, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newModel(context.Background(), Options{
+		ProviderName:    "s",
+		ModelName:       "s-model",
+		Provider:        &fakeProvider{},
+		ProviderProfile: seed.Providers[0],
+		SavedProviders:  seed.Providers,
+		UserConfigPath:  configPath,
+	})
+	m.providerWizard = &providerWizardState{
+		step:         providerWizardStepEditMenu,
+		editOriginal: seed.Providers[1],
+		editDraft: config.ProviderProfile{
+			Name:         "ſ",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://long-s.example.com/v1",
+			Model:        "edited-long-s-model",
+		},
+	}
+
+	next, _ := m.saveManagerEdit()
+	persisted := readManagerConfig(t, configPath)
+	if persisted.Providers[0].Model != "s-model" || persisted.Providers[1].Model != "edited-long-s-model" {
+		t.Fatalf("persisted edit targeted wrong identity: %+v", persisted.Providers)
+	}
+	if next.savedProviders[0].Model != "s-model" || next.savedProviders[1].Model != "edited-long-s-model" {
+		t.Fatalf("in-memory edit targeted wrong identity: %+v", next.savedProviders)
+	}
+	if next.providerName != "s" || next.providerProfile.Name != "s" || os.Getenv(config.ActiveProviderEnv) != "s" {
+		t.Fatalf("unrelated live session changed: provider=%q profile=%q env=%q", next.providerName, next.providerProfile.Name, os.Getenv(config.ActiveProviderEnv))
+	}
+	if strings.Contains(next.providerWizard.manageStatus, "Press Enter") {
+		t.Fatalf("unrelated edit produced live-session restart note: %q", next.providerWizard.manageStatus)
 	}
 }
 

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"net"
 	"net/http"
@@ -137,7 +138,7 @@ func (m model) applyProviderWizardDeviceCode(msg providerWizardDeviceCodeMsg) (m
 	}
 	m.providerWizard.deviceUserCode = msg.userCode
 	m.providerWizard.deviceVerificationURI = msg.verifyURL
-	return m, providerWizardDevicePollCmd(msg.providerID, msg.attemptID, msg.cfg, msg.auth)
+	return m, providerWizardDevicePollCmd(msg.providerID, msg.attemptID, msg.cfg, msg.auth, m.userConfigPath)
 }
 
 // providerWizardSupportsOAuth reports whether the credential step should offer a
@@ -155,11 +156,15 @@ func providerWizardSupportsOAuth(provider providercatalog.Descriptor) bool {
 // from the ID token and stores it on the saved token so the Codex provider can
 // inject it as a header on every request; other OAuth providers (xAI) run the
 // generic engine login which stores a refreshable token.
-func providerWizardOAuthCmdFor(provider providercatalog.Descriptor, attemptID int) tea.Cmd {
+func providerWizardOAuthCmdFor(provider providercatalog.Descriptor, attemptID int, configPath ...string) tea.Cmd {
 	providerID := provider.ID
+	path := firstString(configPath)
 	switch {
 	case provider.OAuthMintsKey:
 		return func() tea.Msg {
+			if err := preflightOAuthProviderConfig(path, providerID); err != nil {
+				return providerWizardOAuthMsg{providerID: providerID, attemptID: attemptID, err: err}
+			}
 			key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
 				OpenBrowser: browser.OpenURL,
 				Timeout:     3 * time.Minute,
@@ -168,12 +173,12 @@ func providerWizardOAuthCmdFor(provider providercatalog.Descriptor, attemptID in
 		}
 	case providerID == "chatgpt":
 		return func() tea.Msg {
-			err := runProviderChatGPTLogin()
+			err := runProviderChatGPTLogin(path)
 			return providerWizardOAuthMsg{providerID: providerID, attemptID: attemptID, tokenLogin: true, err: err}
 		}
 	default:
 		return func() tea.Msg {
-			return providerWizardOAuthMsg{providerID: providerID, attemptID: attemptID, tokenLogin: true, err: runProviderTokenLogin(providerID)}
+			return providerWizardOAuthMsg{providerID: providerID, attemptID: attemptID, tokenLogin: true, err: runProviderTokenLogin(providerID, path)}
 		}
 	}
 }
@@ -183,7 +188,11 @@ func providerWizardOAuthCmdFor(provider providercatalog.Descriptor, attemptID in
 // the token's Account field) and persists the resulting token via the oauth
 // store. The runtime resolver then attaches the bearer to Codex calls and the
 // Codex provider reads the Account field for the `chatgpt-account-id` header.
-func runProviderChatGPTLogin() error {
+func runProviderChatGPTLogin(configPath ...string) error {
+	path := firstString(configPath)
+	if err := preflightOAuthProviderConfig(path, "chatgpt"); err != nil {
+		return err
+	}
 	env := buildOAuthPresetEnv()
 	token, err := provideroauth.ChatGPTLogin(context.Background(), provideroauth.ChatGPTOptions{
 		Env:         env,
@@ -198,20 +207,37 @@ func runProviderChatGPTLogin() error {
 	if err != nil {
 		return err
 	}
+	if err := preflightOAuthProviderConfig(path, "chatgpt"); err != nil {
+		return err
+	}
 	return store.Save(oauth.ProviderKey("chatgpt"), token)
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func preflightOAuthProviderConfig(path string, providerID string) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	return config.PreflightCatalogProviderLogin(path, providerID)
 }
 
 // appendOAuthLoginProfile mirrors the profile persistOAuthLoginProvider wrote to
 // config into an in-memory saved-provider list, skipping when a profile already
-// serves the catalog entry (by name or catalog id).
+// positively owns the catalog entry.
 func appendOAuthLoginProfile(saved []config.ProviderProfile, providerID string) []config.ProviderProfile {
 	descriptor, ok := providercatalog.Get(providerID)
 	if !ok {
 		return saved
 	}
 	for _, profile := range saved {
-		if strings.EqualFold(strings.TrimSpace(profile.CatalogID), descriptor.ID) ||
-			strings.EqualFold(strings.TrimSpace(profile.Name), descriptor.ID) {
+		if strings.TrimSpace(profile.CatalogID) != "" &&
+			config.SameProviderIdentity(profile.CatalogID, descriptor.ID) {
 			return saved
 		}
 	}
@@ -260,7 +286,11 @@ func buildOAuthPresetEnv() map[string]string {
 // runProviderTokenLogin runs the generic OAuth engine login for a provider that
 // has a built-in preset (e.g. xAI), storing a refreshable token under
 // provider:<name>. The runtime resolver then attaches it to model calls.
-func runProviderTokenLogin(name string) error {
+func runProviderTokenLogin(name string, configPath ...string) error {
+	path := firstString(configPath)
+	if err := preflightOAuthProviderConfig(path, name); err != nil {
+		return err
+	}
 	store, err := oauth.NewStore(oauth.StoreOptions{})
 	if err != nil {
 		return err
@@ -273,6 +303,7 @@ func runProviderTokenLogin(name string) error {
 		// into its baked-in preset (e.g. xAI's public client_id); without this the
 		// config never resolves and the browser never opens.
 		AllowPresets: true,
+		BeforeSave:   func() error { return preflightOAuthProviderConfig(path, name) },
 	})
 	if err != nil {
 		return err
@@ -297,8 +328,11 @@ type providerWizardDeviceCodeMsg struct {
 
 // providerWizardDevicePrepareCmd runs phase 1 of the device-code login off the UI
 // goroutine and reports the code to display (or an error).
-func providerWizardDevicePrepareCmd(name string, attemptID int) tea.Cmd {
+func providerWizardDevicePrepareCmd(name string, attemptID int, configPath ...string) tea.Cmd {
 	return func() tea.Msg {
+		if err := preflightOAuthProviderConfig(firstString(configPath), name); err != nil {
+			return providerWizardDeviceCodeMsg{providerID: name, attemptID: attemptID, err: err}
+		}
 		auth, cfg, err := oauthDevicePrepare(name)
 		if err != nil {
 			return providerWizardDeviceCodeMsg{providerID: name, attemptID: attemptID, err: err}
@@ -316,9 +350,13 @@ func providerWizardDevicePrepareCmd(name string, attemptID int) tea.Cmd {
 
 // providerWizardDevicePollCmd runs phase 2 (poll for the token + store) off the
 // UI goroutine and reports completion as a regular OAuth result.
-func providerWizardDevicePollCmd(name string, attemptID int, cfg oauth.Config, auth oauth.DeviceAuth) tea.Cmd {
+func providerWizardDevicePollCmd(name string, attemptID int, cfg oauth.Config, auth oauth.DeviceAuth, configPath ...string) tea.Cmd {
 	return func() tea.Msg {
-		return providerWizardOAuthMsg{providerID: name, attemptID: attemptID, tokenLogin: true, err: oauthDeviceComplete(name, cfg, auth)}
+		path := firstString(configPath)
+		if err := preflightOAuthProviderConfig(path, name); err != nil {
+			return providerWizardOAuthMsg{providerID: name, attemptID: attemptID, tokenLogin: true, err: err}
+		}
+		return providerWizardOAuthMsg{providerID: name, attemptID: attemptID, tokenLogin: true, err: oauthDeviceComplete(name, cfg, auth, path)}
 	}
 }
 
@@ -330,7 +368,7 @@ func (m model) startProviderDeviceLogin() (model, tea.Cmd) {
 		return m, nil
 	}
 	attemptID := m.providerWizard.beginOAuthAttempt(true)
-	return m, providerWizardDevicePrepareCmd(provider.ID, attemptID)
+	return m, providerWizardDevicePrepareCmd(provider.ID, attemptID, m.userConfigPath)
 }
 
 const maxProviderWizardProvidersVisible = 10
@@ -968,7 +1006,7 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 			if providerWizardSupportsOAuth(m.providerWizard.currentProvider()) {
 				provider := m.providerWizard.currentProvider()
 				attemptID := m.providerWizard.beginOAuthAttempt(false)
-				return m, providerWizardOAuthCmdFor(provider, attemptID)
+				return m, providerWizardOAuthCmdFor(provider, attemptID, m.userConfigPath)
 			}
 			return m, nil
 		case keyText(msg) != "":
@@ -1261,6 +1299,24 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 		nextProvider = built
 	}
 	if strings.TrimSpace(m.userConfigPath) != "" {
+		// A catalog-default name yields to the row that already owns that catalog
+		// identity, matching the CLI login path; a user-chosen name still collides.
+		adopted, adoptErr := config.AdoptPersistedCatalogProviderName(m.userConfigPath, profile)
+		if adoptErr != nil {
+			wizard.err = adoptErr.Error()
+			if provider.OAuthMintsKey && strings.TrimSpace(wizard.apiKey) != "" {
+				wizard.err = oauthMintedKeySaveError(wizard.err, wizard.apiKey)
+			}
+			return m, nil
+		}
+		profile = adopted
+		if err := config.PreflightProviderWrite(m.userConfigPath, profile.Name); err != nil {
+			wizard.err = err.Error()
+			if provider.OAuthMintsKey && strings.TrimSpace(wizard.apiKey) != "" {
+				wizard.err = oauthMintedKeySaveError(wizard.err, wizard.apiKey)
+			}
+			return m, nil
+		}
 		// Capture flip: move the freshly entered key into the encrypted credential
 		// store before persisting, so config.json never holds the cleartext. The
 		// provider was already built above from runtimeProfile, which has the key.
@@ -1270,6 +1326,9 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 		}
 		if _, err := config.UpsertProvider(m.userConfigPath, profile, true); err != nil {
 			wizard.err = redaction.RedactString(err.Error(), redaction.Options{ExtraSecretValues: []string{secret, profile.APIKey}})
+			if provider.OAuthMintsKey && strings.TrimSpace(secret) != "" {
+				wizard.err = oauthMintedKeySaveError(wizard.err, secret)
+			}
 			return m, nil // nothing committed to live state yet
 		}
 	}
@@ -1295,21 +1354,38 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 	return m, nil
 }
 
-// wizardProviderStoredKey reports the saved provider name that has a key in the
-// credential store matching the wizard-selected descriptor, so the wizard can offer
-// keep/replace/remove instead of forcing a new key entry.
-func (m model) wizardProviderStoredKey(provider providercatalog.Descriptor) (string, bool) {
+// wizardProviderStoredKey reports the persisted profile whose stored key belongs
+// to the wizard-selected catalog descriptor. An exactly named positive owner wins;
+// otherwise a catalog id must identify one row, never an arbitrary file-order
+// winner among shared catalog profiles.
+func (m model) wizardProviderStoredKey(provider providercatalog.Descriptor) (string, bool, error) {
+	providerID := strings.TrimSpace(provider.ID)
+	var owner config.ProviderProfile
+	owners := 0
 	for _, profile := range m.savedProviders {
-		if !profile.APIKeyStored {
+		profileCatalogID := strings.TrimSpace(profile.CatalogID)
+		if profileCatalogID == "" || !config.SameProviderIdentity(profileCatalogID, providerID) {
+			if config.SameProviderIdentity(profile.Name, providerID) {
+				return "", false, fmt.Errorf("saved profile %q does not prove ownership of catalog provider %q (catalogId is %q)", strings.TrimSpace(profile.Name), providerID, profileCatalogID)
+			}
 			continue
 		}
-		if strings.EqualFold(strings.TrimSpace(profile.Name), strings.TrimSpace(provider.Name)) ||
-			strings.EqualFold(strings.TrimSpace(profile.CatalogID), strings.TrimSpace(provider.ID)) ||
-			strings.EqualFold(strings.TrimSpace(profile.Name), strings.TrimSpace(provider.ID)) {
-			return profile.Name, true
+		if strings.TrimSpace(profile.Name) == providerID {
+			if profile.APIKeyStored {
+				return profile.Name, true, nil
+			}
+			return "", false, nil
 		}
+		owner = profile
+		owners++
 	}
-	return "", false
+	if owners > 1 {
+		return "", false, fmt.Errorf("provider identity %q is ambiguous: %d saved profiles use it as a catalog id; manage the intended profile by its exact name", providerID, owners)
+	}
+	if owners == 1 && owner.APIKeyStored {
+		return owner.Name, true, nil
+	}
+	return "", false, nil
 }
 
 // applyManageKeyChoice acts on the keep/replace/remove selection. Keep closes the
@@ -1329,12 +1405,39 @@ func (m model) applyManageKeyChoice() (model, tea.Cmd) {
 		return m, nil
 	case 2: // Remove
 		if strings.TrimSpace(m.userConfigPath) != "" {
-			if store, err := config.ProviderKeyStoreAt(filepath.Dir(m.userConfigPath)); err == nil {
-				_, _ = store.Delete(name)
+			if err := config.PreflightUserConfig(m.userConfigPath); err != nil {
+				wizard.err = err.Error()
+				return m, nil
 			}
-			_, _ = config.ClearProviderKeyStored(m.userConfigPath, name)
+			credentialCandidates, _, err := config.ProviderCredentialCandidates(m.userConfigPath, name)
+			if err != nil {
+				wizard.err = err.Error()
+				return m, nil
+			}
+			store, err := config.ProviderKeyStoreAt(filepath.Dir(m.userConfigPath))
+			if err != nil {
+				wizard.err = "remove stored key: " + err.Error()
+				return m, nil
+			}
+			for _, candidate := range credentialCandidates {
+				if _, err := store.Delete(candidate); err != nil {
+					wizard.err = "remove stored key: " + err.Error()
+					return m, nil
+				}
+			}
+			// The credential store keys secrets case-folded, so a case-variant
+			// sibling row (e.g. "work" beside the deleted key's "WORK") pointed at
+			// the same now-gone entry — clear the marker on every folded match,
+			// not just the exact row the user picked.
+			if _, err := config.ClearProviderKeyStoredCaseVariants(m.userConfigPath, name); err != nil {
+				wizard.err = "stored key removed, but its config marker could not be cleared: " + err.Error()
+				return m, nil
+			}
 		} else {
-			_, _ = config.ForgetProviderKey(name)
+			if _, err := config.ForgetProviderKey(name); err != nil {
+				wizard.err = "remove stored key: " + err.Error()
+				return m, nil
+			}
 		}
 		m.providerWizard = nil
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Provider\nRemoved the stored key for " + name + ". Re-add it any time with /provider."})

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1299,38 +1299,27 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 		nextProvider = built
 	}
 	if strings.TrimSpace(m.userConfigPath) != "" {
-		// A catalog-default name yields to the row that already owns that catalog
-		// identity, matching the CLI login path; a user-chosen name still collides.
-		adopted, adoptErr := config.AdoptPersistedCatalogProviderName(m.userConfigPath, profile)
-		if adoptErr != nil {
-			wizard.err = adoptErr.Error()
-			if provider.OAuthMintsKey && strings.TrimSpace(wizard.apiKey) != "" {
-				wizard.err = oauthMintedKeySaveError(wizard.err, wizard.apiKey)
-			}
-			return m, nil
-		}
-		profile = adopted
-		if err := config.PreflightProviderWrite(m.userConfigPath, profile.Name); err != nil {
-			wizard.err = err.Error()
-			if provider.OAuthMintsKey && strings.TrimSpace(wizard.apiKey) != "" {
-				wizard.err = oauthMintedKeySaveError(wizard.err, wizard.apiKey)
-			}
-			return m, nil
-		}
-		// Capture flip: move the freshly entered key into the encrypted credential
-		// store before persisting, so config.json never holds the cleartext. The
-		// provider was already built above from runtimeProfile, which has the key.
+		// One serialized transaction, matching the CLI login path: a catalog-default
+		// name yields to the row that already owns that catalog identity (a
+		// user-chosen name still collides), the capture flip moves the freshly
+		// entered key into the encrypted credential store so config.json never holds
+		// the cleartext, and the row is persisted. A rejected write restores the
+		// credential entry the capture displaced. The provider was already built
+		// above from runtimeProfile, which has the key.
 		secret := profile.APIKey
-		if !preserveExistingCredentialReference {
-			profile = config.SecureProviderProfile(profile, m.userConfigPath)
-		}
-		if _, err := config.UpsertProvider(m.userConfigPath, profile, true); err != nil {
+		committed, err := config.CommitProviderProfile(m.userConfigPath, config.ProviderCommit{
+			Profile:       profile,
+			SetActive:     true,
+			KeepStoredKey: preserveExistingCredentialReference,
+		})
+		if err != nil {
 			wizard.err = redaction.RedactString(err.Error(), redaction.Options{ExtraSecretValues: []string{secret, profile.APIKey}})
 			if provider.OAuthMintsKey && strings.TrimSpace(secret) != "" {
 				wizard.err = oauthMintedKeySaveError(wizard.err, secret)
 			}
 			return m, nil // nothing committed to live state yet
 		}
+		profile = committed.Persisted
 	}
 
 	// Both succeeded — commit the live provider, profile, model, and the child

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -48,7 +48,7 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 			return m.startProviderDeviceLogin()
 		}
 		attemptID := m.providerWizard.beginOAuthAttempt(false)
-		return m, providerWizardOAuthCmdFor(provider, attemptID)
+		return m, providerWizardOAuthCmdFor(provider, attemptID, m.userConfigPath)
 	}
 	// A non-OAuth provider that already has a key in the credential store: offer
 	// keep/replace/remove before re-entering credentials.
@@ -65,7 +65,10 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 			m.providerWizard.enterAimlapi()
 			return m, nil
 		}
-		if name, ok := m.wizardProviderStoredKey(m.providerWizard.currentProvider()); ok {
+		if name, ok, err := m.wizardProviderStoredKey(m.providerWizard.currentProvider()); err != nil {
+			m.providerWizard.err = err.Error()
+			return m, nil
+		} else if ok {
 			// Generic/custom providers (custom-openai-compatible etc.) all share
 			// the same CatalogID — matching on CatalogID would block creating a
 			// second instance. Skip ManageKey and fall through to the shared
@@ -99,7 +102,7 @@ func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, b
 	activeName := strings.TrimSpace(m.providerProfile.Name)
 	if activeName != "" {
 		for index, profile := range profiles {
-			if strings.EqualFold(strings.TrimSpace(profile.Name), activeName) && aimlapiProfile(profile) {
+			if strings.TrimSpace(profile.Name) == activeName && aimlapiProfile(profile) {
 				profiles[0], profiles[index] = profiles[index], profiles[0]
 				break
 			}
@@ -151,8 +154,8 @@ func (m model) existingAimlapiConfiguration() (config.ProviderProfile, string, b
 }
 
 func aimlapiProfile(profile config.ProviderProfile) bool {
-	return strings.EqualFold(strings.TrimSpace(profile.CatalogID), "aimlapi") ||
-		strings.EqualFold(strings.TrimSpace(profile.Name), "aimlapi")
+	return strings.TrimSpace(profile.CatalogID) != "" &&
+		config.SameProviderIdentity(profile.CatalogID, "aimlapi")
 }
 
 func (m model) checkExistingAimlapiBalance() (model, tea.Cmd) {

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -364,6 +364,39 @@ func TestApplyProviderWizardOAuthIgnoresStaleAttempt(t *testing.T) {
 	}
 }
 
+func TestProviderWizardSurfacesMintedOpenRouterKeyWhenSaveFails(t *testing.T) {
+	const mintedKey = "sk-or-wizard-recovery"
+	m := wizardModelAt(t, "openrouter", providerWizardStepDone)
+	m.providerWizard.oauthMode = true
+	m.providerWizard.apiKey = mintedKey
+	m.userConfigPath = t.TempDir() // A directory cannot be read as config.json.
+
+	next, _ := m.applyProviderWizard()
+	if !strings.Contains(next.providerWizard.err, mintedKey) || !strings.Contains(next.providerWizard.err, "was not saved") {
+		t.Fatalf("wizard error = %q, want minted-key recovery", next.providerWizard.err)
+	}
+}
+
+func TestProviderWizardDevicePreparePreflightsConfigBeforeRequestingCode(t *testing.T) {
+	msg := providerWizardDevicePrepareCmd("xai", 42, t.TempDir())().(providerWizardDeviceCodeMsg)
+	if msg.err == nil {
+		t.Fatal("device-code preparation should reject an unreadable config before requesting a code")
+	}
+	if msg.attemptID != 42 {
+		t.Fatalf("attemptID = %d, want 42", msg.attemptID)
+	}
+}
+
+func TestOAuthPreflightRequiresPositiveCatalogOwnership(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"providers":[{"name":"OpenRouter","catalogId":"custom-openai-compatible"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := preflightOAuthProviderConfig(path, "openrouter"); err == nil || !strings.Contains(err.Error(), "does not prove ownership") {
+		t.Fatalf("preflight error = %v, want ownership rejection", err)
+	}
+}
+
 func TestProviderWizardDeviceCodeIgnoresStaleAttempt(t *testing.T) {
 	m := mouseTestModel()
 	m.providerWizard = m.newProviderWizard()

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1119,16 +1119,34 @@ func providerWizardModelIDs(models []providerWizardModel) []string {
 func TestWizardProviderStoredKey(t *testing.T) {
 	m := model{savedProviders: []config.ProviderProfile{
 		{Name: "acme", CatalogID: "acme-cloud", APIKeyStored: true},
-		{Name: "nokey"},
+		{Name: "nokey", CatalogID: "nokey"},
 	}}
-	if name, ok := m.wizardProviderStoredKey(providercatalog.Descriptor{Name: "acme"}); !ok || name != "acme" {
-		t.Fatalf("match by name = %q,%v", name, ok)
+	if name, ok, err := m.wizardProviderStoredKey(providercatalog.Descriptor{ID: "acme-cloud"}); err != nil || !ok || name != "acme" {
+		t.Fatalf("match by catalog id = %q,%v,%v", name, ok, err)
 	}
-	if name, ok := m.wizardProviderStoredKey(providercatalog.Descriptor{ID: "acme-cloud"}); !ok || name != "acme" {
-		t.Fatalf("match by catalog id = %q,%v", name, ok)
+	if _, ok, err := m.wizardProviderStoredKey(providercatalog.Descriptor{ID: "nokey"}); err != nil || ok {
+		t.Fatalf("provider without a stored key matched: ok=%v err=%v", ok, err)
 	}
-	if _, ok := m.wizardProviderStoredKey(providercatalog.Descriptor{Name: "nokey"}); ok {
-		t.Fatal("provider without a stored key must not match")
+	if _, _, err := (model{savedProviders: []config.ProviderProfile{{Name: "OpenRouter", CatalogID: "custom-openai-compatible", APIKeyStored: true}}}).wizardProviderStoredKey(providercatalog.Descriptor{ID: "openrouter", Name: "OpenRouter"}); err == nil {
+		t.Fatal("a matching display name must report that it does not own the catalog provider")
+	}
+	if _, ok, err := (model{savedProviders: []config.ProviderProfile{{Name: "s", APIKeyStored: true}}}).wizardProviderStoredKey(providercatalog.Descriptor{ID: "ſ", Name: "ſ"}); err != nil || ok {
+		t.Fatal("Unicode long-s must not reuse the distinct s profile's key")
+	}
+
+	exact := model{savedProviders: []config.ProviderProfile{
+		{Name: "work-xai", CatalogID: "xai", APIKeyStored: true},
+		{Name: "xai", CatalogID: "xai", APIKeyStored: true},
+	}}
+	if name, ok, err := exact.wizardProviderStoredKey(providercatalog.Descriptor{ID: "xai"}); err != nil || !ok || name != "xai" {
+		t.Fatalf("exact catalog owner must win: name=%q ok=%v err=%v", name, ok, err)
+	}
+	ambiguous := model{savedProviders: []config.ProviderProfile{
+		{Name: "work-xai", CatalogID: "xai", APIKeyStored: true},
+		{Name: "personal-xai", CatalogID: "xai", APIKeyStored: true},
+	}}
+	if _, _, err := ambiguous.wizardProviderStoredKey(providercatalog.Descriptor{ID: "xai"}); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("shared catalog owners error = %v, want ambiguity", err)
 	}
 }
 
@@ -1138,14 +1156,14 @@ func TestProviderWizardManageKeyRemove(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"acme","apiKeyStored":true}]}`), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte(`{"providers":[{"name":"acme","catalogId":"acme-cloud","apiKeyStored":true}]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	store, err := config.ProviderKeyStoreAt(filepath.Dir(configPath))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Set("acme", "sk-secret"); err != nil {
+	if err := store.Set("acme-cloud", "sk-secret"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1155,8 +1173,8 @@ func TestProviderWizardManageKeyRemove(t *testing.T) {
 	if next.providerWizard != nil {
 		t.Fatal("remove should close the wizard")
 	}
-	if _, ok, _ := store.Get("acme"); ok {
-		t.Fatal("remove should delete the key from the credential store")
+	if _, ok, _ := store.Get("acme-cloud"); ok {
+		t.Fatal("remove should delete the catalog-alias key from the credential store")
 	}
 }
 
@@ -1417,6 +1435,18 @@ func TestExistingAimlapiConfigurationSkipsCustomEndpointCredential(t *testing.T)
 	}
 }
 
+func TestExistingAimlapiConfigurationRequiresCatalogOwnership(t *testing.T) {
+	t.Setenv("AIMLAPI_API_KEY", "")
+	m := model{savedProviders: []config.ProviderProfile{{
+		Name: "aimlapi", BaseURL: "https://api.aimlapi.com/v1", APIKey: "foreign-secret",
+	}}}
+
+	profile, runtimeKey, ok := m.existingAimlapiConfiguration()
+	if ok || profile.Name != "" || runtimeKey != "" {
+		t.Fatalf("name-only profile was treated as AIMLAPI-owned: (%+v, %q, %v)", profile, runtimeKey, ok)
+	}
+}
+
 func TestAdvanceAimlapiWithExistingCredentialShowsConfiguredPreflight(t *testing.T) {
 	t.Setenv("AIMLAPI_API_KEY", "aimlapi-env-secret")
 	provider, err := providercatalog.Require("aimlapi")
@@ -1594,6 +1624,42 @@ func TestApplyProviderWizardExportsActiveProviderEnv(t *testing.T) {
 	}
 	if got := os.Getenv(config.ActiveProviderEnv); got != next.providerName {
 		t.Fatalf("%s = %q after wizard apply, want %q (children would spawn on the stale provider)", config.ActiveProviderEnv, got, next.providerName)
+	}
+}
+
+func TestApplyProviderWizardRejectsExactNameWithoutCatalogOwnership(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	original := config.FileConfig{Providers: []config.ProviderProfile{{
+		Name: "openrouter", CatalogID: "custom-openai-compatible",
+		ProviderKind: config.ProviderKindOpenAICompatible, BaseURL: "https://corp.example/v1",
+		Model: "corp-model", APIKeyStored: true,
+	}}}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := providercatalog.Require("openrouter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := newModel(context.Background(), Options{})
+	m.userConfigPath = configPath
+	m.newProvider = func(config.ProviderProfile) (zeroruntime.Provider, error) { return &fakeProvider{}, nil }
+	m.providerWizard = &providerWizardState{
+		step: providerWizardStepModel, providers: []providercatalog.Descriptor{descriptor},
+		models: []providerWizardModel{{ID: descriptor.DefaultModel}},
+	}
+
+	next, _ := m.applyProviderWizard()
+	if next.providerWizard == nil || !strings.Contains(next.providerWizard.err, "does not prove ownership") {
+		t.Fatalf("wizard error = %q, want ownership rejection", next.providerWizard.err)
+	}
+	after := readProviderWizardConfigFixture(t, configPath)
+	if len(after.Providers) != 1 || after.Providers[0].CatalogID != "custom-openai-compatible" || after.Providers[0].BaseURL != "https://corp.example/v1" || after.Providers[0].Model != "corp-model" || !after.Providers[0].APIKeyStored {
+		t.Fatalf("foreign exact-name profile changed: %+v", after.Providers)
 	}
 }
 


### PR DESCRIPTION
## Summary
- report when `ZERO_PROVIDER` overrides a provider saved by `providers use`, including resolved, deferred, unresolvable, and unrelated config-error outcomes
- expose whether provider-list entries are selectable from user config or come from the fully resolved runtime configuration
- use exact persisted names for config mutations while using the credential store's normalized identity consistently for collision, cleanup, and session decisions
- centralize OAuth/API-key credential candidates across status, refresh, logout, CLI removal, and TUI key cleanup without deleting shared catalog credentials
- require positive `catalogId` ownership for catalog setup/login/persistence and reject ambiguous shared catalog IDs instead of adopting by name or file order
- keep TUI live provider state and `ZERO_PROVIDER` synchronized for case-only renames without retargeting case-variant project providers

## Validation
- `make fmt-check`
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `make lint-static` (0 issues)
- `make vulncheck` (no vulnerabilities found)
- `git diff HEAD --check`

Fixes #721