### PR TITLE
fix(cli): include plugins info in shell completions

### DIFF
--- a/internal/cli/completions.go
+++ b/internal/cli/completions.go
@@ -59,7 +59,7 @@ var completionRoot = completionNode{
 			{names: []string{"delete", "rm"}}, {names: []string{"edit"}}, {names: []string{"path"}},
 		}},
 		{names: []string{"plugins", "plugin"}, children: []completionNode{
-			{names: []string{"list"}}, {names: []string{"add"}}, {names: []string{"remove", "rm"}},
+			{names: []string{"list"}}, {names: []string{"add"}}, {names: []string{"info"}}, {names: []string{"remove", "rm"}},
 		}},
 		{names: []string{"backends", "backend"}, children: leafNodes("doctor")},
 		{names: []string{"skills", "skill"}, children: []completionNode{

--- a/internal/cli/completions_test.go
+++ b/internal/cli/completions_test.go
@@ -159,6 +159,8 @@ func TestCompletionTreeCoversAliasesNestingAndCommonFlags(t *testing.T) {
 	assertCandidates(t, byPath["mcp oauth"], "login", "logout", "status")
 	assertCandidates(t, byPath["sandbox grants"], "list", "allow", "deny", "revoke", "clear")
 	assertCandidates(t, byPath["completions"], "bash", "zsh", "fish", "powershell", "elvish")
+	assertCandidates(t, byPath["plugins"], "list", "add", "info", "remove", "rm")
+	assertCandidates(t, byPath["plugin"], "list", "add", "info", "remove", "rm")
 }
 
 func assertCandidates(t *testing.T, got []string, wants ...string) {


### PR DESCRIPTION
## Summary

- Add `info` to the `plugins` / `plugin` shell-completion tree
- Cover it in completion-tree tests

`zero plugins info` landed in #773, but `zero completions` still omitted it.

Closes #791

## Test plan

- [x] `go test ./internal/cli/ -run 'Completions|CompletionTree' -count=1`
- [x] `go vet ./internal/cli/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added shell completion support for the `plugins info` command.
  * Updated completions for both `plugin` and `plugins` command paths to include all available subcommands and aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->