### PR TITLE
fix(tools): read_file recovers a backwards line range instead of erroring

### DIFF
--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -879,12 +879,11 @@ func TestReadFileToolValidRangeUnchangedByRecovery(t *testing.T) {
 	if result.Status != StatusOK {
 		t.Fatalf("valid range failed: %s: %s", result.Status, result.Output)
 	}
-	if strings.Contains(result.Output, "was before start_line") {
-		t.Fatalf("valid range must carry no recovery note: %q", result.Output)
-	}
-	for _, want := range []string{"File: notes.txt (lines 2-4 of 5)", "2 | beta", "3 | gamma", "4 | delta"} {
-		if !strings.Contains(result.Output, want) {
-			t.Fatalf("expected %q, got %q", want, result.Output)
-		}
+	// Byte-for-byte: header, blank separator, the exact selected lines, and no
+	// recovery note or trailing content. An altered header/separator or a stray
+	// out-of-range line would fail this where a substring check would not.
+	const want = "File: notes.txt (lines 2-4 of 5)\n\n2 | beta\n3 | gamma\n4 | delta"
+	if result.Output != want {
+		t.Fatalf("valid-range output changed by the recovery path:\n got: %q\nwant: %q", result.Output, want)
 	}
 }

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -829,3 +829,62 @@ func TestGlobSkipsWorkspaceExcludedDirectoriesAndBinaryFiles(t *testing.T) {
 		t.Fatalf("expected only keep.txt, got:\n%s", res.Output)
 	}
 }
