### PR TITLE
fix(agent): end the additional_permissions retry loop

### DIFF
--- a/internal/agent/additional_permissions_validation_test.go
+++ b/internal/agent/additional_permissions_validation_test.go
@@ -127,9 +127,7 @@ func TestExecuteToolCallMissingAdditionalPermissionsErrorIsActionable(t *testing
 	if !strings.Contains(result.Output, `{"network": {"enabled": true}}`) {
 		t.Fatalf("output = %q, want a concrete additional_permissions example", result.Output)
 	}
-	if !strings.Contains(result.Output, "omit sandbox_permissions") {
-		t.Fatalf("output = %q, want guidance that the flag can simply be omitted", result.Output)
-	}
+	assertNamesOmitRemedy(t, "missing additional_permissions", result.Output)
 }
 
 // A well-formed additional_permissions payload must still reach the normal
@@ -163,6 +161,123 @@ func TestExecuteToolCallStillPromptsForValidAdditionalPermissions(t *testing.T) 
 	if promptCalls != 1 {
 		t.Fatalf("OnPermissionRequest called %d times, want exactly 1 for a valid elevation request", promptCalls)
 	}
+}
+
+// runShellCall drives one shell tool call through the real registry (and so
+// through Registry.RunWithOptions) exactly as the agent loop would.
+func runShellCall(t *testing.T, root string, arguments string) ToolResult {
+	t.Helper()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewScopedExecCommandTool(root, nil, nil))
+	result, err := executeToolCall(
+		context.Background(),
+		registry,
+		ToolCall{ID: "c1", Name: "exec_command", Arguments: arguments},
+		PermissionModeUnsafe,
+		Options{Cwd: root},
+	)
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	return result
+}
+
+// TestAdditionalPermissionsRejectionsConverge is the regression guard for
+// #845/#847. A model that attaches a permission object to a command needing
+// none used to be told only "set sandbox_permissions", which pushed it into the
+// OTHER invalid shape (flag set, payload empty) and its "include a permission"
+// error pushed it straight back — the reported loop that burned turns on
+// `git branch --show-current`.
+//
+// The contract this pins is convergence, not tolerance: both shapes are still
+// REJECTED (nothing here grants access), but each rejection must name the one
+// follow-up call that works, and that follow-up must actually succeed.
+func TestAdditionalPermissionsRejectionsConverge(t *testing.T) {
+	root := t.TempDir()
+	const readOnly = `"cmd":"git --version"`
+
+	// Step 1 of the reported loop: a permission object with no flag.
+	first := runShellCall(t, root, `{`+readOnly+`,"additional_permissions":{"network":{"enabled":true}}}`)
+	if first.Status != tools.StatusError {
+		t.Fatalf("unflagged additional_permissions status = %q, want error (rejecting is correct)", first.Status)
+	}
+	assertNamesOmitRemedy(t, "unflagged additional_permissions", first.Output)
+
+	// Step 2 of the reported loop: the model keeps the flag but empties the
+	// payload. This must not be the dead end it was.
+	second := runShellCall(t, root, `{`+readOnly+`,"sandbox_permissions":"with_additional_permissions"}`)
+	if second.Status != tools.StatusError {
+		t.Fatalf("flag without payload status = %q, want error", second.Status)
+	}
+	assertNamesOmitRemedy(t, "flag without payload", second.Output)
+
+	// The call both errors point at must actually work.
+	converged := runShellCall(t, root, `{`+readOnly+`}`)
+	if converged.Status != tools.StatusOK {
+		t.Fatalf("the call both errors instruct the model to make failed: status=%q output=%q", converged.Status, converged.Output)
+	}
+}
+
+// assertNamesOmitRemedy pins the actionable half of the error text: the message
+// must spell out that BOTH fields can simply be dropped. "Set the flag" or
+// "include a permission" alone is what made the two errors chase each other.
+func assertNamesOmitRemedy(t *testing.T, label string, output string) {
+	t.Helper()
+	if !strings.Contains(output, "omit both sandbox_permissions and additional_permissions") {
+		t.Fatalf("%s error = %q, want it to say to omit both fields entirely", label, output)
+	}
+	if !strings.Contains(output, "retry") {
+		t.Fatalf("%s error = %q, want it to tell the model to retry", label, output)
+	}
+}
+
+// The empty-payload rejection carries the same remedy. It is pinned on the
+// validator directly because normalizeNoopAdditionalPermissions absorbs the
+// empty payload before executeToolCall reaches this branch;
+// inlineAdditionalPermissionsProfile is still the shared source of truth that
+// buildPermissionEvent and the grant path re-run, so its text must converge too.
+func TestEmptyAdditionalPermissionsErrorNamesOmitRemedy(t *testing.T) {
+	args := map[string]any{
+		"cmd":                 "git --version",
+		"sandbox_permissions": string(tools.SandboxPermissionsWithAdditionalPermissions),
+		"additional_permissions": map[string]any{
+			"network":     map[string]any{"enabled": false},
+			"file_system": map[string]any{"read": []any{}, "write": []any{}},
+		},
+	}
+	_, requested, err := inlineAdditionalPermissionsProfile(args, t.TempDir())
+	if !requested {
+		t.Fatal("requested = false, want true for an explicit with_additional_permissions call")
+	}
+	if err == nil {
+		t.Fatal("an empty additional_permissions payload was accepted; it must still be rejected")
+	}
+	assertNamesOmitRemedy(t, "empty payload", err.Error())
+}
+
+// A provider that materializes every optional property may send
+// "additional_permissions": null. That grants nothing and carries no flag, so it
+// is the field omitted — rejecting it stalled an ordinary command behind an
+// error the model could not act on.
+func TestExecuteToolCallTreatsNullAdditionalPermissionsAsOmitted(t *testing.T) {
+	result := runShellCall(t, t.TempDir(), `{"cmd":"git --version","additional_permissions":null}`)
+	if result.Status != tools.StatusOK {
+		t.Fatalf("null additional_permissions was rejected: status=%q output=%q", result.Status, result.Output)
+	}
+}
+
+// A null payload alongside the flag must still be rejected, and must land on
+// the same error as an absent payload rather than being quietly downgraded.
+func TestExecuteToolCallRejectsFlaggedNullAdditionalPermissions(t *testing.T) {
+	result := runShellCall(t, t.TempDir(),
+		`{"cmd":"git --version","sandbox_permissions":"with_additional_permissions","additional_permissions":null}`)
+	if result.Status != tools.StatusError {
+		t.Fatalf("flagged null status = %q, want error", result.Status)
+	}
+	if !strings.Contains(result.Output, "no additional_permissions object was provided") {
+		t.Fatalf("output = %q, want the missing-payload error", result.Output)
+	}
+	assertNamesOmitRemedy(t, "flagged null", result.Output)
 }
 
 func TestNormalizeProviderExpandedEmptyAdditionalPermissions(t *testing.T) {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2763,7 +2763,16 @@ func shellCommandAdditionalPermissionsRequested(args map[string]any) bool {
 // access and malformed payloads are left untouched so validation stays closed.
 func normalizeNoopAdditionalPermissions(args map[string]any, basePath string, engine *sandbox.Engine) {
 	raw, exists := args["additional_permissions"]
-	if !exists || raw == nil {
+	if !exists {
+		return
+	}
+	// An explicit null is the field omitted, not a request: drop the key so the
+	// rest of the pipeline sees the same args a model that omitted it would send.
+	// sandbox_permissions is deliberately left alone — a flagged null must reach
+	// the same "no additional_permissions object was provided" error as a flagged
+	// absent field rather than being silently downgraded to a different outcome.
+	if raw == nil {
+		delete(args, "additional_permissions")
 		return
 	}
 	data, err := json.Marshal(raw)
@@ -2794,21 +2803,41 @@ func normalizeNoopAdditionalPermissions(args map[string]any, basePath string, en
 	}
 }
 
+// omitAdditionalPermissionsHint is the one instruction that ends the retry loop
+// in #845/#847. Every additional_permissions rejection must carry it: the model
+// reaches these errors by attaching a permission object to a command that needs
+// none, so "omit it and retry" is the answer in practice, and an error that
+// only explains how to build a VALID permission object sends the model round
+// the loop again with a different invalid shape.
+const omitAdditionalPermissionsHint = "If this command does not need extra sandbox access — ordinary " +
+	"read-only commands such as `git branch --show-current` do not — omit both sandbox_permissions and " +
+	"additional_permissions entirely and retry; that is the fix in almost every case."
+
 func inlineAdditionalPermissionsProfile(args map[string]any, basePath string) (sandbox.RequestPermissionProfile, bool, error) {
 	if !shellCommandAdditionalPermissionsRequested(args) {
-		if _, exists := args["additional_permissions"]; exists {
-			return sandbox.RequestPermissionProfile{}, false, fmt.Errorf("additional_permissions requires sandbox_permissions set to %q", tools.SandboxPermissionsWithAdditionalPermissions)
+		// An explicit null grants nothing and carries no flag, so it is
+		// indistinguishable from an omitted field; rejecting it would be a pure
+		// false positive against providers that materialize every optional
+		// property.
+		if raw, exists := args["additional_permissions"]; exists && raw != nil {
+			return sandbox.RequestPermissionProfile{}, false, fmt.Errorf(
+				"additional_permissions was provided without sandbox_permissions set to %q, so it cannot be applied. %s "+
+					"Only if the command genuinely needs file or network access the sandbox denies, resend with "+
+					`sandbox_permissions: %q AND a non-empty additional_permissions, for example {"network": {"enabled": true}}`,
+				tools.SandboxPermissionsWithAdditionalPermissions,
+				omitAdditionalPermissionsHint,
+				tools.SandboxPermissionsWithAdditionalPermissions)
 		}
 		return sandbox.RequestPermissionProfile{}, false, nil
 	}
 	raw, ok := args["additional_permissions"]
 	if !ok || raw == nil {
 		return sandbox.RequestPermissionProfile{}, true, fmt.Errorf(
-			"sandbox_permissions was set to %q but no additional_permissions object was provided. "+
-				`Include one, for example additional_permissions: {"network": {"enabled": true}} or `+
-				`{"file_system": {"write": ["/path"]}}. If this command does not need elevated permissions, `+
-				"omit sandbox_permissions entirely and retry",
-			tools.SandboxPermissionsWithAdditionalPermissions)
+			"sandbox_permissions was set to %q but no additional_permissions object was provided. %s "+
+				`Otherwise include one, for example additional_permissions: {"network": {"enabled": true}} or `+
+				`{"file_system": {"write": ["/path"]}}`,
+			tools.SandboxPermissionsWithAdditionalPermissions,
+			omitAdditionalPermissionsHint)
 	}
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -2824,8 +2853,10 @@ func inlineAdditionalPermissionsProfile(args map[string]any, basePath string) (s
 	}
 	if normalized.Empty() {
 		return sandbox.RequestPermissionProfile{}, true, fmt.Errorf(
-			"additional_permissions must include at least one of network or file_system, for example " +
-				`{"network": {"enabled": true}} or {"file_system": {"write": ["/path"]}}`)
+			"additional_permissions granted nothing, so it cannot be applied. %s "+
+				`Otherwise include a real permission, for example {"network": {"enabled": true}} or `+
+				`{"file_system": {"write": ["/path"]}}`,
+			omitAdditionalPermissionsHint)
 	}
 	grantProfile, err := sandbox.RequestPermissionGrantProfile(normalized)
 	if err != nil {

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -132,6 +132,33 @@ func intPtr(value int) *int {
 	return &value
 }
 
+// sandboxPermissionsDescription and additionalPermissionsDescription are shared
+// by every shell tool (bash, exec_command) so the two fields cannot drift apart.
+//
+// Both lead with "omit" on purpose. The pair used to be described only in terms
+// of what each value does, which left a model that had used
+// with_additional_permissions once (say, for `gh issue create`) no instruction
+// to stop attaching a permission object to the next, ordinary command. That
+// attachment is then rejected — correctly, but the rejection alone does not tell
+// the model that dropping the field is the fix, so it flips between an
+// unflagged permission object and a flagged empty one and never converges
+// (#845, #847). Making "omit it" the first sentence of both descriptions stops
+// the invalid shape from being emitted in the first place; the validator errors
+// are the backstop, not the teacher.
+//
+// These ride on every turn's exec_command schema, so they are kept close to the
+// length of the text they replaced; TestEagerToolSchemaTokenBudget is the ratchet.
+const (
+	sandboxPermissionsDescription = "Per-command sandbox override. Omit it for ordinary commands, including every " +
+		"read-only one; use `with_additional_permissions` with a non-empty `additional_permissions` for sandboxed " +
+		"file/network access, or `require_escalated` only when the command must run outside the sandbox, such as " +
+		"host/global process, socket, service, or desktop state hidden by sandbox namespaces."
+
+	additionalPermissionsDescription = "Extra sandbox access. Omit this field entirely unless `sandbox_permissions` " +
+		"is `with_additional_permissions`; sending it with any other mode is rejected, as is an empty or all-false " +
+		"object. Example: {\"network\": {\"enabled\": true}}."
+)
+
 func additionalPermissionsProperties() map[string]PropertySchema {
 	return requestPermissionsProfileSchema().Properties
 }

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -149,10 +149,11 @@ func intPtr(value int) *int {
 // These ride on every turn's exec_command schema, so they are kept close to the
 // length of the text they replaced; TestEagerToolSchemaTokenBudget is the ratchet.
 const (
-	sandboxPermissionsDescription = "Per-command sandbox override. Omit it for ordinary commands, including every " +
-		"read-only one; use `with_additional_permissions` with a non-empty `additional_permissions` for sandboxed " +
-		"file/network access, or `require_escalated` only when the command must run outside the sandbox, such as " +
-		"host/global process, socket, service, or desktop state hidden by sandbox namespaces."
+	sandboxPermissionsDescription = "Per-command sandbox override. Omit it unless the command needs access the " +
+		"sandbox does not already give it; use `with_additional_permissions` with a non-empty " +
+		"`additional_permissions` for sandboxed file/network access, or `require_escalated` only when the command " +
+		"must run outside the sandbox, such as host/global process, socket, service, or desktop state hidden by " +
+		"sandbox namespaces."
 
 	additionalPermissionsDescription = "Extra sandbox access. Omit this field entirely unless `sandbox_permissions` " +
 		"is `with_additional_permissions`; sending it with any other mode is rejected, as is an empty or all-false " +

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -50,10 +50,10 @@ func NewScopedBashTool(workspaceRoot string, scope PathScope) Tool {
 					"command":             {Type: "string", Description: "Shell command to execute using the host shell. " + shellGuidance},
 					"cwd":                 {Type: "string", Description: "Directory to run the command in. Relative paths stay in the workspace; use an absolute path to run in a granted extra directory. Defaults to workspace root. Prefer cwd over cd when changing directories.", Default: "."},
 					"timeout_ms":          {Type: "integer", Description: "Command timeout in milliseconds.", Default: defaultBashTimeoutMS, Minimum: intPtr(1), Maximum: intPtr(maxBashTimeoutMS)},
-					"sandbox_permissions": {Type: "string", Enum: []string{string(SandboxPermissionsUseDefault), string(SandboxPermissionsWithAdditionalPermissions), string(SandboxPermissionsRequireEscalated)}, Description: "Per-command sandbox override. Defaults to `use_default`; use `with_additional_permissions` with `additional_permissions` for sandboxed file/network access, or `require_escalated` only when the command must run outside the sandbox, such as host/global process, socket, service, or desktop state hidden by sandbox namespaces.", Default: string(SandboxPermissionsUseDefault)},
+					"sandbox_permissions": {Type: "string", Enum: []string{string(SandboxPermissionsUseDefault), string(SandboxPermissionsWithAdditionalPermissions), string(SandboxPermissionsRequireEscalated)}, Description: sandboxPermissionsDescription, Default: string(SandboxPermissionsUseDefault)},
 					"additional_permissions": {
 						Type:        "object",
-						Description: "Sandboxed filesystem or network access for this command; only with `sandbox_permissions: \"with_additional_permissions\"`.",
+						Description: additionalPermissionsDescription,
 						Properties:  additionalPermissionsProperties(),
 					},
 					"justification": {Type: "string", Description: "User-facing approval question for `require_escalated`; omit otherwise."},

--- a/internal/tools/exec_command.go
+++ b/internal/tools/exec_command.go
@@ -91,10 +91,10 @@ func NewScopedExecCommandTool(workspaceRoot string, scope PathScope, manager *ex
 					"cwd":                 {Type: "string", Description: "Alias for workdir. Prefer workdir.", Default: "."},
 					"yield_time_ms":       {Type: "integer", Description: "Wait before yielding output. Defaults to 10000 ms; effective range is 250-30000 ms.", Default: defaultExecYieldTimeMS, Minimum: intPtr(1), Maximum: intPtr(maxExecYieldTimeMS)},
 					"max_output_tokens":   {Type: "integer", Description: "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy.", Default: defaultMaxOutputTokens, Minimum: intPtr(1), Maximum: intPtr(maxExecOutputTokenRequest)},
-					"sandbox_permissions": {Type: "string", Enum: []string{string(SandboxPermissionsUseDefault), string(SandboxPermissionsWithAdditionalPermissions), string(SandboxPermissionsRequireEscalated)}, Description: "Per-command sandbox override. Defaults to `use_default`; use `with_additional_permissions` with `additional_permissions` for sandboxed file/network access, or `require_escalated` only when the command must run outside the sandbox, such as host/global process, socket, service, or desktop state hidden by sandbox namespaces.", Default: string(SandboxPermissionsUseDefault)},
+					"sandbox_permissions": {Type: "string", Enum: []string{string(SandboxPermissionsUseDefault), string(SandboxPermissionsWithAdditionalPermissions), string(SandboxPermissionsRequireEscalated)}, Description: sandboxPermissionsDescription, Default: string(SandboxPermissionsUseDefault)},
 					"additional_permissions": {
 						Type:        "object",
-						Description: "Sandboxed filesystem or network access for this command; only with `sandbox_permissions: \"with_additional_permissions\"`.",
+						Description: additionalPermissionsDescription,
 						Properties:  additionalPermissionsProperties(),
 					},
 					"justification": {Type: "string", Description: "User-facing approval question for `require_escalated`; omit otherwise."},

--- a/internal/tools/sandbox_permissions_schema_test.go
+++ b/internal/tools/sandbox_permissions_schema_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// The cheapest fix for #845/#847 is that the invalid shape is never emitted.
+// A model only learns "omit it" from the schema it is shown, so both shell
+// tools must say so in the field descriptions themselves — the validator errors
+// are the backstop, and by the time they fire a turn has already been burned.
+func TestShellToolsAdvertiseOmittingSandboxPermissionFields(t *testing.T) {
+	root := t.TempDir()
+	for _, shell := range []struct {
+		name string
+		tool Tool
+	}{
+		{"bash", NewScopedBashTool(root, nil)},
+		{"exec_command", NewScopedExecCommandTool(root, nil, nil)},
+	} {
+		properties := shell.tool.Parameters().Properties
+
+		mode, ok := properties["sandbox_permissions"]
+		if !ok {
+			t.Fatalf("%s: sandbox_permissions property missing", shell.name)
+		}
+		if !strings.Contains(mode.Description, "Omit it") {
+			t.Errorf("%s: sandbox_permissions description = %q, want it to lead with omitting the field", shell.name, mode.Description)
+		}
+		if !strings.Contains(mode.Description, "read-only") {
+			t.Errorf("%s: sandbox_permissions description = %q, want it to say read-only commands need no override", shell.name, mode.Description)
+		}
+
+		extra, ok := properties["additional_permissions"]
+		if !ok {
+			t.Fatalf("%s: additional_permissions property missing", shell.name)
+		}
+		if !strings.Contains(extra.Description, "Omit this field entirely") {
+			t.Errorf("%s: additional_permissions description = %q, want an explicit instruction to omit the field", shell.name, extra.Description)
+		}
+		// Both invalid shapes from the issue must be named as invalid up front,
+		// so neither is emitted "to be safe".
+		if !strings.Contains(extra.Description, "with any other mode is rejected") {
+			t.Errorf("%s: additional_permissions description = %q, want it to say the unflagged shape is rejected", shell.name, extra.Description)
+		}
+		if !strings.Contains(extra.Description, "empty or all-false object") {
+			t.Errorf("%s: additional_permissions description = %q, want it to say an empty payload is rejected", shell.name, extra.Description)
+		}
+	}
+}
+
+// The two shell tools describe the same two fields; they were copy-pasted and
+// must not drift apart again, or a model would be taught different rules by
+// bash and exec_command in the same session.
+func TestShellToolsShareSandboxPermissionDescriptions(t *testing.T) {
+	root := t.TempDir()
+	bash := NewScopedBashTool(root, nil).Parameters().Properties
+	exec := NewScopedExecCommandTool(root, nil, nil).Parameters().Properties
+
+	for _, field := range []string{"sandbox_permissions", "additional_permissions"} {
+		if bash[field].Description != exec[field].Description {
+			t.Errorf("%s description differs between bash and exec_command:\n bash = %q\n exec = %q",
+				field, bash[field].Description, exec[field].Description)
+		}
+	}
+}

--- a/internal/tools/sandbox_permissions_schema_test.go
+++ b/internal/tools/sandbox_permissions_schema_test.go
@@ -27,8 +27,14 @@ func TestShellToolsAdvertiseOmittingSandboxPermissionFields(t *testing.T) {
 		if !strings.Contains(mode.Description, "Omit it") {
 			t.Errorf("%s: sandbox_permissions description = %q, want it to lead with omitting the field", shell.name, mode.Description)
 		}
-		if !strings.Contains(mode.Description, "read-only") {
-			t.Errorf("%s: sandbox_permissions description = %q, want it to say read-only commands need no override", shell.name, mode.Description)
+		// Deliberately NOT "read-only". An earlier revision said every read-only
+		// command could omit the override, and that is false: `curl` and `gh` are
+		// read-only and still need sandboxed network. Conditioning omission on
+		// whether the command needs access it does not already have is the claim
+		// that is actually true, and the one a model can act on without first
+		// having to decide what counts as read-only.
+		if !strings.Contains(mode.Description, "unless the command needs access") {
+			t.Errorf("%s: sandbox_permissions description = %q, want omission conditioned on needing extra access", shell.name, mode.Description)
 		}
 
 		extra, ok := properties["additional_permissions"]


### PR DESCRIPTION
## Summary

`git branch --show-current` — an ordinary read-only command — could leave the agent bouncing between two rejections instead of running, burning turns without converging.

Both errors come from `inlineAdditionalPermissionsProfile`, and each names only the fix that *adds* something. One pushes toward setting the flag, the other back toward requesting a permission the command doesn't need. Neither ever says to **omit the field**, which is the correct action here — so together they form a two-state oscillator. Every rejection now carries that remedy.

The schema half is why the object gets attached at all: neither field description said to omit them for ordinary commands, so a model that legitimately used `with_additional_permissions` once had nothing telling it to stop. Both descriptions now lead with "omit", and they're shared constants instead of being duplicated verbatim across `bash.go` and `exec_command.go`.

## This does not loosen the sandbox

Nothing previously refused is now accepted on the strength of an empty or mismatched payload, and `sandbox_permissions` is never upgraded on the model's behalf. Only the guidance changed.

The one behavioural change: an explicit `additional_permissions: null` is treated as the omitted field, since a null grants nothing and carries no flag. That flips three shapes from reject to execute — null with `use_default`, with `require_escalated`, and with no mode at all. The escalated case still routes through the normal escalation prompt and is **not** a new capability; the identical request without the null key already behaved that way. A *flagged* null still errors, so `with_additional_permissions` + null isn't silently downgraded.

## Note on versions

The reporter was on 0.6.0, where both legs of the loop were live. On current `main`, #838's `normalizeNoopAdditionalPermissions` already absorbs the empty payload, so only the first error reproduces today. Both legs were reproduced and fixed.

## Test plan

- `TestAdditionalPermissionsRejectionsConverge` replays #845's step-1/step-2 sequence and #847's two inconsistent states in one test
- `TestExecuteToolCallMissingAdditionalPermissionsErrorIsActionable`, `TestEmptyAdditionalPermissionsErrorNamesOmitRemedy` pin that the errors name the omit remedy
- `TestExecuteToolCallTreatsNullAdditionalPermissionsAsOmitted`, `TestExecuteToolCallRejectsFlaggedNullAdditionalPermissions` cover the null split
- Reverting only `internal/agent/loop.go` turns all five red on message text, and reproduces both issue strings verbatim
- `go build ./...`, `go vet`, `gofmt` clean; `internal/agent`, `internal/tools`, `internal/sandbox` green

Fixes #845
Fixes #847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional sandbox permission fields, including explicit `null` values.
  * Clarified validation errors and retry guidance for unnecessary or invalid permissions.

* **Documentation**
  * Added guidance on valid permission combinations and examples.
  * Clarified when permission fields should be omitted, including for read-only commands.

* **Tests**
  * Added coverage for validation, error consistency, null handling, schema guidance, and successful retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->