### PR TITLE
test(cli): order the prewarm probe against the turn

### DIFF
--- a/internal/cli/exec_turn_session_test.go
+++ b/internal/cli/exec_turn_session_test.go
@@ -29,6 +29,7 @@ func TestRunExecOptimizedSessionUnderGate(t *testing.T) {
 	// does. See the POST handler for why that ordering has to be forced.
 	headSeen := make(chan struct{})
 	var headOnce sync.Once
+	var prewarmWaitTimedOut atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodHead:
@@ -59,6 +60,11 @@ func TestRunExecOptimizedSessionUnderGate(t *testing.T) {
 			select {
 			case <-headSeen:
 			case <-time.After(10 * time.Second):
+				// Record it. A probe that shows up after this gave up would still
+				// leave heads at 1, so the count alone proves the probe was
+				// eventually received, not that it was ordered before the turn,
+				// which is the whole claim of this test.
+				prewarmWaitTimedOut.Store(true)
 			}
 			posts.Add(1)
 			w.Header().Set("Content-Type", "text/event-stream")
@@ -105,8 +111,13 @@ func TestRunExecOptimizedSessionUnderGate(t *testing.T) {
 	if got := posts.Load(); got < 1 {
 		t.Fatalf("server saw %d chat-completions POSTs, want >= 1", got)
 	}
-	// No polling: the turn above could not complete until the probe landed, or
-	// until the guard above gave up, so the count is settled by this point.
+	// Checked before the count, because the count cannot tell the two apart: a
+	// probe that arrived only after the guard expired still leaves heads at 1.
+	if prewarmWaitTimedOut.Load() {
+		t.Fatal("the turn was not held until the prewarm probe arrived; the probe did not precede it")
+	}
+	// No polling: the turn above could not complete until the probe landed, so
+	// the count is settled by this point.
 	if got := heads.Load(); got != 1 {
 		t.Fatalf("server saw %d prewarm HEAD probes, want exactly 1", got)
 	}

--- a/internal/cli/exec_turn_session_test.go
+++ b/internal/cli/exec_turn_session_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,12 +25,41 @@ func TestRunExecOptimizedSessionUnderGate(t *testing.T) {
 	cwd := t.TempDir()
 
 	var heads, posts atomic.Int64
+	// Closed when the prewarm probe lands, so the turn can be held open until it
+	// does. See the POST handler for why that ordering has to be forced.
+	headSeen := make(chan struct{})
+	var headOnce sync.Once
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodHead:
 			heads.Add(1)
+			headOnce.Do(func() { close(headSeen) })
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/chat/completions"):
+			// Hold the turn open until the prewarm probe arrives. The probe is
+			// issued on the run's context, and runExec cancels that context the
+			// moment it returns, because the stop function signalContext hands
+			// back is a CancelFunc. A probe that has not reached the wire by the
+			// end of the run therefore never reaches it at all. That is why the
+			// poll this replaced could not work at any deadline: once the run is
+			// over the probe is cancelled, not merely slow.
+			//
+			// This widens the window, it does not close it. Once the goroutine is
+			// scheduled it still has only prewarmTimeout to dial loopback and
+			// write the request, and that timeout is armed inside the goroutine
+			// itself, so holding the turn here cannot extend it. If this test
+			// ever fails again, prewarmTimeout is where to look, not this hold.
+			//
+			// No self-deadlock: the pinned transport leaves MaxConnsPerHost at 0,
+			// so the HEAD dials its own connection instead of queueing behind
+			// this held POST. Do not set a per-host connection limit there.
+			//
+			// Bounded, so a probe that genuinely never fires fails the assertion
+			// below with a useful message instead of hanging the test.
+			select {
+			case <-headSeen:
+			case <-time.After(10 * time.Second):
+			}
 			posts.Add(1)
 			w.Header().Set("Content-Type", "text/event-stream")
 			_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n"))
@@ -75,14 +105,8 @@ func TestRunExecOptimizedSessionUnderGate(t *testing.T) {
 	if got := posts.Load(); got < 1 {
 		t.Fatalf("server saw %d chat-completions POSTs, want >= 1", got)
 	}
-	// The prewarm probe is asynchronous; it fires well before the model turn
-	// finishes, but poll rather than assuming scheduling order. The deadline
-	// exceeds the production prewarmTimeout (3s) so a slow probe cannot flake
-	// this assertion.
-	deadline := time.Now().Add(5 * time.Second)
-	for heads.Load() == 0 && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
+	// No polling: the turn above could not complete until the probe landed, or
+	// until the guard above gave up, so the count is settled by this point.
 	if got := heads.Load(); got != 1 {
 		t.Fatalf("server saw %d prewarm HEAD probes, want exactly 1", got)
 	}


### PR DESCRIPTION
`TestRunExecOptimizedSessionUnderGate` fails intermittently on the Windows smoke job with `server saw 0 prewarm HEAD probes, want exactly 1`.

## Why it flakes

The test polled for up to 5s after the run returned, on the reasoning that the deadline exceeded the 3s prewarm timeout so a slow probe could not flake it. That reasoning does not hold.

The probe is issued on the run's context, and `runExec` cancels that context as it returns: the stop function `signalContext` hands back is a `CancelFunc`, which I confirmed rather than assumed.

```
before stop, ctx.Err() = <nil>
after  stop, ctx.Err() = context canceled
```

So once the run is over the probe is cancelled, not slow, and no deadline makes a cancelled probe observable. Against a mock server the turn finishes in microseconds, which leaves the probe racing teardown with nothing to protect it.

## What this does

The turn now blocks until the probe arrives, so the probe gets its window while the run is still alive rather than after it. The wait is bounded, so a probe that genuinely never fires still fails the assertion with a useful message instead of hanging.

Worth being straight about the limit: this widens the window, it does not close it. `prewarmTimeout` is armed inside the probe goroutine, so holding the turn open here cannot extend it. The comment says that and names `prewarmTimeout` as the thing to look at if this ever comes back.

One trade-off to call out. The assertion loses what little timing sensitivity it had, so a `Prewarm` that became arbitrarily late would now pass. That coverage was already illusory at a 5s poll, and if this does recur the better answer is to assert the wire behaviour in `internal/providers/openai`, which has a real happens-before seam in `prewarmDone`, and leave this test asserting only that the gate selects the optimized session.

## Checks

`gofmt`, `go vet`, `go build ./...` clean. Ran the test 6x locally and 5x under CPU contention, green throughout, no change to the happy-path duration.

Not related to any open feature work; this hits every PR that touches the Windows job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test synchronization for optimized session prewarming.
  * Replaced timing-based polling with deterministic request coordination, reducing potential test flakiness.
  * Preserved verification that the prewarm request occurs exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->