### PR TITLE
fix: use OAuth credentials in provider health checks

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -585,6 +585,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	baseProbeProviderHealth := deps.probeProviderHealth
 	deps.probeProviderHealth = func(ctx context.Context, options providerhealth.Options) providerhealth.Result {
 		options.Profile = applyStoredProviderKeyAt(options.Profile, userConfigPath)
+		if options.OAuthResolver == nil {
+			options.OAuthResolver, _ = oauthLoginForProfile(options.Profile)
+		}
 		return baseProbeProviderHealth(ctx, options)
 	}
 	return deps

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -114,6 +114,7 @@ func TestRunDoctorConnectivityProbesProvider(t *testing.T) {
 
 func TestRunDoctorConnectivityUsesOAuthLogin(t *testing.T) {
 	tokenPath := filepath.Join(t.TempDir(), "oauth-tokens.json")
+	userConfigPath := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("ZERO_OAUTH_STORAGE", "file")
 	t.Setenv("ZERO_OAUTH_TOKENS_PATH", tokenPath)
 	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: tokenPath})
@@ -147,6 +148,9 @@ func TestRunDoctorConnectivityUsesOAuthLogin(t *testing.T) {
 	exitCode := runWithDeps([]string{"doctor", "--connectivity"}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) {
 			return t.TempDir(), nil
+		},
+		userConfigPath: func() (string, error) {
+			return userConfigPath, nil
 		},
 		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
 			return config.ResolvedConfig{

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -114,7 +114,7 @@ func TestRunDoctorConnectivityProbesProvider(t *testing.T) {
 
 func TestRunDoctorConnectivityUsesOAuthLogin(t *testing.T) {
 	tokenPath := filepath.Join(t.TempDir(), "oauth-tokens.json")
-	userConfigPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("ZERO_OAUTH_STORAGE", "file")
 	t.Setenv("ZERO_OAUTH_TOKENS_PATH", tokenPath)
 	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: tokenPath})
@@ -148,9 +148,6 @@ func TestRunDoctorConnectivityUsesOAuthLogin(t *testing.T) {
 	exitCode := runWithDeps([]string{"doctor", "--connectivity"}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) {
 			return t.TempDir(), nil
-		},
-		userConfigPath: func() (string, error) {
-			return userConfigPath, nil
 		},
 		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
 			return config.ResolvedConfig{

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/sessions"
 )
@@ -106,6 +109,64 @@ func TestRunDoctorConnectivityProbesProvider(t *testing.T) {
 	}
 	if strings.Contains(output, "not wired") {
 		t.Fatalf("doctor still returned placeholder connectivity message: %q", output)
+	}
+}
+
+func TestRunDoctorConnectivityUsesOAuthLogin(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "oauth-tokens.json")
+	t.Setenv("ZERO_OAUTH_STORAGE", "file")
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", tokenPath)
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: tokenPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(oauth.ProviderKey("xai"), oauth.Token{
+		AccessToken: "oauth-doctor-token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed OAuth token: %v", err)
+	}
+
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	profile := config.ProviderProfile{
+		Name:         "xai",
+		CatalogID:    "xai",
+		ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL:      server.URL + "/v1",
+		Model:        "grok-4",
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"doctor", "--connectivity"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{
+				Provider:       profile,
+				Providers:      []config.ProviderProfile{profile},
+				ActiveProvider: profile.Name,
+			}, nil
+		},
+		probeProviderHealth: providerhealth.Probe,
+		now:                 fixedCLITime("2026-07-29T20:00:00Z"),
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("doctor exit = %d, want success; stderr=%q\n%s", exitCode, stderr.String(), stdout.String())
+	}
+	if gotAuth != "Bearer oauth-doctor-token" {
+		t.Fatalf("Authorization = %q, want OAuth bearer", gotAuth)
+	}
+	if !strings.Contains(stdout.String(), "[pass] provider.connectivity") {
+		t.Fatalf("doctor did not report passing connectivity:\n%s", stdout.String())
 	}
 }
 

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -209,7 +209,7 @@ func Probe(ctx context.Context, options Options) Result {
 	}, profile))
 
 	oauthConfigured := options.OAuthResolver != nil