+
+// A backwards range (end_line < start_line) is a caller-arithmetic slip, not a
+// fatal error: read_file recovers by reading just start_line and surfaces a note
+// explaining the adjustment, matching how an end_line past EOF is auto-clamped.
+// It must never hard-error the way it used to.
+func TestReadFileToolRecoversBackwardsRange(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "notes.txt"), "alpha\nbeta\ngamma\ndelta\nepsilon")
+
+	result := NewReadFileTool(root).Run(context.Background(), map[string]any{
+		"path":       "notes.txt",
+		"start_line": 3,
+		"end_line":   2, // backwards
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("backwards range must recover, not error; got %s: %s", result.Status, result.Output)
+	}
+	if strings.Contains(result.Output, "must be greater than or equal to start_line") {
+		t.Fatalf("backwards range still hard-errors: %q", result.Output)
+	}
+	for _, want := range []string{
+		"end_line 2 was before start_line 3", // the note
+		"only line 3 was read",
+		"3 | gamma",
+	} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("expected %q in output, got %q", want, result.Output)
+		}
+	}
+	// It read exactly start_line, nothing adjacent.
+	if strings.Contains(result.Output, "beta") || strings.Contains(result.Output, "delta") {
+		t.Fatalf("recovery read the wrong lines: %q", result.Output)
+	}
+}
+
+// A valid range with end_line >= start_line is byte-for-byte unchanged: the
+// recovery path must not touch normal reads (no stray note, exact same window).
+func TestReadFileToolValidRangeUnchangedByRecovery(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "notes.txt"), "alpha\nbeta\ngamma\ndelta\nepsilon")
+
+	result := NewReadFileTool(root).Run(context.Background(), map[string]any{
+		"path":       "notes.txt",
+		"start_line": 2,
+		"end_line":   4,
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("valid range failed: %s: %s", result.Status, result.Output)
+	}
+	if strings.Contains(result.Output, "was before start_line") {
+		t.Fatalf("valid range must carry no recovery note: %q", result.Output)
+	}
+	for _, want := range []string{"File: notes.txt (lines 2-4 of 5)", "2 | beta", "3 | gamma", "4 | delta"} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("expected %q, got %q", want, result.Output)
+		}
+	}
+}

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -106,8 +106,18 @@ func renderReadFileRange(absolutePath string, relativePath string, total int, st
 	if endLine == 0 || endLine > total {
 		endLine = total
 	}
+	// A backwards range (end_line < start_line) is a caller slip, not a fatal
+	// error. Recover the way an end_line past EOF is already recovered a few lines
+	// up (clamped down to the last line): clamp end_line UP to start_line and read
+	// just that one line. Erroring here instead cost the caller a whole retry for
+	// an off-by-arithmetic mistake, and it was inconsistent — start_line past EOF
+	// and end_line past EOF both recover gracefully; only this case hard-failed.
+	// The recovery is surfaced in the output (rangeNote) so it is never silent: the
+	// caller sees it read a different range than it asked for and why.
+	rangeNote := ""
 	if endLine < startLine {
-		return errorResult("Error: Invalid arguments for read_file: end_line must be greater than or equal to start_line")
+		rangeNote = fmt.Sprintf("(note: end_line %d was before start_line %d, so only line %d was read — pass end_line >= start_line to read a wider range)", endLine, startLine, startLine)
+		endLine = startLine
 	}
 
 	truncated := false
@@ -135,7 +145,12 @@ func renderReadFileRange(absolutePath string, relativePath string, total int, st
 		budgetedOutput = newHeadTailOutputBudgetBuilder(readOutputBudgetBytes, "use start_line/end_line or max_lines to continue with a smaller range")
 	}
 	budgetedOutput.WriteString(header)
-	budgetedOutput.WriteString("\n\n")
+	budgetedOutput.WriteString("\n")
+	if rangeNote != "" {
+		budgetedOutput.WriteString(rangeNote)
+		budgetedOutput.WriteString("\n")
+	}
+	budgetedOutput.WriteString("\n")
 	if err := appendReadFileRange(budgetedOutput, absolutePath, startLine, selectedLines, width); err != nil {
 		return errorResult("Error reading file " + relativePath + ": " + err.Error())
 	}


### PR DESCRIPTION
## The problem

`read_file` hard-failed when a caller passed `end_line < start_line`:

```
Error: Invalid arguments for read_file: end_line must be greater than or equal to start_line
```

That is a caller arithmetic slip (e.g. `start_line: 3, end_line: 2` while paging through a file), and hard-erroring costs a whole retry turn. It was also **inconsistent** with the two neighbouring bad-range cases in `renderReadFileRange`:

```go
if startLine > total { return okResult("…start_line is past the end…") }   // friendly note
if endLine == 0 || endLine > total { endLine = total }                       // auto-clamped
if endLine < startLine { return errorResult("…") }                           // hard error ← the outlier
```

`start_line` past EOF returns a friendly note; `end_line` past EOF is silently clamped down; only a backwards range hard-failed.

## The fix

Recover it the same way the others recover — clamp `end_line` **up** to `start_line` (read just that one line) — and surface the adjustment in the output so it is never silent:

```
File: n.txt (lines 3-3 of 5)
(note: end_line 2 was before start_line 3, so only line 3 was read — pass end_line >= start_line to read a wider range)

3 | c
```

The model gets a usable result **and** learns its range was off, instead of burning a turn on an error.

## No performance cost

The change is in the argument-validation phase, **before any file is opened** — one branch that returned an error now sets a note and clamps an integer. No new I/O, no loop, the file-reading path (`appendReadFileRange`) is untouched. `read_file` is one call per invocation, not a hot loop. If anything it saves the agent a wasted retry.

## Verification

- `TestReadFileToolRecoversBackwardsRange` — recovers, shows the note, reads only `start_line`, leaks no adjacent lines. **Mutation-verified**: restoring the hard error fails it.
- `TestReadFileToolValidRangeUnchangedByRecovery` — a valid `end_line >= start_line` range carries **no** note and reads the byte-identical window as before.
- `gofmt`/`go vet` clean. `internal/tools` has the same three pre-existing sandbox failures on this branch and on `main` — no new failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-range handling when the ending line precedes the starting line.
  * The tool now treats this as a recoverable input and returns only the requested starting line.
  * The rendered output includes a visible note explaining the adjustment, instead of failing.
  * Valid line ranges continue to return the expected content with no additional notices.
* **Tests**
  * Added unit tests covering both backward-range recovery and unchanged output for valid ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->