### PR TITLE
docs(community): wire Discussions as the front door for questions and ideas

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Questions and setup help
+    url: https://github.com/Gitlawb/zero/discussions/categories/q-a
+    about: Ask in Discussions Q&A. Include zero --version, your OS, provider/model, and zero doctor output for setup problems.
+  - name: Feature ideas
+    url: https://github.com/Gitlawb/zero/discussions/categories/ideas
+    about: Propose and discuss ideas in Discussions before opening a PR (Zero is in controlled development, see CONTRIBUTING.md).
   - name: Security vulnerability
     url: https://github.com/Gitlawb/zero/security/advisories/new
     about: Report security issues privately via GitHub Security Advisories (see SECURITY.md). Do not file a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,22 @@
-name: Feature request
-description: Propose a new capability or change
+name: Feature request (previously discussed)
+description: File only after your idea gained traction in Discussions Ideas or a maintainer asked for a tracking issue
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Please do not begin implementation until the issue has been reviewed and marked with the
+        New feature ideas start in [Discussions Ideas](https://github.com/Gitlawb/zero/discussions/categories/ideas),
+        not here. This form is for the step after that: an idea that gained traction in Discussions,
+        or one a maintainer asked to have tracked as an issue. Please link the discussion below.
+        Do not begin implementation until the issue has been reviewed and marked with the
         `issue-approved` label (see CONTRIBUTING.md).
+  - type: input
+    id: discussion
+    attributes:
+      label: Ideas discussion
+      description: Link to the Discussions Ideas thread (or note which maintainer asked for this issue).
+    validations:
+      required: true
   - type: textarea
     id: problem
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,13 @@ stabilizes. Community participation is still welcome, especially through bug
 reports, feature requests, reproduction details, logs, and discussion on existing
 issues.
 
+Questions and setup help belong in
+[GitHub Discussions](https://github.com/Gitlawb/zero/discussions) (see
+[SUPPORT.md](SUPPORT.md)), not in the issue tracker. Feature ideas start in the
+[Ideas](https://github.com/Gitlawb/zero/discussions/categories/ideas) category;
+an idea that gains traction there is also the natural path to an
+`issue-approved` issue.
+
 Please read this policy before opening a pull request. Pull requests that do not
 follow it may be closed without review.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ Questions and setup help belong in
 [GitHub Discussions](https://github.com/Gitlawb/zero/discussions) (see
 [SUPPORT.md](SUPPORT.md)), not in the issue tracker. Feature ideas start in the
 [Ideas](https://github.com/Gitlawb/zero/discussions/categories/ideas) category;
-an idea that gains traction there is also the natural path to an
-`issue-approved` issue.
+an idea that gains traction there is the path to an approved issue and,
+eventually, an accepted PR.
 
 Please read this policy before opening a pull request. Pull requests that do not
 follow it may be closed without review.
@@ -40,7 +40,11 @@ unless the issue has been explicitly approved for outside contribution.
 There are three primary ways to contribute:
 
 1. Open a bug report with clear reproduction steps.
-2. Open a feature request describing the problem, use case, and expected behavior.
+2. Propose a feature in
+   [Discussions Ideas](https://github.com/Gitlawb/zero/discussions/categories/ideas),
+   describing the problem, use case, and expected behavior. A feature-request
+   issue is filed only after the idea gains traction there or a maintainer asks
+   for one.
 3. Add useful context to an existing issue, such as logs, screenshots, examples,
    affected versions, or reproduction cases.
 
@@ -53,7 +57,8 @@ All community pull requests require an approved parent issue.
 
 Before starting implementation work:
 
-1. Open an issue using the appropriate issue template.
+1. For a bug, open an issue using the bug-report template. For a feature, start
+   in Discussions Ideas; the feature-request issue comes after the discussion.
 2. Describe the bug, feature request, or functional change clearly.
 3. Wait for the core team to review the issue.
 4. Do not open a pull request unless the issue has the `issue-approved` label.
@@ -140,7 +145,12 @@ Clear bug reports are the most useful way to help the project during this phase.
 
 ## Submitting a Feature Request
 
-When filing a feature request, please include:
+Feature requests start as a thread in
+[Discussions Ideas](https://github.com/Gitlawb/zero/discussions/categories/ideas),
+not as an issue. The feature-request issue form exists for the step AFTER that:
+when an idea has gained traction in Discussions or a maintainer has asked for an
+issue to track it. Whether in the discussion or the eventual issue, please
+include:
 
 - The problem you are trying to solve.
 - The behavior or functionality you are requesting.
@@ -163,5 +173,9 @@ contribution phase.
 
 ## Getting Help
 
-If you are unsure whether a change is appropriate, open an issue first and ask.
-Please keep discussion focused, specific, and respectful of maintainer time.
+General questions, setup help, and "is this a bug or my config" uncertainty all
+go to
+[Discussions Q&A](https://github.com/Gitlawb/zero/discussions/categories/q-a).
+If you are unsure whether a proposed code change is appropriate, raise it in
+Discussions Ideas or on the relevant issue first and ask. Please keep discussion
+focused, specific, and respectful of maintainer time.

--- a/README.md
+++ b/README.md
@@ -396,6 +396,24 @@ go run ./cmd/zero-release build --goos windows --goarch amd64 --output dist/zero
 - [Performance](docs/PERFORMANCE.md)
 - [Agent evals](docs/AGENT_EVALS.md)
 
+## Community
+
+Questions, setup help, ideas, and sharing all live in
+[GitHub Discussions](https://github.com/Gitlawb/zero/discussions):
+
+| Category | Use it for |
+|---|---|
+| [Q&A](https://github.com/Gitlawb/zero/discussions/categories/q-a) | Setup help, provider/model configuration, "how do I" questions |
+| [Ideas](https://github.com/Gitlawb/zero/discussions/categories/ideas) | Feature proposals and design discussion before any PR |
+| [Show and tell](https://github.com/Gitlawb/zero/discussions/categories/show-and-tell) | Your skills, plugins, MCP setups, themes, and workflows |
+| [Announcements](https://github.com/Gitlawb/zero/discussions/categories/announcements) | Releases and project news from the maintainers |
+
+For a good Q&A answer fast, include `zero --version`, your OS and install
+method, the provider/model in use, and `zero doctor` output. See
+[SUPPORT.md](SUPPORT.md). Bugs belong in
+[issues](https://github.com/Gitlawb/zero/issues/new/choose); security reports
+follow [SECURITY.md](SECURITY.md), never a public thread.
+
 ## Contributing
 
 Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md), run the

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,36 @@
+# Getting help with Zero
+
+## Questions, setup help, configuration
+
+Ask in [GitHub Discussions](https://github.com/Gitlawb/zero/discussions). Use
+[Q&A](https://github.com/Gitlawb/zero/discussions/categories/q-a) so answers can
+be marked and found by the next person.
+
+The fastest way to a useful answer is to include:
+
+- `zero --version` output
+- your OS (Windows, macOS, Linux) and how you installed Zero (npm, install
+  script, source)
+- the provider and model you are using (`zero providers list`)
+- `zero doctor` output for setup problems
+- the exact command you ran and the exact error text
+
+## Bugs
+
+If Zero does something wrong (crashes, wrong output, broken behavior), file a
+[bug report](https://github.com/Gitlawb/zero/issues/new/choose). If you are not
+sure whether it is a bug or a setup problem, start in Discussions and we will
+promote it to an issue if it is one.
+
+## Feature ideas
+
+Start a thread in
+[Ideas](https://github.com/Gitlawb/zero/discussions/categories/ideas). Zero is
+in controlled development (see CONTRIBUTING.md), so discussing an idea first is
+also the path to getting a PR accepted.
+
+## Security issues
+
+Never file a public issue or discussion. Report privately via
+[GitHub Security Advisories](https://github.com/Gitlawb/zero/security/advisories/new)
+(see SECURITY.md).


### PR DESCRIPTION
Sets up the community entry points so Discussions actually gets used instead of the issue tracker filling with questions.

- New SUPPORT.md: where to ask, and exactly what to include for a fast answer (zero --version, OS and install method, provider/model, zero doctor output). GitHub surfaces this file automatically when people open issues.
- Issue chooser (config.yml) now routes questions to Discussions Q&A and feature ideas to the Ideas category, alongside the existing private security link. Blank issues stay disabled, so the tracker stays for actionable bugs.
- README gains a Community section with a what-goes-where table for the four categories.
- CONTRIBUTING points questions at Discussions and frames Ideas as the natural path toward an issue-approved issue, matching the controlled-development policy.

Docs only, no code. No performance change expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `SUPPORT.md` with guidance for getting help, reporting bugs, proposing feature ideas, and handling security issues.
  * Updated `README.md` “Community” section with clear GitHub Discussions category guidance (Q&A, Ideas, Show and tell, Announcements) and posting tips.
  * Revised `CONTRIBUTING.md` to route questions and setup help to Discussions and to start feature ideas in the Ideas category before creating trackable work.
  * Updated issue/feature request templates to encourage prior discussion and to capture a related Discussions thread link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->