### PR TITLE
fix(tui): hide unavailable sidebar shortcut

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3036,9 +3036,18 @@ func (m model) composerIdleHint() string {
 	case tierNarrow:
 		hint = "? shortcuts"
 	case tierMedium:
-		hint = fmt.Sprintf("? shortcuts · Ctrl+X cmds · %s sidebar", sidebarKey)
+		parts := []string{"? shortcuts", "Ctrl+X cmds"}
+		if m.sidebarAvailable() {
+			parts = append(parts, sidebarKey+" sidebar")
+		}
+		hint = strings.Join(parts, " · ")
 	default:
-		hint = fmt.Sprintf("? shortcuts · Ctrl+X cmds · %s sidebar · %s detail · %s copy · Shift+Tab mode", sidebarKey, detailKey, mouseKey)
+		parts := []string{"? shortcuts", "Ctrl+X cmds"}
+		if m.sidebarAvailable() {
+			parts = append(parts, sidebarKey+" sidebar")
+		}
+		parts = append(parts, detailKey+" detail", mouseKey+" copy", "Shift+Tab mode")
+		hint = strings.Join(parts, " · ")
 	}
 	return zeroTheme.faint.Render(hint)
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2502,8 +2502,21 @@ func TestComposerIdleHintAndJumpCue(t *testing.T) {
 	m.transcript = append(m.transcript, transcriptRow{kind: rowAssistant, text: "hi", final: true})
 
 	// Idle, empty composer, managed mode -> the discoverability hint shows.
-	if h := plainRender(t, m.composerIdleHint()); !strings.Contains(h, "shortcuts") {
-		t.Fatalf("expected idle hint, got %q", h)
+	hint := plainRender(t, m.composerIdleHint())
+	if !strings.Contains(hint, "shortcuts") {
+		t.Fatalf("expected idle hint, got %q", hint)
+	}
+	if strings.Contains(hint, "sidebar") {
+		t.Fatalf("empty sidebar should not be advertised, got %q", hint)
+	}
+	withSidebar := m
+	withSidebar.plan.steps = []planStep{{content: "inspect footer", status: "in_progress"}}
+	if hint := plainRender(t, withSidebar.composerIdleHint()); !strings.Contains(hint, "Ctrl+B sidebar") {
+		t.Fatalf("available sidebar should be advertised, got %q", hint)
+	}
+	withSidebar.sidebarHidden = true
+	if hint := plainRender(t, withSidebar.composerIdleHint()); !strings.Contains(hint, "Ctrl+B sidebar") {
+		t.Fatalf("collapsed sidebar should keep its restore shortcut, got %q", hint)
 	}
 	// Hidden during a run.
 	busy := m

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2501,22 +2501,36 @@ func TestComposerIdleHintAndJumpCue(t *testing.T) {
 	m.width, m.height = 100, 30
 	m.transcript = append(m.transcript, transcriptRow{kind: rowAssistant, text: "hi", final: true})
 
-	// Idle, empty composer, managed mode -> the discoverability hint shows.
-	hint := plainRender(t, m.composerIdleHint())
-	if !strings.Contains(hint, "shortcuts") {
-		t.Fatalf("expected idle hint, got %q", hint)
-	}
-	if strings.Contains(hint, "sidebar") {
-		t.Fatalf("empty sidebar should not be advertised, got %q", hint)
-	}
-	withSidebar := m
-	withSidebar.plan.steps = []planStep{{content: "inspect footer", status: "in_progress"}}
-	if hint := plainRender(t, withSidebar.composerIdleHint()); !strings.Contains(hint, "Ctrl+B sidebar") {
-		t.Fatalf("available sidebar should be advertised, got %q", hint)
-	}
-	withSidebar.sidebarHidden = true
-	if hint := plainRender(t, withSidebar.composerIdleHint()); !strings.Contains(hint, "Ctrl+B sidebar") {
-		t.Fatalf("collapsed sidebar should keep its restore shortcut, got %q", hint)
+	for _, test := range []struct {
+		name  string
+		width int
+	}{
+		{name: "medium", width: 80},
+		{name: "full", width: 100},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			idle := m
+			idle.width = test.width
+
+			// Idle, empty composer, managed mode -> the discoverability hint shows.
+			hint := plainRender(t, idle.composerIdleHint())
+			if !strings.Contains(hint, "shortcuts") {
+				t.Fatalf("expected idle hint, got %q", hint)
+			}
+			if strings.Contains(hint, "sidebar") {
+				t.Fatalf("empty sidebar should not be advertised, got %q", hint)
+			}
+
+			withSidebar := idle
+			withSidebar.plan.steps = []planStep{{content: "inspect footer", status: "in_progress"}}
+			if hint := plainRender(t, withSidebar.composerIdleHint()); !strings.Contains(hint, "Ctrl+B sidebar") {
+				t.Fatalf("available sidebar should be advertised, got %q", hint)
+			}
+			withSidebar.sidebarHidden = true
+			if hint := plainRender(t, withSidebar.composerIdleHint()); !strings.Contains(hint, "Ctrl+B sidebar") {
+				t.Fatalf("collapsed sidebar should keep its restore shortcut, got %q", hint)
+			}
+		})
 	}
 	// Hidden during a run.
 	busy := m


### PR DESCRIPTION
## What changed

- hide the `Ctrl+B sidebar` footer shortcut when the sidebar has no content
- keep the shortcut visible when a plan, agent, or changed-file activity makes the sidebar available
- keep the shortcut visible while an available sidebar is collapsed so users can restore it
- add regression coverage for empty, available, and collapsed sidebar states

## Why

The footer previously advertised `Ctrl+B sidebar` unconditionally on medium and wide terminals. In sessions without sidebar content, pressing the shortcut produced no visible result and made the control appear broken.

The footer now uses the same availability predicate as the sidebar layout, while intentionally ignoring the user's collapsed preference for the restore case.

## Validation

- `make fmt-check`
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `make lint-static`
- `make vulncheck`
- `git diff HEAD --check`
- manual termctrl verification of empty, visible, collapsed, and restored sidebar states


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composer idle footer hints to display only relevant shortcuts.
  * Sidebar shortcut messaging now appears only when the sidebar is available, and remains correct even when the sidebar is collapsed.
  * Wide layouts now show additional detail, copy, and mode-switching hints.
* **Tests**
  * Expanded coverage for composer idle hint and jump cue rendering across width variants and sidebar availability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->