### PR TITLE
fix(tools): give write_stdin's invalid-session errors the same recovery guidance (#749 follow-up)

### DIFF
--- a/internal/tools/exec_command.go
+++ b/internal/tools/exec_command.go
@@ -775,12 +775,20 @@ func (tool writeStdinTool) Run(ctx context.Context, args map[string]any) Result 
 }
 
 func (tool writeStdinTool) RunWithOptions(ctx context.Context, args map[string]any, _ RunOptions) Result {
-	if value, ok := args["session_id"]; !ok || value == nil {
-		return errorResult("Error: Invalid arguments for write_stdin: session_id is required")
-	}
-	sessionID, err := intArg(args, "session_id", 0, 1, 0)
-	if err != nil {
-		return errorResult("Error: Invalid arguments for write_stdin: " + err.Error())
+	// A missing, non-integer, or < 1 session_id all mean the same thing: the model
+	// has no live session to write to. Route them to the SAME recovery guidance the
+	// no-live-session case uses (UnknownExecSessionError) instead of a terse
+	// "session_id must be at least 1". The terse error gives no way forward and, by
+	// naming the minimum, nudges the model to try 1, 2, 3... — the exact id-probing
+	// #749 works to suppress. The recovery message instead tells it to start a
+	// session or edit files directly, and because that message is id-invariant, the
+	// missing/zero/non-integer entry points and id-probing collapse to ONE
+	// repeated-failure signature, so any mix of them accumulates toward the halt
+	// rather than resetting the streak on each class of mistake.
+	value, present := args["session_id"]
+	sessionID, sessionErr := intArg(args, "session_id", 0, 1, 0)
+	if !present || value == nil || sessionErr != nil {
+		return errorResult(UnknownExecSessionError(sessionID))
 	}
 	chars, err := stringArgWithEmpty(args, "chars", "", false, true)
 	if err != nil {

--- a/internal/tools/exec_command_test.go
+++ b/internal/tools/exec_command_test.go
@@ -923,19 +923,34 @@ func TestWriteStdinSchemaPinsSessionIDMinimum(t *testing.T) {
 	}
 }
 
+// A missing, zero, negative, or non-integer session_id all mean the model has no
+// live session, so write_stdin returns the SAME recovery guidance the no-live-
+// session case uses (start a session with exec_command, or edit files directly),
+// not a terse "session_id must be at least 1" that gives no way forward and names
+// a minimum that nudges the model to probe ids 1, 2, 3... Sharing one id-invariant
+// message also keeps a single repeated-failure signature, so any mix of these
+// mistakes accumulates toward the halt instead of resetting the streak (#749).
 func TestWriteStdinRequiresPositiveSessionID(t *testing.T) {
 	tool := NewWriteStdinTool(newExecSessionManager())
-	for _, args := range []map[string]any{
-		{},
-		{"session_id": 0},
+	want := UnknownExecSessionError(0)
+	for name, args := range map[string]map[string]any{
+		"missing":     {},
+		"zero":        {"session_id": 0},
+		"negative":    {"session_id": -3},
+		"non-integer": {"session_id": "abc"},
 	} {
-		result := tool.Run(context.Background(), args)
-		if result.Status != StatusError {
-			t.Fatalf("Run(%#v) status = %s, want error", args, result.Status)
-		}
-		if !strings.Contains(result.Output, "Invalid arguments for write_stdin") {
-			t.Fatalf("Run(%#v) output = %q, want invalid arguments", args, result.Output)
-		}
+		t.Run(name, func(t *testing.T) {
+			result := tool.Run(context.Background(), args)
+			if result.Status != StatusError {
+				t.Fatalf("status = %s, want error", result.Status)
+			}
+			if result.Output != want {
+				t.Fatalf("output = %q,\n want the recovery message %q", result.Output, want)
+			}
+			if strings.Contains(result.Output, "must be at least 1") {
+				t.Fatalf("still returns the terse minimum error: %q", result.Output)
+			}
+		})
 	}
 }
 

--- a/internal/tools/exec_command_test.go
+++ b/internal/tools/exec_command_test.go
@@ -935,6 +935,7 @@ func TestWriteStdinRequiresPositiveSessionID(t *testing.T) {
 	want := UnknownExecSessionError(0)
 	for name, args := range map[string]map[string]any{
 		"missing":     {},
+		"nil":         {"session_id": nil},
 		"zero":        {"session_id": 0},
 		"negative":    {"session_id": -3},
 		"non-integer": {"session_id": "abc"},


### PR DESCRIPTION
Follow-up to #749 / #702.

## The issue

`write_stdin` sends keystrokes to a running `exec_command` session; its `session_id` must be an id (>= 1) returned by a still-running session. It had **three** "no valid live session" error paths with **three different messages and signatures**:

| input | old error |
|---|---|
| `session_id` missing | `session_id is required` |
| `session_id: 0` (or negative / non-integer) | `session_id must be at least 1` |
| `session_id: 5`, no live session | rich recovery guidance (`UnknownExecSessionError`) |

A model that calls `write_stdin` with `session_id: 0` (the common "I have no real id" placeholder, and the reported symptom) got the terse `must be at least 1`, which:

- gives **no way forward** (unlike the rich message, it doesn't say "start a session or edit files directly"), and
- names a minimum, which **nudges the model to try `1`, then `2`...**, the exact id-probing #749 works to suppress.

And because the three cases have different signatures (`errorSignature` keys on the normalized 80-char prefix), a model moving `0 -> 1 -> 2` **resets the repeated-failure streak** on each class of mistake, delaying the halt.

## The fix

Route the missing / non-integer / `< 1` cases through the same `UnknownExecSessionError` message the no-live-session case already uses. Now:

- every "no live session" mistake gives the **same recovery guidance**, and
- because that message is **id-invariant**, they share **one repeated-failure signature**, so any mix of missing / zero / probing accumulates toward the same halt (extending #749's intent to the `0`/missing entry points).

No behavior change for a valid `session_id`. `TestWriteStdinRequiresPositiveSessionID` now covers missing/zero/negative/non-integer and asserts the recovery message; the guardrail signature/halt tests (`TestUnknownExecSessionErrorSignatureIsIDInvariant`, `TestUnknownExecSessionProbingTripsFailureHalt`) are unchanged and pass. Full `internal/tools` package green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid or missing execution session IDs.
  * All invalid session ID inputs now provide consistent recovery guidance instead of terse validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->