### PR TITLE
fix(tools): derive SeenWhole from the recorded ranges

### DIFF
--- a/internal/tools/file_tracker.go
+++ b/internal/tools/file_tracker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"os"
+	"sort"
 	"sync"
 	"time"
 )
@@ -56,7 +57,11 @@ type lineRange struct {
 }
 
 type fileObservation struct {
-	whole  bool
+	whole bool
+	// total is the file's line count as of the last recorded read, so coverage
+	// can be judged from the ranges alone. Without it a file read in pieces
+	// could never be known to have been seen in full.
+	total  int
 	ranges []lineRange
 }
 
@@ -102,6 +107,13 @@ func (tracker *FileTracker) RecordSeenRange(absPath string, start, end, total in
 	if end < start {
 		return
 	}
+	// A new line count means the file changed shape since the last read, so
+	// previously recorded ranges no longer describe it.
+	if observation.total != 0 && observation.total != total {
+		observation.ranges = nil
+		observation.whole = false
+	}
+	observation.total = total
 	if start == 1 && end >= total {
 		observation.whole = true
 		observation.ranges = nil
@@ -110,6 +122,41 @@ func (tracker *FileTracker) RecordSeenRange(absPath string, start, end, total in
 	}
 	observation.ranges = append(observation.ranges, lineRange{start: start, end: end})
 	tracker.seen[absPath] = observation
+}
+
+// coversFully reports whether ranges together cover every line in [start, end].
+//
+// Ranges are merged rather than scanned line by line: a caller asking about a
+// large file would otherwise walk every line against every recorded range, and
+// the answer is the same.
+func coversFully(ranges []lineRange, start int, end int) bool {
+	if start > end {
+		return true
+	}
+	if len(ranges) == 0 {
+		return false
+	}
+	sorted := make([]lineRange, len(ranges))
+	copy(sorted, ranges)
+	sort.Slice(sorted, func(left int, right int) bool {
+		if sorted[left].start != sorted[right].start {
+			return sorted[left].start < sorted[right].start
+		}
+		return sorted[left].end < sorted[right].end
+	})
+	next := start
+	for _, seen := range sorted {
+		if seen.start > next {
+			return false
+		}
+		if seen.end >= next {
+			next = seen.end + 1
+		}
+		if next > end {
+			return true
+		}
+	}
+	return next > end
 }
 
 // SeenRange reports whether every line in the requested range was returned
@@ -127,19 +174,7 @@ func (tracker *FileTracker) SeenRange(absPath string, start, end int) bool {
 	if observation.whole {
 		return true
 	}
-	for line := start; line <= end; line++ {
-		covered := false
-		for _, seen := range observation.ranges {
-			if line >= seen.start && line <= seen.end {
-				covered = true
-				break
-			}
-		}
-		if !covered {
-			return false
-		}
-	}
-	return true
+	return coversFully(observation.ranges, start, end)
 }
 
 func (tracker *FileTracker) SeenWhole(absPath string) bool {
@@ -148,7 +183,22 @@ func (tracker *FileTracker) SeenWhole(absPath string) bool {
 	}
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
-	return tracker.seen[absPath].whole
+	observation, ok := tracker.seen[absPath]
+	if !ok {
+		return false
+	}
+	if observation.whole {
+		return true
+	}
+	// Derived from the ranges rather than tracked as its own flag. The flag was
+	// only ever set by a SINGLE read covering the file, so a file read in two
+	// halves stayed "not seen whole" forever even though SeenRange agreed every
+	// line had been seen — and write_file, which gates on this, then refused the
+	// overwrite with advice to read the file that could not change the answer.
+	if observation.total <= 0 {
+		return false
+	}
+	return coversFully(observation.ranges, 1, observation.total)
 }
 
 // Version returns the recorded version for absPath and whether one exists.

--- a/internal/tools/file_tracker_coverage_test.go
+++ b/internal/tools/file_tracker_coverage_test.go
@@ -1,0 +1,96 @@
+package tools
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// SeenWhole used to be a flag set only by a SINGLE read that covered the file,
+// while SeenRange judged coverage from the accumulated ranges. The two then
+// disagreed about the same reads, and write_file — which gates on SeenWhole —
+// refused overwrites it should have allowed.
+func TestSeenWholeIsDerivedFromAccumulatedRanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f.go")
+
+	for name, testCase := range map[string]struct {
+		reads [][3]int // start, end, total
+		want  bool
+	}{
+		"one read covering the file": {
+			reads: [][3]int{{1, 100, 100}},
+			want:  true,
+		},
+		"two adjacent reads covering it together": {
+			reads: [][3]int{{1, 50, 100}, {51, 100, 100}},
+			want:  true,
+		},
+		"overlapping reads covering it together": {
+			reads: [][3]int{{1, 60, 100}, {40, 100, 100}},
+			want:  true,
+		},
+		"out-of-order reads covering it together": {
+			reads: [][3]int{{51, 100, 100}, {1, 50, 100}},
+			want:  true,
+		},
+		"a gap in the middle": {
+			reads: [][3]int{{1, 40, 100}, {60, 100, 100}},
+			want:  false,
+		},
+		"missing the first line": {
+			reads: [][3]int{{2, 100, 100}},
+			want:  false,
+		},
+		"missing the last line": {
+			reads: [][3]int{{1, 99, 100}},
+			want:  false,
+		},
+		"nothing read at all": {
+			reads: nil,
+			want:  false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tracker := NewFileTracker()
+			for _, read := range testCase.reads {
+				tracker.RecordSeenRange(path, read[0], read[1], read[2])
+			}
+			if got := tracker.SeenWhole(path); got != testCase.want {
+				t.Errorf("SeenWhole = %v, want %v after reads %v", got, testCase.want, testCase.reads)
+			}
+		})
+	}
+}
+
+// SeenWhole and SeenRange must not disagree about the same reads.
+func TestSeenWholeAgreesWithSeenRange(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f.go")
+	tracker := NewFileTracker()
+	tracker.RecordSeenRange(path, 1, 50, 100)
+	tracker.RecordSeenRange(path, 51, 100, 100)
+
+	if !tracker.SeenRange(path, 1, 100) {
+		t.Fatal("SeenRange says the whole file was not seen")
+	}
+	if !tracker.SeenWhole(path) {
+		t.Error("SeenRange covers every line but SeenWhole disagrees")
+	}
+}
+
+// A file that changed length since the recorded reads must not stay "seen":
+// the old ranges describe a shape the file no longer has.
+func TestSeenWholeResetsWhenTheFileChangesLength(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f.go")
+	tracker := NewFileTracker()
+	tracker.RecordSeenRange(path, 1, 100, 100)
+	if !tracker.SeenWhole(path) {
+		t.Fatal("precondition: the whole file was read")
+	}
+	// The file grew; only the first 100 lines of 200 have been seen.
+	tracker.RecordSeenRange(path, 1, 100, 200)
+	if tracker.SeenWhole(path) {
+		t.Error("file grew to 200 lines but is still reported as seen whole")
+	}
+	if !tracker.SeenRange(path, 1, 100) {
+		t.Error("the lines that were read should still count as seen")
+	}
+}

