### PR TITLE
oauth: reject redirects for token endpoint requests

### DIFF
--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -163,6 +163,9 @@ func PostToken(ctx context.Context, client *http.Client, tokenEndpoint string, f
 	if client == nil {
 		client = http.DefaultClient
 	}
+
+	tokenClient := *client
+	tokenClient.CheckRedirect = checkTokenRedirect
 	if now == nil {
 		now = time.Now
 	}
@@ -173,7 +176,7 @@ func PostToken(ctx context.Context, client *http.Client, tokenEndpoint string, f
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("Accept", "application/json")
 
-	response, err := client.Do(request)
+	response, err := tokenClient.Do(request)
 	if err != nil {
 		return Token{}, fmt.Errorf("oauth: token request failed: %w", err)
 	}
@@ -220,4 +223,8 @@ func PostToken(ctx context.Context, client *http.Client, tokenEndpoint string, f
 		token.IDToken = parsed.IDToken
 	}
 	return token, nil
+}
+
+func checkTokenRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
 }

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -188,6 +188,79 @@ func TestPostTokenRefusesInsecureEndpoint(t *testing.T) {
 		t.Fatalf("err = %v, want ErrInsecureTokenEndpoint", err)
 	}
 }
+func TestExchangeCodeRejects307Redirect(t *testing.T) {
+	var attackerHit bool
+
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerHit = true
+		t.Errorf("redirect target received unexpected request")
+	}))
+	defer attacker.Close()
+
+	redirect := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+
+	cfg := Config{
+		ClientID:      "c",
+		TokenEndpoint: redirect.URL,
+	}
+
+	_, err := ExchangeCode(
+		context.Background(),
+		redirect.Client(),
+		cfg,
+		"code",
+		"verifier",
+		"http://127.0.0.1/cb",
+		nil,
+	)
+
+	if err == nil {
+		t.Fatal("expected redirect error")
+	}
+
+	if attackerHit {
+		t.Fatal("redirect target received credential-bearing request")
+	}
+}
+
+func TestRefreshRejects308Redirect(t *testing.T) {
+	var attackerHit bool
+
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerHit = true
+		t.Errorf("redirect target received unexpected request")
+	}))
+	defer attacker.Close()
+
+	redirect := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL, http.StatusPermanentRedirect)
+	}))
+	defer redirect.Close()
+
+	cfg := Config{
+		ClientID:      "c",
+		TokenEndpoint: redirect.URL,
+	}
+
+	_, err := Refresh(
+		context.Background(),
+		redirect.Client(),
+		cfg,
+		Token{RefreshToken: "refresh-token"},
+		nil,
+	)
+
+	if err == nil {
+		t.Fatal("expected redirect error")
+	}
+
+	if attackerHit {
+		t.Fatal("redirect target received credential-bearing request")
+	}
+}
 
 func TestRefreshNoToken(t *testing.T) {
 	_, err := Refresh(context.Background(), http.DefaultClient, Config{TokenEndpoint: "https://a/token"}, Token{}, nil)


### PR DESCRIPTION
## Summary

This PR hardens OAuth token requests by rejecting HTTP redirects.

### Changes
- Clone the selected HTTP client before issuing token requests.
- Install a token-specific `CheckRedirect` policy to prevent following redirects.
- Use the cloned client when sending token requests.

### Tests
- Added a regression test for 307 redirects during authorization code exchange.
- Added a regression test for 308 redirects during token refresh.
- Verified that redirected endpoints do not receive credential-bearing requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth token security by preventing automatic redirects from token endpoints.
  * Token exchanges and refreshes now reject redirect responses without sending credentials to the redirected destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->