### PR TITLE
fix(oauth): validate discovered endpoints before merge/use (#511)

### DIFF
--- a/internal/mcp/oauth.go
+++ b/internal/mcp/oauth.go
@@ -133,6 +133,26 @@ func discoverAuthorizationServer(ctx context.Context, client *http.Client, baseU
 	}, nil
 }
 
+// validateResolvedEndpoints applies the shared https/loopback endpoint rule to
+// every non-empty endpoint in the resolved metadata — configured or discovered
+// alike — so discovery metadata can never downgrade an MCP login to an insecure
+// or attacker-controlled authorization, token, or registration endpoint.
+func validateResolvedEndpoints(metadata authServerMetadata) error {
+	for _, ep := range []struct{ kind, url string }{
+		{"authorization", metadata.AuthorizationEndpoint},
+		{"token", metadata.TokenEndpoint},
+		{"registration", metadata.RegistrationEndpoint},
+	} {
+		if strings.TrimSpace(ep.url) == "" {
+			continue
+		}
+		if err := oauth.ValidateEndpointURL(ep.url); err != nil {
+			return fmt.Errorf("mcp oauth: %s endpoint: %w", ep.kind, err)
+		}
+	}
+	return nil
+}
+
 // resolveAuthorizationServer discovers metadata and applies explicit config
 // overrides. Configured endpoints take precedence over discovered ones, and act
 // as a fallback when discovery fails or omits a value.
@@ -147,6 +167,9 @@ func resolveAuthorizationServer(ctx context.Context, client *http.Client, baseUR
 			AuthorizationEndpoint: strings.TrimSpace(cfg.AuthorizationEndpoint),
 			TokenEndpoint:         strings.TrimSpace(cfg.TokenEndpoint),
 			RegistrationEndpoint:  strings.TrimSpace(cfg.RegistrationEndpoint),
+		}
+		if err := validateResolvedEndpoints(metadata); err != nil {
+			return authServerMetadata{}, err
 		}
 		return metadata, nil
 	}
@@ -178,6 +201,9 @@ func resolveAuthorizationServer(ctx context.Context, client *http.Client, baseUR
 	}
 	if strings.TrimSpace(metadata.TokenEndpoint) == "" {
 		return authServerMetadata{}, errors.New("no token endpoint discovered or configured")
+	}
+	if err := validateResolvedEndpoints(metadata); err != nil {
+		return authServerMetadata{}, err
 	}
 	return metadata, nil
 }

--- a/internal/mcp/oauth_test.go
+++ b/internal/mcp/oauth_test.go
@@ -73,6 +73,22 @@ func TestResolveEndpointsFallsBackToConfig(t *testing.T) {
 	}
 }
 
