### PR TITLE
fix(tui): a copied NUL byte no longer panics the TUI on Windows

### DIFF
--- a/internal/tui/clipboard_nul_test.go
+++ b/internal/tui/clipboard_nul_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// A COPIED NUL KILLED THE WHOLE PROGRAM ON WINDOWS.
+//
+// github.com/atotto/clipboard's Windows path calls syscall.StringToUTF16, which
+// PANICS rather than returning an error when the string contains a NUL — so
+// selecting transcript text that carried one took the TUI down with "program
+// experienced a panic" and a stack ending in clipboard.writeAll. A teammate hit
+// it on a real Windows machine.
+//
+// The NUL reaches the clipboard because ansi.Strip removes escape SEQUENCES and
+// leaves C0 bytes alone, and the transcript carries them from two directions:
+// tool output (binary reads, git's -z listings) and this package's own card
+// protocol, whose prefixes are literally "\x00command-card\x00".
+func TestNulNeverReachesTheClipboard(t *testing.T) {
+	// The card prefix is a real, in-repo source: ansi.Strip leaves it intact.
+	if !strings.ContainsRune(ansi.Strip(commandCardTranscriptPrefix+"Profile"), 0) {
+		t.Fatal("setup: the card prefix no longer carries a NUL; this test guards the wrong thing")
+	}
+	for _, tc := range []struct{ name, in string }{
+		{"card prefix", commandCardTranscriptPrefix + "Profile\nstatus: ok"},
+		{"plan card prefix", planCardTranscriptPrefix + "plan"},
+		{"binary tool output", "before\x00after"},
+		{"git -z listing", "a.go\x00b.go\x00c.go"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clipboardSafeText(tc.in)
+			if strings.ContainsRune(got, 0) {
+				t.Fatalf("a NUL survived to the clipboard write: %q — Windows would panic here", got)
+			}
+			// The readable content must survive: this sanitises, it does not truncate.
+			for _, want := range strings.Split(strings.ReplaceAll(tc.in, "\x00", "\n"), "\n") {
+				if want = strings.TrimSpace(want); want != "" && !strings.Contains(got, want) {
+					t.Fatalf("sanitising dropped real content %q from %q", want, got)
+				}
+			}
+		})
+	}
+}
+
+// Newlines and tabs are legal clipboard content and must survive — a multi-line
+// selection is the normal case, not the exception.
+func TestClipboardSanitisingKeepsLayout(t *testing.T) {
+	in := "line one\n\tindented\nline three"
+	if got := clipboardSafeText(in); got != in {
+		t.Fatalf("clean multi-line text was altered:\n got %q\nwant %q", got, in)
+	}
+	// Other C0 bytes go: they would terminate the OSC52 escape early and
+	// corrupt the copy even where they do not panic.
+	if got := clipboardSafeText("a\x07b\x1bc"); got != "abc" {
+		t.Fatalf("control bytes survived: %q", got)
+	}
+}

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -1499,7 +1499,54 @@ func (m model) selectedTranscriptText() string {
 	return strings.Join(parts, "\n")
 }
 
