### PR TITLE
Add transcript-grounded structured task state

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -56,14 +56,10 @@ type CompactionOptions struct {
 	// injected so Compact stays pure and testable; the agent loop wires it to a
 	// real provider call.
 	Summarize func(toSummarize []zeroruntime.Message) (string, error)
-	// taskState is a transcript-corroborated snapshot supplied by the running
-	// agent. It is unexported so standalone callers cannot accidentally promote
-	// structured state above the messages they are compacting.
+	// taskState is a snapshot supplied by the running agent. Its immutable
+	// objective is always preserved; mutable fields are admitted only when its
+	// plan projection still matches the transcript.
 	taskState *taskStateSnapshot
-	// taskStateChecked distinguishes "no running task projection" from "the
-	// projection disagreed with the transcript". The latter must drop any older
-	// carried copy rather than silently preserving stale structured state.
-	taskStateChecked bool
 }
 
 // CompactionResult is the metadata-bearing result returned by CompactMessages.
@@ -228,7 +224,7 @@ func CompactMessages(messages []zeroruntime.Message, opts CompactionOptions) (Co
 
 	// Preserve structured state (active plan + loaded skills) from the elided
 	// middle verbatim, so it is not lost or paraphrased away by the prose summary.
-	content := appendPreservedState(summaryLabel+"\n"+summary, middle, opts.taskState, opts.taskStateChecked)
+	content := appendPreservedState(summaryLabel+"\n"+summary, middle, opts.taskState)
 
 	compacted := make([]zeroruntime.Message, 0, systemEnd+1+(len(messages)-boundary))
 	compacted = append(compacted, messages[:systemEnd]...)
@@ -374,15 +370,13 @@ func (state *compactionState) calibratedTokens(raw int) int {
 	return int(float64(raw) * state.calibrationRatio)
 }
 
-func newCompactionState(options Options, tasks ...*taskState) *compactionState {
+func newCompactionState(options Options, task *taskState) *compactionState {
 	state := &compactionState{
 		enabled:      options.ContextWindow > 0,
 		threshold:    compactionThreshold(options.ContextWindow),
 		preserveLast: options.CompactionPreserveLast,
 		onUsage:      options.OnUsage,
-	}
-	if len(tasks) > 0 {
-		state.task = tasks[0]
+		task:         task,
 	}
 	return state
 }
@@ -429,10 +423,9 @@ func (state *compactionState) maybeCompact(
 	}
 
 	compacted, err := Compact(messages, CompactionOptions{
-		PreserveLast:     state.preserveLast,
-		Summarize:        summarizeClosure(ctx, provider, state.onUsage),
-		taskState:        state.task.snapshotForCompaction(messages),
-		taskStateChecked: state.task != nil,
+		PreserveLast: state.preserveLast,
+		Summarize:    summarizeClosure(ctx, provider, state.onUsage),
+		taskState:    state.task.snapshotForCompaction(messages),
 	})
 	if err != nil {
 		// Summarizer failed: keep the original history. The reactive path (or a
@@ -481,10 +474,9 @@ func (state *compactionState) recover(
 	}
 
 	result, compactErr := Compact(messages, CompactionOptions{
-		PreserveLast:     state.preserveLast,
-		Summarize:        summarizeClosure(ctx, provider, state.onUsage),
-		taskState:        state.task.snapshotForCompaction(messages),
-		taskStateChecked: state.task != nil,
+		PreserveLast: state.preserveLast,
+		Summarize:    summarizeClosure(ctx, provider, state.onUsage),
+		taskState:    state.task.snapshotForCompaction(messages),
 	})
 	if compactErr != nil {
 		// A genuine compaction attempt was made (and failed): the budget is spent

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -56,6 +56,14 @@ type CompactionOptions struct {
 	// injected so Compact stays pure and testable; the agent loop wires it to a
 	// real provider call.
 	Summarize func(toSummarize []zeroruntime.Message) (string, error)
+	// taskState is a transcript-corroborated snapshot supplied by the running
+	// agent. It is unexported so standalone callers cannot accidentally promote
+	// structured state above the messages they are compacting.
+	taskState *taskStateSnapshot
+	// taskStateChecked distinguishes "no running task projection" from "the
+	// projection disagreed with the transcript". The latter must drop any older
+	// carried copy rather than silently preserving stale structured state.
+	taskStateChecked bool
 }
 
 // CompactionResult is the metadata-bearing result returned by CompactMessages.
@@ -220,7 +228,7 @@ func CompactMessages(messages []zeroruntime.Message, opts CompactionOptions) (Co
 
 	// Preserve structured state (active plan + loaded skills) from the elided
 	// middle verbatim, so it is not lost or paraphrased away by the prose summary.
-	content := appendPreservedState(summaryLabel+"\n"+summary, middle)
+	content := appendPreservedState(summaryLabel+"\n"+summary, middle, opts.taskState, opts.taskStateChecked)
 
 	compacted := make([]zeroruntime.Message, 0, systemEnd+1+(len(messages)-boundary))
 	compacted = append(compacted, messages[:systemEnd]...)
@@ -326,6 +334,7 @@ type compactionState struct {
 	// OnText is deliberately NOT forwarded (compaction stays invisible to the user),
 	// but its token COST must still be counted so usage reports and budgets include it.
 	onUsage func(Usage)
+	task    *taskState
 
 	// calibrationRatio scales the raw byte/4 token estimate toward the provider's
 	// real prompt-token count. ApproxTextTokens over-counts code-heavy content by
@@ -365,13 +374,17 @@ func (state *compactionState) calibratedTokens(raw int) int {
 	return int(float64(raw) * state.calibrationRatio)
 }
 
-func newCompactionState(options Options) *compactionState {
-	return &compactionState{
+func newCompactionState(options Options, tasks ...*taskState) *compactionState {
+	state := &compactionState{
 		enabled:      options.ContextWindow > 0,
 		threshold:    compactionThreshold(options.ContextWindow),
 		preserveLast: options.CompactionPreserveLast,
 		onUsage:      options.OnUsage,
 	}
+	if len(tasks) > 0 {
+		state.task = tasks[0]
+	}
+	return state
 }
 
 // maybeCompact runs proactive compaction at the top of a turn. It returns the
@@ -416,8 +429,10 @@ func (state *compactionState) maybeCompact(
 	}
 
 	compacted, err := Compact(messages, CompactionOptions{
-		PreserveLast: state.preserveLast,
-		Summarize:    summarizeClosure(ctx, provider, state.onUsage),
+		PreserveLast:     state.preserveLast,
+		Summarize:        summarizeClosure(ctx, provider, state.onUsage),
+		taskState:        state.task.snapshotForCompaction(messages),
+		taskStateChecked: state.task != nil,
 	})
 	if err != nil {
 		// Summarizer failed: keep the original history. The reactive path (or a
@@ -466,8 +481,10 @@ func (state *compactionState) recover(
 	}
 
 	result, compactErr := Compact(messages, CompactionOptions{
-		PreserveLast: state.preserveLast,
-		Summarize:    summarizeClosure(ctx, provider, state.onUsage),
+		PreserveLast:     state.preserveLast,
+		Summarize:        summarizeClosure(ctx, provider, state.onUsage),
+		taskState:        state.task.snapshotForCompaction(messages),
+		taskStateChecked: state.task != nil,
 	})
 	if compactErr != nil {
 		// A genuine compaction attempt was made (and failed): the budget is spent

--- a/internal/agent/compaction_preserve.go
+++ b/internal/agent/compaction_preserve.go
@@ -426,11 +426,11 @@ type preservedState struct {
 
 type preservedTaskState struct {
 	Objective           string     `json:"objective"`
-	Status              taskStatus `json:"status"`
-	Pending             int        `json:"pending"`
-	InProgress          int        `json:"in_progress"`
-	Completed           int        `json:"completed"`
-	Failed              int        `json:"failed"`
+	Status              taskStatus `json:"status,omitempty"`
+	Pending             int        `json:"pending,omitempty"`
+	InProgress          int        `json:"in_progress,omitempty"`
+	Completed           int        `json:"completed,omitempty"`
+	Failed              int        `json:"failed,omitempty"`
 	VerificationPassed  int        `json:"verification_passed,omitempty"`
 	VerificationFailed  int        `json:"verification_failed,omitempty"`
 	VerificationOutcome Outcome    `json:"verification_outcome,omitempty"`
@@ -463,23 +463,25 @@ type preservedInstruction struct {
 // may live only inside the injected summary message, which on a later compaction
 // lands in middle with no real tool calls left to extract. Fresh tool calls and
 // instruction blocks override the carried-forward copy by name/source.
-func appendPreservedState(summary string, middle []zeroruntime.Message, taskSnapshot *taskStateSnapshot, taskStateChecked bool) string {
+func appendPreservedState(summary string, middle []zeroruntime.Message, taskSnapshot *taskStateSnapshot) string {
 	priorState := parsePreservedStateBlock(latestSummaryContent(middle))
 	task := priorState.Task
-	if taskStateChecked {
-		task = nil
-	}
 	if taskSnapshot != nil {
 		task = &preservedTaskState{
-			Objective:           capTaskObjective(taskSnapshot.Objective),
-			Status:              taskSnapshot.Status,
-			Pending:             taskSnapshot.Plan.Pending,
-			InProgress:          taskSnapshot.Plan.InProgress,
-			Completed:           taskSnapshot.Plan.Completed,
-			Failed:              taskSnapshot.Plan.Failed,
-			VerificationPassed:  taskSnapshot.Verification.Passed,
-			VerificationFailed:  taskSnapshot.Verification.Failed,
-			VerificationOutcome: taskSnapshot.Verification.LastOutcome,
+			Objective: capTaskObjective(taskSnapshot.Objective),
+		}
+		// Plan parity corroborates only the mutable task projection. The objective
+		// comes directly from the run prompt and is immutable, so it must survive
+		// even after compaction removes the plan tool call needed for comparison.
+		if taskSnapshot.PlanParity == taskPlanParityMatch {
+			task.Status = taskSnapshot.Status
+			task.Pending = taskSnapshot.Plan.Pending
+			task.InProgress = taskSnapshot.Plan.InProgress
+			task.Completed = taskSnapshot.Plan.Completed
+			task.Failed = taskSnapshot.Plan.Failed
+			task.VerificationPassed = taskSnapshot.Verification.Passed
+			task.VerificationFailed = taskSnapshot.Verification.Failed
+			task.VerificationOutcome = taskSnapshot.Verification.LastOutcome
 		}
 	}
 

--- a/internal/agent/compaction_preserve.go
+++ b/internal/agent/compaction_preserve.go
@@ -30,6 +30,10 @@ const (
 const (
 	maxRecentEdits   = 20
 	maxEditNoteBytes = 160
+	// maxTaskObjectiveBytes keeps the original objective recognizable after
+	// compaction without allowing an unusually large prompt to recreate the
+	// context pressure the compaction just removed.
+	maxTaskObjectiveBytes = 512
 )
 
 const (
@@ -76,32 +80,14 @@ func extractLatestPlan(messages []zeroruntime.Message) string {
 // ({"plan":[{content,status,...}]}) as terse status-tagged bullet lines. Returns
 // "" on malformed arguments or an empty plan.
 func formatPlanArguments(arguments string) string {
-	var parsed struct {
-		Plan []struct {
-			Content string `json:"content"`
-			Step    string `json:"step"`
-			Status  string `json:"status"`
-			Notes   string `json:"notes"`
-		} `json:"plan"`
-	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(arguments)), &parsed); err != nil {
+	plan, ok := parseTaskPlan(arguments)
+	if !ok {
 		return ""
 	}
-	lines := make([]string, 0, len(parsed.Plan))
-	for _, item := range parsed.Plan {
-		content := strings.TrimSpace(item.Content)
-		if content == "" {
-			content = strings.TrimSpace(item.Step)
-		}
-		if content == "" {
-			continue
-		}
-		status := strings.TrimSpace(item.Status)
-		if status == "" {
-			status = "pending"
-		}
-		line := "- [" + status + "] " + content
-		if notes := strings.TrimSpace(item.Notes); notes != "" {
+	lines := make([]string, 0, len(plan))
+	for _, item := range plan {
+		line := "- [" + item.Status + "] " + item.Content
+		if notes := item.Notes; notes != "" {
 			line += "\n  Notes: " + notes
 		}
 		lines = append(lines, line)
@@ -431,10 +417,23 @@ func capBody(body string) string {
 // preservedState is the JSON shape of the carried-across-compaction block.
 type preservedState struct {
 	Plan                string                 `json:"plan,omitempty"`
+	Task                *preservedTaskState    `json:"task,omitempty"`
 	RecentEdits         []preservedEdit        `json:"recent_edits,omitempty"`
 	Tools               []preservedTool        `json:"tools,omitempty"`
 	Skills              []preservedSkill       `json:"skills,omitempty"`
 	ProjectInstructions []preservedInstruction `json:"project_instructions,omitempty"`
+}
+
+type preservedTaskState struct {
+	Objective           string     `json:"objective"`
+	Status              taskStatus `json:"status"`
+	Pending             int        `json:"pending"`
+	InProgress          int        `json:"in_progress"`
+	Completed           int        `json:"completed"`
+	Failed              int        `json:"failed"`
+	VerificationPassed  int        `json:"verification_passed,omitempty"`
+	VerificationFailed  int        `json:"verification_failed,omitempty"`
+	VerificationOutcome Outcome    `json:"verification_outcome,omitempty"`
 }
 
 type preservedEdit struct {
@@ -464,8 +463,25 @@ type preservedInstruction struct {
 // may live only inside the injected summary message, which on a later compaction
 // lands in middle with no real tool calls left to extract. Fresh tool calls and
 // instruction blocks override the carried-forward copy by name/source.
-func appendPreservedState(summary string, middle []zeroruntime.Message) string {
+func appendPreservedState(summary string, middle []zeroruntime.Message, taskSnapshot *taskStateSnapshot, taskStateChecked bool) string {
 	priorState := parsePreservedStateBlock(latestSummaryContent(middle))
+	task := priorState.Task
+	if taskStateChecked {
+		task = nil
+	}
+	if taskSnapshot != nil {
+		task = &preservedTaskState{
+			Objective:           capTaskObjective(taskSnapshot.Objective),
+			Status:              taskSnapshot.Status,
+			Pending:             taskSnapshot.Plan.Pending,
+			InProgress:          taskSnapshot.Plan.InProgress,
+			Completed:           taskSnapshot.Plan.Completed,
+			Failed:              taskSnapshot.Plan.Failed,
+			VerificationPassed:  taskSnapshot.Verification.Passed,
+			VerificationFailed:  taskSnapshot.Verification.Failed,
+			VerificationOutcome: taskSnapshot.Verification.LastOutcome,
+		}
+	}
 
 	// Plan: a fresh update_plan in middle is authoritative; otherwise carry the
 	// plan preserved by an earlier compaction.
@@ -493,10 +509,23 @@ func appendPreservedState(summary string, middle []zeroruntime.Message) string {
 		projectInstructionEntries(middle),
 	)
 
-	if block := formatPreservedState(plan, edits, tools, skills, instructions); block != "" {
+	if block := formatPreservedState(plan, task, edits, tools, skills, instructions); block != "" {
 		summary += "\n\n" + block
 	}
 	return summary
+}
+
+func capTaskObjective(objective string) string {
+	objective = strings.TrimSpace(objective)
+	if len(objective) <= maxTaskObjectiveBytes {
+		return objective
+	}
+	const suffix = "…"
+	limit := maxTaskObjectiveBytes - len(suffix)
+	for limit > 0 && !utf8.RuneStart(objective[limit]) {
+		limit--
+	}
+	return strings.TrimSpace(objective[:limit]) + suffix
 }
 
 // mergeRecentEdits overlays fresh edits onto edits preserved by an earlier
@@ -555,11 +584,11 @@ func preservedEditsToEntries(edits []preservedEdit) []skillEntry {
 
 // formatPreservedState renders state as the labelled, single-line
 // JSON block. Returns "" when there is nothing to preserve.
-func formatPreservedState(plan string, edits, tools, skills, instructions []skillEntry) string {
-	if plan == "" && len(edits) == 0 && len(tools) == 0 && len(skills) == 0 && len(instructions) == 0 {
+func formatPreservedState(plan string, task *preservedTaskState, edits, tools, skills, instructions []skillEntry) string {
+	if plan == "" && task == nil && len(edits) == 0 && len(tools) == 0 && len(skills) == 0 && len(instructions) == 0 {
 		return ""
 	}
-	state := preservedState{Plan: plan}
+	state := preservedState{Plan: plan, Task: task}
 	for _, e := range edits {
 		state.RecentEdits = append(state.RecentEdits, preservedEdit{Path: e.name, Note: e.body})
 	}

--- a/internal/agent/compaction_preserve_test.go
+++ b/internal/agent/compaction_preserve_test.go
@@ -62,7 +62,7 @@ func TestCompactPreservesActivePlan(t *testing.T) {
 
 func TestCompactPreservesBoundedTaskContext(t *testing.T) {
 	objective := strings.Repeat("世", maxTaskObjectiveBytes)
-	task := newTaskState(objective)
+	task := newTaskState(objective, nil)
 	task.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"write code","status":"in_progress"},{"content":"add tests","status":"pending"}]}`})
 	messages := stateConversation()
 	compacted, err := Compact(messages, CompactionOptions{
@@ -82,7 +82,7 @@ func TestCompactPreservesBoundedTaskContext(t *testing.T) {
 	}
 }
 
-func TestCompactDropsCarriedTaskContextAfterParityMismatch(t *testing.T) {
+func TestCompactPreservesObjectiveAfterPlanParityMismatch(t *testing.T) {
 	prior := preservedState{Task: &preservedTaskState{Objective: "stale objective", Status: taskStatusActive, Pending: 1}}
 	encoded, err := json.Marshal(prior)
 	if err != nil {
@@ -98,16 +98,62 @@ func TestCompactDropsCarriedTaskContextAfterParityMismatch(t *testing.T) {
 		{Role: zeroruntime.MessageRoleAssistant, Content: "done"},
 	}
 	compacted, err := Compact(messages, CompactionOptions{
-		PreserveLast:     2,
-		Summarize:        func([]zeroruntime.Message) (string, error) { return "SUMMARY", nil },
-		taskStateChecked: true,
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "SUMMARY", nil },
+		taskState: &taskStateSnapshot{
+			Objective:  "current objective",
+			PlanParity: taskPlanParityMismatch,
+		},
 	})
 	if err != nil {
 		t.Fatalf("Compact: %v", err)
 	}
 	state := parsePreservedStateBlock(compacted[1].Content)
-	if state.Task != nil {
-		t.Fatalf("stale task context survived a parity mismatch: %#v", state.Task)
+	if state.Task == nil || state.Task.Objective != "current objective" {
+		t.Fatalf("immutable objective was lost on plan mismatch: %#v", state.Task)
+	}
+	if state.Task.Status != "" || state.Task.Pending != 0 {
+		t.Fatalf("uncorroborated mutable task fields survived plan mismatch: %#v", state.Task)
+	}
+}
+
+func TestTaskObjectiveSurvivesRepeatedCompactionWithoutPlanRefresh(t *testing.T) {
+	task := newTaskState("keep this objective", nil)
+	task.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"write code","status":"in_progress"},{"content":"add tests","status":"pending"}]}`})
+	messages := stateConversation()
+
+	first, err := Compact(messages, CompactionOptions{
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "FIRST", nil },
+		taskState:    task.snapshotForCompaction(messages),
+	})
+	if err != nil {
+		t.Fatalf("first Compact: %v", err)
+	}
+	secondInput := append(append([]zeroruntime.Message{}, first...),
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "more"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "working"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "again"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "done"},
+	)
+	snapshot := task.snapshotForCompaction(secondInput)
+	if snapshot.PlanParity != taskPlanParityMismatch {
+		t.Fatalf("plan call should be absent after first compaction, parity=%q", snapshot.PlanParity)
+	}
+	second, err := Compact(secondInput, CompactionOptions{
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "SECOND", nil },
+		taskState:    snapshot,
+	})
+	if err != nil {
+		t.Fatalf("second Compact: %v", err)
+	}
+	state := parsePreservedStateBlock(second[1].Content)
+	if state.Task == nil || state.Task.Objective != "keep this objective" {
+		t.Fatalf("objective lost after second compaction: %#v", state.Task)
+	}
+	if state.Task.Status != "" || state.Task.InProgress != 0 {
+		t.Fatalf("uncorroborated mutable fields survived second compaction: %#v", state.Task)
 	}
 }
 
@@ -335,12 +381,10 @@ func TestExtractLatestPlanReturnsMostRecent(t *testing.T) {
 	}
 }
 
-func TestFormatPlanArgumentsAcceptsStepAlias(t *testing.T) {
+func TestFormatPlanArgumentsRejectsUnsupportedStepAlias(t *testing.T) {
 	got := formatPlanArguments(`{"plan":[{"step":"write failing test","status":"in_progress"},{"content":"keep existing shape","status":"pending"}]}`)
-	for _, want := range []string{"- [in_progress] write failing test", "- [pending] keep existing shape"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("expected %q in formatted plan, got %q", want, got)
-		}
+	if got != "" {
+		t.Fatalf("unsupported alias should reject the whole plan like update_plan, got %q", got)
 	}
 }
 

--- a/internal/agent/compaction_preserve_test.go
+++ b/internal/agent/compaction_preserve_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -56,6 +57,57 @@ func TestCompactPreservesActivePlan(t *testing.T) {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("plan item %q not preserved in %q", want, summary)
 		}
+	}
+}
+
+func TestCompactPreservesBoundedTaskContext(t *testing.T) {
+	objective := strings.Repeat("世", maxTaskObjectiveBytes)
+	task := newTaskState(objective)
+	task.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"write code","status":"in_progress"},{"content":"add tests","status":"pending"}]}`})
+	messages := stateConversation()
+	compacted, err := Compact(messages, CompactionOptions{
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "SUMMARY", nil },
+		taskState:    task.snapshotForCompaction(messages),
+	})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	state := parsePreservedStateBlock(compacted[1].Content)
+	if state.Task == nil || state.Task.Status != taskStatusActive || state.Task.InProgress != 1 || state.Task.Pending != 1 {
+		t.Fatalf("unexpected compact task state: %#v", state.Task)
+	}
+	if len(state.Task.Objective) > maxTaskObjectiveBytes || !utf8.ValidString(state.Task.Objective) {
+		t.Fatalf("objective was not safely bounded: %d bytes %q", len(state.Task.Objective), state.Task.Objective)
+	}
+}
+
+func TestCompactDropsCarriedTaskContextAfterParityMismatch(t *testing.T) {
+	prior := preservedState{Task: &preservedTaskState{Objective: "stale objective", Status: taskStatusActive, Pending: 1}}
+	encoded, err := json.Marshal(prior)
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: summaryLabel + "\nold\n\n" + preservedStateLabel + "\n" + string(encoded)},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "continuing"},
+		{Role: zeroruntime.MessageRoleUser, Content: "more"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "working"},
+		{Role: zeroruntime.MessageRoleUser, Content: "again"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "done"},
+	}
+	compacted, err := Compact(messages, CompactionOptions{
+		PreserveLast:     2,
+		Summarize:        func([]zeroruntime.Message) (string, error) { return "SUMMARY", nil },
+		taskStateChecked: true,
+	})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	state := parsePreservedStateBlock(compacted[1].Content)
+	if state.Task != nil {
+		t.Fatalf("stale task context survived a parity mismatch: %#v", state.Task)
 	}
 }
 

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -581,7 +581,7 @@ func TestCompactNeverProducesConsecutiveUserMessages(t *testing.T) {
 }
 
 func TestRecoverNoopDoesNotConsumeReactiveBudget(t *testing.T) {
-	st := newCompactionState(Options{ContextWindow: 1000, CompactionPreserveLast: 2})
+	st := newCompactionState(Options{ContextWindow: 1000, CompactionPreserveLast: 2}, nil)
 	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
 		{Type: zeroruntime.StreamEventText, Content: "SUMMARY"}, {Type: zeroruntime.StreamEventDone},
 	}}}
@@ -628,7 +628,7 @@ func TestRecoverNoopDoesNotConsumeReactiveBudget(t *testing.T) {
 }
 
 func TestRecoverDisabledIsNoop(t *testing.T) {
-	st := newCompactionState(Options{ContextWindow: 0})
+	st := newCompactionState(Options{ContextWindow: 0}, nil)
 	msgs := []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "x"}}
 	called := false
 	// recover must not invoke the provider/summarize when disabled, even on a

--- a/internal/agent/completion_policy.go
+++ b/internal/agent/completion_policy.go
@@ -39,7 +39,7 @@ func newCompletionPolicy(requireSemanticCheck bool) *completionPolicy {
 	return &completionPolicy{requireSemanticCheck: requireSemanticCheck}
 }
 
-func (policy *completionPolicy) evaluate(text string, planPending bool) completionEvaluation {
+func (policy *completionPolicy) evaluate(text string, context completionContext) completionEvaluation {
 	// A direct admission is strong local evidence and takes precedence over all
 	// weaker signals, avoiding both continuation nudges and semantic checks.
 	if reason := selfReportedIncompletion(text); reason != "" {
@@ -50,7 +50,7 @@ func (policy *completionPolicy) evaluate(text string, planPending bool) completi
 	// weak evidence because bookkeeping can be stale. Both get a bounded chance
 	// to continue, but only a persisted cue is ultimately incomplete.
 	cue := endsWithContinuationCue(text)
-	if cue || planPending {
+	if cue || context.PlanPending {
 		if policy.continueNudges < maxContinueNudges {
 			policy.continueNudges++
 			reason := "your message ended mid-step"

--- a/internal/agent/completion_policy_test.go
+++ b/internal/agent/completion_policy_test.go
@@ -1,16 +1,19 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestCompletionPolicyLocalEvidenceDecidesWithoutSemanticCheck(t *testing.T) {
 	policy := newCompletionPolicy(false)
 
-	complete := policy.evaluate("Done. All required checks pass.", false)
+	complete := policy.evaluate("Done. All required checks pass.", completionContext{})
 	if complete.Decision != CompletionComplete {
 		t.Fatalf("confident completion decision = %q, want %q", complete.Decision, CompletionComplete)
 	}
 
-	incomplete := policy.evaluate("I couldn't verify the result, so this is my best guess.", false)
+	incomplete := policy.evaluate("I couldn't verify the result, so this is my best guess.", completionContext{})
 	if incomplete.Decision != CompletionIncomplete {
 		t.Fatalf("admitted failure decision = %q, want %q", incomplete.Decision, CompletionIncomplete)
 	}
@@ -19,13 +22,13 @@ func TestCompletionPolicyLocalEvidenceDecidesWithoutSemanticCheck(t *testing.T) 
 func TestCompletionPolicyPreservesBoundedPlanStallProtection(t *testing.T) {
 	policy := newCompletionPolicy(false)
 	for attempt := 0; attempt < maxContinueNudges; attempt++ {
-		got := policy.evaluate("Let me inspect the remaining configuration:", true)
+		got := policy.evaluate("Let me inspect the remaining configuration:", completionContext{PlanPending: true})
 		if got.Decision != CompletionUncertain || got.Action != completionActionContinue {
 			t.Fatalf("attempt %d = (%q, %q), want uncertain continue", attempt+1, got.Decision, got.Action)
 		}
 	}
 
-	got := policy.evaluate("Let me inspect the remaining configuration:", true)
+	got := policy.evaluate("Let me inspect the remaining configuration:", completionContext{PlanPending: true})
 	if got.Decision != CompletionIncomplete {
 		t.Fatalf("decision after nudge budget = %q, want %q", got.Decision, CompletionIncomplete)
 	}
@@ -34,13 +37,13 @@ func TestCompletionPolicyPreservesBoundedPlanStallProtection(t *testing.T) {
 func TestCompletionPolicyTreatsPendingPlanAsWeakEvidence(t *testing.T) {
 	policy := newCompletionPolicy(false)
 	for attempt := 0; attempt < maxContinueNudges; attempt++ {
-		got := policy.evaluate("All set.", true)
+		got := policy.evaluate("All set.", completionContext{PlanPending: true})
 		if got.Decision != CompletionUncertain || got.Action != completionActionContinue {
 			t.Fatalf("attempt %d = (%q, %q), want uncertain continue", attempt+1, got.Decision, got.Action)
 		}
 	}
 
-	got := policy.evaluate("All set.", true)
+	got := policy.evaluate("All set.", completionContext{PlanPending: true})
 	if got.Decision != CompletionComplete {
 		t.Fatalf("stale plan decision after nudge budget = %q, want %q", got.Decision, CompletionComplete)
 	}
@@ -49,16 +52,24 @@ func TestCompletionPolicyTreatsPendingPlanAsWeakEvidence(t *testing.T) {
 func TestCompletionPolicyAllowsExactlyOneRequiredSemanticCheck(t *testing.T) {
 	policy := newCompletionPolicy(true)
 
-	first := policy.evaluate("Implemented and tested.", false)
+	first := policy.evaluate("Implemented and tested.", completionContext{})
 	if first.Decision != CompletionUncertain || first.Action != completionActionSemanticCheck {
 		t.Fatalf("first decision = (%q, %q), want uncertain semantic check", first.Decision, first.Action)
 	}
 
-	second := policy.evaluate("PASS. The result meets the task criterion.", false)
+	second := policy.evaluate("PASS. The result meets the task criterion.", completionContext{})
 	if second.Decision != CompletionComplete {
 		t.Fatalf("post-check decision = %q, want %q", second.Decision, CompletionComplete)
 	}
 	if second.Action == completionActionSemanticCheck {
 		t.Fatal("semantic check was requested more than once")
+	}
+}
+
+func TestAcceptanceVerificationNudgeIncludesBoundedObjective(t *testing.T) {
+	objective := "make the requested behavior observable"
+	nudge := acceptanceVerificationNudge(objective)
+	if !strings.Contains(nudge, "Task objective: "+objective) {
+		t.Fatalf("semantic check was not grounded in the objective: %q", nudge)
 	}
 }

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -127,9 +126,8 @@ func endsWithContinuationCue(text string) bool {
 // which the update_plan tool coerces to "pending") counts as remaining, matching
 // that tool's own status normalization.
 func planStatusRemaining(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "completed", "complete", "done", "finished", "resolved", "✓", "x", "[x]",
-		"failed", "fail", "error", "errored", "blocked", "cancelled", "canceled", "abandoned", "skipped":
+	switch normalizeTaskPlanStatus(status) {
+	case "completed", "failed":
 		return false
 	default:
 		return true
@@ -307,8 +305,8 @@ func hasAnyPrefix(s string, prefixes []string) bool {
 // the bug-hunt surfaced: well-formed output treated as correct; pre-existing tests
 // passing treated as the objective being met; and a result that merely matches a
 // baseline the task asked to beat or improve. General — no task-specific content.
-func acceptanceVerificationNudge() string {
-	return "Before this task can be marked complete, " + acceptanceNudgeMarker + " — " +
+func acceptanceVerificationNudge(objective string) string {
+	nudge := "Before this task can be marked complete, " + acceptanceNudgeMarker + " — " +
 		"NOT the shape or format of your output, NOT that pre-existing tests pass, and NOT that your " +
 		"result merely matches a baseline you were asked to beat or improve. " +
 		"Re-read the original task, then run a concrete check that exercises the actual requirement: " +
@@ -316,6 +314,10 @@ func acceptanceVerificationNudge() string {
 		"thing the task asked you to produce, recover, fix, or optimize. " +
 		"If that check passes, reply PASS and cite the evidence. " +
 		"If it does not pass — or you cannot run such a check — say so plainly and keep working; do not claim success."
+	if objective = capTaskObjective(objective); objective != "" {
+		nudge += "\n\nTask objective: " + objective
+	}
+	return nudge
 }
 
 // toolFailureHintMarker is a stable substring for tests.
@@ -553,16 +555,12 @@ func (state *guardState) pendingPlanItems() bool {
 // many items are still remaining. Malformed arguments leave the prior count
 // unchanged (best-effort — the plan panel itself tolerates the same).
 func (state *guardState) observePlanUpdate(arguments string) {
-	var parsed struct {
-		Plan []struct {
-			Status string `json:"status"`
-		} `json:"plan"`
-	}
-	if json.Unmarshal([]byte(arguments), &parsed) != nil {
+	plan, ok := parseTaskPlan(arguments)
+	if !ok {
 		return
 	}
 	pending := 0
-	for _, item := range parsed.Plan {
+	for _, item := range plan {
 		if planStatusRemaining(item.Status) {
 			pending++
 		}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -190,7 +190,10 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	defer func() {
 		// A final transcript comparison is observational. It records drift but
 		// never rewrites the result or changes execution after the fact.
-		task.compareTranscript(result.Messages)
+		task.observePlanParity(result.Messages)
+		// Tool-result observations are intentionally coalesced; this final event
+		// guarantees their aggregate counts are present even on an early return.
+		task.emit()
 	}()
 	// The execution-profile posture controller. nil Options.Profile (every
 	// existing caller) makes every observe/decide call a no-op, keeping the

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -185,7 +185,13 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	messages := zeroruntime.SeedMessagesWithImages(promptParts.prompt, prompt, options.Images)
 
 	guards := newGuardState()
-	compactor := newCompactionState(options)
+	task := newTaskState(prompt, options.Trace)
+	compactor := newCompactionState(options, task)
+	defer func() {
+		// A final transcript comparison is observational. It records drift but
+		// never rewrites the result or changes execution after the fact.
+		task.compareTranscript(result.Messages)
+	}()
 	// The execution-profile posture controller. nil Options.Profile (every
 	// existing caller) makes every observe/decide call a no-op, keeping the
 	// loop byte-identical for unprofiled runs.
@@ -570,7 +576,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			// model's final answer ONLY when the work is actually done. Default off
 			// (RequireCompletionSignal), so interactive runs stay byte-identical.
 			if options.RequireCompletionSignal {
-				evaluation := completionPolicy.evaluate(collected.Text, guards.pendingPlanItems())
+				completionContext := task.completionContext(messages, guards.pendingPlanItems())
+				evaluation := completionPolicy.evaluate(collected.Text, completionContext)
+				task.observe(taskStateEvent{kind: taskStateEventCompletion, completion: evaluation})
 				switch evaluation.Decision {
 				case CompletionIncomplete:
 					result.Incomplete = true
@@ -595,13 +603,15 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 						options.Trace.Counter(trace.CounterAcceptanceChecks, 1)
 						messages = append(messages, zeroruntime.Message{
 							Role:    zeroruntime.MessageRoleUser,
-							Content: acceptanceVerificationNudge(),
+							Content: acceptanceVerificationNudge(completionContext.Objective),
 						})
 					}
 					continue
 				case CompletionComplete:
 					// Local evidence is sufficient; proceed to final diagnostics.
 				}
+			} else {
+				task.observe(taskStateEvent{kind: taskStateEventCompletion, completion: completionEvaluation{Decision: CompletionComplete}})
 			}
 			// Finalization diagnostics gate: edits from this run may still have
 			// checks in flight — the per-turn drain waits only briefly and defers
@@ -625,6 +635,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		// executing so the empty-turn counter resets and plan-tracking signals
 		// stay current.
 		guards.observeTurn(collected)
+		for _, call := range collected.ToolCalls {
+			if call.Name == planToolName {
+				task.observe(taskStateEvent{kind: taskStateEventPlan, arguments: call.Arguments})
+			}
+		}
 
 		failureHint := ""
 		// turnRequestedModel records the FIRST mid-run escalation target requested
@@ -676,6 +691,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			}
 			options.Trace.Counter(trace.CounterToolCalls, 1)
 			recordOutputBudgetTrace(options.Trace, toolResult)
+			task.observe(taskStateEvent{kind: taskStateEventToolResult, toolResult: toolResult})
 			if options.OnToolResult != nil {
 				options.OnToolResult(toolResult)
 			}
@@ -757,6 +773,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		if options.SelfCorrect != nil && len(changedFilesThisBatch) > 0 {
 			feedback, selfCorrectOutcome := options.SelfCorrect.AfterEdit(ctx, dedupeStrings(changedFilesThisBatch))
 			posture.observeSelfCorrect(selfCorrectOutcome)
+			task.observe(taskStateEvent{kind: taskStateEventVerification, verification: selfCorrectOutcome})
 			if feedback != "" {
 				messages = append(messages, zeroruntime.Message{
 					Role:    zeroruntime.MessageRoleUser,

--- a/internal/agent/task_state.go
+++ b/internal/agent/task_state.go
@@ -1,8 +1,6 @@
 package agent
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"reflect"
 	"sort"
@@ -21,12 +19,12 @@ const (
 	taskStatusIncomplete taskStatus = "incomplete"
 )
 
-type taskStateParity string
+type taskPlanParity string
 
 const (
-	taskStateParityUnknown  taskStateParity = "unknown"
-	taskStateParityMatch    taskStateParity = "match"
-	taskStateParityMismatch taskStateParity = "mismatch"
+	taskPlanParityUnknown  taskPlanParity = "unknown"
+	taskPlanParityMatch    taskPlanParity = "match"
+	taskPlanParityMismatch taskPlanParity = "mismatch"
 )
 
 type taskPlanItem struct {
@@ -64,7 +62,7 @@ type taskStateSnapshot struct {
 	ChangedFiles       []string              `json:"changed_files,omitempty"`
 	CompletionDecision CompletionDecision    `json:"completion_decision,omitempty"`
 	CompletionReason   string                `json:"completion_reason,omitempty"`
-	TranscriptParity   taskStateParity       `json:"transcript_parity"`
+	PlanParity         taskPlanParity        `json:"plan_parity"`
 }
 
 type taskStateEventKind int
@@ -94,18 +92,16 @@ type taskState struct {
 	planObserved  bool
 }
 
-func newTaskState(objective string, recorders ...*trace.Recorder) *taskState {
+func newTaskState(objective string, recorder *trace.Recorder) *taskState {
 	state := &taskState{
 		snapshotValue: taskStateSnapshot{
-			Objective:        strings.TrimSpace(objective),
-			Status:           taskStatusActive,
-			TranscriptParity: taskStateParityUnknown,
+			Objective:  strings.TrimSpace(objective),
+			Status:     taskStatusActive,
+			PlanParity: taskPlanParityUnknown,
 		},
 		changedFiles: map[string]struct{}{},
 	}
-	if len(recorders) > 0 {
-		state.recorder = recorders[0]
-	}
+	state.recorder = recorder
 	return state
 }
 
@@ -167,7 +163,9 @@ func (state *taskState) observe(event taskStateEvent) bool {
 	}
 	if changed {
 		state.snapshotValue.Revision++
-		state.emit()
+		if event.kind != taskStateEventToolResult {
+			state.emit()
+		}
 	}
 	return changed
 }
@@ -188,18 +186,22 @@ func (state *taskState) snapshot() taskStateSnapshot {
 	return snapshot
 }
 
-func (state *taskState) compareTranscript(messages []zeroruntime.Message) taskStateParity {
+// observePlanParity compares only the latest plan projection with the plan tool
+// calls still present in messages. It mutates the snapshot and emits when the
+// parity value changes; objective, tool, and verification fields are not part of
+// this comparison.
+func (state *taskState) observePlanParity(messages []zeroruntime.Message) taskPlanParity {
 	if state == nil {
-		return taskStateParityUnknown
+		return taskPlanParityUnknown
 	}
 	transcriptPlan, found, valid := latestTaskPlan(messages)
 	tracked := state.snapshotValue.Plan.Items
-	parity := taskStateParityMatch
+	parity := taskPlanParityMatch
 	if !valid || found != state.planObserved || (found && !reflect.DeepEqual(transcriptPlan, tracked)) {
-		parity = taskStateParityMismatch
+		parity = taskPlanParityMismatch
 	}
-	if state.snapshotValue.TranscriptParity != parity {
-		state.snapshotValue.TranscriptParity = parity
+	if state.snapshotValue.PlanParity != parity {
+		state.snapshotValue.PlanParity = parity
 		state.snapshotValue.Revision++
 		state.emit()
 	}
@@ -207,9 +209,9 @@ func (state *taskState) compareTranscript(messages []zeroruntime.Message) taskSt
 }
 
 type completionContext struct {
-	Objective              string
-	PlanPending            bool
-	StateMatchesTranscript bool
+	Objective             string
+	PlanPending           bool
+	PlanMatchesTranscript bool
 }
 
 func (state *taskState) completionContext(messages []zeroruntime.Message, transcriptPlanPending bool) completionContext {
@@ -218,17 +220,18 @@ func (state *taskState) completionContext(messages []zeroruntime.Message, transc
 		return context
 	}
 	context.Objective = state.snapshotValue.Objective
-	context.StateMatchesTranscript = state.compareTranscript(messages) == taskStateParityMatch
-	if context.StateMatchesTranscript {
+	context.PlanMatchesTranscript = state.observePlanParity(messages) == taskPlanParityMatch
+	if context.PlanMatchesTranscript {
 		context.PlanPending = state.snapshotValue.Plan.Pending+state.snapshotValue.Plan.InProgress > 0
 	}
 	return context
 }
 
 func (state *taskState) snapshotForCompaction(messages []zeroruntime.Message) *taskStateSnapshot {
-	if state == nil || state.compareTranscript(messages) != taskStateParityMatch {
+	if state == nil {
 		return nil
 	}
+	state.observePlanParity(messages)
 	snapshot := state.snapshot()
 	return &snapshot
 }
@@ -238,11 +241,9 @@ func (state *taskState) emit() {
 		return
 	}
 	snapshot := state.snapshotValue
-	digest := sha256.Sum256([]byte(snapshot.Objective))
 	state.recorder.EmitTaskState(trace.TaskStateEvent{
 		Revision:            snapshot.Revision,
 		Status:              string(snapshot.Status),
-		ObjectiveHash:       hex.EncodeToString(digest[:]),
 		PlanPending:         snapshot.Plan.Pending,
 		PlanInProgress:      snapshot.Plan.InProgress,
 		PlanCompleted:       snapshot.Plan.Completed,
@@ -254,35 +255,37 @@ func (state *taskState) emit() {
 		VerificationOutcome: string(snapshot.Verification.LastOutcome),
 		ChangedFileCount:    len(snapshot.ChangedFiles),
 		CompletionDecision:  string(snapshot.CompletionDecision),
-		TranscriptParity:    string(snapshot.TranscriptParity),
+		PlanParity:          string(snapshot.PlanParity),
 	})
 }
 
 func parseTaskPlan(arguments string) ([]taskPlanItem, bool) {
-	var parsed struct {
-		Plan []struct {
-			Content string `json:"content"`
-			Step    string `json:"step"`
-			Status  string `json:"status"`
-			Notes   string `json:"notes"`
-		} `json:"plan"`
-	}
-	if json.Unmarshal([]byte(strings.TrimSpace(arguments)), &parsed) != nil {
+	var object map[string]json.RawMessage
+	if json.Unmarshal([]byte(strings.TrimSpace(arguments)), &object) != nil {
 		return nil, false
 	}
-	plan := make([]taskPlanItem, 0, len(parsed.Plan))
-	for _, raw := range parsed.Plan {
-		content := strings.TrimSpace(raw.Content)
-		if content == "" {
-			content = strings.TrimSpace(raw.Step)
-		}
-		if content == "" {
-			continue
+	rawPlan, ok := object["plan"]
+	if !ok || string(rawPlan) == "null" {
+		return nil, false
+	}
+	var parsed []struct {
+		ID      *string `json:"id"`
+		Content string  `json:"content"`
+		Status  string  `json:"status"`
+		Notes   string  `json:"notes"`
+	}
+	if json.Unmarshal(rawPlan, &parsed) != nil {
+		return nil, false
+	}
+	plan := make([]taskPlanItem, 0, len(parsed))
+	for _, raw := range parsed {
+		if raw.Content == "" {
+			return nil, false
 		}
 		plan = append(plan, taskPlanItem{
-			Content: content,
+			Content: raw.Content,
 			Status:  normalizeTaskPlanStatus(raw.Status),
-			Notes:   strings.TrimSpace(raw.Notes),
+			Notes:   raw.Notes,
 		})
 	}
 	lastInProgress := -1

--- a/internal/agent/task_state.go
+++ b/internal/agent/task_state.go
@@ -1,0 +1,356 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/trace"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+type taskStatus string
+
+const (
+	taskStatusActive     taskStatus = "active"
+	taskStatusComplete   taskStatus = "complete"
+	taskStatusIncomplete taskStatus = "incomplete"
+)
+
+type taskStateParity string
+
+const (
+	taskStateParityUnknown  taskStateParity = "unknown"
+	taskStateParityMatch    taskStateParity = "match"
+	taskStateParityMismatch taskStateParity = "mismatch"
+)
+
+type taskPlanItem struct {
+	Content string `json:"content"`
+	Status  string `json:"status"`
+	Notes   string `json:"notes,omitempty"`
+}
+
+type taskPlanState struct {
+	Items      []taskPlanItem `json:"items,omitempty"`
+	Pending    int            `json:"pending"`
+	InProgress int            `json:"in_progress"`
+	Completed  int            `json:"completed"`
+	Failed     int            `json:"failed"`
+}
+
+type taskToolState struct {
+	Succeeded int `json:"succeeded"`
+	Failed    int `json:"failed"`
+}
+
+type taskVerificationState struct {
+	Passed      int     `json:"passed"`
+	Failed      int     `json:"failed"`
+	LastOutcome Outcome `json:"last_outcome,omitempty"`
+}
+
+type taskStateSnapshot struct {
+	Revision           int                   `json:"revision"`
+	Objective          string                `json:"objective"`
+	Status             taskStatus            `json:"status"`
+	Plan               taskPlanState         `json:"plan"`
+	Tools              taskToolState         `json:"tools"`
+	Verification       taskVerificationState `json:"verification"`
+	ChangedFiles       []string              `json:"changed_files,omitempty"`
+	CompletionDecision CompletionDecision    `json:"completion_decision,omitempty"`
+	CompletionReason   string                `json:"completion_reason,omitempty"`
+	TranscriptParity   taskStateParity       `json:"transcript_parity"`
+}
+
+type taskStateEventKind int
+
+const (
+	taskStateEventPlan taskStateEventKind = iota + 1
+	taskStateEventToolResult
+	taskStateEventVerification
+	taskStateEventCompletion
+)
+
+type taskStateEvent struct {
+	kind         taskStateEventKind
+	arguments    string
+	toolResult   ToolResult
+	verification Outcome
+	completion   completionEvaluation
+}
+
+// taskState is a deterministic projection of facts the loop already observes.
+// It does not initiate work or replace the transcript; consumers must check
+// transcript parity before using its compact representation.
+type taskState struct {
+	snapshotValue taskStateSnapshot
+	changedFiles  map[string]struct{}
+	recorder      *trace.Recorder
+	planObserved  bool
+}
+
+func newTaskState(objective string, recorders ...*trace.Recorder) *taskState {
+	state := &taskState{
+		snapshotValue: taskStateSnapshot{
+			Objective:        strings.TrimSpace(objective),
+			Status:           taskStatusActive,
+			TranscriptParity: taskStateParityUnknown,
+		},
+		changedFiles: map[string]struct{}{},
+	}
+	if len(recorders) > 0 {
+		state.recorder = recorders[0]
+	}
+	return state
+}
+
+func (state *taskState) observe(event taskStateEvent) bool {
+	if state == nil {
+		return false
+	}
+	changed := false
+	switch event.kind {
+	case taskStateEventPlan:
+		plan, ok := parseTaskPlan(event.arguments)
+		if !ok {
+			return false
+		}
+		state.snapshotValue.Plan = summarizeTaskPlan(plan)
+		state.planObserved = true
+		state.markActive()
+		changed = true
+	case taskStateEventToolResult:
+		state.markActive()
+		if event.toolResult.Status == tools.StatusOK {
+			state.snapshotValue.Tools.Succeeded++
+		} else {
+			state.snapshotValue.Tools.Failed++
+		}
+		for _, path := range event.toolResult.ChangedFiles {
+			path = strings.TrimSpace(path)
+			if path != "" {
+				state.changedFiles[path] = struct{}{}
+			}
+		}
+		state.snapshotValue.ChangedFiles = sortedKeys(state.changedFiles)
+		changed = true
+	case taskStateEventVerification:
+		if event.verification == OutcomeDisabled {
+			return false
+		}
+		state.markActive()
+		state.snapshotValue.Verification.LastOutcome = event.verification
+		switch event.verification {
+		case OutcomePassed:
+			state.snapshotValue.Verification.Passed++
+		case OutcomeCorrecting, OutcomeReported, OutcomeAborted:
+			state.snapshotValue.Verification.Failed++
+		}
+		changed = true
+	case taskStateEventCompletion:
+		state.snapshotValue.CompletionDecision = event.completion.Decision
+		state.snapshotValue.CompletionReason = event.completion.Reason
+		switch event.completion.Decision {
+		case CompletionComplete:
+			state.snapshotValue.Status = taskStatusComplete
+		case CompletionIncomplete:
+			state.snapshotValue.Status = taskStatusIncomplete
+		default:
+			state.snapshotValue.Status = taskStatusActive
+		}
+		changed = true
+	}
+	if changed {
+		state.snapshotValue.Revision++
+		state.emit()
+	}
+	return changed
+}
+
+func (state *taskState) markActive() {
+	state.snapshotValue.Status = taskStatusActive
+	state.snapshotValue.CompletionDecision = ""
+	state.snapshotValue.CompletionReason = ""
+}
+
+func (state *taskState) snapshot() taskStateSnapshot {
+	if state == nil {
+		return taskStateSnapshot{}
+	}
+	snapshot := state.snapshotValue
+	snapshot.Plan.Items = append([]taskPlanItem(nil), state.snapshotValue.Plan.Items...)
+	snapshot.ChangedFiles = append([]string(nil), state.snapshotValue.ChangedFiles...)
+	return snapshot
+}
+
+func (state *taskState) compareTranscript(messages []zeroruntime.Message) taskStateParity {
+	if state == nil {
+		return taskStateParityUnknown
+	}
+	transcriptPlan, found, valid := latestTaskPlan(messages)
+	tracked := state.snapshotValue.Plan.Items
+	parity := taskStateParityMatch
+	if !valid || found != state.planObserved || (found && !reflect.DeepEqual(transcriptPlan, tracked)) {
+		parity = taskStateParityMismatch
+	}
+	if state.snapshotValue.TranscriptParity != parity {
+		state.snapshotValue.TranscriptParity = parity
+		state.snapshotValue.Revision++
+		state.emit()
+	}
+	return parity
+}
+
+type completionContext struct {
+	Objective              string
+	PlanPending            bool
+	StateMatchesTranscript bool
+}
+
+func (state *taskState) completionContext(messages []zeroruntime.Message, transcriptPlanPending bool) completionContext {
+	context := completionContext{PlanPending: transcriptPlanPending}
+	if state == nil {
+		return context
+	}
+	context.Objective = state.snapshotValue.Objective
+	context.StateMatchesTranscript = state.compareTranscript(messages) == taskStateParityMatch
+	if context.StateMatchesTranscript {
+		context.PlanPending = state.snapshotValue.Plan.Pending+state.snapshotValue.Plan.InProgress > 0
+	}
+	return context
+}
+
+func (state *taskState) snapshotForCompaction(messages []zeroruntime.Message) *taskStateSnapshot {
+	if state == nil || state.compareTranscript(messages) != taskStateParityMatch {
+		return nil
+	}
+	snapshot := state.snapshot()
+	return &snapshot
+}
+
+func (state *taskState) emit() {
+	if state == nil || state.recorder == nil {
+		return
+	}
+	snapshot := state.snapshotValue
+	digest := sha256.Sum256([]byte(snapshot.Objective))
+	state.recorder.EmitTaskState(trace.TaskStateEvent{
+		Revision:            snapshot.Revision,
+		Status:              string(snapshot.Status),
+		ObjectiveHash:       hex.EncodeToString(digest[:]),
+		PlanPending:         snapshot.Plan.Pending,
+		PlanInProgress:      snapshot.Plan.InProgress,
+		PlanCompleted:       snapshot.Plan.Completed,
+		PlanFailed:          snapshot.Plan.Failed,
+		ToolsSucceeded:      snapshot.Tools.Succeeded,
+		ToolsFailed:         snapshot.Tools.Failed,
+		VerificationPassed:  snapshot.Verification.Passed,
+		VerificationFailed:  snapshot.Verification.Failed,
+		VerificationOutcome: string(snapshot.Verification.LastOutcome),
+		ChangedFileCount:    len(snapshot.ChangedFiles),
+		CompletionDecision:  string(snapshot.CompletionDecision),
+		TranscriptParity:    string(snapshot.TranscriptParity),
+	})
+}
+
+func parseTaskPlan(arguments string) ([]taskPlanItem, bool) {
+	var parsed struct {
+		Plan []struct {
+			Content string `json:"content"`
+			Step    string `json:"step"`
+			Status  string `json:"status"`
+			Notes   string `json:"notes"`
+		} `json:"plan"`
+	}
+	if json.Unmarshal([]byte(strings.TrimSpace(arguments)), &parsed) != nil {
+		return nil, false
+	}
+	plan := make([]taskPlanItem, 0, len(parsed.Plan))
+	for _, raw := range parsed.Plan {
+		content := strings.TrimSpace(raw.Content)
+		if content == "" {
+			content = strings.TrimSpace(raw.Step)
+		}
+		if content == "" {
+			continue
+		}
+		plan = append(plan, taskPlanItem{
+			Content: content,
+			Status:  normalizeTaskPlanStatus(raw.Status),
+			Notes:   strings.TrimSpace(raw.Notes),
+		})
+	}
+	lastInProgress := -1
+	for index := range plan {
+		if plan[index].Status == "in_progress" {
+			if lastInProgress >= 0 {
+				plan[lastInProgress].Status = "completed"
+			}
+			lastInProgress = index
+		}
+	}
+	if len(plan) == 0 {
+		return nil, true
+	}
+	return plan, true
+}
+
+func normalizeTaskPlanStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "complete", "done", "finished", "resolved", "✓", "x", "[x]":
+		return "completed"
+	case "in_progress", "in-progress", "inprogress", "in progress", "active", "doing", "started", "current", "wip", "ongoing", "running":
+		return "in_progress"
+	case "failed", "fail", "error", "errored", "blocked", "cancelled", "canceled", "abandoned", "skipped":
+		return "failed"
+	default:
+		return "pending"
+	}
+}
+
+func summarizeTaskPlan(items []taskPlanItem) taskPlanState {
+	plan := taskPlanState{Items: append([]taskPlanItem(nil), items...)}
+	for _, item := range items {
+		switch item.Status {
+		case "completed":
+			plan.Completed++
+		case "in_progress":
+			plan.InProgress++
+		case "failed":
+			plan.Failed++
+		default:
+			plan.Pending++
+		}
+	}
+	return plan
+}
+
+func latestTaskPlan(messages []zeroruntime.Message) ([]taskPlanItem, bool, bool) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		for j := len(messages[i].ToolCalls) - 1; j >= 0; j-- {
+			call := messages[i].ToolCalls[j]
+			if call.Name != planToolName {
+				continue
+			}
+			plan, ok := parseTaskPlan(call.Arguments)
+			return plan, true, ok
+		}
+	}
+	return nil, false, true
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for value := range values {
+		keys = append(keys, value)
+	}
+	// Paths are evidence, not chronology. Stable ordering makes replay snapshots
+	// deterministic even if events originate from parallel read batches later.
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/agent/task_state_test.go
+++ b/internal/agent/task_state_test.go
@@ -19,8 +19,8 @@ func TestTaskStateReplayIsDeterministic(t *testing.T) {
 		{kind: taskStateEventCompletion, completion: completionEvaluation{Decision: CompletionUncertain, Reason: "pending work"}},
 	}
 
-	first := newTaskState("ship the change")
-	second := newTaskState("ship the change")
+	first := newTaskState("ship the change", nil)
+	second := newTaskState("ship the change", nil)
 	for _, event := range events {
 		first.observe(event)
 		second.observe(event)
@@ -38,6 +38,28 @@ func TestTaskStateReplayIsDeterministic(t *testing.T) {
 	}
 	if got.Verification.Passed != 1 || got.Verification.Failed != 0 || got.Verification.LastOutcome != OutcomePassed {
 		t.Fatalf("unexpected verification snapshot: %#v", got.Verification)
+	}
+}
+
+func TestTaskStateCoalescesToolResultsIntoNextTraceEvent(t *testing.T) {
+	recorder := trace.NewRecorder("session", "run", "")
+	state := newTaskState("objective", recorder)
+	for range 20 {
+		state.observe(taskStateEvent{kind: taskStateEventToolResult, toolResult: ToolResult{Status: tools.StatusOK}})
+	}
+	if events := recorder.Finish().TaskStates; len(events) != 0 {
+		t.Fatalf("tool results should be coalesced, got %d trace events", len(events))
+	}
+
+	recorder = trace.NewRecorder("session", "run-2", "")
+	state = newTaskState("objective", recorder)
+	for range 20 {
+		state.observe(taskStateEvent{kind: taskStateEventToolResult, toolResult: ToolResult{Status: tools.StatusOK}})
+	}
+	state.observe(taskStateEvent{kind: taskStateEventCompletion, completion: completionEvaluation{Decision: CompletionComplete}})
+	events := recorder.Finish().TaskStates
+	if len(events) != 1 || events[0].ToolsSucceeded != 20 {
+		t.Fatalf("coalesced tool total missing from completion snapshot: %#v", events)
 	}
 }
 
@@ -73,13 +95,13 @@ func TestRunEmitsTaskStateFromExistingLoopEvents(t *testing.T) {
 		t.Fatalf("expected plan, tool, completion, and parity snapshots, got %#v", events)
 	}
 	last := events[len(events)-1]
-	if last.Status != string(taskStatusComplete) || last.PlanCompleted != 1 || last.ToolsSucceeded != 1 || last.TranscriptParity != string(taskStateParityMatch) {
+	if last.Status != string(taskStatusComplete) || last.PlanCompleted != 1 || last.ToolsSucceeded != 1 || last.PlanParity != string(taskPlanParityMatch) {
 		t.Fatalf("unexpected final task snapshot: %#v", last)
 	}
 }
 
 func TestTaskStateSnapshotIsImmutable(t *testing.T) {
-	state := newTaskState("objective")
+	state := newTaskState("objective", nil)
 	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"one","status":"pending"}]}`})
 	state.observe(taskStateEvent{kind: taskStateEventToolResult, toolResult: ToolResult{Status: tools.StatusOK, ChangedFiles: []string{"one.go"}}})
 
@@ -93,26 +115,26 @@ func TestTaskStateSnapshotIsImmutable(t *testing.T) {
 	}
 }
 
-func TestTaskStateTranscriptParityUsesLatestPlan(t *testing.T) {
-	state := newTaskState("objective")
+func TestTaskStatePlanParityUsesLatestPlan(t *testing.T) {
+	state := newTaskState("objective", nil)
 	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"old","status":"completed"}]}`})
 	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"new","status":"in_progress"}]}`})
 
 	messages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
 		{Name: planToolName, Arguments: `{"plan":[{"content":"new","status":"in_progress"}]}`},
 	}}}
-	if parity := state.compareTranscript(messages); parity != taskStateParityMatch {
+	if parity := state.observePlanParity(messages); parity != taskPlanParityMatch {
 		t.Fatalf("parity = %q, want match", parity)
 	}
 
 	messages[0].ToolCalls[0].Arguments = `{"plan":[{"content":"different","status":"pending"}]}`
-	if parity := state.compareTranscript(messages); parity != taskStateParityMismatch {
+	if parity := state.observePlanParity(messages); parity != taskPlanParityMismatch {
 		t.Fatalf("parity = %q, want mismatch", parity)
 	}
 }
 
 func TestTaskStateMatchesPlanToolNormalization(t *testing.T) {
-	state := newTaskState("objective")
+	state := newTaskState("objective", nil)
 	arguments := `{"plan":[{"content":"first","status":"in_progress"},{"content":"second","status":"in_progress"}]}`
 	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: arguments})
 
@@ -121,27 +143,27 @@ func TestTaskStateMatchesPlanToolNormalization(t *testing.T) {
 		t.Fatalf("multiple active items were not normalized like the plan tool: %#v", snapshot.Plan)
 	}
 	messages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{Name: planToolName, Arguments: arguments}}}}
-	if parity := state.compareTranscript(messages); parity != taskStateParityMatch {
+	if parity := state.observePlanParity(messages); parity != taskPlanParityMatch {
 		t.Fatalf("normalized state should still match its transcript event, got %q", parity)
 	}
 
-	empty := newTaskState("objective")
+	empty := newTaskState("objective", nil)
 	empty.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[]}`})
 	emptyMessages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{Name: planToolName, Arguments: `{"plan":[]}`}}}}
-	if parity := empty.compareTranscript(emptyMessages); parity != taskStateParityMatch {
+	if parity := empty.observePlanParity(emptyMessages); parity != taskPlanParityMatch {
 		t.Fatalf("explicit empty plan should match transcript, got %q", parity)
 	}
 }
 
 func TestTaskStateContextFallsBackWhenTranscriptDiffers(t *testing.T) {
-	state := newTaskState("objective")
+	state := newTaskState("objective", nil)
 	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"tracked","status":"completed"}]}`})
 	messages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
 		{Name: planToolName, Arguments: `{"plan":[{"content":"transcript","status":"pending"}]}`},
 	}}}
 
 	context := state.completionContext(messages, true)
-	if !context.PlanPending || context.StateMatchesTranscript {
+	if !context.PlanPending || context.PlanMatchesTranscript {
 		t.Fatalf("completion context must retain transcript truth on mismatch: %#v", context)
 	}
 	if context.Objective != "objective" {
@@ -149,8 +171,8 @@ func TestTaskStateContextFallsBackWhenTranscriptDiffers(t *testing.T) {
 	}
 }
 
-func TestTaskStateCompactionSnapshotRequiresTranscriptParity(t *testing.T) {
-	state := newTaskState("objective")
+func TestTaskStateCompactionSnapshotRetainsObjectiveOnPlanMismatch(t *testing.T) {
+	state := newTaskState("objective", nil)
 	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"verify","status":"pending"}]}`})
 	matching := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
 		{Name: planToolName, Arguments: `{"plan":[{"content":"verify","status":"pending"}]}`},
@@ -161,7 +183,22 @@ func TestTaskStateCompactionSnapshotRequiresTranscriptParity(t *testing.T) {
 
 	mismatching := append([]zeroruntime.Message(nil), matching...)
 	mismatching[0].ToolCalls = []zeroruntime.ToolCall{{Name: planToolName, Arguments: `{"plan":[{"content":"other","status":"pending"}]}`}}
-	if snapshot := state.snapshotForCompaction(mismatching); snapshot != nil {
-		t.Fatalf("mismatching transcript must suppress compact state, got %#v", snapshot)
+	if snapshot := state.snapshotForCompaction(mismatching); snapshot == nil || snapshot.Objective != "objective" || snapshot.PlanParity != taskPlanParityMismatch {
+		t.Fatalf("plan mismatch must retain immutable objective and mark mutable state uncorroborated, got %#v", snapshot)
+	}
+}
+
+func TestParseTaskPlanRejectsArgumentsTheToolWouldReject(t *testing.T) {
+	for _, arguments := range []string{
+		`{}`,
+		`{"plan":null}`,
+		`{"plan":[{"step":"alias is not accepted"}]}`,
+		`{"plan":[{"content":""}]}`,
+		`{"plan":[{"content":"valid"},{"content":""}]}`,
+		`{"plan":[{"id":4,"content":"valid"}]}`,
+	} {
+		if plan, ok := parseTaskPlan(arguments); ok {
+			t.Fatalf("parseTaskPlan(%s) = %#v, true; want rejected", arguments, plan)
+		}
 	}
 }

--- a/internal/agent/task_state_test.go
+++ b/internal/agent/task_state_test.go
@@ -1,0 +1,167 @@
+package agent
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/trace"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestTaskStateReplayIsDeterministic(t *testing.T) {
+	events := []taskStateEvent{
+		{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"inspect","status":"done"},{"content":"implement","status":"in progress"},{"content":"verify"}]}`},
+		{kind: taskStateEventToolResult, toolResult: ToolResult{Name: "apply_patch", Status: tools.StatusOK, ChangedFiles: []string{"a.go", "a.go", "b.go"}}},
+		{kind: taskStateEventToolResult, toolResult: ToolResult{Name: "go test", Status: tools.StatusError}},
+		{kind: taskStateEventVerification, verification: OutcomePassed},
+		{kind: taskStateEventCompletion, completion: completionEvaluation{Decision: CompletionUncertain, Reason: "pending work"}},
+	}
+
+	first := newTaskState("ship the change")
+	second := newTaskState("ship the change")
+	for _, event := range events {
+		first.observe(event)
+		second.observe(event)
+	}
+
+	if !reflect.DeepEqual(first.snapshot(), second.snapshot()) {
+		t.Fatalf("replaying the same events produced different snapshots:\nfirst:  %#v\nsecond: %#v", first.snapshot(), second.snapshot())
+	}
+	got := first.snapshot()
+	if got.Status != taskStatusActive || got.Plan.Pending != 1 || got.Plan.InProgress != 1 || got.Plan.Completed != 1 {
+		t.Fatalf("unexpected plan snapshot: %#v", got)
+	}
+	if got.Tools.Succeeded != 1 || got.Tools.Failed != 1 || len(got.ChangedFiles) != 2 {
+		t.Fatalf("unexpected evidence snapshot: %#v", got)
+	}
+	if got.Verification.Passed != 1 || got.Verification.Failed != 0 || got.Verification.LastOutcome != OutcomePassed {
+		t.Fatalf("unexpected verification snapshot: %#v", got.Verification)
+	}
+}
+
+func TestRunEmitsTaskStateFromExistingLoopEvents(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewUpdatePlanTool())
+	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		{
+			{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "plan-1", ToolName: planToolName},
+			{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "plan-1", ArgumentsFragment: `{"plan":[{"content":"implement","status":"completed"}]}`},
+			{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "plan-1"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+		{
+			{Type: zeroruntime.StreamEventText, Content: "done"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+	}}
+	recorder := trace.NewRecorder("session", "run", "")
+
+	result, err := Run(context.Background(), "implement the change", provider, Options{
+		Registry: registry,
+		Trace:    recorder,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("final answer = %q, want done", result.FinalAnswer)
+	}
+	events := recorder.Finish().TaskStates
+	if len(events) < 3 {
+		t.Fatalf("expected plan, tool, completion, and parity snapshots, got %#v", events)
+	}
+	last := events[len(events)-1]
+	if last.Status != string(taskStatusComplete) || last.PlanCompleted != 1 || last.ToolsSucceeded != 1 || last.TranscriptParity != string(taskStateParityMatch) {
+		t.Fatalf("unexpected final task snapshot: %#v", last)
+	}
+}
+
+func TestTaskStateSnapshotIsImmutable(t *testing.T) {
+	state := newTaskState("objective")
+	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"one","status":"pending"}]}`})
+	state.observe(taskStateEvent{kind: taskStateEventToolResult, toolResult: ToolResult{Status: tools.StatusOK, ChangedFiles: []string{"one.go"}}})
+
+	snapshot := state.snapshot()
+	snapshot.Plan.Items[0].Content = "mutated"
+	snapshot.ChangedFiles[0] = "mutated.go"
+
+	fresh := state.snapshot()
+	if fresh.Plan.Items[0].Content != "one" || fresh.ChangedFiles[0] != "one.go" {
+		t.Fatalf("snapshot mutation leaked into task state: %#v", fresh)
+	}
+}
+
+func TestTaskStateTranscriptParityUsesLatestPlan(t *testing.T) {
+	state := newTaskState("objective")
+	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"old","status":"completed"}]}`})
+	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"new","status":"in_progress"}]}`})
+
+	messages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
+		{Name: planToolName, Arguments: `{"plan":[{"content":"new","status":"in_progress"}]}`},
+	}}}
+	if parity := state.compareTranscript(messages); parity != taskStateParityMatch {
+		t.Fatalf("parity = %q, want match", parity)
+	}
+
+	messages[0].ToolCalls[0].Arguments = `{"plan":[{"content":"different","status":"pending"}]}`
+	if parity := state.compareTranscript(messages); parity != taskStateParityMismatch {
+		t.Fatalf("parity = %q, want mismatch", parity)
+	}
+}
+
+func TestTaskStateMatchesPlanToolNormalization(t *testing.T) {
+	state := newTaskState("objective")
+	arguments := `{"plan":[{"content":"first","status":"in_progress"},{"content":"second","status":"in_progress"}]}`
+	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: arguments})
+
+	snapshot := state.snapshot()
+	if snapshot.Plan.Completed != 1 || snapshot.Plan.InProgress != 1 {
+		t.Fatalf("multiple active items were not normalized like the plan tool: %#v", snapshot.Plan)
+	}
+	messages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{Name: planToolName, Arguments: arguments}}}}
+	if parity := state.compareTranscript(messages); parity != taskStateParityMatch {
+		t.Fatalf("normalized state should still match its transcript event, got %q", parity)
+	}
+
+	empty := newTaskState("objective")
+	empty.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[]}`})
+	emptyMessages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{Name: planToolName, Arguments: `{"plan":[]}`}}}}
+	if parity := empty.compareTranscript(emptyMessages); parity != taskStateParityMatch {
+		t.Fatalf("explicit empty plan should match transcript, got %q", parity)
+	}
+}
+
+func TestTaskStateContextFallsBackWhenTranscriptDiffers(t *testing.T) {
+	state := newTaskState("objective")
+	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"tracked","status":"completed"}]}`})
+	messages := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
+		{Name: planToolName, Arguments: `{"plan":[{"content":"transcript","status":"pending"}]}`},
+	}}}
+
+	context := state.completionContext(messages, true)
+	if !context.PlanPending || context.StateMatchesTranscript {
+		t.Fatalf("completion context must retain transcript truth on mismatch: %#v", context)
+	}
+	if context.Objective != "objective" {
+		t.Fatalf("objective lost from completion context: %#v", context)
+	}
+}
+
+func TestTaskStateCompactionSnapshotRequiresTranscriptParity(t *testing.T) {
+	state := newTaskState("objective")
+	state.observe(taskStateEvent{kind: taskStateEventPlan, arguments: `{"plan":[{"content":"verify","status":"pending"}]}`})
+	matching := []zeroruntime.Message{{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
+		{Name: planToolName, Arguments: `{"plan":[{"content":"verify","status":"pending"}]}`},
+	}}}
+	if snapshot := state.snapshotForCompaction(matching); snapshot == nil || snapshot.Objective != "objective" {
+		t.Fatalf("matching transcript should produce compact state, got %#v", snapshot)
+	}
+
+	mismatching := append([]zeroruntime.Message(nil), matching...)
+	mismatching[0].ToolCalls = []zeroruntime.ToolCall{{Name: planToolName, Arguments: `{"plan":[{"content":"other","status":"pending"}]}`}}
+	if snapshot := state.snapshotForCompaction(mismatching); snapshot != nil {
+		t.Fatalf("mismatching transcript must suppress compact state, got %#v", snapshot)
+	}
+}

--- a/internal/trace/emit.go
+++ b/internal/trace/emit.go
@@ -142,7 +142,6 @@ func WriteNDJSON(w io.Writer, t *TurnTrace) error {
 			"type":                 "task_state",
 			"revision":             event.Revision,
 			"status":               event.Status,
-			"objective_hash":       event.ObjectiveHash,
 			"plan_pending":         event.PlanPending,
 			"plan_in_progress":     event.PlanInProgress,
 			"plan_completed":       event.PlanCompleted,
@@ -154,7 +153,7 @@ func WriteNDJSON(w io.Writer, t *TurnTrace) error {
 			"verification_outcome": event.VerificationOutcome,
 			"changed_file_count":   event.ChangedFileCount,
 			"completion_decision":  event.CompletionDecision,
-			"transcript_parity":    event.TranscriptParity,
+			"plan_parity":          event.PlanParity,
 		}); err != nil {
 			return err
 		}
@@ -230,11 +229,11 @@ func WriteText(w io.Writer, t *TurnTrace) error {
 	}
 	if len(t.TaskStates) > 0 {
 		latest := t.TaskStates[len(t.TaskStates)-1]
-		write("task state: revision=%d status=%s plan=%d/%d/%d/%d tools=%d/%d verification=%d/%d(%s) files=%d parity=%s completion=%s\n",
+		write("task state: revision=%d status=%s plan=%d/%d/%d/%d tools=%d/%d verification=%d/%d(%s) files=%d plan_parity=%s completion=%s\n",
 			latest.Revision, latest.Status, latest.PlanPending, latest.PlanInProgress,
 			latest.PlanCompleted, latest.PlanFailed, latest.ToolsSucceeded,
 			latest.ToolsFailed, latest.VerificationPassed, latest.VerificationFailed,
-			latest.VerificationOutcome, latest.ChangedFileCount, latest.TranscriptParity,
+			latest.VerificationOutcome, latest.ChangedFileCount, latest.PlanParity,
 			latest.CompletionDecision)
 	}
 	return firstErr

--- a/internal/trace/emit.go
+++ b/internal/trace/emit.go
@@ -137,6 +137,28 @@ func WriteNDJSON(w io.Writer, t *TurnTrace) error {
 			return err
 		}
 	}
+	for _, event := range t.TaskStates {
+		if err := enc.Encode(map[string]any{
+			"type":                 "task_state",
+			"revision":             event.Revision,
+			"status":               event.Status,
+			"objective_hash":       event.ObjectiveHash,
+			"plan_pending":         event.PlanPending,
+			"plan_in_progress":     event.PlanInProgress,
+			"plan_completed":       event.PlanCompleted,
+			"plan_failed":          event.PlanFailed,
+			"tools_succeeded":      event.ToolsSucceeded,
+			"tools_failed":         event.ToolsFailed,
+			"verification_passed":  event.VerificationPassed,
+			"verification_failed":  event.VerificationFailed,
+			"verification_outcome": event.VerificationOutcome,
+			"changed_file_count":   event.ChangedFileCount,
+			"completion_decision":  event.CompletionDecision,
+			"transcript_parity":    event.TranscriptParity,
+		}); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -205,6 +227,15 @@ func WriteText(w io.Writer, t *TurnTrace) error {
 				event.EstimatedRetainedTokens, event.EstimatedOriginalTokens,
 				event.Truncated, event.Reason, event.SpillCreated)
 		}
+	}
+	if len(t.TaskStates) > 0 {
+		latest := t.TaskStates[len(t.TaskStates)-1]
+		write("task state: revision=%d status=%s plan=%d/%d/%d/%d tools=%d/%d verification=%d/%d(%s) files=%d parity=%s completion=%s\n",
+			latest.Revision, latest.Status, latest.PlanPending, latest.PlanInProgress,
+			latest.PlanCompleted, latest.PlanFailed, latest.ToolsSucceeded,
+			latest.ToolsFailed, latest.VerificationPassed, latest.VerificationFailed,
+			latest.VerificationOutcome, latest.ChangedFileCount, latest.TranscriptParity,
+			latest.CompletionDecision)
 	}
 	return firstErr
 }

--- a/internal/trace/parse.go
+++ b/internal/trace/parse.go
@@ -139,7 +139,6 @@ func ReadNDJSON(r io.Reader) (*TurnTrace, error) {
 			t.TaskStates = append(t.TaskStates, TaskStateEvent{
 				Revision:            int(parseInt64(obj["revision"])),
 				Status:              stringField(obj, "status"),
-				ObjectiveHash:       stringField(obj, "objective_hash"),
 				PlanPending:         int(parseInt64(obj["plan_pending"])),
 				PlanInProgress:      int(parseInt64(obj["plan_in_progress"])),
 				PlanCompleted:       int(parseInt64(obj["plan_completed"])),
@@ -151,7 +150,7 @@ func ReadNDJSON(r io.Reader) (*TurnTrace, error) {
 				VerificationOutcome: stringField(obj, "verification_outcome"),
 				ChangedFileCount:    int(parseInt64(obj["changed_file_count"])),
 				CompletionDecision:  stringField(obj, "completion_decision"),
-				TranscriptParity:    stringField(obj, "transcript_parity"),
+				PlanParity:          stringField(obj, "plan_parity"),
 			})
 		default:
 			// Unknown event type: tolerate (forward-compat) but only after a

--- a/internal/trace/parse.go
+++ b/internal/trace/parse.go
@@ -132,6 +132,27 @@ func ReadNDJSON(r io.Reader) (*TurnTrace, error) {
 				Reason:                  stringField(obj, "reason"),
 				SpillCreated:            boolField(obj, "spill_created"),
 			})
+		case "task_state":
+			if !sawTraceHeader {
+				return nil, errors.New("parse trace: not a valid NDJSON trace (no type:trace header)")
+			}
+			t.TaskStates = append(t.TaskStates, TaskStateEvent{
+				Revision:            int(parseInt64(obj["revision"])),
+				Status:              stringField(obj, "status"),
+				ObjectiveHash:       stringField(obj, "objective_hash"),
+				PlanPending:         int(parseInt64(obj["plan_pending"])),
+				PlanInProgress:      int(parseInt64(obj["plan_in_progress"])),
+				PlanCompleted:       int(parseInt64(obj["plan_completed"])),
+				PlanFailed:          int(parseInt64(obj["plan_failed"])),
+				ToolsSucceeded:      int(parseInt64(obj["tools_succeeded"])),
+				ToolsFailed:         int(parseInt64(obj["tools_failed"])),
+				VerificationPassed:  int(parseInt64(obj["verification_passed"])),
+				VerificationFailed:  int(parseInt64(obj["verification_failed"])),
+				VerificationOutcome: stringField(obj, "verification_outcome"),
+				ChangedFileCount:    int(parseInt64(obj["changed_file_count"])),
+				CompletionDecision:  stringField(obj, "completion_decision"),
+				TranscriptParity:    stringField(obj, "transcript_parity"),
+			})
 		default:
 			// Unknown event type: tolerate (forward-compat) but only after a
 			// header has been seen.
@@ -152,8 +173,8 @@ func ReadNDJSON(r io.Reader) (*TurnTrace, error) {
 	if !sawTraceHeader {
 		return nil, errors.New("parse trace: non-empty input had no type:trace header")
 	}
-	if len(t.Spans) == 0 && len(t.Counters) == 0 && len(t.PrefixHashes) == 0 && len(t.OutputBudgets) == 0 {
-		return nil, errors.New("parse trace: header present but no spans, counters, or prefix hashes recovered (corrupt or truncated)")
+	if len(t.Spans) == 0 && len(t.Counters) == 0 && len(t.PrefixHashes) == 0 && len(t.OutputBudgets) == 0 && len(t.TaskStates) == 0 {
+		return nil, errors.New("parse trace: header present but no events recovered (corrupt or truncated)")
 	}
 	return t, nil
 }

--- a/internal/trace/recorder.go
+++ b/internal/trace/recorder.go
@@ -29,6 +29,10 @@ type Recorder struct {
 	firstActionStamped  bool
 }
 
+// maxTaskStateEvents bounds trace growth in pathological long runs. Once full,
+// the latest aggregate replaces the tail so final state is never lost.
+const maxTaskStateEvents = 128
+
 // NewRecorder returns a ready recorder. sessionID correlates with the agent
 // session (Options.SessionID); runID is a per-Run sequence; profile is an
 // optional label (e.g. "cold", "warm") for benchmark runs.
@@ -214,7 +218,11 @@ func (r *Recorder) EmitTaskState(event TaskStateEvent) {
 	if r.finished {
 		return
 	}
-	r.tr.TaskStates = append(r.tr.TaskStates, event)
+	if len(r.tr.TaskStates) < maxTaskStateEvents {
+		r.tr.TaskStates = append(r.tr.TaskStates, event)
+		return
+	}
+	r.tr.TaskStates[len(r.tr.TaskStates)-1] = event
 }
 
 // Finish stamps CompletedAt, derives each span's parent (by interval

--- a/internal/trace/recorder.go
+++ b/internal/trace/recorder.go
@@ -203,6 +203,20 @@ func (r *Recorder) EmitOutputBudget(event OutputBudgetEvent) {
 	r.tr.OutputBudgets = append(r.tr.OutputBudgets, event)
 }
 
+// EmitTaskState records one content-free structured task snapshot. Calls retain
+// event order so revisions can be replayed alongside the tool and turn stream.
+func (r *Recorder) EmitTaskState(event TaskStateEvent) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.finished {
+		return
+	}
+	r.tr.TaskStates = append(r.tr.TaskStates, event)
+}
+
 // Finish stamps CompletedAt, derives each span's parent (by interval
 // containment) and exclusive time, and returns a snapshot of the trace. Calling
 // Finish more than once returns the same snapshot.
@@ -223,6 +237,7 @@ func (r *Recorder) Finish() *TurnTrace {
 	snap.Counters = append([]Counter(nil), r.tr.Counters...)
 	snap.PrefixHashes = append([]PrefixHash(nil), r.tr.PrefixHashes...)
 	snap.OutputBudgets = append([]OutputBudgetEvent(nil), r.tr.OutputBudgets...)
+	snap.TaskStates = append([]TaskStateEvent(nil), r.tr.TaskStates...)
 	return &snap
 }
 

--- a/internal/trace/task_state_test.go
+++ b/internal/trace/task_state_test.go
@@ -12,7 +12,6 @@ func TestTaskStateTraceRoundTripContainsNoTaskContent(t *testing.T) {
 	event := TaskStateEvent{
 		Revision:            4,
 		Status:              "active",
-		ObjectiveHash:       "abc123",
 		PlanPending:         2,
 		PlanCompleted:       1,
 		ToolsSucceeded:      3,
@@ -20,7 +19,7 @@ func TestTaskStateTraceRoundTripContainsNoTaskContent(t *testing.T) {
 		VerificationPassed:  1,
 		VerificationOutcome: "passed",
 		ChangedFileCount:    2,
-		TranscriptParity:    "match",
+		PlanParity:          "match",
 	}
 	recorder.EmitTaskState(event)
 
@@ -30,6 +29,9 @@ func TestTaskStateTraceRoundTripContainsNoTaskContent(t *testing.T) {
 	}
 	if strings.Contains(output.String(), "secret objective") || strings.Contains(output.String(), "private.go") {
 		t.Fatalf("task content leaked into trace: %s", output.String())
+	}
+	if strings.Contains(output.String(), "objective_hash") {
+		t.Fatalf("trace contains a confirmable objective fingerprint: %s", output.String())
 	}
 	parsed, err := ReadNDJSON(strings.NewReader(output.String()))
 	if err != nil {
@@ -47,4 +49,18 @@ func TestTaskStateIsDocumentedAsOptionalTraceEvent(t *testing.T) {
 		}
 	}
 	t.Fatal("task_state missing from OptionalEventKeys")
+}
+
+func TestTaskStateTraceIsBoundedAndRetainsLatestSnapshot(t *testing.T) {
+	recorder := NewRecorder("session", "run", "")
+	for revision := 1; revision <= maxTaskStateEvents+20; revision++ {
+		recorder.EmitTaskState(TaskStateEvent{Revision: revision})
+	}
+	events := recorder.Finish().TaskStates
+	if len(events) != maxTaskStateEvents {
+		t.Fatalf("task state events = %d, want cap %d", len(events), maxTaskStateEvents)
+	}
+	if got := events[len(events)-1].Revision; got != maxTaskStateEvents+20 {
+		t.Fatalf("latest revision = %d, want %d", got, maxTaskStateEvents+20)
+	}
 }

--- a/internal/trace/task_state_test.go
+++ b/internal/trace/task_state_test.go
@@ -1,0 +1,50 @@
+package trace
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTaskStateTraceRoundTripContainsNoTaskContent(t *testing.T) {
+	recorder := NewRecorder("session", "run", "")
+	recorder.Start()
+	event := TaskStateEvent{
+		Revision:            4,
+		Status:              "active",
+		ObjectiveHash:       "abc123",
+		PlanPending:         2,
+		PlanCompleted:       1,
+		ToolsSucceeded:      3,
+		ToolsFailed:         1,
+		VerificationPassed:  1,
+		VerificationOutcome: "passed",
+		ChangedFileCount:    2,
+		TranscriptParity:    "match",
+	}
+	recorder.EmitTaskState(event)
+
+	var output bytes.Buffer
+	if err := WriteNDJSON(&output, recorder.Finish()); err != nil {
+		t.Fatalf("WriteNDJSON: %v", err)
+	}
+	if strings.Contains(output.String(), "secret objective") || strings.Contains(output.String(), "private.go") {
+		t.Fatalf("task content leaked into trace: %s", output.String())
+	}
+	parsed, err := ReadNDJSON(strings.NewReader(output.String()))
+	if err != nil {
+		t.Fatalf("ReadNDJSON: %v", err)
+	}
+	if len(parsed.TaskStates) != 1 || parsed.TaskStates[0] != event {
+		t.Fatalf("unexpected round trip: %#v", parsed.TaskStates)
+	}
+}
+
+func TestTaskStateIsDocumentedAsOptionalTraceEvent(t *testing.T) {
+	for _, key := range OptionalEventKeys() {
+		if key == "task_state" {
+			return
+		}
+	}
+	t.Fatal("task_state missing from OptionalEventKeys")
+}

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -104,13 +104,12 @@ type OutputBudgetEvent struct {
 }
 
 // TaskStateEvent is a content-free snapshot of the run's structured task
-// projection. Objective text, plan content, tool output, and file paths are
-// deliberately excluded; only a one-way objective hash and aggregate evidence
-// are emitted so tracing cannot become a secret-bearing side channel.
+// projection. Objective text, plan content, tool output, file paths, and
+// confirmable content fingerprints are deliberately excluded so tracing cannot
+// become a secret-bearing side channel.
 type TaskStateEvent struct {
 	Revision            int    `json:"revision"`
 	Status              string `json:"status"`
-	ObjectiveHash       string `json:"objective_hash"`
 	PlanPending         int    `json:"plan_pending"`
 	PlanInProgress      int    `json:"plan_in_progress"`
 	PlanCompleted       int    `json:"plan_completed"`
@@ -122,7 +121,7 @@ type TaskStateEvent struct {
 	VerificationOutcome string `json:"verification_outcome,omitempty"`
 	ChangedFileCount    int    `json:"changed_file_count"`
 	CompletionDecision  string `json:"completion_decision,omitempty"`
-	TranscriptParity    string `json:"transcript_parity"`
+	PlanParity          string `json:"plan_parity"`
 }
 
 // TurnTrace is the finished record for one agent.Run. It is the value

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -103,6 +103,28 @@ type OutputBudgetEvent struct {
 	SpillCreated            bool   `json:"spill_created"`
 }
 
+// TaskStateEvent is a content-free snapshot of the run's structured task
+// projection. Objective text, plan content, tool output, and file paths are
+// deliberately excluded; only a one-way objective hash and aggregate evidence
+// are emitted so tracing cannot become a secret-bearing side channel.
+type TaskStateEvent struct {
+	Revision            int    `json:"revision"`
+	Status              string `json:"status"`
+	ObjectiveHash       string `json:"objective_hash"`
+	PlanPending         int    `json:"plan_pending"`
+	PlanInProgress      int    `json:"plan_in_progress"`
+	PlanCompleted       int    `json:"plan_completed"`
+	PlanFailed          int    `json:"plan_failed"`
+	ToolsSucceeded      int    `json:"tools_succeeded"`
+	ToolsFailed         int    `json:"tools_failed"`
+	VerificationPassed  int    `json:"verification_passed"`
+	VerificationFailed  int    `json:"verification_failed"`
+	VerificationOutcome string `json:"verification_outcome,omitempty"`
+	ChangedFileCount    int    `json:"changed_file_count"`
+	CompletionDecision  string `json:"completion_decision,omitempty"`
+	TranscriptParity    string `json:"transcript_parity"`
+}
+
 // TurnTrace is the finished record for one agent.Run. It is the value
 // emitters serialize; it is not mutated after Finish returns a snapshot.
 type TurnTrace struct {
@@ -118,6 +140,7 @@ type TurnTrace struct {
 	Counters            []Counter           `json:"counters"`
 	PrefixHashes        []PrefixHash        `json:"prefix_hashes,omitempty"`
 	OutputBudgets       []OutputBudgetEvent `json:"output_budgets,omitempty"`
+	TaskStates          []TaskStateEvent    `json:"task_states,omitempty"`
 }
 
 // PrefixHash is one fingerprint of the prompt prefix emitted by an agent run.
@@ -280,5 +303,6 @@ func OptionalEventKeys() []string {
 		"counter:" + CounterPrefixDrift,
 		"counter:" + CounterPostureEscalations,
 		"event:prefix_hash",
+		"task_state",
 	}
 }


### PR DESCRIPTION
## Summary

- add a deterministic per-run TaskState projection for objective, plan, tool results, changed files, verification, and completion
- emit bounded, content-free aggregate snapshots through the existing trace recorder
- preserve the immutable objective across repeated compaction and ground completion checks in that objective
- use structured plan state only when plan parity matches the transcript; mismatches retain transcript-derived completion behavior and omit uncorroborated mutable compact state

## Scope and safety

- no new dependency, model call, tool, database, UI, or autonomous execution behavior
- trace events exclude objective text, objective fingerprints, plan text, tool output, and file paths
- task-state trace history is coalesced and capped while retaining the latest aggregate
- compact objective context is capped at 512 bytes
- plan parsing now matches update_plan rejection and normalization behavior

## Validation

- make fmt-check
- go vet ./...
- go test ./...
- go test -race ./internal/agent ./internal/trace
- go run ./cmd/zero-release build
- go run ./cmd/zero-release smoke
- govulncheck ./... (no vulnerabilities found)
- git diff HEAD --check

The pinned advisory golangci-lint command reports only unrelated pre-existing repository findings; no finding points to a file changed by this PR.