+// Discovered MCP metadata that serves an insecure endpoint must be rejected
+// before use, so discovery cannot downgrade the MCP login to an
+// attacker-controlled origin (issue #511).
+func TestResolveAuthorizationServerRejectsInsecureDiscovered(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"issuer":"` + server.URL + `","token_endpoint":"` + server.URL + `/token","authorization_endpoint":"http://evil.example/authorize"}`))
+	})
+	_, err := resolveAuthorizationServer(context.Background(), server.Client(), server.URL, OAuthConfig{})
+	if err == nil || !strings.Contains(err.Error(), "authorization endpoint") {
+		t.Fatalf("err = %v, want insecure authorization endpoint rejection", err)
+	}
+}
+
 // roundTripperFunc adapts a function to http.RoundTripper so a test can
 // observe every outbound request.
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -39,6 +39,13 @@ func BuildAuthorizationURL(cfg Config, pkce PKCE, state, redirectURI string, ext
 	if endpoint == "" {
 		return "", errors.New("oauth: no authorization endpoint configured")
 	}
+	// Backstop: validate the authorization endpoint at the shared choke point
+	// both the provider and MCP flows build their browser URL through, so a
+	// discovery-downgraded endpoint can never open in the browser even if a
+	// merge site missed it.
+	if err := ValidateEndpointURL(endpoint); err != nil {
+		return "", err
+	}
 	parsed, err := url.Parse(endpoint)
 	if err != nil {
 		return "", fmt.Errorf("oauth: parse authorization endpoint: %w", err)
@@ -83,13 +90,15 @@ func isReservedAuthParam(key string) bool {
 	}
 }
 
-// validateTokenEndpoint refuses to send a credential to a token endpoint that is
-// not https, unless it is a loopback host (mirrors oauth2-client.js
-// validateTokenEndpointURL). This prevents leaking codes/tokens over cleartext.
-func validateTokenEndpoint(endpoint string) error {
+// ValidateEndpointURL refuses an OAuth endpoint that is not https, unless it is
+// a loopback host (mirrors oauth2-client.js validateTokenEndpointURL). Every
+// credential-bearing endpoint — configured OR learned from discovery — must
+// pass this single rule, so discovery metadata can never downgrade a login to
+// cleartext or redirect it to an attacker-controlled http origin.
+func ValidateEndpointURL(endpoint string) error {
 	parsed, err := url.Parse(trimmed(endpoint))
 	if err != nil || parsed.Host == "" {
-		return fmt.Errorf("oauth: invalid token endpoint %q", endpoint)
+		return fmt.Errorf("oauth: invalid endpoint %q", endpoint)
 	}
 	if parsed.Scheme == "https" {
 		return nil
@@ -98,6 +107,13 @@ func validateTokenEndpoint(endpoint string) error {
 		return nil
 	}
 	return fmt.Errorf("%w: %s", ErrInsecureTokenEndpoint, parsed.Scheme+"://"+parsed.Host)
+}
+
+// validateTokenEndpoint checks a token endpoint against the shared endpoint rule
+// (kept as a named helper for the token-exchange and device call sites). This
+// prevents leaking codes/tokens over cleartext.
+func validateTokenEndpoint(endpoint string) error {
+	return ValidateEndpointURL(endpoint)
 }
 
 func isLoopbackHost(host string) bool {

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -112,6 +112,20 @@ func TestBuildAuthorizationURLRejectsPlain(t *testing.T) {
 	}
 }
 
+// The shared choke point both flows build their browser URL through must refuse
+// an insecure authorization endpoint, so a discovery-downgraded endpoint can
+// never open in the browser even if a merge site missed it (issue #511).
+func TestBuildAuthorizationURLRejectsInsecureEndpoint(t *testing.T) {
+	_, err := BuildAuthorizationURL(
+		Config{AuthorizationEndpoint: "http://evil.example/authorize", ClientID: "c"},
+		PKCE{Method: MethodS256, Challenge: "chal"},
+		"state", "http://127.0.0.1/cb", nil,
+	)
+	if !errors.Is(err, ErrInsecureTokenEndpoint) {
+		t.Fatalf("err = %v, want ErrInsecureTokenEndpoint", err)
+	}
+}
+
 func TestValidateTokenEndpoint(t *testing.T) {
 	cases := map[string]bool{
 		"https://auth.example.com/token": true,

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -218,13 +218,26 @@ func (m *Manager) resolveEndpoints(ctx context.Context, cfg Config) (Config, err
 	// may already be sufficient for the chosen flow. Only merge on success (and
 	// never return from the error branch, which would trip the nilerr linter).
 	if meta, err := m.discover(ctx, cfg.IssuerURL); err == nil {
-		if cfg.AuthorizationEndpoint == "" {
+		// A discovered endpoint must pass the same https/loopback rule as a
+		// configured one before it is merged, so discovery metadata can never
+		// silently downgrade the login to an insecure or attacker-controlled
+		// endpoint. Fail closed on a bad endpoint rather than merging it.
+		if cfg.AuthorizationEndpoint == "" && meta.AuthorizationEndpoint != "" {
+			if err := ValidateEndpointURL(meta.AuthorizationEndpoint); err != nil {
+				return cfg, fmt.Errorf("oauth: discovered authorization endpoint: %w", err)
+			}
 			cfg.AuthorizationEndpoint = meta.AuthorizationEndpoint
 		}
-		if cfg.TokenEndpoint == "" {
+		if cfg.TokenEndpoint == "" && meta.TokenEndpoint != "" {
+			if err := ValidateEndpointURL(meta.TokenEndpoint); err != nil {
+				return cfg, fmt.Errorf("oauth: discovered token endpoint: %w", err)
+			}
 			cfg.TokenEndpoint = meta.TokenEndpoint
 		}
-		if cfg.DeviceAuthorizationEndpoint == "" {
+		if cfg.DeviceAuthorizationEndpoint == "" && meta.DeviceAuthorizationEndpoint != "" {
+			if err := ValidateEndpointURL(meta.DeviceAuthorizationEndpoint); err != nil {
+				return cfg, fmt.Errorf("oauth: discovered device authorization endpoint: %w", err)
+			}
 			cfg.DeviceAuthorizationEndpoint = meta.DeviceAuthorizationEndpoint
 		}
 	}

--- a/internal/oauth/manager_test.go
+++ b/internal/oauth/manager_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -197,6 +198,24 @@ func TestManagerGetFreshDiscoversIssuerEndpoints(t *testing.T) {
 	}
 	if atomic.LoadInt32(&tokenHits) == 0 {
 		t.Fatal("token endpoint never hit — discovery/refresh did not run")
+	}
+}
+
+// A discovery document that serves an insecure (non-https, non-loopback)
+// endpoint must be rejected before it is merged, so discovery metadata cannot
+// silently downgrade the login to an attacker-controlled origin (issue #511).
+func TestResolveEndpointsRejectsInsecureDiscoveredEndpoint(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		// Loopback issuer, but an attacker-controlled http authorization endpoint.
+		_, _ = io.WriteString(w, `{"issuer":"`+server.URL+`","token_endpoint":"`+server.URL+`/token","authorization_endpoint":"http://evil.example/authorize"}`)
+	})
+	m := managerFor(t, map[string]string{}, nil)
+	_, err := m.resolveEndpoints(context.Background(), Config{IssuerURL: server.URL})
+	if !errors.Is(err, ErrInsecureTokenEndpoint) {
+		t.Fatalf("resolveEndpoints err = %v, want ErrInsecureTokenEndpoint", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #511.

Discovery-learned OAuth endpoints were merged and used **without** the https/loopback endpoint-safety rule that configured endpoints already pass. A malicious issuer's discovery document could therefore downgrade the authorization, token, device, or MCP registration endpoint *after* the provider config had already validated — silently redirecting the login to an attacker-controlled `http://` origin. This affects both the provider OAuth flow and the MCP OAuth flow (MCP delegates discovery to `internal/oauth`).

