### PR TITLE
fix(oauth): refuse redirects on credential POSTs (#729)

### DIFF
--- a/internal/oauth/device.go
+++ b/internal/oauth/device.go
@@ -49,9 +49,9 @@ func RequestDeviceCode(ctx context.Context, client *http.Client, cfg Config, now
 	if err := validateTokenEndpoint(endpoint); err != nil {
 		return DeviceAuth{}, err
 	}
-	if client == nil {
-		client = http.DefaultClient
-	}
+	// Refuse redirects so a device-authorization redirect can't replay the
+	// client_id/client_secret POST body to an unvalidated origin.
+	client = withoutRedirects(client)
 	if now == nil {
 		now = time.Now
 	}
@@ -157,9 +157,9 @@ func pollDeviceOnce(ctx context.Context, client *http.Client, cfg Config, device
 	if err := validateTokenEndpoint(cfg.TokenEndpoint); err != nil {
 		return Token{}, err
 	}
-	if client == nil {
-		client = http.DefaultClient
-	}
+	// Refuse redirects so a poll redirect can't replay the device_code/secret
+	// POST body to an unvalidated origin.
+	client = withoutRedirects(client)
 	form := url.Values{}
 	form.Set("grant_type", deviceGrantType)
 	form.Set("device_code", deviceCode)

--- a/internal/oauth/device_test.go
+++ b/internal/oauth/device_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,6 +26,30 @@ func TestRequestDeviceCodeSendsClientSecret(t *testing.T) {
 	}
 	if gotSecret != "shh" {
 		t.Fatalf("client_secret = %q, want shh", gotSecret)
+	}
+}
+
+func TestRequestDeviceCodeRefusesRedirect(t *testing.T) {
+	endpoint, hits := redirectTrap(t, http.StatusTemporaryRedirect) // 307
+	_, err := RequestDeviceCode(context.Background(), http.DefaultClient,
+		Config{ClientID: "c", ClientSecret: "shh", DeviceAuthorizationEndpoint: endpoint}, nil)
+	if !errors.Is(err, ErrUnsafeRedirect) {
+		t.Fatalf("RequestDeviceCode err = %v, want ErrUnsafeRedirect", err)
+	}
+	if n := hits(); n != 0 {
+		t.Fatalf("attacker received %d request(s) — client_secret replayed", n)
+	}
+}
+
+func TestPollDeviceOnceRefusesRedirect(t *testing.T) {
+	endpoint, hits := redirectTrap(t, http.StatusPermanentRedirect) // 308
+	_, err := pollDeviceOnce(context.Background(), http.DefaultClient,
+		Config{ClientID: "c", ClientSecret: "shh", TokenEndpoint: endpoint}, "device-code", nil)
+	if !errors.Is(err, ErrUnsafeRedirect) {
+		t.Fatalf("pollDeviceOnce err = %v, want ErrUnsafeRedirect", err)
+	}
+	if n := hits(); n != 0 {
+		t.Fatalf("attacker received %d request(s) — device_code/secret replayed", n)
 	}
 }
 

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -116,6 +116,23 @@ func validateTokenEndpoint(endpoint string) error {
 	return ValidateEndpointURL(endpoint)
 }
 
+// withoutRedirects returns a shallow copy of client whose redirect policy
+// refuses to follow ANY redirect. A credential-bearing OAuth POST (token
+// exchange/refresh, device authorization, device-token poll) must never let a
+// 307/308 replay its form body — codes, PKCE verifiers, refresh tokens, client
+// secrets — to a target that was never endpoint-validated. The caller's client
+// is left unmodified.
+func withoutRedirects(client *http.Client) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	copied := *client
+	copied.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return ErrUnsafeRedirect
+	}
+	return &copied
+}
+
 func isLoopbackHost(host string) bool {
 	if host == "localhost" {
 		return true
@@ -176,9 +193,9 @@ func PostToken(ctx context.Context, client *http.Client, tokenEndpoint string, f
 	if err := validateTokenEndpoint(tokenEndpoint); err != nil {
 		return Token{}, err
 	}
-	if client == nil {
-		client = http.DefaultClient
-	}
+	// Refuse redirects so a 307/308 from the token endpoint can't replay this
+	// credential-bearing POST body to another (unvalidated) origin.
+	client = withoutRedirects(client)
 	if now == nil {
 		now = time.Now
 	}

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -5,10 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -123,6 +125,64 @@ func TestBuildAuthorizationURLRejectsInsecureEndpoint(t *testing.T) {
 	)
 	if !errors.Is(err, ErrInsecureTokenEndpoint) {
 		t.Fatalf("err = %v, want ErrInsecureTokenEndpoint", err)
+	}
+}
+
+// redirectTrap starts an "attacker" server that counts any hit, and a credential
+// endpoint that redirects to it with the given status. It returns the endpoint
+// URL and a func reporting how many times the attacker was contacted — a
+// non-zero count means the credential-bearing POST body was replayed (#729).
+func redirectTrap(t *testing.T, status int) (endpoint string, attackerHits func() int32) {
+	t.Helper()
+	var hits int32
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = io.WriteString(w, `{"access_token":"leaked","refresh_token":"leaked"}`)
+	}))
+	t.Cleanup(attacker.Close)
+	endp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL, status)
+	}))
+	t.Cleanup(endp.Close)
+	return endp.URL, func() int32 { return atomic.LoadInt32(&hits) }
+}
+
+func TestPostTokenRefusesRedirect(t *testing.T) {
+	endpoint, hits := redirectTrap(t, http.StatusTemporaryRedirect) // 307
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "the-code")
+	form.Set("client_secret", "shh")
+	_, err := PostToken(context.Background(), http.DefaultClient, endpoint, form, Token{}, nil)
+	if !errors.Is(err, ErrUnsafeRedirect) {
+		t.Fatalf("PostToken err = %v, want ErrUnsafeRedirect", err)
+	}
+	if n := hits(); n != 0 {
+		t.Fatalf("attacker received %d request(s) — credential body was replayed", n)
+	}
+}
+
+func TestExchangeCodeRefusesRedirect(t *testing.T) {
+	endpoint, hits := redirectTrap(t, http.StatusPermanentRedirect) // 308
+	_, err := ExchangeCode(context.Background(), http.DefaultClient,
+		Config{ClientID: "c", TokenEndpoint: endpoint}, "the-code", "verifier", "http://127.0.0.1/cb", nil)
+	if !errors.Is(err, ErrUnsafeRedirect) {
+		t.Fatalf("ExchangeCode err = %v, want ErrUnsafeRedirect", err)
+	}
+	if n := hits(); n != 0 {
+		t.Fatalf("attacker received %d request(s) — code/verifier replayed", n)
+	}
+}
+
+func TestRefreshRefusesRedirect(t *testing.T) {
+	endpoint, hits := redirectTrap(t, http.StatusTemporaryRedirect) // 307
+	_, err := Refresh(context.Background(), http.DefaultClient,
+		Config{ClientID: "c", TokenEndpoint: endpoint}, Token{RefreshToken: "rt"}, nil)
+	if !errors.Is(err, ErrUnsafeRedirect) {
+		t.Fatalf("Refresh err = %v, want ErrUnsafeRedirect", err)
+	}
+	if n := hits(); n != 0 {
+		t.Fatalf("attacker received %d request(s) — refresh_token replayed", n)
 	}
 }
 

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -90,6 +90,11 @@ var (
 	// ErrInsecureTokenEndpoint is returned when a credential would be sent over a
 	// non-https, non-loopback endpoint.
 	ErrInsecureTokenEndpoint = errors.New("oauth: refusing to send credential to a non-https token endpoint")
+	// ErrUnsafeRedirect is returned when a credential-bearing OAuth POST (token
+	// exchange/refresh, device authorization, or device-token poll) is redirected.
+	// Following it would replay the form body — codes, PKCE verifiers, refresh
+	// tokens, client secrets — to a target that never passed endpoint validation.
+	ErrUnsafeRedirect = errors.New("oauth: refusing to follow a redirect from a credential endpoint")
 	// ErrNoRefreshToken is returned when a refresh is attempted without one.
 	ErrNoRefreshToken = errors.New("oauth: no refresh token available")
 	// ErrAuthorizationPending is the RFC 8628 "keep polling" signal.


### PR DESCRIPTION
## Summary

Closes #729.

OAuth token requests validated only the initial endpoint, then let the supplied or default `http.Client` follow a `307`/`308` redirect that **replays the POST body** — authorization codes, PKCE verifiers, refresh tokens, client secrets, client IDs — to another origin (or an HTTPS→HTTP downgrade) that never passed endpoint validation.

## Affected paths

- `internal/oauth/flow.go` `PostToken` — token exchange + refresh (and MCP OAuth login/refresh, which delegate to `oauth.ExchangeCode`/`oauth.Refresh`).
- `internal/oauth/device.go` `RequestDeviceCode` — the device authorization POST (`client_id` + `client_secret`).
- `internal/oauth/device.go` `pollDeviceOnce` — the device-token poll (`device_code` + `client_secret`).

## Fix

New `withoutRedirects(client)` returns a **shallow copy** of the client whose `CheckRedirect` refuses every redirect (`ErrUnsafeRedirect`). Applied at all three credential POSTs before `client.Do`. Because the copy is per-request, the caller's client is never mutated, and a legitimate token endpoint that returns `200` is unaffected (real token endpoints don't redirect).

