### PR TITLE
test(config): remove Windows startup timing assumptions

### DIFF
--- a/internal/config/command_test.go
+++ b/internal/config/command_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -87,7 +88,7 @@ func TestLoadProviderCommandTimeout(t *testing.T) {
 	if elapsed > maxElapsed {
 		t.Fatalf("timeout returned after %s, want roughly 5s", elapsed)
 	}
-	assertProcessTerminated(t, pidFile)
+	assertProcessTerminatedIfStarted(t, pidFile)
 }
 
 // TestLoadProviderCommandTerminatesBackgroundChild covers a command that
@@ -97,9 +98,10 @@ func TestLoadProviderCommandTimeout(t *testing.T) {
 // leftover child instead of just returning and leaking it.
 func TestLoadProviderCommandTerminatesBackgroundChild(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "bg.pid")
+	childLifetime := 10 * time.Second
 	command := writeCommand(t, commandScript{
 		Stdout:                 `{"name":"cmd","provider":"openai","apiKey":"sk-command","model":"gpt-command"}`,
-		BackgroundSleepSeconds: 10,
+		BackgroundSleepSeconds: int(childLifetime / time.Second),
 		BackgroundPidFile:      pidFile,
 	})
 
@@ -112,8 +114,8 @@ func TestLoadProviderCommandTerminatesBackgroundChild(t *testing.T) {
 	if !strings.Contains(err.Error(), "timed out after 5s") {
 		t.Fatalf("error = %q, want timeout", err.Error())
 	}
-	if elapsed > 4*time.Second {
-		t.Fatalf("returned after %s, want well under the 5s provider-command timeout since WaitDelay (1s) should trigger termination", elapsed)
+	if elapsed >= childLifetime {
+		t.Fatalf("returned after %s, want before the background child finishes naturally after %s", elapsed, childLifetime)
 	}
 	assertProcessTerminated(t, pidFile)
 }
@@ -126,10 +128,11 @@ func TestLoadProviderCommandTerminatesBackgroundChild(t *testing.T) {
 // be terminated on that path.
 func TestLoadProviderCommandTerminatesBackgroundChildOnFailure(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "bg-fail.pid")
+	childLifetime := 10 * time.Second
 	command := writeCommand(t, commandScript{
 		Stderr:                 "boom",
 		ExitCode:               7,
-		BackgroundSleepSeconds: 10,
+		BackgroundSleepSeconds: int(childLifetime / time.Second),
 		BackgroundPidFile:      pidFile,
 	})
 
@@ -142,8 +145,21 @@ func TestLoadProviderCommandTerminatesBackgroundChildOnFailure(t *testing.T) {
 	if !strings.Contains(err.Error(), "exit status") {
 		t.Fatalf("error = %q, want exit status failure", err.Error())
 	}
-	if elapsed > 4*time.Second {
-		t.Fatalf("returned after %s, want well under the 5s provider-command timeout since WaitDelay (1s) should trigger termination", elapsed)
+	if elapsed >= childLifetime {
+		t.Fatalf("returned after %s, want before the background child finishes naturally after %s", elapsed, childLifetime)
+	}
+	assertProcessTerminated(t, pidFile)
+}
+
+func assertProcessTerminatedIfStarted(t *testing.T, pidFile string) {
+	t.Helper()
+
+	// The basic timeout fixture is intentionally unsynchronized. On a loaded
+	// Windows runner, the cold PowerShell child can be terminated before it
+	// records its PID; the synchronized background-child tests below retain
+	// the strict PID and liveness checks.
+	if _, err := os.Stat(pidFile); errors.Is(err, os.ErrNotExist) {
+		return
 	}
 	assertProcessTerminated(t, pidFile)
 }


### PR DESCRIPTION
## Summary

- remove cold PowerShell startup assumptions from provider-command timeout tests
- bound background-child completion by the child's natural lifetime instead of an arbitrary four seconds
- retain strict PID and liveness checks for synchronized background children

## Why

Windows smoke runs repeatedly failed even though provider-command cleanup was working:

- the basic timeout fixture could be terminated before cold PowerShell startup recorded its PID
- background-child setup could consume more than three seconds under concurrent CI load, making the one-second `WaitDelay` path exceed a fixed four-second assertion

The actual safety contract is that execution returns before the 10-second child finishes naturally and that every child known to have started is dead afterward. These tests now assert that behavior directly.

## Verification

- repeated focused provider-command tests
- Windows/amd64 test-binary cross-compilation
- `make fmt-check`
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`
- pinned advisory lint (existing unrelated findings only)
- `git diff origin/main...HEAD --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved command timeout and background-process termination test reliability.
  * Added platform-tolerant handling for processes that exit before recording their process ID.
  * Strengthened timing checks to verify commands return before background processes naturally finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->