### PR TITLE
fix(sandbox): scrub the daemon token file pointer (#677)

### DIFF
--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -1027,6 +1027,13 @@ func scrubSensitiveEnv(env []string, additionalKeys ...string) []string {
 		"GH_TOKEN",
 		"ZERO_WEBSEARCH_API_KEY",
 		"ZERO_DAEMON_REMOTE_TOKEN",
+		// The file form of the same bridge token. TokenFromEnv accepts either,
+		// so scrubbing only the inline variable left the pointer readable, and
+		// the default sandbox posture is read-all. There is no fallback
+		// location to guess at, the path comes from this variable alone, so
+		// removing it closes the leak rather than half of it. Same reasoning as
+		// GOOGLE_APPLICATION_CREDENTIALS below.
+		"ZERO_DAEMON_REMOTE_TOKEN_FILE",
 	}
 	for _, descriptor := range providercatalog.All() {
 		for _, key := range descriptor.AuthEnvVars {

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -699,6 +699,11 @@ func TestScrubSensitiveEnv(t *testing.T) {
 		"XAI_API_KEY=xai-12345",
 		"HUGGINGFACE_API_KEY=hf_12345",
 		"GOOGLE_APPLICATION_CREDENTIALS=/home/user/sa-key.json",
+		// Both forms of the daemon bridge token. The inline one was already
+		// scrubbed; the file form was not, which left a sandboxed command the
+		// path to read it from (#677).
+		"ZERO_DAEMON_REMOTE_TOKEN=bridge-token-inline",
+		"ZERO_DAEMON_REMOTE_TOKEN_FILE=/home/user/.zero/remote-token",
 		"COMPANY_LLM_SECRET=custom-secret",
 		"ZERO_OAUTH_MY_SVC_CLIENT_SECRET=oauth-secret",
 		"zero_oauth_second_client_secret=case-insensitive-secret",


### PR DESCRIPTION
Fixes #677.

`scrubSensitiveEnv` removed `ZERO_DAEMON_REMOTE_TOKEN` but not `ZERO_DAEMON_REMOTE_TOKEN_FILE`. `TokenFromEnv` (`internal/daemon/remote/auth.go:72-86`) accepts either form, so a sandboxed command still inherited the path to the bridge token, and since the default posture is read-all it could then read the token out of that file.

## Why the one line is the whole fix

I considered also adding the target to the credential deny-read list, and decided against it. The path comes from this variable alone and `TokenFromEnv` has no default location to fall back on, so a command that never sees the variable has nothing to guess at. Adding a deny rule for an arbitrary env-supplied path would also collide with #816, which is currently in flight in the same function, for no extra protection.

This mirrors the existing treatment of `GOOGLE_APPLICATION_CREDENTIALS`, which is scrubbed for exactly this reason. The comment there already spells out the rule; this variable simply matched the description and was missed.

## Verification

Extended the existing scrub table rather than adding a new test, because `TestScrubSensitiveEnv` compares the surviving environment exactly, so a missed key fails the assertion by construction. Both forms of the token now go in and neither is expected out.

Dropping the production line reproduces the leak:

```
scrubSensitiveEnv() = map[... ZERO_DAEMON_REMOTE_TOKEN_FILE:/home/user/.zero/remote-token ...]
                want map[AWS_PROFILE:staging PATH:/usr/bin SAFE_VAR:hello ZERO_OAUTH_CLIENT_SECRET:not-a-provider-secret]
```

`go test ./internal/sandbox/` passes in full, `gofmt` and `go vet` clean.

## Scope

Two files, twelve added lines, no behaviour change beyond the scrub itself. Keeping it deliberately small: #685 covered adjacent ground and grew to fifteen files, which is a large part of why it stalled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when running sandboxed commands by removing both inline daemon tokens and token file paths from inherited environments.
  * Prevents sandboxed processes from accessing sensitive daemon credentials through environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->