### PR TITLE
fix(tui): fill alt-screen frame with theme panel background

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2773,6 +2773,7 @@ func (m model) View() tea.View {
 		// ClearScreen repaints to the theme color instead of white.
 		if m.width > 0 && m.height > 0 {
 			content = zeroTheme.panel.Width(m.width).Height(m.height).Render(content)
+			view.SetContent(content)
 		}
 	}
 	// Always requested, independent of the notifier: the composer cursor's

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2763,6 +2763,17 @@ func (m model) View() tea.View {
 	// background behind in the user's scrollback after exit.
 	if m.altScreen {
 		view.BackgroundColor = zeroTheme.bgPanel
+		// Also fill the frame content with the panel surface, not just the
+		// terminal's default background. Relying on view.BackgroundColor alone
+		// leaves blank/padding cells (and anything ClearScreen erases) on the
+		// terminal's own default, which is white on a light terminal — so light
+		// themes flash a blinding white instead of their cream surface. Wrapping
+		// the content paints every cell (including blank lines) with the theme
+		// panel, so the surface is uniform regardless of the terminal default and
+		// ClearScreen repaints to the theme color instead of white.
+		if m.width > 0 && m.height > 0 {
+			content = zeroTheme.panel.Width(m.width).Height(m.height).Render(content)
+		}
 	}
 	// Always requested, independent of the notifier: the composer cursor's
 	// focus/blink behavior (composerBlinkMsg above) needs tea.FocusMsg/BlurMsg


### PR DESCRIPTION
## Summary
- Blank/cleared cells in the alt-screen frame fell back to the terminal's own default background instead of the theme's panel color, so light themes flashed white on resize or whenever ClearScreen erased the frame
- Wraps the rendered content in `zeroTheme.panel` sized to the full frame so every cell is explicitly painted, not just the cells `view.BackgroundColor` covers

## Test plan
- [ ] resize the TUI under a light theme and confirm no white flash
- [ ] confirm dark themes are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alternate-screen rendering by applying the configured theme background consistently across the full terminal area.
  * Blank spaces and cleared screen regions now display the correct panel surface color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->