### PR TITLE
fix(sandbox): deny reads of git's credential stores (#815)

### DIFF
--- a/internal/sandbox/profile.go
+++ b/internal/sandbox/profile.go
@@ -212,6 +212,14 @@ func credentialDenyReadPathsForEnvironment(env credentialPathEnvironment, allowR
 		candidates = append(candidates,
 			filepath.Join(home, ".aws"),
 			filepath.Join(home, ".azure"),
+			// git's credential store backend, which holds host passwords and
+			// personal access tokens in cleartext. Denied rather than the whole
+			// of ~/.ssh, because these cost nothing functionally: git reads them
+			// through a credential helper for authentication, not for identity,
+			// so a sandboxed git still works and simply cannot authenticate as
+			// the user. SSH key material is a harder trade and is tracked
+			// separately (#815).
+			filepath.Join(home, ".git-credentials"),
 		)
 	}
 	npmUserConfig := strings.TrimSpace(env.NPMUserConfig)
@@ -233,6 +241,12 @@ func credentialDenyReadPathsForEnvironment(env credentialPathEnvironment, allowR
 	if configHome != "" {
 		candidates = append(candidates,
 			filepath.Join(configHome, "zero"),
+			// The XDG location of the same git credential store. Denying the file
+			// rather than the directory is deliberate: ~/.config/git also holds
+			// the global git config, which userGitConfigReadPaths grants on
+			// purpose so a sandboxed git can read user.name and aliases instead
+			// of failing outright.
+			filepath.Join(configHome, "git", "credentials"),
 		)
 	}
 	cloudSDKConfig := strings.TrimSpace(env.CloudSDKConfig)

--- a/internal/sandbox/profile_test.go
+++ b/internal/sandbox/profile_test.go
@@ -1,0 +1,79 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// git's credential store holds host passwords and personal access tokens in
+// cleartext, in one of two locations depending on whether the user is on the
+// XDG layout. Neither was denied, so a sandboxed command could read them
+// (#815).
+//
+// Scoped to the credential files on purpose. Denying ~/.ssh as well would stop
+// a sandboxed git push over SSH from working, which is a functional trade that
+// issue tracks separately; these two cost nothing, because git reads them for
+// authentication rather than identity.
+func TestCredentialDenyReadPathsCoversGitCredentialStores(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	if err := os.MkdirAll(filepath.Join(configHome, "git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// The builder only emits paths that exist, so these have to be real.
+	gitCredentials := filepath.Join(home, ".git-credentials")
+	xdgCredentials := filepath.Join(configHome, "git", "credentials")
+	gitConfig := filepath.Join(configHome, "git", "config")
+	for _, path := range []string{gitCredentials, xdgCredentials, gitConfig} {
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	denied := credentialDenyReadPathsForEnvironment(credentialPathEnvironment{
+		Home:       home,
+		ConfigHome: configHome,
+	}, nil)
+	covered := func(target string) bool {
+		norm := normalizeProfilePath(target)
+		for _, entry := range denied {
+			if entry == norm || pathWithinRoot(entry, norm) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !covered(gitCredentials) {
+		t.Fatalf("~/.git-credentials is readable; deny list = %v", denied)
+	}
+	if !covered(xdgCredentials) {
+		t.Fatalf("~/.config/git/credentials is readable; deny list = %v", denied)
+	}
+	// The global git config must stay readable. userGitConfigReadPaths grants it
+	// deliberately so a sandboxed git can read user.name and aliases rather than
+	// failing with "unable to access", so denying the directory instead of the
+	// credential file would break that on purpose-built setups.
+	if covered(gitConfig) {
+		t.Fatalf("~/.config/git/config was denied; a sandboxed git loses its identity config")
+	}
+}
+
+// An explicit read grant still wins, matching how every other entry behaves: a
+// user who deliberately scopes a workspace over one of these paths is not
+// overridden by the default deny.
+func TestGitCredentialDenyYieldsToExplicitAllowRead(t *testing.T) {
+	home := t.TempDir()
+	gitCredentials := filepath.Join(home, ".git-credentials")
+	if err := os.WriteFile(gitCredentials, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	denied := credentialDenyReadPathsForEnvironment(credentialPathEnvironment{Home: home}, []string{home})
+	for _, entry := range denied {
+		if entry == normalizeProfilePath(gitCredentials) {
+			t.Fatalf("explicit allowRead %q did not re-include the credential store", home)
+		}
+	}
+}

--- a/internal/sandbox/profile_test.go
+++ b/internal/sandbox/profile_test.go
@@ -63,17 +63,31 @@ func TestCredentialDenyReadPathsCoversGitCredentialStores(t *testing.T) {
 // An explicit read grant still wins, matching how every other entry behaves: a
 // user who deliberately scopes a workspace over one of these paths is not
 // overridden by the default deny.
+//
+// Asserted from both sides on purpose. Checking only that the path is absent
+// under an allowRead is satisfied just as well by a deny rule that was never
+// added, so the run without allowRead has to establish that there is something
+// there for the grant to override.
 func TestGitCredentialDenyYieldsToExplicitAllowRead(t *testing.T) {
 	home := t.TempDir()
 	gitCredentials := filepath.Join(home, ".git-credentials")
 	if err := os.WriteFile(gitCredentials, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-
-	denied := credentialDenyReadPathsForEnvironment(credentialPathEnvironment{Home: home}, []string{home})
-	for _, entry := range denied {
-		if entry == normalizeProfilePath(gitCredentials) {
-			t.Fatalf("explicit allowRead %q did not re-include the credential store", home)
+	target := normalizeProfilePath(gitCredentials)
+	listed := func(entries []string) bool {
+		for _, entry := range entries {
+			if entry == target {
+				return true
+			}
 		}
+		return false
+	}
+
+	if !listed(credentialDenyReadPathsForEnvironment(credentialPathEnvironment{Home: home}, nil)) {
+		t.Fatalf("~/.git-credentials is not denied without an allowRead; nothing for the grant to override")
+	}
+	if listed(credentialDenyReadPathsForEnvironment(credentialPathEnvironment{Home: home}, []string{home})) {
+		t.Fatalf("explicit allowRead %q did not re-include the credential store", home)
 	}
 }


### PR DESCRIPTION
Takes option 1 from #815: the git credential stores only.

## What

`~/.git-credentials` and `~/.config/git/credentials` are git's credential-store backend. They hold host passwords and personal access tokens in cleartext, and neither was on the deny list, so any command the agent ran could read them.

Measured on `main` before the change, with the files materialised, since the builder only emits paths that exist:

```
denied=false  ~/.git-credentials
denied=false  ~/.config/git/credentials
denied=true   ~/.aws/credentials     (included to show the mechanism works)
```

## Why only these two, and not the rest of #815

#815 also covers SSH private keys and the GPG keyring. Those are a genuinely harder trade and this deliberately does not attempt them:

- Denying `~/.ssh` stops a sandboxed `git push` over SSH from working. That is a functional cost, not a free win.
- Excluding `~/.ssh` is not even sufficient. An `IdentityFile` directive, or an `Include` chain, can point key material anywhere, so a directory rule leaves the key readable exactly when a careful user has moved it.

The credential stores have neither problem. git reads them to authenticate, not to know who the user is, so a sandboxed git keeps working and simply cannot act as the user. That is the behaviour you want from a sandbox.

## One asymmetry worth explaining

The XDG entry denies the FILE, `~/.config/git/credentials`, not the directory around it. That is the opposite of the choice made for `~/.config/zero` in #801, and it is deliberate.

`~/.config/git` also holds the global git config, and `userGitConfigReadPaths` grants that on purpose so a sandboxed git can read `user.name` and aliases rather than failing with "unable to access". Denying the directory would take that away. Its comment already says the surrounding directory should not be exposed, which is the same instinct, applied from the allow side on macOS.

## Verification

`gofmt`, `go vet`, `GOOS=windows go vet`, and builds for linux, darwin and windows are clean. `internal/sandbox` passes.

Three tests, each mutation-checked rather than merely written:

- dropping `~/.git-credentials` fails the coverage test
- dropping the XDG entry fails it too
- widening the XDG entry to the whole directory fails the assertion that the git config beside it stays readable, which is the regression this scoping exists to prevent

The third is the one worth having. It is what stops someone "simplifying" this later into a directory deny and quietly breaking git identity inside the sandbox.

## Scope

Linux in practice, like the rest of the list: it is skipped on Windows by design, and macOS allow-lists reads. #815 stays open for the SSH and GPG half, which still needs the posture decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential protection by blocking access to Git credential helper store files in sandboxed environments (including both legacy and XDG locations).
  * Deny rules still respect explicit allow-read permissions, so explicitly permitted paths are not blocked.
* **Tests**
  * Added coverage to verify credential store deny-path behavior and precedence with allow-read settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->