### PR TITLE
fix: suppress gosec G204 warning for trusted local config commands

### DIFF
--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -76,8 +76,10 @@ func shellCommand(command string) *exec.Cmd {
 		if strings.HasPrefix(strings.TrimSpace(command), `"`) {
 			command = "call " + command
 		}
+		/* #nosec G204 -- Provider commands are intentionally evaluated by a shell to support features like pipes and env expansions. The command string originates from the user's trusted local config. */
 		return exec.Command("cmd", "/C", command)
 	}
+	/* #nosec G204 -- Provider commands are intentionally evaluated by a shell to support features like pipes and env expansions. The command string originates from the user's trusted local config. */
 	return exec.Command("sh", "-c", command)
 }
 


### PR DESCRIPTION
## Summary
- Provider command strings are intentionally passed through `sh -c` / `cmd /C` to support pipes and env expansions, and originate only from the user's trusted local config
- Gosec flags this as a G204 command-injection risk; removing the shell invocation would be a breaking change, so this adds a documented `#nosec G204` annotation instead of degrading functionality

## Test plan
- [ ] `gosec` no longer flags `internal/config/command.go`
- [ ] existing provider-command tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added security annotations for provider command execution on supported platforms.
  * No user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->