## Scope

`internal/oauth` only. No config or API change. No behavior change for non-redirecting endpoints. No performance change expected.

## Testing

- 5 regression tests (`PostToken`, `ExchangeCode`, `Refresh`, `RequestDeviceCode`, `pollDeviceOnce`) using a redirect trap: a credential endpoint that `307`/`308`-redirects to an attacker server which counts hits. Each asserts the call returns `ErrUnsafeRedirect` **and the attacker receives zero requests** (the body was never replayed). All five were confirmed to **fail without the fix** (reverted the source, kept the tests).
- `go test -race ./internal/oauth/... ./internal/mcp/...` green. `go build ./...`, `go vet ./...`, `gofmt`, `govulncheck`, `git diff HEAD --check` all clean.
- **Manual end-to-end through the real CLI.** With a device endpoint that `307`-redirects to an attacker, `zero auth login <provider> --device` now fails with `refusing to follow a redirect from a credential endpoint` (exit 1) and the attacker server receives **0** requests — whereas unpatched `main` replays the `client_secret`-bearing POST (attacker hit) and proceeds.

## Related

Pairs with #511 (validate discovered endpoints) — the other half of the OAuth endpoint-safety hardening. Independent branch; no stacking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * OAuth credential-bearing requests now refuse temporary/permanent redirects to prevent sensitive form data from being replayed to unvalidated destinations.
  * Added a clear `ErrUnsafeRedirect` error surfaced when redirects are blocked for token exchange, refresh, device authorization, and device polling.
* **Tests**
  * Added coverage ensuring redirects are rejected and that no additional requests occur to confirm sensitive payloads are not replayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->