### PR TITLE
test(config): wait for background PID file

### DIFF
--- a/internal/config/command_test.go
+++ b/internal/config/command_test.go
@@ -153,13 +153,26 @@ func TestLoadProviderCommandTerminatesBackgroundChildOnFailure(t *testing.T) {
 
 func TestAssertProcessTerminatedWaitsForDelayedPIDFile(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "delayed.pid")
+	firstMissing := make(chan struct{})
 	writeDone := make(chan error, 1)
 	go func() {
-		time.Sleep(50 * time.Millisecond)
-		writeDone <- os.WriteFile(pidFile, []byte("2147483647\n"), 0o600)
+		<-firstMissing
+		tempFile := pidFile + ".tmp"
+		if err := os.WriteFile(tempFile, []byte("2147483647\n"), 0o600); err != nil {
+			writeDone <- err
+			return
+		}
+		writeDone <- os.Rename(tempFile, pidFile)
 	}()
 
-	assertProcessTerminated(t, pidFile)
+	missingObserved := false
+	assertProcessTerminatedAfterMissing(t, pidFile, func() {
+		missingObserved = true
+		close(firstMissing)
+	})
+	if !missingObserved {
+		t.Fatal("PID file existed before the missing-file polling path was exercised")
+	}
 	if err := <-writeDone; err != nil {
 		t.Fatalf("write delayed pid file: %v", err)
 	}
@@ -181,9 +194,16 @@ func assertProcessTerminatedIfStarted(t *testing.T, pidFile string) {
 func assertProcessTerminated(t *testing.T, pidFile string) {
 	t.Helper()
 
+	assertProcessTerminatedAfterMissing(t, pidFile, nil)
+}
+
+func assertProcessTerminatedAfterMissing(t *testing.T, pidFile string, onMissing func()) {
+	t.Helper()
+
 	deadline := time.Now().Add(3 * time.Second)
 	var data []byte
 	var err error
+	missingObserved := false
 	for time.Now().Before(deadline) {
 		data, err = os.ReadFile(pidFile)
 		if err == nil {
@@ -191,6 +211,12 @@ func assertProcessTerminated(t *testing.T, pidFile string) {
 		}
 		if !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("read sleeper pid file: %v", err)
+		}
+		if !missingObserved {
+			missingObserved = true
+			if onMissing != nil {
+				onMissing()
+			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/config/command_test.go
+++ b/internal/config/command_test.go
@@ -151,6 +151,20 @@ func TestLoadProviderCommandTerminatesBackgroundChildOnFailure(t *testing.T) {
 	assertProcessTerminated(t, pidFile)
 }
 
+func TestAssertProcessTerminatedWaitsForDelayedPIDFile(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "delayed.pid")
+	writeDone := make(chan error, 1)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		writeDone <- os.WriteFile(pidFile, []byte("2147483647\n"), 0o600)
+	}()
+
+	assertProcessTerminated(t, pidFile)
+	if err := <-writeDone; err != nil {
+		t.Fatalf("write delayed pid file: %v", err)
+	}
+}
+
 func assertProcessTerminatedIfStarted(t *testing.T, pidFile string) {
 	t.Helper()
 
@@ -167,16 +181,28 @@ func assertProcessTerminatedIfStarted(t *testing.T, pidFile string) {
 func assertProcessTerminated(t *testing.T, pidFile string) {
 	t.Helper()
 
-	data, err := os.ReadFile(pidFile)
+	deadline := time.Now().Add(3 * time.Second)
+	var data []byte
+	var err error
+	for time.Now().Before(deadline) {
+		data, err = os.ReadFile(pidFile)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read sleeper pid file: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if err != nil {
-		t.Fatalf("read sleeper pid file: %v", err)
+		t.Fatalf("read sleeper pid file before timeout: %v", err)
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
 		t.Fatalf("parse sleeper pid %q: %v", data, err)
 	}
 
-	deadline := time.Now().Add(3 * time.Second)
+	deadline = time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		if !processAlive(pid) {
 			return


### PR DESCRIPTION
## Summary
- wait briefly for a background provider command PID file to become readable before checking process termination
- preserve the strict child-liveness assertion once the PID is available
- add a deterministic regression covering delayed PID-file visibility

## Why
Windows Smoke can start and terminate the provider command correctly while the PID file is not yet readable when the test assertion runs. #800 handled the basic timeout fixture, but the strict background-child fixtures still performed an immediate read and remained flaky.

## Validation
- `make fmt-check`
- `go vet ./...`
- `go test ./...`
- `go test ./internal/config -run TestAssertProcessTerminatedWaitsForDelayedPIDFile -count=100`
- Windows cross-compilation of `./internal/config` tests
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `govulncheck ./...` (no vulnerabilities found)
- `git diff HEAD --check`
- pinned advisory golangci-lint (pre-existing repository findings only; none in the changed file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process termination checks to correctly handle PID files that are initially missing and appear shortly after monitoring begins.
  * Added a short wait window for PID file availability, reducing false failures during delayed shutdown.

* **Tests**
  * Added coverage for the delayed PID-file scenario to ensure the new waiting behavior is exercised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->