### PR TITLE
fix(sandbox): don't auto-allow shell when re-entrancy skips wrapping (#727)

### DIFF
--- a/internal/sandbox/auto_allow_bash_test.go
+++ b/internal/sandbox/auto_allow_bash_test.go
@@ -93,6 +93,40 @@ func TestSandboxedBashAutoAllowDoesNotAffectNonShell(t *testing.T) {
 	}
 }
 
+// Forged re-entrancy markers (ambient ZERO_SANDBOXED=1 + ZERO_SANDBOX_BACKEND at
+// an unsandboxed process boundary) must NOT let a shell command combine an
+// auto-allow decision with an unwrapped pass-through plan (issue #727). The
+// runner skips wrapping when the markers are present, so the policy must stop
+// auto-allowing on the basis of an "active sandbox" — the command takes the
+// normal prompt instead. Without the markers the identical setup auto-allows
+// (TestSandboxedBashAutoAllowedWhenSandboxActive), so this is the before/after.
+func TestForgedReentrancyMarkersDoNotAutoAllowUnwrappedShell(t *testing.T) {
+	t.Setenv(EnvSandboxed, "1")
+	t.Setenv(EnvSandboxBackend, string(BackendLinuxBwrap))
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        DefaultPolicy(),
+		Backend:       nativeWrappingBackend,
+	})
+
+	// Policy side: the shell command must NOT be auto-allowed.
+	decision := engine.Evaluate(context.Background(), bashRequest())
+	if decision.Action != ActionPrompt || decision.AutoAllowed {
+		t.Fatalf("forged markers must not auto-allow the shell command, got %#v", decision)
+	}
+
+	// Planning side: the same command is an unwrapped pass-through. Together with
+	// the prompt above, this proves auto-allow and unwrapped can no longer combine.
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "echo hi"}, Dir: root})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	if plan.Wrapped {
+		t.Fatalf("re-entrancy plan must be an unwrapped pass-through, got wrapped=%v", plan.Wrapped)
+	}
+}
+
 // TestShellSandboxActive reports correctly across backends and policy modes.
 func TestShellSandboxActive(t *testing.T) {
 	root := t.TempDir()

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -232,6 +232,15 @@ func (engine *Engine) shellSandboxActive(policy Policy) bool {
 	if policy.Mode == ModeDisabled {
 		return false
 	}
+	// Re-entrancy skips wrapping: when the process carries the sandbox markers,
+	// the runner returns a pass-through (unwrapped) plan, so the native sandbox
+	// is NOT the boundary for THIS command. Because the markers are ambient and
+	// forgeable at an unsandboxed process boundary (issue #727), auto-allowing a
+	// shell command on that basis would run it unwrapped with no prompt. Mirror
+	// the runner: report inactive so the command takes the normal approval path.
+	if IsAlreadySandboxed() {
+		return false
+	}
 	backend := engine.backend
 	if !(backend.Available && backend.Executable != "" && backend.CommandWrapping && backend.NativeIsolation) {
 		return false


### PR DESCRIPTION
## Summary

Closes #727.

Zero trusted the ambient `ZERO_SANDBOXED=1` + non-empty `ZERO_SANDBOX_BACKEND` environment markers as proof the current process is already sandboxed. Those values are user-controlled when Zero starts outside a sandbox, so at an unsandboxed process boundary they are forgeable. Policy evaluation could **auto-allow** an ordinary shell command (the configured backend reports native wrapping) while command planning, seeing the same forged markers, independently emitted an **unwrapped pass-through** plan — the command then ran directly on the host with no filesystem/network isolation and no prompt.

## Root cause

`shellSandboxActive()` (`internal/sandbox/engine.go`) reported the sandbox active whenever the backend *could* wrap a command, but never checked `IsAlreadySandboxed()`. Meanwhile `planCommand`/the runner (`internal/sandbox/runner.go`) sets `SandboxPreferenceForbid` — a pass-through plan — when `IsAlreadySandboxed()`. So the auto-allow decision and the wrapping decision disagreed: auto-allowed **and** unwrapped.

## Fix

`shellSandboxActive` now mirrors the runner: when `IsAlreadySandboxed()` (the markers are present, so wrapping is skipped) it reports inactive, so the native sandbox is not treated as the boundary for that command and the shell command takes the normal approval path instead of auto-allowing. This is the issue's recommended immediate mitigation; authenticated in-process launch provenance is the longer-term fix and is out of scope here.

The change is conservative: a genuinely re-entrant process (a real Zero-wrapped child) now prompts for a shell command instead of auto-allowing it, which is safe — the outer sandbox still confines it. The forgery path can no longer combine an auto-allow with an unwrapped plan.

## Scope

`internal/sandbox` only. No config or API change. No performance change expected.

## Testing

- New regression test `TestForgedReentrancyMarkersDoNotAutoAllowUnwrappedShell`: with forged markers set, the shell decision is `prompt` (not `AutoAllowed`) **and** the command plan is an unwrapped pass-through — proving the two can no longer combine. The identical setup without markers auto-allows (`TestSandboxedBashAutoAllowedWhenSandboxActive`), so this is the before/after. Confirmed to **fail without the fix** (reverted the source, kept the test).
- `go test -race ./internal/sandbox/...` green. `make fmt-check`, `go vet ./...`, `go run ./cmd/zero-release build`, `go run ./cmd/zero-release smoke`, `govulncheck`, `git diff HEAD --check` all clean.
- **Manual end-to-end via the real CLI** (`zero sandbox check`, macos-seatbelt backend): with forged `ZERO_SANDBOXED=1` + `ZERO_SANDBOX_BACKEND` the decision is now `prompt`, where unpatched `main` reports `allow` ("auto-allowed: sandbox is active"); a run with no markers still auto-allows (happy path intact).

## Related

Part of the sandbox/OAuth security-hardening set alongside #511 and #729. Independent branch off current `main`; no stacking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command safety in re-entrant sandboxed runs.
  * Prevented forged sandbox indicators from automatically approving unwrapped shell commands; these commands now require policy evaluation and prompting when appropriate.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->