### PR TITLE
test(agent): raise the eager tool schema ceiling to 3650

### DIFF
--- a/internal/agent/prompt_budget_test.go
+++ b/internal/agent/prompt_budget_test.go
@@ -20,7 +20,20 @@ import (
 // without a session id. Higher-risk tools that do not opt into auto remain excluded.
 const (
 	maxBaseSystemPromptTokens = 3500
-	maxEagerToolSchemaTokens  = 3550
+	// Raised deliberately from 3550 on 2026-08-08. view_image (#843) took the set
+	// to 3588, and #867 trimmed it back to 3578: still 28 tokens over.
+	//
+	// The overrun is a rounding error rather than a regression. view_image costs
+	// 82 tokens, the second cheapest tool in the set, against exec_command's 909
+	// and request_permissions' 397; it is simply the one that crossed the line.
+	// Raised rather than paid down because the alternative was trimming a
+	// description to claw back 28 tokens, degrading a tool's usability to satisfy
+	// a line drawn against a 2026-07 measurement that predates two tools.
+	//
+	// The ratchet did its job: it caught the creep and forced a decision instead
+	// of a drift. That is the point of it, so keep raising it deliberately rather
+	// than reflexively.
+	maxEagerToolSchemaTokens = 3650
 )
 
 func TestSystemPromptTokenBudget(t *testing.T) {
@@ -46,6 +59,11 @@ func TestEagerToolSchemaTokenBudget(t *testing.T) {
 	got := estimateToolDefTokens(exposed)
 	t.Logf("eager core tool schemas: %d tokens across %d tools", got, len(exposed))
 	if got > maxEagerToolSchemaTokens {
-		t.Fatalf("eager tool schemas are %d tokens, over the %d ceiling — defer a tool or raise the ceiling deliberately", got, maxEagerToolSchemaTokens)
+		// NOT "defer a tool": this test pins DeferThreshold at 0, so marking a
+		// tool deferred leaves it exposed here and changes nothing. Deferral is
+		// still worth doing for real sessions, it just cannot move this number.
+		// The levers that do are a smaller schema, one fewer core tool, or a
+		// deliberate raise.
+		t.Fatalf("eager tool schemas are %d tokens, over the %d ceiling — trim a schema, drop a core tool, or raise the ceiling deliberately (deferring will NOT help: this test disables deferral)", got, maxEagerToolSchemaTokens)
 	}
 }


### PR DESCRIPTION
`main` is red and every open PR inherits it. `TestEagerToolSchemaTokenBudget` fails at 3578 tokens against a 3550 ceiling.

## Where it came from

Bisected: `edf660ab` and `4ca4fa75` pass, `cd0eb194` (#843, which added `view_image` to the core set) fails at 3588. #867 later trimmed it to 3578, still over.

#843's own CI was green. The ceiling is only crossed once the tool set is combined, so no per-PR check could have caught it, and I merged it on the strength of "CLEAN, no failing checks". Worth knowing that is a blind spot for anything measuring a whole-set budget.

## Raised rather than paid down

The overrun is 28 tokens. Per-tool cost in the eager set:

```
exec_command        909      request_permissions  397
ask_user            387      update_plan          256
lsp_navigate        252      grep                 215
write_stdin         205      web_fetch            187
read_file           181      glob                 160
read_minified_file  121      list_directory       114
skill               112      view_image            82
```

`view_image` is the second cheapest tool in the set. It is not the problem, it is just what crossed the line. The alternative was trimming a description to reclaim 28 tokens, degrading a tool's usability to satisfy a line drawn against a 2026-07 measurement that predates two tools since added.

The ratchet did its job: it caught the creep and forced this to be a decision rather than a drift. Keeping it that way means raising it deliberately, with the reason written down, which is what this does.

## The failure message was wrong

It advised "defer a tool". This test pins `DeferThreshold` at 0, so deferral is inactive and marking a tool deferred leaves it exposed here, changing nothing. I confirmed that by actually deferring `view_image`: the count stayed at 3578 across 14 tools, and it broke `registry_test.go` besides, since the deferrable-builtin list is curated.

Deferring is still worth doing for real sessions, it just cannot move this number. The message now names the levers that can: a smaller schema, one fewer core tool, or a deliberate raise.

## Validation

`go build ./...`, `go vet`, `gofmt`, and the full `internal/agent` and `internal/tools` suites pass. One file changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the allowed tool-schema token threshold.
  * Improved test failure guidance with clearer troubleshooting options and rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->