### PR TITLE
fix(tui): reset quiet clock for new runs

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4807,6 +4807,7 @@ func (m model) beginRun(cancel context.CancelFunc) model {
 	// suppressed by a stale preference.
 	m.sidebarHidden = false
 	m.turnStartedAt = m.now()
+	m.lastStreamActivity = m.turnStartedAt
 	m.turnStreamedRunes = 0
 	m.spinnerTicking = true
 	return m

--- a/internal/tui/working_status_test.go
+++ b/internal/tui/working_status_test.go
@@ -106,6 +106,20 @@ func TestQuietGenerationHint(t *testing.T) {
 	}
 }
 
+func TestBeginRunResetsQuietGenerationClock(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	m := model{
+		now:                func() time.Time { return now },
+		lastStreamActivity: now.Add(-time.Minute),
+	}
+
+	m = m.beginRun(nil)
+
+	if got := m.quietGenerationHint(); got != "" {
+		t.Fatalf("new run inherited a stale quiet-generation warning: %q", got)
+	}
+}
+
 // TestQuietGenerationHintEscalatesPastHalfIdleTimeout: a heartbeating-but-
 // silent stream (chatgpt/gpt-5.x, ollama reasoning models — see
 // providerio.ErrStreamStalled) and a genuinely healthy-but-slow one look


### PR DESCRIPTION
## Summary

- initialize stream activity from the new turn's start time
- prevent fresh turns from inheriting a stale quiet-generation duration
- add a deterministic regression test for the stale-clock behavior

## Why

`beginRun()` reset the turn clock but retained `lastStreamActivity` from an earlier turn or window event. Before the first new stream delta arrived, a fresh request could therefore immediately display a misleading message such as `still generating… 1m39s`.

## Verification

- `make fmt-check`
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`
- pinned advisory lint (existing unrelated findings only)
- manual TUI check through a real PTY with `termctrl`
- `git diff origin/main...HEAD --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale “quiet generation” warnings appearing when a new agent turn begins.
  * Quiet-generation timing now resets correctly at the start of each run.

* **Tests**
  * Added coverage to verify quiet-generation warnings are cleared for new runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->