### PR TITLE
fix(lsp): make the real-gopls check opt-in so a broken gopls can't fail the suite (#684)

### DIFF
--- a/internal/lsp/real_gopls_manual_test.go
+++ b/internal/lsp/real_gopls_manual_test.go
@@ -11,9 +11,16 @@ import (
 
 // TestManagerCheckRealGopls drives the exact path the self-correct LSP wiring
 // uses (NewManager -> Check) against a REAL gopls and asserts a real diagnostic
-// comes back. Skips when gopls is not installed. Temporary manual-verification
-// test (the rest of the suite uses a fake server).
+// comes back. It is an OPT-IN integration check: an installed-but-unhealthy
+// gopls (e.g. an unusable persistent-index cache) exits during initialization
+// and would otherwise fail `go test ./...` for every developer who merely has
+// gopls on PATH (issue #684). So it runs only when ZERO_GOPLS_INTEGRATION is
+// set, matching the repo's other real-server opt-ins (internal/dictation smoke
+// tests). The default suite keeps its coverage on the fake server.
 func TestManagerCheckRealGopls(t *testing.T) {
+	if os.Getenv("ZERO_GOPLS_INTEGRATION") == "" {
+		t.Skip("set ZERO_GOPLS_INTEGRATION=1 to run the real gopls integration check")
+	}
 	if _, err := exec.LookPath("gopls"); err != nil {
 		t.Skip("gopls not on PATH; skipping real-server check")
 	}

--- a/internal/lsp/real_gopls_manual_test.go
+++ b/internal/lsp/real_gopls_manual_test.go
@@ -14,11 +14,13 @@ import (
 // comes back. It is an OPT-IN integration check: an installed-but-unhealthy
 // gopls (e.g. an unusable persistent-index cache) exits during initialization
 // and would otherwise fail `go test ./...` for every developer who merely has
-// gopls on PATH (issue #684). So it runs only when ZERO_GOPLS_INTEGRATION is
-// set, matching the repo's other real-server opt-ins (internal/dictation smoke
-// tests). The default suite keeps its coverage on the fake server.
+// gopls on PATH (issue #684). So it runs only when ZERO_GOPLS_INTEGRATION=1,
+// matching the repo's other real-server opt-ins (internal/dictation smoke
+// tests). Requiring exactly "1" (not merely non-empty) means an explicit
+// ZERO_GOPLS_INTEGRATION=0 keeps the integration check OFF, as its value implies.
+// The default suite keeps its coverage on the fake server.
 func TestManagerCheckRealGopls(t *testing.T) {
-	if os.Getenv("ZERO_GOPLS_INTEGRATION") == "" {
+	if os.Getenv("ZERO_GOPLS_INTEGRATION") != "1" {
 		t.Skip("set ZERO_GOPLS_INTEGRATION=1 to run the real gopls integration check")
 	}
 	if _, err := exec.LookPath("gopls"); err != nil {


### PR DESCRIPTION
Closes #684.

`TestManagerCheckRealGopls` skipped only when `gopls` was absent from PATH, so an installed-but-unhealthy `gopls` (the issue's repro: an unusable persistent-index cache makes the server exit during init with `EOF`) failed `go test ./...` for every developer who merely has `gopls` on PATH.

Gate it behind `ZERO_GOPLS_INTEGRATION`, matching the repo's existing real-server opt-ins (`internal/dictation` smoke tests use `ZERO_STT_*`). The default hermetic suite keeps its coverage on the fake server and never touches the developer's global `gopls`; the real check still runs on demand:

```
ZERO_GOPLS_INTEGRATION=1 go test ./internal/lsp -run '^TestManagerCheckRealGopls$'
```

Verified: default `go test ./internal/lsp` now skips the real check unconditionally (before even probing PATH), and the opt-in path runs it. gofmt clean, package green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Real-language-server integration checks are now explicitly opt-in and run only when enabled.
  * The default test suite no longer fails due to an unavailable or unhealthy installed language server detected on PATH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->