### PR TITLE
feat: add builtin /review   command

### DIFF
--- a/internal/securityreview/securityreview.go
+++ b/internal/securityreview/securityreview.go
@@ -1,0 +1,140 @@
+// Package securityreview builds the prompt for the builtin /security-review
+// slash command. It pre-collects the pending branch changes with a fixed set of
+// read-only git commands and injects them into the review prompt template, so
+// the model starts its first turn with the full diff already in context instead
+// of spending turns discovering it.
+//
+// The git invocations are a hard-coded allowlist — no user input is ever
+// interpolated into a command line, and no shell is involved.
+package securityreview
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// MaxOutputBytes caps each collected git output so a huge diff cannot blow up
+// the model's context. Truncated sections say so in place.
+const MaxOutputBytes = 256 * 1024
+
+// commandTimeout bounds each individual git invocation.
+const commandTimeout = 30 * time.Second
+
+// ErrNotGitRepo is returned by CollectGitContext when dir is not inside a git
+// working tree.
+var ErrNotGitRepo = errors.New("not inside a git repository")
+
+//go:embed prompt.md
+var promptTemplate string
+
+// GitContext holds the collected, read-only view of the pending branch changes.
+type GitContext struct {
+	Status  string // git status
+	Files   string // git diff --name-only origin/HEAD...
+	Commits string // git log --no-decorate origin/HEAD...
+	Diff    string // git diff origin/HEAD...
+}
+
+// gitCommands is the allowlisted set of read-only git invocations used to fill
+// a GitContext, in template order. Each entry is a fixed argv (no shell).
+var gitCommands = []struct {
+	field string
+	args  []string
+}{
+	{"status", []string{"status"}},
+	{"files", []string{"diff", "--name-only", "origin/HEAD..."}},
+	{"commits", []string{"log", "--no-decorate", "origin/HEAD..."}},
+	{"diff", []string{"diff", "origin/HEAD..."}},
+}
+
+// IsGitRepo reports whether dir is inside a git working tree.
+func IsGitRepo(ctx context.Context, dir string) bool {
+	ctx, cancel := context.WithTimeout(ctx, commandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--is-inside-work-tree")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return err == nil && strings.TrimSpace(string(out)) == "true"
+}
+
+// CollectGitContext runs the allowlisted read-only git commands in dir and
+// returns their (possibly truncated) outputs. It returns ErrNotGitRepo before
+// running anything else when dir is not inside a git working tree.
+func CollectGitContext(ctx context.Context, dir string) (GitContext, error) {
+	if !IsGitRepo(ctx, dir) {
+		return GitContext{}, ErrNotGitRepo
+	}
+	var gc GitContext
+	for _, spec := range gitCommands {
+		out, err := runGit(ctx, dir, spec.args)
+		if err != nil {
+			// A missing origin/HEAD (detached, no upstream, brand-new clone) is
+			// common; surface it inside the section instead of failing the
+			// whole review so the model can work with what exists.
+			out = fmt.Sprintf("[command `git %s` failed: %v]", strings.Join(spec.args, " "), err)
+		}
+		switch spec.field {
+		case "status":
+			gc.Status = out
+		case "files":
+			gc.Files = out
+		case "commits":
+			gc.Commits = out
+		case "diff":
+			gc.Diff = out
+		}
+	}
+	return gc, nil
+}
+
+// BuildPrompt renders the review prompt template with the collected git
+// context injected.
+func BuildPrompt(gc GitContext) string {
+	replacer := strings.NewReplacer(
+		"{{GIT_STATUS}}", gc.Status,
+		"{{GIT_FILES}}", gc.Files,
+		"{{GIT_COMMITS}}", gc.Commits,
+		"{{GIT_DIFF}}", gc.Diff,
+	)
+	return replacer.Replace(promptTemplate)
+}
+
+// BuildPromptForDir is the one-call convenience path used by the TUI command:
+// collect, then render.
+func BuildPromptForDir(ctx context.Context, dir string) (string, error) {
+	gc, err := CollectGitContext(ctx, dir)
+	if err != nil {
+		return "", err
+	}
+	return BuildPrompt(gc), nil
+}
+
+// runGit executes one allowlisted git command and returns its combined output,
+// truncated to MaxOutputBytes with a marker.
+func runGit(ctx context.Context, dir string, args []string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, commandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = err.Error()
+		}
+		return "", errors.New(detail)
+	}
+	out := stdout.String()
+	if len(out) > MaxOutputBytes {
+		out = out[:MaxOutputBytes] + fmt.Sprintf("\n\n[... truncated at %d bytes ...]", MaxOutputBytes)
+	}
+	return strings.TrimSpace(out), nil
+}

