### PR TITLE
feat(tui): add /undo as an alias for /rewind (#698)

### DIFF
--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -253,6 +253,7 @@ var commandDefinitions = []commandDefinition{
 	},
 	{
 		name:        "/rewind",
+		aliases:     []string{"/undo"},
 		usage:       "/rewind [latest|<sequence>]",
 		group:       commandGroupSession,
 		description: "Restore workspace files to a checkpoint and truncate the session.",

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -996,9 +996,13 @@ func TestUndoAliasesRewind(t *testing.T) {
 	if !ok || alias.kind != rewind.kind {
 		t.Fatalf("expected /undo to alias /rewind, got ok=%v command=%#v", ok, alias)
 	}
-	// End-to-end: a typed /undo dispatches to the rewind handler with args intact.
+	// End-to-end: a typed /undo dispatches to the rewind handler with args intact,
+	// for both the "latest" and numeric-<sequence> forms of the /rewind contract.
 	if parsed := parseCommand("/undo latest"); parsed.kind != commandRewind || parsed.text != "latest" {
 		t.Fatalf("parseCommand(%q) = %#v, want commandRewind with text=latest", "/undo latest", parsed)
+	}
+	if parsed := parseCommand("/undo 123"); parsed.kind != commandRewind || parsed.text != "123" {
+		t.Fatalf("parseCommand(%q) = %#v, want commandRewind with text=123", "/undo 123", parsed)
 	}
 	// Guard: without the alias it would be commandUnknown.
 	if parsed := parseCommand("/undo"); parsed.kind == commandUnknown {

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -985,6 +985,27 @@ func TestParseBackgroundTerminalCommands(t *testing.T) {
 	}
 }
 
+// /undo is an alias for /rewind (issue #698): previously it fell through to
+// commandUnknown.
+func TestUndoAliasesRewind(t *testing.T) {
+	rewind, ok := resolveCommand("/rewind")
+	if !ok {
+		t.Fatal("expected /rewind to resolve")
+	}
+	alias, ok := resolveCommand("/undo")
+	if !ok || alias.kind != rewind.kind {
+		t.Fatalf("expected /undo to alias /rewind, got ok=%v command=%#v", ok, alias)
+	}
+	// End-to-end: a typed /undo dispatches to the rewind handler with args intact.
+	if parsed := parseCommand("/undo latest"); parsed.kind != commandRewind || parsed.text != "latest" {
+		t.Fatalf("parseCommand(%q) = %#v, want commandRewind with text=latest", "/undo latest", parsed)
+	}
+	// Guard: without the alias it would be commandUnknown.
+	if parsed := parseCommand("/undo"); parsed.kind == commandUnknown {
+		t.Fatal("/undo resolved to commandUnknown — the alias is not wired")
+	}
+}
+
 func TestCommandSelectionRequiresInputFromUsage(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Closes #698.

`/undo` was never registered as a command, so typing it fell through to `commandUnknown`. Zero already has `/rewind`, which restores workspace files to a checkpoint and truncates the session — exactly "undo".

## Change

Add `/undo` to the `/rewind` command's `aliases`, using the same alias mechanism already used by `/quit`→`/exit`, `/find`→`/search`, and `/mcp-status`→`/mcp`. `resolveCommand` matches aliases, so `/undo` now dispatches to the existing rewind handler with its arguments intact (`/undo`, `/undo latest`, `/undo <sequence>`), and it appears in command autocomplete/help for free.

## Scope

`internal/tui` only. One line of behavior. No change to any existing command.

## Testing

- `TestUndoAliasesRewind`: `/undo` resolves to the same command kind as `/rewind`, and `parseCommand("/undo latest")` yields `commandRewind` with `text=latest`. Confirmed to **fail without the alias** (it resolves to `commandUnknown`).
- `make fmt-check`, `go vet ./...`, `go test -race ./internal/tui/...`, `go run ./cmd/zero-release build`, `go run ./cmd/zero-release smoke`, `govulncheck`, `git diff HEAD --check` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/undo` as an alias for the existing `/rewind` command.
  * Supports undoing the latest action with `/undo latest`.
  * The new alias is displayed in command help and usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->