### PR TITLE
docs(agents): Codify recurring review blockers in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,14 +83,16 @@ These classes drive multi-round reviews. Fix them before requesting review:
   checks over duplicated helpers that drift.
 - **Security edges:** Keep secrets out of argv, env dumps, and logs. Redact
   success and error paths (including stderr). Fail closed on ownership, lease,
-  and permission checks. Lexical path checks alone do not stop symlink or
-  reparse escape: resolve and re-validate containment before use. On multi-step
-  setup, roll back only what this run created; never destroy pre-existing
-  resources you did not create; never report success when cleanup or unlock
-  failed.
-- **Atomic shared state:** Use an atomic replace (or equivalent exclusive
-  write) for files concurrent readers may observe. Serialize read-modify-write
-  of lockfiles and shared stores.
+  and permission checks. Do not rely on pre-open path resolution
+  (`EvalSymlinks` then open) for containment: that is a check-to-use race.
+  Bind containment at open/use time (no-follow or handle-relative APIs, and
+  platform equivalents for reparse points). On multi-step setup, roll back
+  only what this run created; never destroy pre-existing resources you did
+  not create; never report success when cleanup or unlock failed.
+- **Atomic shared state:** Write a complete temporary file, then atomically
+  replace the destination so concurrent readers never see a partial write.
+  Exclusive create or a write lock alone is not enough for readers. Serialize
+  the full read-modify-write sequence for lockfiles and shared stores.
 - **Tests match the claim:** Every behavior or security-boundary change needs a
   regression test, including the failure path. Path-sensitive logic needs at
   least one non-Linux path case (or a hermetic fake that exercises the same

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,10 @@ These classes drive multi-round reviews. Fix them before requesting review:
   success and error paths (including stderr). Fail closed on ownership, lease,
   and permission checks. Do not rely on pre-open path resolution
   (`EvalSymlinks` then open) for containment: that is a check-to-use race.
-  Bind containment at open/use time (no-follow or handle-relative APIs, and
-  platform equivalents for reparse points). On multi-step setup, roll back
+  Bind containment at open/use time with rooted or handle-relative,
+  traversal-resistant APIs. If a no-follow API is used, apply it to every
+  traversed component and enforce the platform's reparse-point protections;
+  final-component-only no-follow is insufficient. On multi-step setup, roll back
   only what this run created; never destroy pre-existing resources you did
   not create; never report success when cleanup or unlock failed.
 - **Atomic shared state:** Write a complete temporary file, then atomically

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,35 @@ requirements. If a related check fails, fix it. If a required check cannot run
 because of the environment or fails for an unrelated external reason, report
 the exact failure and obtain maintainer direction rather than silently ignoring
 it.
+
+## 4. Common Review Blockers
+
+These classes drive multi-round reviews. Fix them before requesting review:
+
+- **Fresh base:** Rebase onto the current PR base (`main` or stacked target)
+  before review. A stale head that rolls back mainline commits is a hard
+  blocker, not a merge-time detail. Resolve conflicts by keeping upstream
+  behavior unless the PR intentionally changes it.
+- **Platform truth:** Code and tests must pass on Linux, macOS, and Windows.
+  Compare paths after canonicalization (physical/`EvalSymlinks` form); never
+  assert raw `t.TempDir()` spellings (`/var` vs `/private/var` on macOS, short
+  paths on Windows). Prefer one cross-platform function with small `GOOS`
+  checks over duplicated helpers that drift.
+- **Security edges:** Keep secrets out of argv, env dumps, and logs. Redact
+  success and error paths (including stderr). Fail closed on ownership, lease,
+  and permission checks. Lexical path checks alone do not stop symlink or
+  reparse escape: resolve and re-validate containment before use. On multi-step
+  setup, roll back only what this run created; never destroy pre-existing
+  resources you did not create; never report success when cleanup or unlock
+  failed.
+- **Atomic shared state:** Use an atomic replace (or equivalent exclusive
+  write) for files concurrent readers may observe. Serialize read-modify-write
+  of lockfiles and shared stores.
+- **Tests match the claim:** Every behavior or security-boundary change needs a
+  regression test, including the failure path. Path-sensitive logic needs at
+  least one non-Linux path case (or a hermetic fake that exercises the same
+  normalization).
+- **Honest scope:** PR description, help text, and comments must match what
+  shipped. Wire advertised entry points or shrink the claim. Do not bundle
+  unrelated fixes. Do not widen security allowlists by name alone; check
+  classification and side effects too.


### PR DESCRIPTION
## Summary

Maintainer review threads (especially multi-round ones) keep restating the same defect classes: stale merge bases that roll back mainline work, non-canonical path tests that break macOS/Windows smoke, secrets in argv or unredacted error paths, fail-open ownership checks, partial setup without safe rollback, missing regression tests, and PR claims that do not match what shipped.

This PR adds a short **Common Review Blockers** section to `AGENTS.md` so coding agents and contributors address those classes before the first review, without bloating the file (~1.9KB / 32 lines).

Closes #856

## Changes

### `AGENTS.md`
- New section 4 covering:
  - Fresh base / no silent mainline rollbacks
  - Platform-truth path handling (canonical paths, `t.TempDir` pitfalls)
  - Security edges (argv, redaction of errors, fail closed, symlink/reparse, setup rollback ownership)
  - Atomic shared-state writes
  - Regression tests that match the claim (including failure and non-Linux path cases)
  - Honest scope (wired entry points, no name-only security allowlists)

## Test plan
- [x] Docs-only change; no Go code
- [x] `git diff HEAD --check`
- [ ] Skim section 4 for density and accuracy against recent multi-round reviews
- [ ] Confirm agents loading repo `AGENTS.md` pick up the new section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for avoiding common code review blockers, including keeping pull requests current, ensuring cross-platform compatibility, protecting sensitive information, enforcing secure failure behavior, handling rollbacks safely, updating shared data atomically, testing behavioral and security changes, and accurately describing the scope of each change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->