### PR TITLE
fix(tui): model rows labelled by id when the description is prose; keep the sidebar under the / palette

### DIFF
--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1959,12 +1959,49 @@ func (wizard *providerWizardState) filteredModels() []providerWizardModel {
 	return models
 }
 
-func (model providerWizardModel) displayLabel() string {
-	description := strings.TrimSpace(model.Description)
-	if description != "" && !providerWizardGenericModelDescription(description) {
-		return description
+// A model Description is only a good row label when it reads like a display
+// NAME — "Grok 4.3" for x-ai/grok-4.3 — which is what the field is for, and why
+// the row prefers it over an ugly raw ID.
+//
+// Providers do not all honour that. Aggregators commonly return a prose blurb
+// instead ("Fast DeepSeek model for efficient chat, coding help, and agent
+// loops"), which fails as a label twice over: it overflows the row, and because
+// such blurbs are written per model FAMILY rather than per model, several
+// DIFFERENT models collapse to byte-identical rows. A picker then offers two
+// visually identical entries with the distinguishing ID visible only in the
+// detail line of whichever one is highlighted.
+//
+// providerWizardGenericModelDescription cannot catch these: it rejects
+// descriptions that are vague ("live model", "catalog default"), whereas these
+// are specific — just shared and sentence-shaped. So the test is shape, not
+// wording: a name is short and few-worded; anything longer is prose, and the ID
+// (unique by construction) makes the better label.
+const (
+	providerWizardMaxModelNameChars = 28
+	providerWizardMaxModelNameWords = 4
+)
+
+func providerWizardDescriptionIsDisplayName(description string) bool {
+	trimmed := strings.TrimSpace(description)
+	if trimmed == "" || providerWizardGenericModelDescription(trimmed) {
+		return false
 	}
-	return model.ID
+	if len(trimmed) > providerWizardMaxModelNameChars {
+		return false
+	}
+	return len(strings.Fields(trimmed)) <= providerWizardMaxModelNameWords
+}
+
+func (model providerWizardModel) displayLabel() string {
+	if providerWizardDescriptionIsDisplayName(model.Description) {
+		return strings.TrimSpace(model.Description)
+	}
+	if id := strings.TrimSpace(model.ID); id != "" {
+		return id
+	}
+	// ID-less sentinel rows built in currentModel ("model name required",
+	// "no matching models") would otherwise render blank.
+	return strings.TrimSpace(model.Description)
 }
 
 func (model providerWizardModel) secondaryText() string {

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -1787,3 +1787,37 @@ func providerWizardIDs(descriptors []providercatalog.Descriptor) []string {
 	}
 	return ids
 }
+
+// A provider that returns prose blurbs instead of display names must not
+// collapse distinct models into identical rows. Reproduces the reported picker
+// where two "Open-weight GPT model..." and two "Kimi multimodal agent model..."
+// rows were indistinguishable, with the ID visible only for the highlighted one.
+func TestProviderWizardModelRowsStayDistinctWithProseDescriptions(t *testing.T) {
+	wizard := &providerWizardState{
+		step:        providerWizardStepModel,
+		modelSource: "models.dev",
+		models: []providerWizardModel{
+			{ID: "gpt-oss-120b", Description: "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"},
+			{ID: "gpt-oss-20b", Description: "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"},
+			{ID: "kimi-k2-thinking", Description: "Kimi multimodal agent model for visual understanding, coding, and planning"},
+			{ID: "kimi-k2-instruct", Description: "Kimi multimodal agent model for visual understanding, coding, and planning"},
+			{ID: "x-ai/grok-4.3", Description: "Grok 4.3"},
+		},
+	}
+	view := plainRender(t, strings.Join(wizard.renderModelStep(96), "\n"))
+
+	// every prose-described model is identified by its unique ID
+	for _, id := range []string{"gpt-oss-120b", "gpt-oss-20b", "kimi-k2-thinking", "kimi-k2-instruct"} {
+		if !strings.Contains(view, id) {
+			t.Errorf("model %q is not identifiable in the list:\n%s", id, view)
+		}
+	}
+	// a genuine display name is still preferred over the raw id
+	if !strings.Contains(view, "Grok 4.3") {
+		t.Errorf("friendly display name was lost:\n%s", view)
+	}
+	// the prose blurb must not be a row label
+	if strings.Contains(view, "❯ Open-weight GPT model") {
+		t.Errorf("prose blurb still used as a row label:\n%s", view)
+	}
+}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -94,12 +94,26 @@ func (m model) sidebarAvailable() bool {
 	if widthTier(m.width) < tierMedium {
 		return false
 	}
-	// Full-screen overlays (setup, wizards, pickers, the empty-state suggestion
-	// list) take over the chat column and render at full width; suppress the
-	// second column while any is active so their geometry and mouse hit-testing
-	// stay full-width as before.
+	// Full-screen overlays (setup, wizards, pickers) take over the chat column and
+	// render at full width; suppress the second column while any is active so
+	// their geometry and mouse hit-testing stay full-width as before.
+	//
+	// The `/` command palette is deliberately NOT in this list. It is not a
+	// full-screen overlay: suggestionOverlay draws it via centerRenderedBlock at
+	// minInt(width, suggestionPaletteMaxWidth) — a centred box capped at 76 cells
+	// — floating over the chat column rather than replacing it. Suppressing the
+	// sidebar for it collapsed the whole layout on every keystroke of `/`: the
+	// plan panel dropped out of the sidebar and re-rendered inline at the bottom
+	// and the transcript re-wrapped to full width, which is at its most jarring
+	// mid-run with a live plan on screen. Since the sidebar already requires the
+	// medium tier (>= 80 cells) the palette is always strictly narrower than the
+	// chat column here, so the two never contend for the same cells.
+	//
+	// Mouse hit-testing is unaffected: sidebarLineAtMouse carries its own
+	// suggestionsActive() guard, so clicks still go to the palette and not to the
+	// sidebar rows underneath it.
 	if m.setup.visible || m.helpOverlay || m.leaderHelpOverlay || m.providerWizard != nil || m.mcpAddWizard != nil ||
-		m.mcpManager != nil || m.picker != nil || m.suggestionsActive() {
+		m.mcpManager != nil || m.picker != nil {
 		return false
 	}
 	// Home/welcome screen: stay single-column until there's real conversation, so

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -631,3 +631,58 @@ func TestTwoColumnTranscriptViewWidth(t *testing.T) {
 func stripSidebar(lines []string) string {
 	return ansiPattern.ReplaceAllString(strings.Join(lines, "\n"), "")
 }
+
+// The `/` command palette must NOT collapse the sidebar. It is a centred box
+// capped at suggestionPaletteMaxWidth floating over the chat column, not a
+// full-screen overlay — suppressing the second column for it dropped the plan
+// out of the sidebar and re-rendered it inline at the bottom on every `/`,
+// which is at its most disruptive mid-run with a live plan on screen. The
+// genuinely full-width overlays must still suppress it.
+func TestSidebarSurvivesCommandPalette(t *testing.T) {
+	base := func() model {
+		m := runningPlanModel(t, 3)
+		m.altScreen = true
+		m.height = 40
+		m.headerPrinted = true
+		m.transcript = append(m.transcript, transcriptRow{kind: rowToolCall, tool: "read_file", detail: "main.go"})
+		return m
+	}
+
+	m := base()
+	if !m.sidebarActive() {
+		t.Fatal("precondition: sidebar should be active for a wide alt-screen model with a plan")
+	}
+
+	// `/` palette open: sidebar stays, so the plan keeps its home and the layout
+	// does not reflow.
+	m.suggestions = []commandSuggestion{{Name: "/model", Desc: "Pick a model."}, {Name: "/plan", Desc: "Show planning mode status."}}
+	if !m.suggestionsActive() {
+		t.Fatal("precondition: suggestions should be active")
+	}
+	if !m.sidebarActive() {
+		t.Error("command palette must not collapse the sidebar")
+	}
+	if got := m.renderPinnedPlanPanel(m.chatColumnWidth(), 10); got != "" {
+		t.Errorf("plan must stay in the sidebar, not fall back to the pinned panel:\n%s", got)
+	}
+	// The palette never contends for the sidebar's cells: the two-column path
+	// renders it at width = chatColumnWidth, so it is centred inside the chat
+	// column and cannot overlap the sidebar.
+	chatW := m.chatColumnWidth()
+	for _, line := range strings.Split(plainRender(t, m.suggestionOverlay(chatW)), "\n") {
+		if w := lipgloss.Width(line); w > chatW {
+			t.Errorf("palette line is %d wide, wider than the chat column %d — it would overlap the sidebar", w, chatW)
+		}
+	}
+	// Clicks still belong to the palette, not the sidebar rows beneath it.
+	if _, ok := m.sidebarLineAtMouse(tea.MouseClickMsg{Button: tea.MouseLeft}); ok {
+		t.Error("sidebar must not take mouse hits while the palette is open")
+	}
+
+	// A genuinely full-width overlay still suppresses the sidebar.
+	full := base()
+	full.picker = &commandPicker{}
+	if full.sidebarActive() {
+		t.Error("a full-screen picker must still collapse the sidebar")
+	}
+}


### PR DESCRIPTION
## The bug

The model picker labels each row with the provider's `Description`, falling back to the model ID only when the description is "generic". In a live picker against an aggregator provider, that produced this:

```
❯ Fast DeepSeek model for efficient chat, coding help, and agent loops
  Flagship DeepSeek model for coding, reasoning, and agentic work
  Open Gemma instruction model for efficient chat and self-hosted deployments
  Flagship GLM model for hybrid reasoning, coding, and agentic engineering
  Open flagship GLM for long-horizon coding agents and million-token context work
  Open-weight GPT model for self-hosted reasoning and instruction-following workloads
  Open-weight GPT model for self-hosted reasoning and instruction-following workloads
  Kimi multimodal agent model for visual understanding, coding, and planning
  Kimi multimodal agent model for visual understanding, coding, and planning
  Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking
  deepseek-v4-flash · 1M ctx · tools · reasoning
```

Two pairs of rows are **byte-identical** while being different models. The distinguishing ID appears only in the detail line, for whichever row happens to be highlighted — so the list cannot be used to choose between them. You have to arrow onto each row in turn and read the line underneath.

## Root cause

`displayLabel` (`internal/tui/provider_wizard.go`) prefers the description over the ID:

```go
description := strings.TrimSpace(model.Description)
if description != "" && !providerWizardGenericModelDescription(description) {
    return description
}
return model.ID
```

That is the right call when `Description` holds a short display **name** — `"Grok 4.3"` for `x-ai/grok-4.3` — which is what the field is for, and why the row prefers it over an ugly raw ID. `TestProviderWizardModelStepUsesFriendlyNamesAndStaysCompact` pins exactly that, including `assertNotContains(view, "❯ x-ai/grok-4.3")`.

Providers do not all honour it. Aggregators commonly return a prose blurb instead, which fails as a label twice over: it overflows the row, and because such blurbs are written per model **family** rather than per model, several different models collapse to identical rows.

`providerWizardGenericModelDescription` cannot catch these. It rejects descriptions that are *vague* — `""`, `"catalog default"`, `"live model"`, anything ending in `" model"` — whereas these are specific, just shared and sentence-shaped. Extending that deny-list cannot work either: none of these strings live in the repo, they arrive from the provider at discovery time (`internal/providermodeldiscovery/discovery.go:336`).

## The fix

Gate on **shape** rather than wording. A display name is short and few-worded; anything longer is prose, and the ID — unique by construction — makes the better label:

```go
const (
    providerWizardMaxModelNameChars = 28
    providerWizardMaxModelNameWords = 4
)
```

Friendly names are still preferred wherever providers supply them, so behaviour is unchanged for well-behaved catalogs. The description is not lost — it moves to the detail line via the existing `secondaryText`.

**This fixes two surfaces.** `internal/tui/onboarding.go` renders its model rows through the same `displayLabel`/`secondaryText` pair (`onboarding.go:1576`, `:1582`), so first-run setup had the identical defect.

Before → after, on the models from the report:

| row label (before) | row label (after) |
|---|---|
| `Open-weight GPT model for self-hosted reasoning…` | `gpt-oss-120b` |
| `Open-weight GPT model for self-hosted reasoning…` | `gpt-oss-20b` |
| `Kimi multimodal agent model for visual understanding…` | `kimi-k2-thinking` |
| `Kimi multimodal agent model for visual understanding…` | `kimi-k2-instruct` |
| `Grok 4.3` | `Grok 4.3` (unchanged) |

## Verification

- `TestProviderWizardModelRowsStayDistinctWithProseDescriptions` added, using the exact models from the report. Mutation-tested: with the fix reverted it fails with `model "gpt-oss-20b" is not identifiable in the list`.
- Both tests that pin the existing friendly-name behaviour still pass unchanged — `TestProviderWizardModelStepUsesFriendlyNamesAndStaysCompact` and `TestProviderWizardModelSearchFiltersAndAppliesRawModelID`.
- Onboarding verified to share the fix: prose model → row `gpt-oss-20b`, named model → row `Grok 4.3`.
- `gofmt`, `go vet ./internal/tui/` clean. Full `internal/tui` suite has the same single failure as `main` (`TestHandleAddDirCommand`, a pre-existing sandbox/TMPDIR artifact) — no new failures.

## Note for reviewers

`TestSuggestionOverlayRenders` asserts `!strings.Contains(plain, "/model")` against the whole rendered view, which includes the git branch name in the title bar. It therefore fails on any branch whose name contains `/model` — this branch was originally `fix/model-picker-label` and had to be renamed to get a green run. Unrelated to this change; worth tightening separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved labeling in the provider setup wizard to make model selections clearer and remain distinct, even with long or generic prose descriptions.
  * When model IDs are missing, row labels no longer render blank; they now use the most appropriate fallback.
  * Fixed sidebar behavior so it remains stable when the command palette/suggestions overlay is open, without layout collisions.
* **Tests**
  * Added regression coverage for distinct model row rendering and sidebar stability during the command palette overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Second fix: the `/` command palette collapsed the sidebar

Same package, same class of defect — a display rule keyed off the wrong signal — so it rides along here.

`sidebarAvailable` grouped `suggestionsActive()` with the full-screen overlays (setup, wizards, pickers), whose stated rationale is that they *"take over the chat column and render at full width"*. That is not true of the `/` palette: `suggestionOverlay` draws it through `centerRenderedBlock` at `minInt(width, suggestionPaletteMaxWidth)` — a centred box capped at 76 cells, floating over the chat column.

Treating it as full-screen collapsed the whole layout on every `/`: the sidebar disappeared, the plan panel dropped out of it and re-rendered inline above the composer, and the transcript re-wrapped to full width. A full reflow for a popup, and worst exactly when it is most visible — mid-run with a live plan on screen.

**It cannot overlap the sidebar either.** `twoColumnTranscriptView` renders the overlay with `width = chatColumnWidth`, so the palette caps at `min(chatColumn, 76)` and is centred *inside* the chat column. Worth stating explicitly because the 76-cell cap alone does not guarantee it — at 100 cells total the chat column is only 67, so the cap is not what bounds it; the call site is. The new test asserts on the rendered line widths rather than the constant, so it stays honest if either changes.

**Mouse hit-testing is unaffected.** `sidebarLineAtMouse` carries its own `suggestionsActive()` guard (`mouse.go:234`), so clicks still reach the palette and not the sidebar rows beneath it. That independent guard is likely why the suppression looked safe to add originally.

`TestSidebarSurvivesCommandPalette` pins all of it: the sidebar survives the palette, the plan stays in the sidebar rather than falling back to the pinned panel, no rendered palette line exceeds the chat column, the sidebar takes no mouse hits while it is open — and a real `picker` still collapses the sidebar. Mutation-verified: restoring `suggestionsActive()` to the condition fails it with *"command palette must not collapse the sidebar"*.

### Verification (both fixes)

`gofmt` and `go vet ./internal/tui/` clean. Full `internal/tui` suite has the same single failure as `main` (`TestHandleAddDirCommand`, a pre-existing sandbox/TMPDIR artifact) — no new failures from either change.