-	if options.Connectivity && oauthConfigured {
+	if oauthConfigured {
 		var resolveErr error
 		profile, oauthConfigured, resolveErr = profileWithOAuthCredential(ctx, profile, options.OAuthResolver, false)
 		if resolveErr != nil {

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -373,7 +373,6 @@ func profileWithOAuthCredential(ctx context.Context, profile config.ProviderProf
 	if strings.TrimSpace(header) == "" {
 		header = "Authorization"
 	}
-	profile.APIKey = ""
 	profile.AuthHeader = header
 	profile.AuthScheme = ""
 	profile.AuthHeaderValue = value

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -807,6 +807,9 @@ func redact(message string, profile config.ProviderProfile) string {
 
 func providerSecrets(profile config.ProviderProfile) []string {
 	secrets := []string{profile.APIKey, profile.AuthHeaderValue}
+	if fields := strings.Fields(profile.AuthHeaderValue); len(fields) == 2 {
+		secrets = append(secrets, fields[1])
+	}
 	for _, value := range profile.CustomHeaders {
 		if strings.TrimSpace(value) != "" {
 			secrets = append(secrets, value)

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -46,12 +46,13 @@ const (
 const defaultTimeout = 5 * time.Second
 
 type Options struct {
-	Profile      config.ProviderProfile
-	Connectivity bool
-	HTTPClient   *http.Client
-	Resolver     Resolver
-	Timeout      time.Duration
-	UserAgent    string
+	Profile       config.ProviderProfile
+	Connectivity  bool
+	HTTPClient    *http.Client
+	Resolver      Resolver
+	OAuthResolver providerio.TokenResolver
+	Timeout       time.Duration
+	UserAgent     string
 }
 
 type Resolver interface {
@@ -207,11 +208,26 @@ func Probe(ctx context.Context, options Options) Result {
 		"providerKind": metadata.ProviderKind,
 	}, profile))
 
-	if credentialRequired(profile, metadata.ProviderKind) && !hasCredential(profile) {
+	oauthConfigured := options.OAuthResolver != nil
+	if options.Connectivity && oauthConfigured {
+		var resolveErr error
+		profile, oauthConfigured, resolveErr = profileWithOAuthCredential(ctx, profile, options.OAuthResolver, false)
+		if resolveErr != nil {
+			result.add(check("provider.auth", "Provider auth", StatusFail, CategoryAuth, "Provider OAuth credential could not be resolved: "+resolveErr.Error(), map[string]any{
+				"oauthLogin": true,
+			}, profile))
+			return result.finalize()
+		}
+	}
+	if credentialRequired(profile, metadata.ProviderKind) && !hasCredential(profile) && !oauthConfigured {
 		result.add(check("provider.auth", "Provider auth", StatusFail, CategoryAuth, fmt.Sprintf("Provider %s requires API credentials.", providerName(profile)), credentialDetails(profile), profile))
 		return result.finalize()
 	}
-	if hasCredential(profile) {
+	if oauthConfigured {
+		result.add(check("provider.auth", "Provider auth", StatusPass, CategoryAuth, fmt.Sprintf("Provider %s has OAuth credentials configured.", providerName(profile)), map[string]any{
+			"oauthLogin": true,
+		}, profile))
+	} else if hasCredential(profile) {
 		result.add(check("provider.auth", "Provider auth", StatusPass, CategoryAuth, fmt.Sprintf("Provider %s has credentials configured.", providerName(profile)), credentialDetails(profile), profile))
 	} else {
 		result.add(check("provider.auth", "Provider auth", StatusPass, CategoryAuth, fmt.Sprintf("Provider %s does not require API credentials.", providerName(profile)), credentialDetails(profile), profile))
@@ -286,9 +302,35 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 	if err != nil {
 		return classifyTransportError(err, profile)
 	}
-	defer func() {
-		_ = response.Body.Close()
-	}()
+	defer func(body io.ReadCloser) {
+		_ = body.Close()
+	}(response.Body)
+	if response.StatusCode == http.StatusUnauthorized && options.OAuthResolver != nil {
+		refreshed, ok, refreshErr := profileWithOAuthCredential(requestCtx, options.Profile, options.OAuthResolver, true)
+		if refreshErr != nil {
+			return check("provider.connectivity", "Provider connectivity", StatusFail, CategoryAuth, "Provider OAuth credential refresh failed: "+refreshErr.Error(), map[string]any{
+				"statusCode": response.StatusCode,
+			}, profile)
+		}
+		if ok {
+			_ = response.Body.Close()
+			profile = refreshed
+			request, allowLoopbackOrPrivate, err = healthRequest(requestCtx, profile, kind, options)
+			if err != nil {
+				return check("provider.connectivity", "Provider connectivity", StatusFail, CategoryConfig, err.Error(), nil, profile)
+			}
+			if options.HTTPClient == nil {
+				client = newConnectivityClient(timeout, options.Resolver, sensitiveAuthHeaderNames(profile, kind), allowLoopbackOrPrivate)
+			}
+			response, err = client.Do(request)
+			if err != nil {
+				return classifyTransportError(err, profile)
+			}
+			defer func(body io.ReadCloser) {
+				_ = body.Close()
+			}(response.Body)
+		}
+	}
 
 	body, err := io.ReadAll(io.LimitReader(response.Body, 64*1024))
 	if err != nil {
@@ -318,6 +360,24 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 		"statusCode": response.StatusCode,
 		"endpoint":   request.URL.String(),
 	}, profile)
+}
+
+func profileWithOAuthCredential(ctx context.Context, profile config.ProviderProfile, resolver providerio.TokenResolver, forceRefresh bool) (config.ProviderProfile, bool, error) {
+	if resolver == nil {
+		return profile, false, nil
+	}
+	header, value, ok, err := resolver(ctx, forceRefresh)
+	if err != nil || !ok {
+		return profile, false, err
+	}
+	if strings.TrimSpace(header) == "" {
+		header = "Authorization"
+	}
+	profile.APIKey = ""
+	profile.AuthHeader = header
+	profile.AuthScheme = ""
+	profile.AuthHeaderValue = value
+	return profile, true, nil
 }
 
 func healthRequest(ctx context.Context, profile config.ProviderProfile, kind config.ProviderKind, options Options) (*http.Request, bool, error) {

--- a/internal/providerhealth/providerhealth_test.go
+++ b/internal/providerhealth/providerhealth_test.go
@@ -221,15 +221,18 @@ func TestProbeConnectivityUsesOAuthCredential(t *testing.T) {
 	}
 }
 
-func TestProbeConnectivityOAuthKeepsStaticKeyRedacted(t *testing.T) {
-	const staticKey = "STATICKEYVALUE1234567890abcdef"
+func TestProbeConnectivityOAuthCredentialsAreRedacted(t *testing.T) {
+	const (
+		staticKey  = "STATICKEYVALUE1234567890abcdef"
+		oauthToken = "hf_VASANTHSENTINEL0011223344"
+	)
 	var authHeaders []string
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
 		return &http.Response{
 			StatusCode: http.StatusUnauthorized,
 			Status:     "401 Unauthorized",
-			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"invalid key ` + staticKey + `"}}`)),
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"invalid credentials ` + staticKey + ` and ` + oauthToken + `"}}`)),
 			Header:     make(http.Header),
 		}, nil
 	})}
@@ -247,7 +250,7 @@ func TestProbeConnectivityOAuthKeepsStaticKeyRedacted(t *testing.T) {
 		HTTPClient:   client,
 		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
 		OAuthResolver: func(context.Context, bool) (string, string, bool, error) {
-			return "Authorization", "Bearer oauth-test-token", true, nil
+			return "Authorization", "Bearer " + oauthToken, true, nil
 		},
 	})
 
@@ -255,7 +258,7 @@ func TestProbeConnectivityOAuthKeepsStaticKeyRedacted(t *testing.T) {
 		t.Fatalf("Authorization headers = %#v, want initial request and one refresh retry", authHeaders)
 	}
 	for _, header := range authHeaders {
-		if header != "Bearer oauth-test-token" {
+		if header != "Bearer "+oauthToken {
 			t.Fatalf("Authorization = %q, want OAuth bearer", header)
 		}
 	}
@@ -266,8 +269,11 @@ func TestProbeConnectivityOAuthKeepsStaticKeyRedacted(t *testing.T) {
 	if strings.Contains(check.Message, staticKey) {
 		t.Fatalf("static API key leaked in message: %q", check.Message)
 	}
-	if !strings.Contains(check.Message, "[REDACTED]") {
-		t.Fatalf("expected static API key to be redacted, got %q", check.Message)
+	if strings.Contains(check.Message, oauthToken) {
+		t.Fatalf("OAuth token leaked in message: %q", check.Message)
+	}
+	if strings.Count(check.Message, "[REDACTED]") != 2 {
+		t.Fatalf("expected both credentials to be redacted, got %q", check.Message)
 	}
 }
 

--- a/internal/providerhealth/providerhealth_test.go
+++ b/internal/providerhealth/providerhealth_test.go
@@ -180,6 +180,98 @@ func TestProbeResolvedKindConnectivityAuthErrorRedactsSecret(t *testing.T) {
 	}
 }
 
+func TestProbeConnectivityUsesOAuthCredential(t *testing.T) {
+	var gotAuth string
+	resolverCalled := false
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotAuth = r.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "xai",
+			CatalogID:    "xai",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			Model:        "grok-4",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
+		OAuthResolver: func(context.Context, bool) (string, string, bool, error) {
+			resolverCalled = true
+			return "Authorization", "Bearer oauth-test-token", true, nil
+		},
+	})
+
+	if result.Status != StatusPass {
+		t.Fatalf("Status = %q, want pass: %#v", result.Status, result.Checks)
+	}
+	if !resolverCalled {
+		t.Fatal("OAuth resolver was not called")
+	}
+	if gotAuth != "Bearer oauth-test-token" {
+		t.Fatalf("Authorization = %q, want OAuth bearer", gotAuth)
+	}
+}
+
+func TestProbeConnectivityRefreshesOAuthCredentialAfterUnauthorized(t *testing.T) {
+	var authHeaders []string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		status := http.StatusOK
+		body := `{"data":[]}`
+		if len(authHeaders) == 1 {
+			status = http.StatusUnauthorized
+			body = `{"error":{"message":"expired"}}`
+		}
+		return &http.Response{
+			StatusCode: status,
+			Status:     http.StatusText(status),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	var refreshFlags []bool
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "xai",
+			CatalogID:    "xai",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			Model:        "grok-4",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
+		OAuthResolver: func(_ context.Context, forceRefresh bool) (string, string, bool, error) {
+			refreshFlags = append(refreshFlags, forceRefresh)
+			token := "stale-token"
+			if forceRefresh {
+				token = "fresh-token"
+			}
+			return "Authorization", "Bearer " + token, true, nil
+		},
+	})
+
+	if result.Status != StatusPass {
+		t.Fatalf("Status = %q, want pass after refresh: %#v", result.Status, result.Checks)
+	}
+	if len(refreshFlags) != 2 || refreshFlags[0] || !refreshFlags[1] {
+		t.Fatalf("OAuth refresh flags = %#v, want [false true]", refreshFlags)
+	}
+	if len(authHeaders) != 2 || authHeaders[0] != "Bearer stale-token" || authHeaders[1] != "Bearer fresh-token" {
+		t.Fatalf("Authorization headers = %#v, want stale then fresh bearer", authHeaders)
+	}
+}
+
 func TestProbeConnectivityClassifiesTimeout(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return nil, context.DeadlineExceeded

--- a/internal/providerhealth/providerhealth_test.go
+++ b/internal/providerhealth/providerhealth_test.go
@@ -221,6 +221,56 @@ func TestProbeConnectivityUsesOAuthCredential(t *testing.T) {
 	}
 }
 
+func TestProbeConnectivityOAuthKeepsStaticKeyRedacted(t *testing.T) {
+	const staticKey = "STATICKEYVALUE1234567890abcdef"
+	var authHeaders []string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"invalid key ` + staticKey + `"}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "xai",
+			CatalogID:    "xai",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			APIKey:       staticKey,
+			Model:        "grok-4",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
+		OAuthResolver: func(context.Context, bool) (string, string, bool, error) {
+			return "Authorization", "Bearer oauth-test-token", true, nil
+		},
+	})
+
+	if len(authHeaders) != 2 {
+		t.Fatalf("Authorization headers = %#v, want initial request and one refresh retry", authHeaders)
+	}
+	for _, header := range authHeaders {
+		if header != "Bearer oauth-test-token" {
+			t.Fatalf("Authorization = %q, want OAuth bearer", header)
+		}
+	}
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Category != CategoryAuth {
+		t.Fatalf("provider.connectivity = %#v, want auth failure", check)
+	}
+	if strings.Contains(check.Message, staticKey) {
+		t.Fatalf("static API key leaked in message: %q", check.Message)
+	}
+	if !strings.Contains(check.Message, "[REDACTED]") {
+		t.Fatalf("expected static API key to be redacted, got %q", check.Message)
+	}
+}
+
 func TestProbeWithoutConnectivityRejectsUnavailableOAuthCredential(t *testing.T) {
 	resolverCalled := false
 	result := Probe(context.Background(), Options{

--- a/internal/providerhealth/providerhealth_test.go
+++ b/internal/providerhealth/providerhealth_test.go
@@ -221,6 +221,34 @@ func TestProbeConnectivityUsesOAuthCredential(t *testing.T) {
 	}
 }
 
+func TestProbeWithoutConnectivityRejectsUnavailableOAuthCredential(t *testing.T) {
+	resolverCalled := false
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "xai",
+			CatalogID:    "xai",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			Model:        "grok-4",
+		},
+		OAuthResolver: func(context.Context, bool) (string, string, bool, error) {
+			resolverCalled = true
+			return "", "", false, nil
+		},
+	})
+
+	if !resolverCalled {
+		t.Fatal("OAuth resolver was not called")
+	}
+	if result.Status != StatusFail {
+		t.Fatalf("Status = %q, want fail: %#v", result.Status, result.Checks)
+	}
+	check := result.Check("provider.auth")
+	if check == nil || check.Status != StatusFail || check.Category != CategoryAuth {
+		t.Fatalf("provider.auth = %#v, want auth failure", check)
+	}
+}
+
 func TestProbeConnectivityRefreshesOAuthCredentialAfterUnauthorized(t *testing.T) {
 	var authHeaders []string
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- pass the existing provider OAuth resolver into health probes
- authenticate connectivity checks with the stored OAuth credential
- refresh the OAuth credential once when a safe, non-generating health request returns 401
- preserve the existing API-key and stored-key paths

## Why

OAuth-authenticated providers worked for normal model requests, but `zero doctor --connectivity` only recognized static API keys and auth headers. A valid OAuth login was therefore reported as missing credentials before the connectivity request was attempted.

## User impact

Doctor and provider-health checks now use the same OAuth credential source as normal provider requests. Users receive the provider's real connectivity result instead of a false missing-credentials failure.

## Verification

- `make fmt-check`
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `make lint-static`
- `make vulncheck`
- verified the saved xAI OAuth profile reaches the provider and reports its actual account response rather than `requires API credentials`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider connectivity diagnostics now support OAuth-based authentication.
  * When OAuth is configured, connectivity checks can refresh OAuth credentials and retry automatically after `401 Unauthorized`.

* **Bug Fixes**
  * Connectivity probing no longer requires a static API key when OAuth credentials are available.
  * Improved auth redaction to hide both static API keys and OAuth bearer tokens in failure output.

* **Tests**
  * Expanded diagnostics/connectivity tests to validate OAuth header selection, refresh/retry behavior, missing/unusable OAuth handling, and token redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->