### PR TITLE
fix(agent): stop write_stdin session_id probing thrash (#702)

### DIFF
--- a/internal/agent/guardrails_test.go
+++ b/internal/agent/guardrails_test.go
@@ -169,6 +169,37 @@ func TestRunResetsEmptyTurnCounterOnToolCall(t *testing.T) {
 	}
 }
 
+// The whole point of #702's fix: the unknown-session error's normalized
+// signature must not vary with the session id, so a model probing ids 1, 2,
+// 3, … produces one repeated signature the failure guard can count. If the id
+// leaked into the first 80 normalized chars, each probe would reset the streak
+// and the halt would never fire.
+func TestUnknownExecSessionErrorSignatureIsIDInvariant(t *testing.T) {
+	a := errorSignature(tools.UnknownExecSessionError(1))
+	b := errorSignature(tools.UnknownExecSessionError(999999))
+	if a != b {
+		t.Fatalf("unknown-session signature varies with id:\n  %q\n  %q", a, b)
+	}
+}
+
+// End to end: with an id-invariant signature, probing a different unknown id
+// each turn now trips the repeated-failure halt at toolFailureStopAt, where
+// before the fix it never would.
+func TestUnknownExecSessionProbingTripsFailureHalt(t *testing.T) {
+	var state guardState
+	var stoppedAt int
+	for i := 1; i <= toolFailureStopAt; i++ {
+		out := state.observeToolResult(tools.WriteStdinToolName, true, tools.UnknownExecSessionError(i))
+		if out.Stop {
+			stoppedAt = i
+			break
+		}
+	}
+	if stoppedAt != toolFailureStopAt {
+		t.Fatalf("probing distinct unknown ids stopped at %d, want %d", stoppedAt, toolFailureStopAt)
+	}
+}
+
 func TestGuardStateResetsToolOnlyStreakOnEmptyNonToolTurn(t *testing.T) {
 	var state guardState
 	toolOnly := zeroruntime.CollectedStream{

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -100,6 +100,9 @@ work.
 - Use exec_command with `tty: true` for interactive terminal-style commands that
   need stdin beyond Ctrl-C. `/ps` and `/stop` are user-facing TUI commands; when
   you need to clean up a running foreground command yourself, use write_stdin.
+- write_stdin's session_id is only ever an id returned by a still-running
+  exec_command; never guess or probe ids. If you have no such session, start one
+  with exec_command, or use write_file/edit_file/apply_patch for file changes.
 - write_stdin with empty input polls an existing exec_command session, and
   `\u0003` interrupts it. Sending other stdin bytes may require approval because
   it can drive the running process beyond the original command. Non-tty sessions

--- a/internal/tools/exec_command.go
+++ b/internal/tools/exec_command.go
@@ -707,6 +707,18 @@ type writeStdinTool struct {
 	manager *execSessionManager
 }
 
+// UnknownExecSessionError is the result returned when write_stdin targets a
+// session_id with no live exec session. The stable recovery guidance leads and
+// the numeric id trails on purpose: the agent's repeated-failure guard keys on
+// a normalized, truncated prefix of the error string, so keeping the id out of
+// that prefix makes a model probing ids 1, 2, 3, … produce ONE signature that
+// finally trips the halt instead of a fresh signature per id — while also
+// telling the model how to actually recover. See TestUnknownExecSessionErrorSignatureIsIDInvariant
+// in internal/agent, which pins this invariant against the real guard.
+func UnknownExecSessionError(sessionID int) string {
+	return fmt.Sprintf("Error: write_stdin needs a session_id returned by a still-running exec_command; do not guess or probe session ids. Start a process with exec_command, or use write_file/edit_file/apply_patch for file changes. (no live session %d)", sessionID)
+}
+
 func (writeStdinTool) outputCategory(map[string]any) outputCategory {
 	return outputCategoryProcess
 }
@@ -722,7 +734,7 @@ func NewWriteStdinTool(manager *execSessionManager) Tool {
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{
-					"session_id":        {Type: "integer", Description: "Identifier of the running unified exec session."},
+					"session_id":        {Type: "integer", Description: "Identifier of a running unified exec session, as returned by exec_command. Never guess or probe ids.", Minimum: intPtr(1)},
 					"chars":             {Type: "string", Description: "Bytes to write to stdin. Defaults to empty, which polls without writing.", Default: ""},
 					"yield_time_ms":     {Type: "integer", Description: "Wait before yielding output. Non-empty writes default to 250 ms and cap at 30000 ms; empty polls wait 5000-300000 ms by default.", Default: defaultPollYieldTimeMS, Minimum: intPtr(1), Maximum: intPtr(maxPollYieldTimeMS)},
 					"max_output_tokens": {Type: "integer", Description: "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy.", Default: defaultMaxOutputTokens, Minimum: intPtr(1), Maximum: intPtr(maxExecOutputTokenRequest)},
@@ -784,7 +796,7 @@ func (tool writeStdinTool) RunWithOptions(ctx context.Context, args map[string]a
 	}
 	session, ok := tool.manager.get(sessionID)
 	if !ok {
-		return errorResult(fmt.Sprintf("Error: Unknown exec session_id %d.", sessionID))
+		return errorResult(UnknownExecSessionError(sessionID))
 	}
 	session.touch()
 	interrupted := false

--- a/internal/tools/exec_command_test.go
+++ b/internal/tools/exec_command_test.go
@@ -881,7 +881,7 @@ func TestRegistryHonorsWriteStdinArgumentPermission(t *testing.T) {
 	registry.Register(NewWriteStdinTool(newExecSessionManager()))
 
 	poll := registry.Run(context.Background(), WriteStdinToolName, map[string]any{"session_id": 9999})
-	if poll.Status != StatusError || !strings.Contains(poll.Output, "Unknown exec session_id") {
+	if poll.Status != StatusError || !strings.Contains(poll.Output, "still-running exec_command") {
 		t.Fatalf("empty poll should reach tool without permission prompt, got status=%s output=%q", poll.Status, poll.Output)
 	}
 
@@ -901,8 +901,25 @@ func TestWriteStdinReportsUnknownSession(t *testing.T) {
 	if result.Status != StatusError {
 		t.Fatalf("status = %s, want error", result.Status)
 	}
-	if !strings.Contains(result.Output, "Unknown exec session_id 1234") {
-		t.Fatalf("unexpected output: %q", result.Output)
+	// The message must lead with recovery guidance and still identify the id.
+	if !strings.Contains(result.Output, "still-running exec_command") {
+		t.Fatalf("unknown-session error must carry recovery guidance, got: %q", result.Output)
+	}
+	if !strings.Contains(result.Output, "1234") {
+		t.Fatalf("unknown-session error must name the offending id, got: %q", result.Output)
+	}
+}
+
+// The runtime rejects session_id < 1 (intArg min 1); the advertised schema must
+// say the same so a model sees the constraint before it probes id 0.
+func TestWriteStdinSchemaPinsSessionIDMinimum(t *testing.T) {
+	schema := NewWriteStdinTool(nil).(writeStdinTool).parameters
+	prop, ok := schema.Properties["session_id"]
+	if !ok {
+		t.Fatal("session_id property missing from write_stdin schema")
+	}
+	if prop.Minimum == nil || *prop.Minimum != 1 {
+		t.Fatalf("session_id schema Minimum = %v, want 1 to match the runtime floor", prop.Minimum)
 	}
 }
 


### PR DESCRIPTION
Closes #702.

## The bug

When the model calls `write_stdin` with no live exec session, it tends to probe sequential `session_id`s (1, 2, 3, …). Each one fails, and the run grinds on for a long time before anything stops it.

The reason it doesn't stop: the repeated-failure guard keys on a normalized, 80-character-truncated signature of the tool error (`errorSignature` in `internal/agent/guardrails.go`). The old message was `Error: Unknown exec session_id %d.`, so the varying id landed inside that 80-char window. Every probe produced a different signature, the same-error streak reset each time, and the 6x-in-a-row halt (`toolFailureStopAt`) never fired. It only tripped if the model repeated one identical id six times, which a probing model never does.

## The fix

- Rewrite the unknown-session error so the stable recovery guidance leads and the id trails past the signature window. Probing distinct ids now collapses to a single signature and trips the halt, and the model is told how to recover: start a process with `exec_command`, or use the file-edit tools. The id is still in the message (just past position 80), so the model still sees which id failed.
- Pin `session_id`'s schema `Minimum` to 1 so the advertised schema matches the runtime floor (`intArg` already rejects `< 1`); before this the schema declared no minimum while the runtime required one.
- `system_prompt.md`: state that `session_id` is only ever an id returned by a still-running `exec_command` and must never be guessed or probed.

## Why this is safe

The whole fix hinges on one invariant: the error's normalized signature must not vary with the id. That is pinned by a test that feeds `UnknownExecSessionError(1)` and `UnknownExecSessionError(999999)` through the real `errorSignature` and asserts equality, so a future edit that reintroduces the id early breaks the test. A second test proves the behavioral consequence end to end: probing a different unknown id each turn now halts at the guard's stop threshold, where before it never would. The schema floor and the recovery text are pinned too, and the two existing tests that asserted the old wording are updated.

No runtime behavior changes beyond the halt firing where it should: the `Minimum` is advisory schema metadata (validation is still done independently by `intArg`), and the error only changes wording.

## Scope note

The issue's fourth criterion (the TUI showing "Sent input" on a *failed* `write_stdin`) is a separate cosmetic concern in a shared rendering path used at several call sites. I left it out to keep this diff focused on the agent-behavior bug; happy to follow up with it as its own small change if you'd like it in scope.

## Testing

`go build ./...`, `go vet`, `gofmt` clean; `internal/tools` and `internal/agent` suites pass. New tests: signature id-invariance, distinct-id probing halts at the stop threshold, schema minimum matches the runtime floor, and the recovery text is present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `write_stdin` errors for unknown sessions with clearer recovery guidance and the affected session ID.
  * Prevented invalid session IDs below the supported minimum.
  * Ensured repeated attempts to access unknown sessions trigger the appropriate failure halt.

* **Documentation**
  * Clarified how to start or resume interactive command sessions and advised against guessing session IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->