--- a/internal/specialist/builtin.go
+++ b/internal/specialist/builtin.go
@@ -34,6 +34,26 @@ func Builtins() []Manifest {
 			Location:     LocationBuiltin,
 			FilePath:     "(builtin)",
 		},
+		{
+			Metadata: Metadata{
+				Name:        "security-scout",
+				Description: "Hunts for candidate security vulnerabilities in a branch diff. Read-only.",
+				Tools:       []string{"read-only"},
+			},
+			SystemPrompt: securityScoutPrompt,
+			Location:     LocationBuiltin,
+			FilePath:     "(builtin)",
+		},
+		{
+			Metadata: Metadata{
+				Name:        "security-verifier",
+				Description: "Re-judges one candidate vulnerability and scores confidence 1-10. Read-only.",
+				Tools:       []string{"read-only"},
+			},
+			SystemPrompt: securityVerifierPrompt,
+			Location:     LocationBuiltin,
+			FilePath:     "(builtin)",
+		},
 	}
 	for index := range builtins {
 		if err := Validate(&builtins[index]); err != nil {
@@ -53,6 +73,82 @@ Complete the assigned task precisely, stay within scope, and report:
 const explorerPrompt = `You are a read-only codebase exploration specialist inside Zero.
 
 Find relevant files, symbols, tests, and behavior quickly. Do not edit files or run shell commands. Report concise findings with paths and line references when useful.`
+
+const securityScoutPrompt = `You are a vulnerability scout working inside a larger security review. You receive a git diff of pending branch changes plus the surrounding review instructions.
+
+Your job is DETECTION, not verification. Produce candidate findings; a separate verifier will re-judge each one, so it is fine to list a borderline candidate, but never invent one.
+
+Work method:
+
+1. Learn before you judge. Use the read tools to study how this codebase already handles security-relevant concerns: which sanitizers, validators, auth checks, escaping helpers, and crypto libraries exist, and the established patterns for using them. A deviation from the project's own secure pattern is a stronger signal than a generic rule.
+2. Trace data flow. For every changed file, follow values from their origin (HTTP input, file content, IPC, message queue, deserialized data) to the sensitive sink (query, shell, filesystem, template, redirect, secret store). Note every privilege or trust boundary the value crosses unchecked.
+3. Consider only what this diff introduces. Pre-existing issues in untouched code are out of scope unless the diff makes them newly reachable.
+
+What counts as a candidate:
+
+- Injection: SQL, OS command, template, XML (XXE), NoSQL, path traversal.
+- Broken authentication or authorization: bypass logic, privilege escalation, session or token handling flaws, missing server-side checks.
+- Cryptography and secrets: hardcoded credentials, weak or misused algorithms, bad randomness for security purposes, skipped certificate validation.
+- Code execution: unsafe deserialization, dynamic eval of untrusted input, cross-site scripting that escapes the framework's protection (e.g. raw HTML sinks).
+- Data exposure: secrets or personal data logged or returned, debug output leaking internals, endpoints returning more than the caller needs.
+
+What does NOT count (report none of these):
+
+- Denial of service, resource exhaustion, rate limiting, ReDoS.
+- Secrets stored on disk that are otherwise protected.
+- Theoretical races or timing side channels without a concrete exploit path.
+- Outdated third-party dependencies (tracked by other tooling).
+- Memory-safety concerns in memory-safe languages.
+- Issues confined to test files, documentation, or example code.
+- Missing hardening, missing audit logging, or missing validation that has no demonstrated security impact.
+- Attacks that require control of environment variables or CLI flags; those are trusted inputs.
+- Findings that hinge on client-side code enforcing security; the server is the trust boundary.
+- Untrusted content appearing inside AI prompts, log spoofing, SSRF that only controls a URL path, and regex injection.
+
+Report format — one block per candidate, nothing else:
+
+## Candidate N: <category>: '<file>:<line>'
+* Severity: High | Medium | Low
+* Description: what is unsafe and why, grounded in the code you read
+* Exploit scenario: concrete steps an attacker would take
+* Suggested fix: the smallest change that removes the issue
+* Rough confidence: 1-10 with one line of justification
+
+If you find nothing that survives these rules, reply exactly: NO CANDIDATES.`
+
+const securityVerifierPrompt = `You are a verification specialist inside a larger security review. You receive ONE candidate vulnerability found by a scout, plus the branch diff it came from. Your job is to decide whether it is a real, exploitable vulnerability or a false positive.
+
+Constraints:
+
+- Reason from the code. Do not edit files, do not run shell commands, and do not try to reproduce the exploit; reading is enough.
+- You may use the read tools to open the affected files and any code they call, to confirm or refute the claimed data flow.
+
+Automatically REJECT the candidate if any of these apply:
+
+1. It is a denial-of-service, resource-exhaustion, rate-limiting, or regex-DoS concern.
+2. It is about secrets on disk that are otherwise protected, or about missing audit logs, missing hardening, or "best practice" gaps with no concrete exploit.
+3. It lives only in test files, documentation, notebooks, or examples — unless there is a concrete path by which untrusted input reaches it in real use.
+4. It is a theoretical race or timing issue without a practical attack.
+5. It is an outdated-dependency observation rather than a flaw in this code.
+6. It claims memory-safety bugs in a memory-safe language.
+7. It requires the attacker to control environment variables or CLI flags, or to guess an unguessable identifier such as a UUID.
+8. It expects client-side JavaScript/TypeScript to enforce authentication or authorization; that is the server's job. Likewise, data sent from the client is validated server-side — check the server, not the sender.
+9. It is log spoofing, SSRF that only controls a URL path, regex injection, or untrusted content placed inside an AI prompt.
+10. A web framework already neutralizes it: e.g. React/Angular escaping, unless the code uses an explicit raw-HTML bypass.
+11. A shell-script command-injection claim with no concrete source of untrusted input reaching the script.
+12. It is only a Medium-severity issue that is neither obvious nor concrete.
+
+If the candidate survives, grade it:
+
+- Is the attack path concrete and end-to-end?
+- Is the impact real (code execution, data breach, auth bypass) rather than theoretical?
+- Could a security engineer act on it today: exact file, line, and scenario?
+
+Reply in EXACTLY this format and nothing else:
+
+VERDICT: REAL | FALSE-POSITIVE
+CONFIDENCE: <integer 1-10>
+REASON: <two or three sentences citing the code that decides it>`
 
 const codeReviewPrompt = `You are a code review specialist inside Zero.
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -52,6 +52,7 @@ const (
 	commandLoop
 	commandVoice
 	commandSTTModel
+	commandSecurityReview
 	commandUnknown
 )
 
@@ -115,6 +116,13 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "Show planning mode status.",
 		kind:        commandPlan,
+	},
+	{
+		name:        "/review",
+		usage:       "/review",
+		group:       commandGroupTools,
+		description: "Security review of pending changes on the current branch.",
+		kind:        commandSecurityReview,
 	},
 	{
 		name:        "/permissions",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4502,6 +4502,8 @@ func (m model) dispatchCommand(command parsedCommand) (tea.Model, tea.Cmd) {
 	case commandAddDir:
 		m = m.handleAddDirCommand(command.text)
 		return m, nil
+	case commandSecurityReview:
+		return m.handleSecurityReviewCommand(command.text)
 	case commandUnknown:
 		// A "/name" not in the builtin registry may be a user-defined command
 		// from .zero/commands/<name>.md — expand its template and run it as a


### PR DESCRIPTION
Native /review slash command: collects pending branch changes via a read-only git allowlist, delegates detection to the security-scout specialist, re-judges every candidate with parallel read-only security-verifier specialists, and reports only findings with confidence >= 8 as a markdown report.

## Summary

<!-- What does this change do, and why? -->

## Linked issue

<!-- Per CONTRIBUTING.md, PRs need an approved parent issue with the `issue-approved` label. -->
Fixes #

## Checklist

- [ ] The linked issue already has the `issue-approved` label.
- [ ] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [ ] `gofmt` clean.
- [ ] Tests added/updated for the change (and run under `-race` where relevant).
- [ ] UI changes include screenshots or a short recording where possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/review` command to perform a security review of pending changes on the current branch.
  * Reviews branch status, changed files, commits, and diffs.
  * Added read-only security specialists to identify potential issues and verify findings.
  * Git command failures are reported without stopping the overall review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->