### PR TITLE
Add Atlas Cloud provider preset

### DIFF
--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -140,6 +140,7 @@ var descriptors = []Descriptor{
 	openAICompat("together", "Together AI", "https://api.together.xyz/v1", "meta-llama/Llama-3.3-70B-Instruct-Turbo", []string{"TOGETHER_API_KEY"}),
 	openAICompat("dashscope", "DashScope", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "qwen-plus", []string{"DASHSCOPE_API_KEY", "QWEN_API_KEY"}, "qwen"),
 	openAICompat("moonshot", "Moonshot AI", "https://api.moonshot.ai/v1", "kimi-k2-0905-preview", []string{"MOONSHOT_API_KEY"}, "kimi"),
+	openAICompat("atlascloud", "Atlas Cloud", "https://api.atlascloud.ai/v1", "qwen/qwen3.5-flash", []string{"ATLASCLOUD_API_KEY"}, "atlas cloud", "atlas"),
 	openAICompat("longcat", "LongCat", "https://api.longcat.chat/openai", "LongCat-2.0", []string{"LONGCAT_API_KEY"}, "meituan longcat", "meituan", "longcat-2.0"),
 	openAICompat("nvidia-nim", "NVIDIA NIM", "https://integrate.api.nvidia.com/v1", "nvidia/llama-3.1-nemotron-70b-instruct", []string{"NVIDIA_API_KEY"}, "nvidia nim"),
 	anthropicCompat("minimax", "MiniMax", "https://api.minimax.io/anthropic", "MiniMax-M3", []string{"MINIMAX_API_KEY"}, "mini-max", "mini_max"),

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -24,6 +24,7 @@ var expectedCatalogIDs = []string{
 	"together",
 	"dashscope",
 	"moonshot",
+	"atlascloud",
 	"longcat",
 	"nvidia-nim",
 	"minimax",
@@ -154,6 +155,28 @@ func TestLongCatDescriptor(t *testing.T) {
 	}
 }
 
+func TestAtlasCloudDescriptor(t *testing.T) {
+	descriptor, err := Require("atlascloud")
+	if err != nil {
+		t.Fatalf("Require(atlascloud) error = %v", err)
+	}
+	if descriptor.Name != "Atlas Cloud" {
+		t.Fatalf("Name = %q, want Atlas Cloud", descriptor.Name)
+	}
+	if descriptor.DefaultBaseURL != "https://api.atlascloud.ai/v1" {
+		t.Fatalf("DefaultBaseURL = %q, want Atlas Cloud OpenAI-compatible endpoint", descriptor.DefaultBaseURL)
+	}
+	if descriptor.DefaultModel != "qwen/qwen3.5-flash" {
+		t.Fatalf("DefaultModel = %q, want qwen/qwen3.5-flash", descriptor.DefaultModel)
+	}
+	if descriptor.Transport != TransportOpenAICompatible {
+		t.Fatalf("Transport = %q, want %q", descriptor.Transport, TransportOpenAICompatible)
+	}
+	if !reflect.DeepEqual(descriptor.AuthEnvVars, []string{"ATLASCLOUD_API_KEY"}) {
+		t.Fatalf("AuthEnvVars = %#v, want ATLASCLOUD_API_KEY", descriptor.AuthEnvVars)
+	}
+}
+
 func TestCatalogDescriptorsExposeRequiredDefaults(t *testing.T) {
 	for _, descriptor := range All() {
 		if descriptor.ID == "" {
@@ -272,6 +295,7 @@ func TestLookupNormalizesIDsAndAliases(t *testing.T) {
 		"lm-studio":                    "lmstudio",
 		"mini_max":                     "minimax",
 		"Moonshot":                     "moonshot",
+		"Atlas Cloud":                  "atlascloud",
 		"nvidia nim":                   "nvidia-nim",
 		"xiaomi mimo":                  "xiaomi-mimo",
 		"custom_openai_compatible":     "custom-openai-compatible",
@@ -322,7 +346,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
 		TransportAnthropicCompat: {"minimax", "minimaxi-cn", "opencode-go-anthropic-compatible", "custom-anthropic-compatible"},
-		TransportOpenAICompat:    {"gitlawb-opengateway", "aimlapi", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "longcat", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "zai-cn", "kilocode", "opencode", "opencode-go", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
+		TransportOpenAICompat:    {"gitlawb-opengateway", "aimlapi", "ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "atlascloud", "longcat", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "zai-cn", "kilocode", "opencode", "opencode-go", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 
 	for transport, wantIDs := range cases {

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -133,6 +133,10 @@ var curatedModels = map[string][]Model{
 		{ID: "kimi-k2-turbo-preview", Description: "fast coding model"},
 		{ID: "moonshot-v1-128k", Description: "long-context model"},
 	},
+	"atlascloud": {
+		{ID: "qwen/qwen3.5-flash", Description: "catalog default"},
+		{ID: "deepseek-ai/deepseek-v4-pro", Description: "reasoning model"},
+	},
 	"nvidia-nim": {
 		{ID: "nvidia/llama-3.1-nemotron-70b-instruct", Description: "catalog default"},
 		{ID: "meta/llama-3.1-70b-instruct", Description: "general model"},

--- a/internal/providermodelcatalog/catalog_test.go
+++ b/internal/providermodelcatalog/catalog_test.go
@@ -39,6 +39,11 @@ func TestModelsAreProviderScoped(t *testing.T) {
 			notWant:  []string{"gpt-4o", "openai/gpt-4o", "anthropic/claude-opus-4.8", "x-ai/grok-4-5"},
 		},
 		{
+			provider: "atlascloud",
+			want:     []string{"qwen/qwen3.5-flash", "deepseek-ai/deepseek-v4-pro"},
+			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5", "openai/gpt-4.1"},
+		},
+		{
 			provider: "mistral",
 			want:     []string{"mistral-large-latest", "codestral-latest"},
 			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5"},


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a built-in OpenAI-compatible provider preset
- configure the default endpoint, ATLASCLOUD_API_KEY auth env var, and qwen/qwen3.5-flash default model
- add Atlas Cloud curated model picker entries for qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro

## Validation
- git diff --check
- Atlas Cloud live catalog check: 434 models returned; qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro confirmed present
- Go tests not run locally because this machine does not have go/gofmt installed

No README or promotional sections were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as a supported OpenAI-compatible provider.
  * Added bundled models: Qwen 3.5 Flash and DeepSeek V4 Pro.
  * Added support for Atlas Cloud aliases, including “Atlas Cloud” and “Atlas”.
  * Configured authentication through the `ATLASCLOUD_API_KEY` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->