+// clipboardSafeText removes the control characters a clipboard write cannot
+// carry, keeping newlines and tabs.
+//
+// A NUL PANICS THE WHOLE PROGRAM ON WINDOWS, and that is not a theoretical
+// concern: syscall.StringToUTF16 — which github.com/atotto/clipboard calls on
+// Windows — PANICS rather than erroring when the string contains one, so a
+// single copied NUL killed the TUI with "program experienced a panic". It
+// reached the clipboard because ansi.Strip removes escape SEQUENCES and leaves
+// C0 bytes untouched, and the transcript legitimately carries them from two
+// directions: tool output (a read of a binary file, git's -z NUL-separated
+// listings) and this package's own card protocol, whose row prefixes are
+// literally "\x00command-card\x00".
+//
+// Stripped at the WRITE, not at each source, because the sources are unbounded:
+// any tool result a user can select from is a source, and a fix per source is
+// one that the next tool re-breaks. The same pass protects the OSC52 fallback,
+// where a stray control byte would terminate the escape sequence early and
+// corrupt the copy rather than crash.
+//
+// \n and \t survive: a multi-line selection is the normal case, and both are
+// legal clipboard content.
+func clipboardSafeText(text string) string {
+	if !strings.ContainsFunc(text, unsafeClipboardRune) {
+		return text
+	}
+	var out strings.Builder
+	out.Grow(len(text))
+	for _, r := range text {
+		if unsafeClipboardRune(r) {
+			continue
+		}
+		out.WriteRune(r)
+	}
+	return out.String()
+}
+
+func unsafeClipboardRune(r rune) bool {
+	if r == '\n' || r == '\t' {
+		return false
+	}
+	return r < 0x20 || r == 0x7f
+}
+
 func copyTranscriptSelectionCmd(text string) tea.Cmd {
+	// SANITISED ONCE, HERE, before either destination sees it — the native
+	// clipboard would panic on a NUL and the OSC52 fallback would be corrupted
+	// by one.
+	text = clipboardSafeText(text)
 	return func() tea.Msg {
 		// Prefer the native OS clipboard (pbcopy / clip.exe / xclip): it works on
 		// local terminals — including macOS Terminal.app, which has no OSC52 support


### PR DESCRIPTION
Fixes #875

## What was wrong

`syscall.StringToUTF16` **panics rather than returning an error** when handed a string containing a NUL — documented standard-library behaviour — and `github.com/atotto/clipboard`'s Windows path calls it directly. One NUL anywhere in a copied transcript selection therefore killed the whole program:

```
panic(...)
syscall.StringToUTF16(...)  syscall_windows.go:33
github.com/atotto/clipboard.writeAll({0x…, 0xb77})
…tui.model.handleTranscriptSelectionMouse.copyTranscriptSelectionCmd.func1()
zero: tui error: program was killed: program experienced a panic
```

The NUL gets through because **`ansi.Strip` removes escape *sequences* and leaves C0 bytes untouched**. The transcript carries NULs from two independent directions:

- **Tool output** — a binary file read, or `git`'s `-z` NUL-separated listings, which this repo itself parses in `files_git_sweep.go:134`
- **Zero's own card protocol** — row prefixes are literally `"\x00command-card\x00"` and `"\x00plan-card\x00"`

## The fix

Sanitise once at the **write**, not per source. The sources are unbounded — any tool result a user can select from is one — so a fix per source is a fix the next tool re-breaks. `clipboardSafeText` drops C0 controls (keeping `\n` and `\t`, which are legal clipboard content and the normal case for a multi-line selection), applied before both destinations.

The **OSC52 fallback needed it too**: a stray control byte terminates the escape sequence early and silently corrupts the copy. That is very likely why this went unnoticed off Windows — the identical NUL produces a bad copy there rather than a dead process.

## Verification

- `TestNulNeverReachesTheClipboard` — four real sources (command-card prefix, plan-card prefix, binary tool output, `git -z` listing); asserts no NUL survives **and** that readable content is not dropped, so this sanitises rather than truncates.
- `TestClipboardSanitisingKeepsLayout` — clean multi-line text with tabs is returned byte-identical; other C0 bytes are removed.
- Mutation-checked: removing the `clipboardSafeText` call makes the panic-guard test fail.
- `make fmt-check`, `go vet ./...`, `go test ./...`, release build + smoke, `git diff --check` all clean. `GOOS=windows go build ./...` and `GOOS=windows go vet` clean.

Two pre-existing failures on `main` are unrelated and unaffected: `TestRunDoctorFormatsRedactedProviderDiagnostics` and `TestRunDoctorConnectivityProbesProvider` fail identically with this change stashed.

I could not execute the Windows path itself (no Windows machine); the crash mechanism is pinned by the standard library's own documented contract and the reported stack, and the sanitiser is proven by the tests above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copying by removing unsafe control characters while preserving readable text, line breaks, and tabs.
  * Prevented copied content from being truncated, corrupted, or causing errors when it contains binary data or special Git output.
  * Copy status counts now accurately reflect the sanitized clipboard content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->