## Root cause

- `internal/oauth/providers.go` validates *configured* endpoints via `validateTokenEndpoint`, but `internal/oauth/manager.go` `resolveEndpoints` merged *discovered* endpoints with no revalidation.
- `internal/mcp/oauth.go` `resolveAuthorizationServer` likewise merged discovered MCP metadata without validation.
- `internal/oauth/flow.go` `BuildAuthorizationURL` parsed the authorization endpoint but never checked its scheme, so a downgraded endpoint reached the browser.

## Fix — defense in depth (3 layers)

1. **One shared rule.** New exported `oauth.ValidateEndpointURL` (https, or http on a loopback host); `validateTokenEndpoint` now delegates to it so configured and discovered endpoints share a single rule.
2. **Backstop at the choke point.** `BuildAuthorizationURL` validates the authorization endpoint. Both the provider loopback flow and the MCP flow build their browser URL through this function, so a downgraded endpoint can never open in the browser even if a merge site is missed.
3. **Validate before merge, fail closed.**
   - Provider: `resolveEndpoints` validates each discovered authorization / token / device endpoint before merging.
   - MCP: new `validateResolvedEndpoints` applied in **both** return branches of `resolveAuthorizationServer` (authorization / token / registration, configured and discovered alike).

## Scope

`internal/oauth` + `internal/mcp` only. No config schema change. No behavior change for valid endpoints — https and http-loopback logins are unaffected. **No performance change expected.**

## Testing

- **3 regression tests** — provider `resolveEndpoints`, MCP `resolveAuthorizationServer`, and the `BuildAuthorizationURL` backstop. Each was confirmed to **fail without the fix** (reverted the source, kept the tests) and pass with it; the pre-existing configured-endpoint test is unchanged.
- `go test -race ./internal/oauth/... ./internal/mcp/...` green. `go build ./...`, `go vet ./...`, `gofmt`, `govulncheck`, `git diff HEAD --check` all clean.
- **Manual end-to-end through the real CLI.** With a discovery document serving `authorization_endpoint: http://evil.example/authorize`, `zero auth login <provider>` now exits 1 with `refusing to send credential to a non-https token endpoint: http://evil.example` and **never opens the browser** — whereas unpatched `main` builds and opens that attacker URL. A legitimate https discovery login still succeeds (happy path intact).

## Follow-up

The paired hardening for #729 (token-endpoint redirect replay in `PostToken`) is a separate PR on the same files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * OAuth authorization, token, registration, and device-authorization endpoints now require HTTPS (HTTP allowed only for loopback).
  * Insecure endpoints from configuration or discovery are rejected before proceeding with OAuth flows.
  * Authorization URL building now validates the endpoint and won’t generate downgraded HTTP links.

* **Bug Fixes**
  * Discovery/endpoint resolution now validates discovered endpoint URLs and fails safely when invalid.

* **Tests**
  * Added coverage to ensure insecure discovered/configured endpoints are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->