--- a/internal/tools/file_tracker_largefile_test.go
+++ b/internal/tools/file_tracker_largefile_test.go
@@ -30,7 +30,7 @@ func TestLargeFileBecomesWritableAfterScopedReadsCoverIt(t *testing.T) {
 	const lines = 2400
 	var builder strings.Builder
 	for index := 0; index < lines; index++ {
-		builder.WriteString(fmt.Sprintf("line %06d %s\n", index, strings.Repeat("x", 60)))
+		fmt.Fprintf(&builder, "line %06d %s\n", index, strings.Repeat("x", 60))
 	}
 	if writeErr := os.WriteFile(path, []byte(builder.String()), 0o600); writeErr != nil {
 		t.Fatalf("seed file: %v", writeErr)

--- a/internal/tools/file_tracker_largefile_test.go
+++ b/internal/tools/file_tracker_largefile_test.go
@@ -1,0 +1,71 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A file past the read byte budget cannot be read whole in one call: the read is
+// truncated and RecordSeenRange is skipped, which is correct — the model did not
+// see those lines. But SeenWhole was a flag only a single whole-file read could
+// set, so no sequence of scoped reads could ever clear it either, and write_file
+// refused the overwrite forever while telling the model to read the file again.
+func TestLargeFileBecomesWritableAfterScopedReadsCoverIt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.go")
+
+	const lines = 2400
+	var builder strings.Builder
+	for index := 0; index < lines; index++ {
+		builder.WriteString(fmt.Sprintf("line %06d %s\n", index, strings.Repeat("x", 60)))
+	}
+	if err := os.WriteFile(path, []byte(builder.String()), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	tracker := NewFileTracker()
+	options := RunOptions{FileTracker: tracker}
+	ctx := context.Background()
+	read := NewReadFileTool(dir).(interface {
+		RunWithOptions(context.Context, map[string]any, RunOptions) Result
+	})
+	write := NewScopedWriteFileTool(dir, nil).(interface {
+		RunWithOptions(context.Context, map[string]any, RunOptions) Result
+	})
+
+	// One unbounded read is byte-truncated, so nothing is recorded.
+	full := read.RunWithOptions(ctx, map[string]any{"path": "big.go"}, options)
+	if full.Meta["truncation_reason"] != "byte_budget" {
+		t.Fatalf("precondition: expected the file to exceed the read byte budget, got reason %q", full.Meta["truncation_reason"])
+	}
+	if tracker.SeenWhole(path) {
+		t.Fatal("a truncated read must not credit the model with the whole file")
+	}
+
+	// Scoped reads that together cover it must.
+	for _, span := range [][2]int{{1, 1200}, {1201, 2400}} {
+		result := read.RunWithOptions(ctx, map[string]any{
+			"path": "big.go", "start_line": span[0], "end_line": span[1],
+		}, options)
+		if result.Status != StatusOK {
+			t.Fatalf("scoped read %v: %s", span, result.Output)
+		}
+		if result.Meta["truncation_reason"] == "byte_budget" {
+			t.Fatalf("scoped read %v was itself truncated; pick smaller spans", span)
+		}
+	}
+	if !tracker.SeenWhole(path) {
+		t.Fatal("scoped reads covered every line but the file is still not seen whole")
+	}
+
+	overwrite := write.RunWithOptions(ctx, map[string]any{
+		"path": "big.go", "content": "replaced\n", "overwrite": true,
+	}, options)
+	if overwrite.Status != StatusOK {
+		t.Fatalf("overwrite refused after the file was fully read in scoped reads: %s", overwrite.Output)
+	}
+}

--- a/internal/tools/file_tracker_largefile_test.go
+++ b/internal/tools/file_tracker_largefile_test.go
@@ -16,15 +16,24 @@ import (
 // refused the overwrite forever while telling the model to read the file again.
 func TestLargeFileBecomesWritableAfterScopedReadsCoverIt(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "big.go")
+	// read_file resolves the workspace root through EvalSymlinks before it
+	// records anything, so the tracker is keyed on the resolved path. On macOS
+	// t.TempDir() sits under /var, a symlink to /private/var, and asserting
+	// against the raw path would look up a key that never existed — passing on
+	// Windows and failing there.
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	path := filepath.Join(resolvedDir, "big.go")
 
 	const lines = 2400
 	var builder strings.Builder
 	for index := 0; index < lines; index++ {
 		builder.WriteString(fmt.Sprintf("line %06d %s\n", index, strings.Repeat("x", 60)))
 	}
-	if err := os.WriteFile(path, []byte(builder.String()), 0o600); err != nil {
-		t.Fatalf("seed file: %v", err)
+	if writeErr := os.WriteFile(path, []byte(builder.String()), 0o600); writeErr != nil {
+		t.Fatalf("seed file: %v", writeErr)
 	}
 
 	tracker := NewFileTracker()


### PR DESCRIPTION
For #838 — targets `feat/harness-efficiency-foundation`, not `main`. Merge it into your branch if you want it, or close it and fold the change in yourself; whatever's least friction.

This is the bug from my testing comment on #838. `SeenWhole` was a flag only a single whole-file read could set, while `SeenRange` judged coverage from the accumulated ranges, so the two disagreed about identical reads:

```
read 1-50, then 51-100 of a 100-line file
  SeenRange(1,100) -> true
  SeenWhole        -> false
```

`write_file` gates overwrites on `SeenWhole`. A file past the read byte budget can't be read whole in one call — the read is truncated and `RecordSeenRange` is skipped, which is *correct*, the model didn't see those lines — so nothing could ever set the flag and the overwrite was refused permanently, with advice to read the file that couldn't change the answer.

`SeenWhole` is now derived from the ranges against the file's recorded line count. Scoped reads that together cover a file make it writable, and the error text becomes actionable.

Two details worth your eye:

**Length changes reset the ranges.** The observation carries the line count from the last read; a read reporting a different one clears what was accumulated, because those ranges describe a shape the file no longer has. Without that, a file read whole at 100 lines then appended to would still report seen-whole at 200.

**Coverage merges sorted ranges** instead of walking every line against every range, which is what `SeenRange` did before. Same answer, but it no longer does a line-by-line scan over a large file — that path is now hit by `SeenWhole` too, so the old cost would have been paid on every overwrite check.

Verified:
- `TestSeenWholeIsDerivedFromAccumulatedRanges` — 8 cases: single read, adjacent, overlapping, out-of-order, gap in the middle, missing first line, missing last line, nothing read
- `TestSeenWholeAgreesWithSeenRange` — the two can't disagree
- `TestSeenWholeResetsWhenTheFileChangesLength`
- `TestLargeFileBecomesWritableAfterScopedReadsCoverIt` — end to end through the real `read_file` and `write_file` tools on a file that genuinely exceeds the byte budget, asserting the truncated read does *not* credit it and the scoped reads do

Mutation-checked both directions: reverting `SeenWhole` to the bare flag and dropping the length-change reset each fail the new tests. `internal/tools` and `internal/agent` green, gofmt and vet clean.

Your existing `file_safety_test.go` and `file_tracker` tests pass unchanged — I didn't touch them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file coverage tracking across multiple reads, including overlapping, adjacent, and out-of-order ranges.
  * Coverage now resets correctly when a file’s length changes.
  * Prevented truncated reads from being treated as complete file coverage.
  * Enabled valid file overwrites after all lines are read through scoped reads.
  * Ensured complete coverage is recognized consistently regardless of read order or grouping.

* **Tests**
  * Added comprehensive coverage for range tracking, file changes, large files, and overwrite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->