### PR TITLE
Bound read_minified_file streaming by page budget

### DIFF
--- a/internal/tools/line_reader.go
+++ b/internal/tools/line_reader.go
@@ -5,7 +5,103 @@ import (
 	"io"
 )
 
+// readRawLine reads one line (including the trailing '\n' when present).
+// On EOF with a non-empty unterminated buffer it returns that buffer with
+// ended=false and err=nil. On EOF with an empty buffer it returns io.EOF.
 func readRawLine(reader *bufio.Reader) ([]byte, bool, error) {
+	line, ended, _, err := readRawLineLimited(reader, 0)
+	return line, ended, err
+}
+
+// readRawLineLimited is like readRawLine but, when maxKeep > 0, retains at most
+// maxKeep bytes of the line (including a trailing newline only if it still fits).
+// Further bytes until the next newline are discarded so a multi-megabyte
+// minified line cannot force a multi-megabyte allocation. clipped is true when
+// any trailing content was discarded.
+func readRawLineLimited(reader *bufio.Reader, maxKeep int) (line []byte, ended bool, clipped bool, err error) {
+	if maxKeep <= 0 {
+		return readRawLineUnlimited(reader)
+	}
+	var kept []byte
+	for {
+		fragment, readErr := reader.ReadSlice('\n')
+		if len(fragment) > 0 {
+			room := maxKeep - len(kept)
+			if room <= 0 {
+				if fragment[len(fragment)-1] == '\n' {
+					// Once maxKeep is full, a fragment containing only the
+					// line break means no line content was discarded.
+					if normalized, onlyLineBreak := trimDiscardedLineBreak(kept, fragment); onlyLineBreak {
+						return normalized, true, false, nil
+					}
+					return kept, true, true, nil
+				}
+				if readErr != nil && readErr != bufio.ErrBufferFull && readErr != io.EOF {
+					return kept, false, true, readErr
+				}
+				dErr := discardThroughNewline(reader)
+				if dErr != nil && dErr != io.EOF {
+					return kept, false, true, dErr
+				}
+				return kept, dErr == nil, true, nil
+			}
+			if len(fragment) <= room {
+				if kept != nil || readErr == bufio.ErrBufferFull {
+					kept = append(kept, fragment...)
+				} else {
+					kept = fragment
+				}
+			} else {
+				kept = append(kept, fragment[:room]...)
+				rest := fragment[room:]
+				// Discarding only the line break is not content clipping.
+				if normalized, onlyLineBreak := trimDiscardedLineBreak(kept, rest); onlyLineBreak {
+					return normalized, true, false, nil
+				}
+				if fragment[len(fragment)-1] == '\n' {
+					// Non-newline content past maxKeep was discarded; line ended.
+					return kept, true, true, nil
+				}
+				if readErr != nil && readErr != bufio.ErrBufferFull && readErr != io.EOF {
+					return kept, false, true, readErr
+				}
+				dErr := discardThroughNewline(reader)
+				if dErr != nil && dErr != io.EOF {
+					return kept, false, true, dErr
+				}
+				return kept, dErr == nil, true, nil
+			}
+		}
+		switch readErr {
+		case nil:
+			return kept, true, false, nil
+		case bufio.ErrBufferFull:
+			continue
+		case io.EOF:
+			if len(kept) > 0 {
+				return kept, false, false, nil
+			}
+			return nil, false, false, io.EOF
+		default:
+			return nil, false, false, readErr
+		}
+	}
+}
+
+func trimDiscardedLineBreak(kept, rest []byte) ([]byte, bool) {
+	if len(rest) == 2 && rest[0] == '\r' && rest[1] == '\n' {
+		return kept, true
+	}
+	if len(rest) != 1 || rest[0] != '\n' {
+		return kept, false
+	}
+	if len(kept) > 0 && kept[len(kept)-1] == '\r' {
+		kept = kept[:len(kept)-1]
+	}
+	return kept, true
+}
+
+func readRawLineUnlimited(reader *bufio.Reader) ([]byte, bool, bool, error) {
 	var line []byte
 	for {
 		fragment, err := reader.ReadSlice('\n')
@@ -18,16 +114,32 @@ func readRawLine(reader *bufio.Reader) ([]byte, bool, error) {
 		}
 		switch err {
 		case nil:
-			return line, true, nil
+			return line, true, false, nil
 		case bufio.ErrBufferFull:
 			continue
 		case io.EOF:
 			if len(line) > 0 {
-				return line, false, nil
+				return line, false, false, nil
 			}
-			return nil, false, io.EOF
+			return nil, false, false, io.EOF
 		default:
-			return nil, false, err
+			return nil, false, false, err
+		}
+	}
+}
+
+// discardThroughNewline drops input until a newline or EOF. Returns nil when a
+// newline was consumed, io.EOF when the stream ended without one.
+func discardThroughNewline(reader *bufio.Reader) error {
+	for {
+		_, err := reader.ReadSlice('\n')
+		switch err {
+		case nil:
+			return nil
+		case bufio.ErrBufferFull:
+			continue
+		default:
+			return err
 		}
 	}
 }

--- a/internal/tools/line_reader.go
+++ b/internal/tools/line_reader.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 )
 
@@ -9,7 +10,7 @@ import (
 // On EOF with a non-empty unterminated buffer it returns that buffer with
 // ended=false and err=nil. On EOF with an empty buffer it returns io.EOF.
 func readRawLine(reader *bufio.Reader) ([]byte, bool, error) {
-	line, ended, _, err := readRawLineLimited(reader, 0)
+	line, ended, _, _, _, err := readRawLineLimited(reader, 0)
 	return line, ended, err
 }
 
@@ -18,13 +19,16 @@ func readRawLine(reader *bufio.Reader) ([]byte, bool, error) {
 // Further bytes until the next newline are discarded so a multi-megabyte
 // minified line cannot force a multi-megabyte allocation. clipped is true when
 // any trailing content was discarded.
-func readRawLineLimited(reader *bufio.Reader, maxKeep int) (line []byte, ended bool, clipped bool, err error) {
+func readRawLineLimited(reader *bufio.Reader, maxKeep int) (line []byte, ended bool, clipped, containsNUL bool, bytesScanned int, err error) {
 	if maxKeep <= 0 {
-		return readRawLineUnlimited(reader)
+		line, ended, clipped, err := readRawLineUnlimited(reader)
+		return line, ended, clipped, bytes.IndexByte(line, 0) >= 0, len(line), err
 	}
 	var kept []byte
 	for {
 		fragment, readErr := reader.ReadSlice('\n')
+		bytesScanned += len(fragment)
+		containsNUL = containsNUL || bytes.IndexByte(fragment, 0) >= 0
 		if len(fragment) > 0 {
 			room := maxKeep - len(kept)
 			if room <= 0 {
@@ -32,18 +36,19 @@ func readRawLineLimited(reader *bufio.Reader, maxKeep int) (line []byte, ended b
 					// Once maxKeep is full, a fragment containing only the
 					// line break means no line content was discarded.
 					if normalized, onlyLineBreak := trimDiscardedLineBreak(kept, fragment); onlyLineBreak {
-						return normalized, true, false, nil
+						return normalized, true, false, containsNUL, bytesScanned, nil
 					}
-					return kept, true, true, nil
+					return kept, true, true, containsNUL, bytesScanned, nil
 				}
 				if readErr != nil && readErr != bufio.ErrBufferFull && readErr != io.EOF {
-					return kept, false, true, readErr
+					return kept, false, true, containsNUL, bytesScanned, readErr
 				}
-				dErr := discardThroughNewline(reader)
+				discardedNUL, discardedBytes, dErr := discardThroughNewline(reader)
+				bytesScanned += discardedBytes
 				if dErr != nil && dErr != io.EOF {
-					return kept, false, true, dErr
+					return kept, false, true, containsNUL || discardedNUL, bytesScanned, dErr
 				}
-				return kept, dErr == nil, true, nil
+				return kept, dErr == nil, true, containsNUL || discardedNUL, bytesScanned, nil
 			}
 			if len(fragment) <= room {
 				if kept != nil || readErr == bufio.ErrBufferFull {
@@ -56,34 +61,35 @@ func readRawLineLimited(reader *bufio.Reader, maxKeep int) (line []byte, ended b
 				rest := fragment[room:]
 				// Discarding only the line break is not content clipping.
 				if normalized, onlyLineBreak := trimDiscardedLineBreak(kept, rest); onlyLineBreak {
-					return normalized, true, false, nil
+					return normalized, true, false, containsNUL, bytesScanned, nil
 				}
 				if fragment[len(fragment)-1] == '\n' {
 					// Non-newline content past maxKeep was discarded; line ended.
-					return kept, true, true, nil
+					return kept, true, true, containsNUL, bytesScanned, nil
 				}
 				if readErr != nil && readErr != bufio.ErrBufferFull && readErr != io.EOF {
-					return kept, false, true, readErr
+					return kept, false, true, containsNUL, bytesScanned, readErr
 				}
-				dErr := discardThroughNewline(reader)
+				discardedTailNUL, discardedBytes, dErr := discardThroughNewline(reader)
+				bytesScanned += discardedBytes
 				if dErr != nil && dErr != io.EOF {
-					return kept, false, true, dErr
+					return kept, false, true, containsNUL || discardedTailNUL, bytesScanned, dErr
 				}
-				return kept, dErr == nil, true, nil
+				return kept, dErr == nil, true, containsNUL || discardedTailNUL, bytesScanned, nil
 			}
 		}
 		switch readErr {
 		case nil:
-			return kept, true, false, nil
+			return kept, true, false, containsNUL, bytesScanned, nil
 		case bufio.ErrBufferFull:
 			continue
 		case io.EOF:
 			if len(kept) > 0 {
-				return kept, false, false, nil
+				return kept, false, false, containsNUL, bytesScanned, nil
 			}
-			return nil, false, false, io.EOF
+			return nil, false, false, containsNUL, bytesScanned, io.EOF
 		default:
-			return nil, false, false, readErr
+			return nil, false, false, containsNUL, bytesScanned, readErr
 		}
 	}
 }
@@ -128,18 +134,22 @@ func readRawLineUnlimited(reader *bufio.Reader) ([]byte, bool, bool, error) {
 	}
 }
 
-// discardThroughNewline drops input until a newline or EOF. Returns nil when a
-// newline was consumed, io.EOF when the stream ended without one.
-func discardThroughNewline(reader *bufio.Reader) error {
+// discardThroughNewline drops input until a newline or EOF and reports whether
+// any discarded fragment contained a NUL byte.
+func discardThroughNewline(reader *bufio.Reader) (bool, int, error) {
+	containsNUL := false
+	bytesScanned := 0
 	for {
-		_, err := reader.ReadSlice('\n')
+		fragment, err := reader.ReadSlice('\n')
+		bytesScanned += len(fragment)
+		containsNUL = containsNUL || bytes.IndexByte(fragment, 0) >= 0
 		switch err {
 		case nil:
-			return nil
+			return containsNUL, bytesScanned, nil
 		case bufio.ErrBufferFull:
 			continue
 		default:
-			return err
+			return containsNUL, bytesScanned, err
 		}
 	}
 }

--- a/internal/tools/line_reader_test.go
+++ b/internal/tools/line_reader_test.go
@@ -1,0 +1,29 @@
+package tools
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestReadRawLineLimitedCRLFAtLimit(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		maxKeep int
+		want    string
+		clipped bool
+	}{
+		{name: "content plus CRLF", maxKeep: 10, want: "abcdefghij", clipped: false},
+		{name: "content plus CRLF over limit", maxKeep: 11, want: "abcdefghij", clipped: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			line, ended, clipped, err := readRawLineLimited(bufio.NewReader(strings.NewReader("abcdefghij\r\n")), test.maxKeep)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(line) != test.want || !ended || clipped != test.clipped {
+				t.Fatalf("line=%q ended=%v clipped=%v", line, ended, clipped)
+			}
+		})
+	}
+}

--- a/internal/tools/line_reader_test.go
+++ b/internal/tools/line_reader_test.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"bufio"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -26,4 +28,58 @@ func TestReadRawLineLimitedCRLFAtLimit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadRawLineLimitedPropagatesFullLineError(t *testing.T) {
+	wantErr := errors.New("full line failed")
+	source := &sequenceReader{steps: []readStep{
+		{data: []byte(strings.Repeat("x", 16)), err: bufio.ErrBufferFull},
+		{data: []byte("tail"), err: wantErr},
+	}}
+	reader := bufio.NewReader(source)
+	_, _, _, _, _, err := readRawLineLimited(reader, 16)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err=%v want %v", err, wantErr)
+	}
+	if source.reads != 2 {
+		t.Fatalf("reads=%d want 2", source.reads)
+	}
+}
+
+func TestReadRawLineLimitedPropagatesOverflowError(t *testing.T) {
+	wantErr := errors.New("read failed")
+	source := &sequenceReader{steps: []readStep{{data: []byte(strings.Repeat("x", 17)), err: wantErr}}}
+	reader := bufio.NewReader(source)
+	_, _, _, _, _, err := readRawLineLimited(reader, 16)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err=%v want %v", err, wantErr)
+	}
+	if source.reads != 1 {
+		t.Fatalf("reads=%d want 1", source.reads)
+	}
+}
+
+type readStep struct {
+	data []byte
+	err  error
+}
+
+type sequenceReader struct {
+	steps []readStep
+	reads int
+}
+
+func (reader *sequenceReader) Read(buffer []byte) (int, error) {
+	reader.reads++
+	if len(reader.steps) == 0 {
+		return 0, io.EOF
+	}
+	step := reader.steps[0]
+	n := copy(buffer, step.data)
+	if n < len(step.data) {
+		reader.steps[0].data = step.data[n:]
+	} else {
+		reader.steps = reader.steps[1:]
+	}
+	return n, step.err
 }

--- a/internal/tools/line_reader_test.go
+++ b/internal/tools/line_reader_test.go
@@ -17,12 +17,12 @@ func TestReadRawLineLimitedCRLFAtLimit(t *testing.T) {
 		{name: "content plus CRLF over limit", maxKeep: 11, want: "abcdefghij", clipped: false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			line, ended, clipped, err := readRawLineLimited(bufio.NewReader(strings.NewReader("abcdefghij\r\n")), test.maxKeep)
+			line, ended, clipped, containsNUL, _, err := readRawLineLimited(bufio.NewReader(strings.NewReader("abcdefghij\r\n")), test.maxKeep)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if string(line) != test.want || !ended || clipped != test.clipped {
-				t.Fatalf("line=%q ended=%v clipped=%v", line, ended, clipped)
+			if string(line) != test.want || !ended || clipped != test.clipped || containsNUL {
+				t.Fatalf("line=%q ended=%v clipped=%v containsNUL=%v", line, ended, clipped, containsNUL)
 			}
 		})
 	}

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -286,7 +286,7 @@ type readFileStats struct {
 }
 
 func scanReadFileStats(path string) (readFileStats, error) {
-	file, err := os.Open(path)
+	file, err := openReadableRegularFile(path)
 	if err != nil {
 		return readFileStats{}, err
 	}
@@ -321,7 +321,7 @@ func renderReadFileBytes(path, relativePath string, total, requestedStart, limit
 	if requestedStart >= total {
 		return okResult(fmt.Sprintf("File: %s\n(byte_offset %d is past the end of the file, which has %d bytes)", relativePath, requestedStart, total)), 0, 0
 	}
-	file, err := os.Open(path)
+	file, err := openReadableRegularFile(path)
 	if err != nil {
 		return errorResult("Error reading file " + relativePath + ": " + err.Error()), 0, 0
 	}
@@ -359,7 +359,7 @@ func renderReadFileBytes(path, relativePath string, total, requestedStart, limit
 }
 
 func appendReadFileRange(output *outputBudgetBuilder, path string, startLine int, selectedLines int) error {
-	file, err := os.Open(path)
+	file, err := openReadableRegularFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/read_minified_file.go
+++ b/internal/tools/read_minified_file.go
@@ -1,13 +1,28 @@
 package tools
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/minify"
+)
+
+const readMinifiedMaxLoadBytes = 512 * 1024
+
+const (
+	readMinifiedDefaultLineLimit = 2000
+	readMinifiedMaxLineRunes     = 2000
+	readMinifiedMaxWindowBytes   = readMinifiedMaxLoadBytes
+	readMinifiedTruncLimit       = "limit"
+	readMinifiedTruncByteBudget  = "byte_budget"
+	readMinifiedTruncLineClamp   = "line_clamp"
 )
 
 type readMinifiedFileTool struct {
@@ -28,13 +43,13 @@ func NewScopedReadMinifiedFileTool(workspaceRoot string, scope PathScope) Tool {
 	return readMinifiedFileTool{
 		baseTool: baseTool{
 			name:        "read_minified_file",
-			description: "Read source code in a token-efficient, language-aware form. Use for exploratory understanding of large or unfamiliar source when no exact edit is planned; use read_file directly for likely edit targets. Do not immediately reread the same file exactly unless a new need for exact text or line numbers appears.",
+			description: "Read source code in a token-efficient, language-aware form. Use for exploratory understanding of large or unfamiliar source when no exact edit is planned; use read_file directly for likely edit targets. Defaults to at most 2000 source lines; large files are not loaded in full. Deep offsets may scan sequentially to reach the requested line.",
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{
 					"path":   {Type: "string", Description: "Source file path."},
 					"offset": {Type: "integer", Description: "Optional 1-based source line to start from.", Minimum: intPtr(1)},
-					"limit":  {Type: "integer", Description: "Optional maximum number of source lines to minify.", Minimum: intPtr(1)},
+					"limit":  {Type: "integer", Description: "Optional maximum number of source lines to minify (default 2000 when omitted).", Minimum: intPtr(1)},
 				},
 				Required:             []string{"path"},
 				AdditionalProperties: false,
@@ -48,14 +63,14 @@ func NewScopedReadMinifiedFileTool(workspaceRoot string, scope PathScope) Tool {
 }
 
 func (tool readMinifiedFileTool) Run(ctx context.Context, args map[string]any) Result {
-	return tool.run(args, RunOptions{}, true)
+	return tool.run(ctx, args, RunOptions{}, true)
 }
 
-func (tool readMinifiedFileTool) RunWithOptions(_ context.Context, args map[string]any, options RunOptions) Result {
-	return tool.run(args, options, false)
+func (tool readMinifiedFileTool) RunWithOptions(ctx context.Context, args map[string]any, options RunOptions) Result {
+	return tool.run(ctx, args, options, false)
 }
 
-func (tool readMinifiedFileTool) run(args map[string]any, options RunOptions, directBudget bool) Result {
+func (tool readMinifiedFileTool) run(ctx context.Context, args map[string]any, options RunOptions, directBudget bool) Result {
 	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filepath", "filename"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for read_minified_file: " + err.Error())
@@ -68,86 +83,375 @@ func (tool readMinifiedFileTool) run(args map[string]any, options RunOptions, di
 	if err != nil {
 		return errorResult("Error: Invalid arguments for read_minified_file: " + err.Error())
 	}
+	explicitLimit := limit > 0
+	if !explicitLimit {
+		limit = readMinifiedDefaultLineLimit
+	}
 
 	absolutePath, relativePath, err := resolveScopedReadPath(tool.workspaceRoot, tool.scope, requestedPath)
 	if err != nil {
 		return errorResult("Error reading file " + requestedPath + ": " + err.Error())
 	}
-
-	content, err := os.ReadFile(absolutePath)
+	file, err := os.Open(absolutePath)
 	if err != nil {
 		return errorResult("Error reading file " + relativePath + ": " + err.Error())
 	}
-	// Record the raw whole-file baseline (matching read_file/edit_file) so a later
-	// write can still detect an out-of-Zero modification — the minification only
-	// affects what the model SEES, not the tracked on-disk state.
-	info, _ := os.Stat(absolutePath)
-	options.FileTracker.Record(absolutePath, content, info)
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return errorResult("Error reading file " + relativePath + ": " + err.Error())
+	}
 
-	selected := selectSourceLines(content, offset, limit)
-	if selected.pastEnd {
-		return okResult(fmt.Sprintf("File: %s\n(offset %d is past the end of the file, which has %d lines)", relativePath, offset, selected.totalLines))
+	classification, err := classifyMinifiedPrefix(ctx, file)
+	if err != nil {
+		return errorResult("Error reading file " + relativePath + ": " + err.Error())
 	}
-	ranged := offset > 1 || limit > 0
-	result := minify.File(relativePath, selected.content)
-	if ranged {
-		result = minify.ContextualFragment(relativePath, content, selected.content, selected.startByte)
+	if classification.binary {
+		return binaryMinifiedResult(relativePath, classification.mime)
 	}
-	rawLines := lineCount(string(selected.content))
-	minLines := lineCount(result.Content)
-	pct := 0
-	if rawBytes := len(selected.content); rawBytes > 0 {
-		if saved := rawBytes - len(result.Content); saved > 0 {
-			pct = saved * 100 / rawBytes
+
+	loaded, err := loadMinifiedFile(ctx, file, info.Size(), offset, limit)
+	if err != nil {
+		return errorResult("Error reading file " + relativePath + ": " + err.Error())
+	}
+	if loaded.partial {
+		if bytesContainMinifiedNUL(loaded.window.content) {
+			return binaryMinifiedResult(relativePath, "application/octet-stream")
 		}
+	} else if bytesContainMinifiedNUL(loaded.content) {
+		return binaryMinifiedResult(relativePath, "application/octet-stream")
 	}
 
-	var header string
-	if result.Applied {
-		header = fmt.Sprintf("File: %s — minified %s view (comments stripped, no line numbers; %d→%d lines, ~%d%% fewer bytes). For exact text/comments or before editing, use read_file.",
-			relativePath, result.Language, rawLines, minLines, pct)
-	} else if ranged {
-		header = fmt.Sprintf("File: %s — safe ranged view (whitespace normalized, no line numbers; %d→%d lines; context-sensitive stripping disabled because the range may begin inside a multiline construct). For exact text, use read_file.",
-			relativePath, rawLines, minLines)
+	var content []byte
+	var selected sourceSelection
+	var sourceTotal int
+	var windowHitLimit bool
+	var partialLoad bool
+	var lineClamps int
+	var loadNote string
+	if loaded.partial {
+		partialLoad = true
+		window := loaded.window
+		if window.pastEnd {
+			return okResult(fmt.Sprintf("File: %s\n(offset %d is past the end of the file, which has %d lines)", relativePath, offset, window.totalLines))
+		}
+		content = window.content
+		sourceTotal = window.totalLines
+		windowHitLimit = window.hitLimit
+		lineClamps = window.clampedLines
+		selected = sourceSelection{content: content, totalLines: sourceTotal, emitted: window.emitted}
+		loadNote = fmt.Sprintf("(note: file is %d bytes; streamed %d source line(s) from offset %d without scanning the remainder)", info.Size(), window.emitted, offset)
 	} else {
-		header = fmt.Sprintf("File: %s — whitespace-normalized view (no line numbers; %d→%d lines; full minification not available for this file type). For exact text, use read_file.",
-			relativePath, rawLines, minLines)
+		content = loaded.content
+		options.FileTracker.Record(absolutePath, content, info)
+		if len(content) == 0 {
+			return Result{Status: StatusOK, Output: fmt.Sprintf("File: %s is empty", relativePath), Meta: map[string]string{"empty": "true", "path": relativePath}}
+		}
+		selected = selectSourceLines(content, offset, limit)
+		if selected.pastEnd {
+			return okResult(fmt.Sprintf("File: %s\n(offset %d is past the end of the file, which has %d lines)", relativePath, offset, selected.totalLines))
+		}
+		sourceTotal = selected.totalLines
+	}
+
+	selectedSourceLines := selected.emitted
+	truncatedByWindow := windowHitLimit
+	selectionIncomplete := selected.startByte > 0 || len(selected.content) < len(content)
+	if !partialLoad && sourceTotal > 0 {
+		start := offset
+		if start < 1 {
+			start = 1
+		}
+		truncatedByWindow = start-1+selectedSourceLines < sourceTotal
+	}
+	truncated := truncatedByWindow || lineClamps > 0
+	ranged := offset > 1 || explicitLimit || partialLoad || selectionIncomplete || truncated
+
+	var minified minify.Result
+	if partialLoad || lineClamps > 0 {
+		minified = minify.File("_window.txt", selected.content)
+	} else if ranged {
+		minified = minify.ContextualFragment(relativePath, content, selected.content, selected.startByte)
+	} else {
+		minified = minify.File(relativePath, selected.content)
+	}
+
+	rawLines := lineCount(string(selected.content))
+	minLines := lineCount(minified.Content)
+	pct := 0
+	if rawBytes := len(selected.content); rawBytes > 0 && len(minified.Content) < rawBytes {
+		pct = (rawBytes - len(minified.Content)) * 100 / rawBytes
+	}
+	header := minifiedHeader(relativePath, minified, rawLines, minLines, pct, ranged || partialLoad)
+	if loadNote != "" {
+		header += "\n" + loadNote
+	}
+	if lineClamps > 0 {
+		header += fmt.Sprintf("\n(note: %d line(s) exceeded %d characters and were clamped; use read_file with byte_offset/byte_limit for exact bytes)", lineClamps, readMinifiedMaxLineRunes)
+	}
+	if truncatedByWindow {
+		header += fmt.Sprintf("\n[truncated: more source lines remain; set offset=%d to continue]", offset+selectedSourceLines)
 	}
 
 	rawBytes := len(selected.content)
-	compactBytes := len(result.Content)
+	compactBytes := len(minified.Content)
 	savedTokens := 0
 	if savedBytes := rawBytes - compactBytes; savedBytes > 0 {
 		savedTokens = estimatedTokensFromBytes(savedBytes)
 	}
-	output := header + "\n\n" + result.Content
-	meta := map[string]string{}
-	meta["path"] = relativePath
-	meta["mode"] = result.Language
-	meta["compacted"] = strconv.FormatBool(result.Applied)
-	meta["raw_bytes"] = strconv.Itoa(rawBytes)
-	meta["compact_bytes"] = strconv.Itoa(compactBytes)
-	meta["emitted_bytes"] = strconv.Itoa(len(output))
-	meta["raw_lines"] = strconv.Itoa(rawLines)
-	meta["emitted_lines"] = strconv.Itoa(minLines)
-	meta["estimated_tokens_saved"] = strconv.Itoa(savedTokens)
-	toolResult := Result{Status: StatusOK, Output: output, Meta: meta}
-	if directBudget {
-		return applyLegacyByteBudgetToResult(toolResult, readOutputBudgetBytes, "use offset/limit to request a smaller source range, or read_file when exact text is required")
+	output := header + "\n\n" + minified.Content
+	meta := map[string]string{
+		"path":                   relativePath,
+		"mode":                   minified.Language,
+		"compacted":              strconv.FormatBool(minified.Applied),
+		"raw_bytes":              strconv.Itoa(rawBytes),
+		"compact_bytes":          strconv.Itoa(compactBytes),
+		"emitted_bytes":          strconv.Itoa(len(output)),
+		"raw_lines":              strconv.Itoa(rawLines),
+		"emitted_lines":          strconv.Itoa(minLines),
+		"source_lines_emitted":   strconv.Itoa(selectedSourceLines),
+		"requested_limit":        strconv.Itoa(limit),
+		"estimated_tokens_saved": strconv.Itoa(savedTokens),
 	}
-	return toolResult
+	if partialLoad {
+		meta["partial_load"] = "true"
+	}
+	if sourceTotal > 0 {
+		if windowHitLimit {
+			meta["source_total_lines_min"] = strconv.Itoa(sourceTotal)
+		} else {
+			meta["source_total_lines"] = strconv.Itoa(sourceTotal)
+		}
+	}
+	if !explicitLimit {
+		meta["default_line_limit"] = strconv.Itoa(limit)
+	}
+	if truncated {
+		meta["truncated"] = "true"
+		switch {
+		case loaded.window.hitByteLimit:
+			meta["truncation_reason"] = readMinifiedTruncByteBudget
+		case truncatedByWindow && lineClamps > 0:
+			meta["truncation_reason"] = readMinifiedTruncLimit + "+" + readMinifiedTruncLineClamp
+		case lineClamps > 0:
+			meta["truncation_reason"] = readMinifiedTruncLineClamp
+		default:
+			meta["truncation_reason"] = readMinifiedTruncLimit
+		}
+		if lineClamps > 0 {
+			meta["clamped_lines"] = strconv.Itoa(lineClamps)
+		}
+	}
+
+	result := Result{Status: StatusOK, Output: output, Truncated: truncated, Meta: meta}
+	if directBudget {
+		return applyLegacyByteBudgetToResult(result, readOutputBudgetBytes, "use offset/limit to request a smaller source range, or read_file when exact text is required")
+	}
+	return result
+}
+
+func minifiedHeader(path string, result minify.Result, rawLines, minLines, pct int, ranged bool) string {
+	if result.Applied {
+		return fmt.Sprintf("File: %s — minified %s view (comments stripped, no line numbers; %d→%d lines, ~%d%% fewer bytes). For exact text/comments or before editing, use read_file.", path, result.Language, rawLines, minLines, pct)
+	}
+	if ranged {
+		return fmt.Sprintf("File: %s — safe ranged view (whitespace normalized, no line numbers; %d→%d lines; context-sensitive stripping disabled because the range may begin inside a multiline construct). For exact text, use read_file.", path, rawLines, minLines)
+	}
+	return fmt.Sprintf("File: %s — whitespace-normalized view (no line numbers; %d→%d lines; full minification not available for this file type). For exact text, use read_file.", path, rawLines, minLines)
+}
+
+type minifiedLoad struct {
+	content []byte
+	window  fileLineWindow
+	partial bool
+}
+
+func loadMinifiedFile(ctx context.Context, r io.ReadSeeker, snapshotSize int64, offset, limit int) (minifiedLoad, error) {
+	if err := ctx.Err(); err != nil {
+		return minifiedLoad{}, err
+	}
+	if snapshotSize > int64(readMinifiedMaxLoadBytes) {
+		if _, err := r.Seek(0, io.SeekStart); err != nil {
+			return minifiedLoad{}, err
+		}
+		window, err := readFileLineWindow(ctx, r, offset, limit)
+		return minifiedLoad{window: window, partial: true}, err
+	}
+	content, err := readAllContextLimited(ctx, r, readMinifiedMaxLoadBytes+1)
+	if err != nil {
+		return minifiedLoad{}, err
+	}
+	if len(content) <= readMinifiedMaxLoadBytes {
+		return minifiedLoad{content: content}, nil
+	}
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return minifiedLoad{}, err
+	}
+	window, err := readFileLineWindow(ctx, r, offset, limit)
+	return minifiedLoad{window: window, partial: true}, err
+}
+
+func readAllContextLimited(ctx context.Context, r io.Reader, max int) ([]byte, error) {
+	return io.ReadAll(io.LimitReader(&contextReader{ctx: ctx, r: r}, int64(max)))
+}
+
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+type windowReader struct {
+	ctx          context.Context
+	r            io.Reader
+	remaining    int64
+	limited      bool
+	syntheticEOF bool
+}
+
+func (r *windowReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if r.limited {
+		if r.remaining == 0 {
+			r.syntheticEOF = true
+			return 0, io.EOF
+		}
+		if int64(len(p)) > r.remaining {
+			p = p[:r.remaining]
+		}
+	}
+	n, err := r.r.Read(p)
+	if r.limited {
+		r.remaining -= int64(n)
+	}
+	return n, err
+}
+
+func (r *windowReader) limit(bytes int64) {
+	r.remaining = bytes
+	r.limited = true
+	r.syntheticEOF = false
+}
+
+func (r *contextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.r.Read(p)
+}
+
+type fileLineWindow struct {
+	content      []byte
+	totalLines   int
+	emitted      int
+	pastEnd      bool
+	hitLimit     bool
+	hitByteLimit bool
+	clampedLines int
+}
+
+func readFileLineWindow(ctx context.Context, r io.Reader, offset, limit int) (fileLineWindow, error) {
+	if offset < 1 {
+		offset = 1
+	}
+	if limit < 1 {
+		limit = readMinifiedDefaultLineLimit
+	}
+	source := &windowReader{ctx: ctx, r: r}
+	reader := bufio.NewReader(source)
+	var out strings.Builder
+	lineNumber := 0
+	emitted := 0
+	clampedLines := 0
+	maxKeep := readMinifiedMaxLineRunes * 4
+	for {
+		if err := ctx.Err(); err != nil {
+			return fileLineWindow{}, err
+		}
+		if lineNumber+1 == offset && !source.limited {
+			// The byte budget applies to the selected page. Bytes buffered while
+			// locating a deep offset are bounded by bufio.Reader's fixed buffer.
+			source.limit(int64(readMinifiedMaxWindowBytes + 1))
+		}
+		raw, ended, clipped, err := readRawLineLimited(reader, maxKeep)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fileLineWindow{}, err
+		}
+		lineNumber++
+		if lineNumber < offset {
+			continue
+		}
+		body := trimLineBreak(raw, ended)
+		clampedBody, runeClamped := clampMinifiedRunes(string(body), readMinifiedMaxLineRunes)
+		separatorBytes := 0
+		if emitted > 0 {
+			separatorBytes = 1
+		}
+		if out.Len()+separatorBytes+len(clampedBody) > readMinifiedMaxWindowBytes {
+			return fileLineWindow{content: []byte(out.String()), totalLines: lineNumber, emitted: emitted, hitLimit: true, hitByteLimit: true, clampedLines: clampedLines}, nil
+		}
+		if emitted > 0 {
+			out.WriteByte('\n')
+		}
+		if clipped || runeClamped {
+			clampedLines++
+		}
+		out.WriteString(clampedBody)
+		emitted++
+		if source.syntheticEOF {
+			return fileLineWindow{content: []byte(out.String()), totalLines: lineNumber, emitted: emitted, hitLimit: true, hitByteLimit: true, clampedLines: clampedLines}, nil
+		}
+		if emitted >= limit {
+			_, peekErr := reader.Peek(1)
+			if peekErr != nil && peekErr != io.EOF {
+				return fileLineWindow{}, peekErr
+			}
+			if peekErr == nil || source.syntheticEOF {
+				return fileLineWindow{content: []byte(out.String()), totalLines: offset + emitted - 1, emitted: emitted, hitLimit: true, clampedLines: clampedLines}, nil
+			}
+			break
+		}
+		if !ended {
+			break
+		}
+	}
+	total := lineNumber
+	if total == 0 {
+		total = 1
+	}
+	if offset > total {
+		return fileLineWindow{totalLines: total, pastEnd: true}, nil
+	}
+	return fileLineWindow{content: []byte(out.String()), totalLines: total, emitted: emitted, clampedLines: clampedLines}, nil
+}
+
+func clampMinifiedRunes(s string, max int) (string, bool) {
+	if max <= 0 {
+		return s, false
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s, false
+	}
+	return string(runes[:max]) + "…", true
 }
 
 type sourceSelection struct {
 	content    []byte
 	startByte  int
 	totalLines int
+	emitted    int
 	pastEnd    bool
 }
 
 func selectSourceLines(content []byte, offset, limit int) sourceSelection {
 	if offset <= 1 && limit == 0 {
-		return sourceSelection{content: content, totalLines: sourceLineCount(content)}
+		total := sourceLineCount(content)
+		return sourceSelection{content: content, totalLines: total, emitted: total}
 	}
 	lines := strings.Split(string(content), "\n")
 	totalLines := sourceLineCount(content)
@@ -163,11 +467,7 @@ func selectSourceLines(content []byte, offset, limit int) sourceSelection {
 	if limit > 0 && limit < end-start {
 		end = start + limit
 	}
-	return sourceSelection{
-		content:    []byte(strings.Join(lines[start:end], "\n")),
-		startByte:  startByte,
-		totalLines: totalLines,
-	}
+	return sourceSelection{content: []byte(strings.Join(lines[start:end], "\n")), startByte: startByte, totalLines: totalLines, emitted: end - start}
 }
 
 func sourceLineCount(content []byte) int {
@@ -176,8 +476,6 @@ func sourceLineCount(content []byte) int {
 	return trackedLineTotal(string(content))
 }
 
-// lineCount reports the number of newline-separated lines in s (an empty string
-// counts as 0 lines, matching how a reader perceives an empty file).
 func lineCount(s string) int {
 	if s == "" {
 		return 0
@@ -200,4 +498,49 @@ func trackedLineTotal(s string) int {
 		total++
 	}
 	return total
+}
+
+type minifiedClassification struct {
+	binary bool
+	mime   string
+}
+
+func classifyMinifiedPrefix(ctx context.Context, file *os.File) (minifiedClassification, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return minifiedClassification{}, err
+	}
+	buf := make([]byte, 512)
+	n, err := io.ReadFull(&contextReader{ctx: ctx, r: file}, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return minifiedClassification{}, err
+	}
+	buf = buf[:n]
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return minifiedClassification{}, err
+	}
+	mime := http.DetectContentType(buf)
+	return minifiedClassification{binary: bytesContainMinifiedNUL(buf) || knownBinaryMinifiedMIME(mime), mime: mime}, nil
+}
+
+func bytesContainMinifiedNUL(content []byte) bool {
+	return bytes.IndexByte(content, 0) >= 0
+}
+
+func knownBinaryMinifiedMIME(mime string) bool {
+	if strings.HasPrefix(mime, "image/") || strings.HasPrefix(mime, "audio/") || strings.HasPrefix(mime, "video/") {
+		return true
+	}
+	switch mime {
+	case "application/zip", "application/pdf", "application/gzip", "application/x-gzip", "application/x-7z-compressed", "application/x-rar-compressed", "application/wasm", "application/octet-stream":
+		return true
+	default:
+		return false
+	}
+}
+
+func binaryMinifiedResult(path, mime string) Result {
+	if mime == "" {
+		mime = "application/octet-stream"
+	}
+	return Result{Status: StatusOK, Output: fmt.Sprintf("File: %s looks binary (%s); not shown as text. Use a specialized tool or convert it first.", path, mime), Meta: map[string]string{"binary": "true", "mime": mime, "path": path}}
 }

--- a/internal/tools/read_minified_file.go
+++ b/internal/tools/read_minified_file.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Gitlawb/zero/internal/minify"
 )
@@ -24,6 +25,10 @@ const (
 	readMinifiedTruncByteBudget  = "byte_budget"
 	readMinifiedTruncLineClamp   = "line_clamp"
 )
+
+// Small files are loaded completely. Large files are streamed as bounded
+// pages. Reaching a deep offset may scan a sequential prefix, and binary
+// detection covers bytes read or discarded while reaching and emitting it.
 
 type readMinifiedFileTool struct {
 	baseTool
@@ -43,7 +48,7 @@ func NewScopedReadMinifiedFileTool(workspaceRoot string, scope PathScope) Tool {
 	return readMinifiedFileTool{
 		baseTool: baseTool{
 			name:        "read_minified_file",
-			description: "Read source code in a token-efficient, language-aware form. Use for exploratory understanding of large or unfamiliar source when no exact edit is planned; use read_file directly for likely edit targets. Defaults to at most 2000 source lines; large files are not loaded in full. Deep offsets may scan sequentially to reach the requested line.",
+			description: "Read source code in a token-efficient, language-aware form. Use for exploratory understanding of large or unfamiliar source when no exact edit is planned; use read_file directly for likely edit targets. Do not immediately reread the same file exactly unless a new need for exact text or line numbers appears. Defaults to at most 2000 source lines; large files are not loaded in full. Deep offsets may scan sequentially to reach the requested line.",
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{
@@ -115,7 +120,7 @@ func (tool readMinifiedFileTool) run(ctx context.Context, args map[string]any, o
 		return errorResult("Error reading file " + relativePath + ": " + err.Error())
 	}
 	if loaded.partial {
-		if bytesContainMinifiedNUL(loaded.window.content) {
+		if loaded.window.containsNUL || bytesContainMinifiedNUL(loaded.window.content) {
 			return binaryMinifiedResult(relativePath, "application/octet-stream")
 		}
 	} else if bytesContainMinifiedNUL(loaded.content) {
@@ -140,23 +145,23 @@ func (tool readMinifiedFileTool) run(ctx context.Context, args map[string]any, o
 		windowHitLimit = window.hitLimit
 		lineClamps = window.clampedLines
 		selected = sourceSelection{content: content, totalLines: sourceTotal, emitted: window.emitted}
-		loadNote = fmt.Sprintf("(note: file is %d bytes; streamed %d source line(s) from offset %d without scanning the remainder)", info.Size(), window.emitted, offset)
+		loadNote = fmt.Sprintf("(note: file is %d bytes; streamed %d source line(s) from offset %d; skipped %d source line(s) before the page; the remainder was not scanned)", info.Size(), window.emitted, offset, window.prefixLinesSkipped)
 	} else {
 		content = loaded.content
 		options.FileTracker.Record(absolutePath, content, info)
-		if len(content) == 0 {
-			return Result{Status: StatusOK, Output: fmt.Sprintf("File: %s is empty", relativePath), Meta: map[string]string{"empty": "true", "path": relativePath}}
-		}
 		selected = selectSourceLines(content, offset, limit)
 		if selected.pastEnd {
 			return okResult(fmt.Sprintf("File: %s\n(offset %d is past the end of the file, which has %d lines)", relativePath, offset, selected.totalLines))
+		}
+		if len(content) == 0 {
+			return Result{Status: StatusOK, Output: fmt.Sprintf("File: %s is empty", relativePath), Meta: map[string]string{"empty": "true", "path": relativePath}}
 		}
 		sourceTotal = selected.totalLines
 	}
 
 	selectedSourceLines := selected.emitted
 	truncatedByWindow := windowHitLimit
-	selectionIncomplete := selected.startByte > 0 || len(selected.content) < len(content)
+	selectionIncomplete := selected.startByte > 0 || selected.emitted < selected.totalLines
 	if !partialLoad && sourceTotal > 0 {
 		start := offset
 		if start < 1 {
@@ -222,6 +227,10 @@ func (tool readMinifiedFileTool) run(ctx context.Context, args map[string]any, o
 		} else {
 			meta["source_total_lines"] = strconv.Itoa(sourceTotal)
 		}
+	}
+	if partialLoad && loaded.window.prefixLinesSkipped > 0 {
+		meta["prefix_lines_skipped"] = strconv.Itoa(loaded.window.prefixLinesSkipped)
+		meta["prefix_bytes_scanned"] = strconv.Itoa(loaded.window.prefixBytesScanned)
 	}
 	if !explicitLimit {
 		meta["default_line_limit"] = strconv.Itoa(limit)
@@ -301,11 +310,14 @@ type contextReader struct {
 }
 
 type windowReader struct {
-	ctx          context.Context
-	r            io.Reader
-	remaining    int64
-	limited      bool
-	syntheticEOF bool
+	ctx              context.Context
+	r                io.Reader
+	remaining        int64
+	limited          bool
+	syntheticEOF     bool
+	probeDone        bool
+	moreData         bool
+	probeContainsNUL bool
 }
 
 func (r *windowReader) Read(p []byte) (int, error) {
@@ -314,6 +326,18 @@ func (r *windowReader) Read(p []byte) (int, error) {
 	}
 	if r.limited {
 		if r.remaining == 0 {
+			if !r.probeDone {
+				r.probeDone = true
+				var probe [1]byte
+				n, probeErr := r.r.Read(probe[:])
+				if n > 0 {
+					r.moreData = true
+					r.probeContainsNUL = probe[0] == 0
+				}
+				if probeErr != nil && probeErr != io.EOF {
+					return 0, probeErr
+				}
+			}
 			r.syntheticEOF = true
 			return 0, io.EOF
 		}
@@ -332,6 +356,9 @@ func (r *windowReader) limit(bytes int64) {
 	r.remaining = bytes
 	r.limited = true
 	r.syntheticEOF = false
+	r.probeDone = false
+	r.moreData = false
+	r.probeContainsNUL = false
 }
 
 func (r *contextReader) Read(p []byte) (int, error) {
@@ -342,13 +369,16 @@ func (r *contextReader) Read(p []byte) (int, error) {
 }
 
 type fileLineWindow struct {
-	content      []byte
-	totalLines   int
-	emitted      int
-	pastEnd      bool
-	hitLimit     bool
-	hitByteLimit bool
-	clampedLines int
+	content            []byte
+	totalLines         int
+	emitted            int
+	pastEnd            bool
+	hitLimit           bool
+	hitByteLimit       bool
+	clampedLines       int
+	containsNUL        bool
+	prefixLinesSkipped int
+	prefixBytesScanned int
 }
 
 func readFileLineWindow(ctx context.Context, r io.Reader, offset, limit int) (fileLineWindow, error) {
@@ -364,17 +394,21 @@ func readFileLineWindow(ctx context.Context, r io.Reader, offset, limit int) (fi
 	lineNumber := 0
 	emitted := 0
 	clampedLines := 0
+	prefixLinesSkipped := 0
+	prefixBytesScanned := 0
+	containsNUL := false
 	maxKeep := readMinifiedMaxLineRunes * 4
 	for {
 		if err := ctx.Err(); err != nil {
 			return fileLineWindow{}, err
 		}
 		if lineNumber+1 == offset && !source.limited {
-			// The byte budget applies to the selected page. Bytes buffered while
-			// locating a deep offset are bounded by bufio.Reader's fixed buffer.
+			// The byte budget applies only to the selected page. Reaching a deep
+			// offset still scans a sequential prefix; bufio bounds buffered memory,
+			// not cumulative prefix I/O.
 			source.limit(int64(readMinifiedMaxWindowBytes + 1))
 		}
-		raw, ended, clipped, err := readRawLineLimited(reader, maxKeep)
+		raw, ended, clipped, lineContainsNUL, lineBytesScanned, err := readRawLineLimited(reader, maxKeep)
 		if err == io.EOF {
 			break
 		}
@@ -382,7 +416,10 @@ func readFileLineWindow(ctx context.Context, r io.Reader, offset, limit int) (fi
 			return fileLineWindow{}, err
 		}
 		lineNumber++
+		containsNUL = containsNUL || lineContainsNUL || source.probeContainsNUL
 		if lineNumber < offset {
+			prefixLinesSkipped++
+			prefixBytesScanned += lineBytesScanned
 			continue
 		}
 		body := trimLineBreak(raw, ended)
@@ -392,7 +429,7 @@ func readFileLineWindow(ctx context.Context, r io.Reader, offset, limit int) (fi
 			separatorBytes = 1
 		}
 		if out.Len()+separatorBytes+len(clampedBody) > readMinifiedMaxWindowBytes {
-			return fileLineWindow{content: []byte(out.String()), totalLines: lineNumber, emitted: emitted, hitLimit: true, hitByteLimit: true, clampedLines: clampedLines}, nil
+			return fileLineWindow{content: []byte(out.String()), totalLines: lineNumber, emitted: emitted, hitLimit: true, hitByteLimit: true, clampedLines: clampedLines, containsNUL: containsNUL, prefixLinesSkipped: prefixLinesSkipped, prefixBytesScanned: prefixBytesScanned}, nil
 		}
 		if emitted > 0 {
 			out.WriteByte('\n')
@@ -403,15 +440,15 @@ func readFileLineWindow(ctx context.Context, r io.Reader, offset, limit int) (fi
 		out.WriteString(clampedBody)
 		emitted++
 		if source.syntheticEOF {
-			return fileLineWindow{content: []byte(out.String()), totalLines: lineNumber, emitted: emitted, hitLimit: true, hitByteLimit: true, clampedLines: clampedLines}, nil
+			return fileLineWindow{content: []byte(out.String()), totalLines: lineNumber, emitted: emitted, hitLimit: source.moreData, hitByteLimit: source.moreData, clampedLines: clampedLines, containsNUL: containsNUL, prefixLinesSkipped: prefixLinesSkipped, prefixBytesScanned: prefixBytesScanned}, nil
 		}
 		if emitted >= limit {
 			_, peekErr := reader.Peek(1)
 			if peekErr != nil && peekErr != io.EOF {
 				return fileLineWindow{}, peekErr
 			}
-			if peekErr == nil || source.syntheticEOF {
-				return fileLineWindow{content: []byte(out.String()), totalLines: offset + emitted - 1, emitted: emitted, hitLimit: true, clampedLines: clampedLines}, nil
+			if peekErr == nil || source.moreData {
+				return fileLineWindow{content: []byte(out.String()), totalLines: offset + emitted - 1, emitted: emitted, hitLimit: true, clampedLines: clampedLines, containsNUL: containsNUL, prefixLinesSkipped: prefixLinesSkipped, prefixBytesScanned: prefixBytesScanned}, nil
 			}
 			break
 		}
@@ -424,12 +461,18 @@ func readFileLineWindow(ctx context.Context, r io.Reader, offset, limit int) (fi
 		total = 1
 	}
 	if offset > total {
-		return fileLineWindow{totalLines: total, pastEnd: true}, nil
+		return fileLineWindow{totalLines: total, pastEnd: true, containsNUL: containsNUL, prefixLinesSkipped: prefixLinesSkipped, prefixBytesScanned: prefixBytesScanned}, nil
 	}
-	return fileLineWindow{content: []byte(out.String()), totalLines: total, emitted: emitted, clampedLines: clampedLines}, nil
+	return fileLineWindow{content: []byte(out.String()), totalLines: total, emitted: emitted, clampedLines: clampedLines, containsNUL: containsNUL, prefixLinesSkipped: prefixLinesSkipped, prefixBytesScanned: prefixBytesScanned}, nil
 }
 
 func clampMinifiedRunes(s string, max int) (string, bool) {
+	if valid, trimmed := trimInvalidUTF8Suffix(s); trimmed {
+		s = valid
+		if max <= 0 || len([]rune(s)) <= max {
+			return s, true
+		}
+	}
 	if max <= 0 {
 		return s, false
 	}
@@ -438,6 +481,17 @@ func clampMinifiedRunes(s string, max int) (string, bool) {
 		return s, false
 	}
 	return string(runes[:max]) + "…", true
+}
+
+func trimInvalidUTF8Suffix(s string) (string, bool) {
+	for index := 0; index < len(s); {
+		runeValue, size := utf8.DecodeRuneInString(s[index:])
+		if runeValue == utf8.RuneError && size == 1 {
+			return s[:index], true
+		}
+		index += size
+	}
+	return s, false
 }
 
 type sourceSelection struct {
@@ -449,12 +503,12 @@ type sourceSelection struct {
 }
 
 func selectSourceLines(content []byte, offset, limit int) sourceSelection {
-	if offset <= 1 && limit == 0 {
-		total := sourceLineCount(content)
+	total := sourceLineCount(content)
+	if offset <= 1 && (limit == 0 || limit >= total) {
 		return sourceSelection{content: content, totalLines: total, emitted: total}
 	}
 	lines := strings.Split(string(content), "\n")
-	totalLines := sourceLineCount(content)
+	totalLines := total
 	start := offset - 1
 	if start >= totalLines {
 		return sourceSelection{startByte: len(content), totalLines: totalLines, pastEnd: true}

--- a/internal/tools/read_minified_file.go
+++ b/internal/tools/read_minified_file.go
@@ -97,7 +97,7 @@ func (tool readMinifiedFileTool) run(ctx context.Context, args map[string]any, o
 	if err != nil {
 		return errorResult("Error reading file " + requestedPath + ": " + err.Error())
 	}
-	file, err := os.Open(absolutePath)
+	file, err := openReadableRegularFile(absolutePath)
 	if err != nil {
 		return errorResult("Error reading file " + relativePath + ": " + err.Error())
 	}

--- a/internal/tools/read_minified_file_test.go
+++ b/internal/tools/read_minified_file_test.go
@@ -204,7 +204,7 @@ func TestReadMinifiedFileNULInClippedLineTail(t *testing.T) {
 
 func TestReadMinifiedFileClippedPageRemainsValidUTF8(t *testing.T) {
 	dir := t.TempDir()
-	line := strings.Repeat("界", readMinifiedMaxWindowBytes/3)
+	line := strings.Repeat("界", readMinifiedMaxLoadBytes/3+1)
 	if err := os.WriteFile(filepath.Join(dir, "unicode.txt"), []byte(line), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -212,6 +212,9 @@ func TestReadMinifiedFileClippedPageRemainsValidUTF8(t *testing.T) {
 	result := tool.RunWithOptions(context.Background(), map[string]any{"path": "unicode.txt", "limit": 1}, RunOptions{})
 	if result.Status != StatusOK || !utf8.ValidString(result.Output) {
 		t.Fatalf("expected valid UTF-8 output: status=%s valid=%v", result.Status, utf8.ValidString(result.Output))
+	}
+	if result.Meta["partial_load"] != "true" || result.Meta["clamped_lines"] != "1" {
+		t.Fatalf("expected streamed clipped page: meta=%#v output=%q", result.Meta, result.Output)
 	}
 }
 
@@ -548,8 +551,8 @@ type peekErrorReader struct {
 func (reader *peekErrorReader) Read(buffer []byte) (int, error) {
 	if !reader.returned {
 		reader.returned = true
-		copy(buffer, "line\n")
-		return len("line\n"), nil
+		n := copy(buffer, "line\n")
+		return n, nil
 	}
 	return 0, reader.wantErr
 }

--- a/internal/tools/read_minified_file_test.go
+++ b/internal/tools/read_minified_file_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestReadToolsDescribeExploratoryAndExactUseWithoutRedundantRereads(t *testing.T) {
@@ -168,6 +169,82 @@ func TestReadMinifiedFileCanonicalOffsetPastEnd(t *testing.T) {
 	})
 	if res.Status != StatusOK || !strings.Contains(res.Output, "offset 10 is past the end") {
 		t.Fatalf("expected canonical out-of-range response, got status=%s output=%q", res.Status, res.Output)
+	}
+}
+
+func TestReadMinifiedFileEmptyOffsetPastEnd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "empty.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := NewScopedReadMinifiedFileTool(dir, nil).Run(context.Background(), map[string]any{
+		"path": "empty.txt", "offset": 2,
+	})
+	if res.Status != StatusOK || !strings.Contains(res.Output, "offset 2 is past the end of the file, which has 1 lines") {
+		t.Fatalf("expected canonical empty-file out-of-range response, got status=%s output=%q", res.Status, res.Output)
+	}
+}
+
+func TestReadMinifiedFileNULInClippedLineTail(t *testing.T) {
+	dir := t.TempDir()
+	line := append(bytes.Repeat([]byte("a"), readMinifiedMaxLineRunes*4), 0)
+	line = append(line, []byte("tail\nsecond\n")...)
+	line = append(line, bytes.Repeat([]byte("padding\n"), 80000)...)
+	if err := os.WriteFile(filepath.Join(dir, "binary.txt"), line, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+	result := tool.RunWithOptions(context.Background(), map[string]any{"path": "binary.txt", "limit": 2}, RunOptions{})
+	if result.Status != StatusOK || result.Meta["binary"] != "true" {
+		t.Fatalf("expected clipped NUL to classify as binary: status=%s meta=%#v output=%q", result.Status, result.Meta, result.Output)
+	}
+}
+
+func TestReadMinifiedFileClippedPageRemainsValidUTF8(t *testing.T) {
+	dir := t.TempDir()
+	line := strings.Repeat("界", readMinifiedMaxWindowBytes/3)
+	if err := os.WriteFile(filepath.Join(dir, "unicode.txt"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+	result := tool.RunWithOptions(context.Background(), map[string]any{"path": "unicode.txt", "limit": 1}, RunOptions{})
+	if result.Status != StatusOK || !utf8.ValidString(result.Output) {
+		t.Fatalf("expected valid UTF-8 output: status=%s valid=%v", result.Status, utf8.ValidString(result.Output))
+	}
+}
+
+func TestReadMinifiedFileExactEndHasNoContinuation(t *testing.T) {
+	dir := t.TempDir()
+	line := strings.Repeat("x", readMinifiedMaxWindowBytes+1)
+	if err := os.WriteFile(filepath.Join(dir, "exact.txt"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+	result := tool.RunWithOptions(context.Background(), map[string]any{"path": "exact.txt", "limit": 1}, RunOptions{})
+	if result.Status != StatusOK || !result.Truncated || strings.Contains(result.Output, "more source lines remain") {
+		t.Fatalf("exact-end read should only report line clipping: status=%s truncated=%v output=%q", result.Status, result.Truncated, result.Output)
+	}
+}
+
+func TestReadMinifiedFileDeepOffsetReportsPrefixScan(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "deep.txt"), []byte(strings.Repeat("line\n", 150000)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+	result := tool.RunWithOptions(context.Background(), map[string]any{
+		"path": "deep.txt", "offset": 100000, "limit": 1,
+	}, RunOptions{})
+	if result.Status != StatusOK || result.Meta["partial_load"] != "true" {
+		t.Fatalf("expected streamed deep read: status=%s meta=%#v", result.Status, result.Meta)
+	}
+	if result.Meta["prefix_lines_skipped"] != "99999" || result.Meta["prefix_bytes_scanned"] == "" {
+		t.Fatalf("expected prefix scan metadata, got %#v", result.Meta)
+	}
+	if !strings.Contains(result.Output, "skipped 99999 source line(s)") {
+		t.Fatalf("expected deep-offset load note, got %q", result.Output)
 	}
 }
 

--- a/internal/tools/read_minified_file_test.go
+++ b/internal/tools/read_minified_file_test.go
@@ -1,9 +1,13 @@
 package tools
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -191,7 +195,7 @@ func TestReadMinifiedFileAppliesByteBudget(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res := NewScopedReadMinifiedFileTool(dir, nil).Run(context.Background(), map[string]any{"path": "large.txt"})
+	res := NewScopedReadMinifiedFileTool(dir, nil).Run(context.Background(), map[string]any{"path": "large.txt", "limit": 9000})
 	if res.Status != StatusOK || !res.Truncated {
 		t.Fatalf("expected ok+truncated, got status=%s truncated=%v", res.Status, res.Truncated)
 	}
@@ -201,4 +205,274 @@ func TestReadMinifiedFileAppliesByteBudget(t *testing.T) {
 	if res.Meta["truncated"] != "true" {
 		t.Fatalf("expected truncation metadata, got %#v", res.Meta)
 	}
+}
+
+func TestLoadMinifiedFileStreamsOnlyRequestedPrefix(t *testing.T) {
+	data := bytes.Repeat([]byte("first line\n"), readMinifiedMaxLoadBytes)
+	reader := &countingReadSeeker{ReadSeeker: bytes.NewReader(data)}
+
+	loaded, err := loadMinifiedFile(context.Background(), reader, int64(len(data)), 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.partial || string(loaded.window.content) != "first line" {
+		t.Fatalf("loaded=%+v", loaded)
+	}
+	if reader.bytesRead > 64*1024 {
+		t.Fatalf("one-line streamed read consumed %d bytes", reader.bytesRead)
+	}
+}
+
+func TestReadMinifiedFileHonorsExplicitLimitAcrossLoadModes(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		lines   int
+		partial bool
+	}{
+		{name: "full load", line: "x\n", lines: 5001},
+		{name: "streamed", line: strings.Repeat("x", 100) + "\n", lines: 5201, partial: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "many.txt")
+			if err := os.WriteFile(path, []byte(strings.Repeat(tc.line, tc.lines)), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+			result := tool.RunWithOptions(context.Background(), map[string]any{
+				"path": "many.txt", "limit": 5000,
+			}, RunOptions{})
+			if result.Status != StatusOK {
+				t.Fatalf("status=%s output=%q", result.Status, result.Output)
+			}
+			if result.Meta["raw_lines"] != "5000" {
+				t.Fatalf("raw_lines=%q want 5000", result.Meta["raw_lines"])
+			}
+			if !strings.Contains(result.Output, "offset=5001") {
+				t.Fatalf("missing continuation from requested range: %q", result.Output)
+			}
+			if got := result.Meta["partial_load"] == "true"; got != tc.partial {
+				t.Fatalf("partial_load=%v want %v", got, tc.partial)
+			}
+		})
+	}
+}
+
+func TestReadMinifiedFileDefaultLimitMatchesLoadModes(t *testing.T) {
+	content := strings.Repeat("x\n", 2001) + strings.Repeat("padding\n", 80000)
+	for _, partial := range []bool{false, true} {
+		t.Run(map[bool]string{false: "full load", true: "streamed"}[partial], func(t *testing.T) {
+			dir := t.TempDir()
+			data := content
+			if !partial {
+				data = strings.Repeat("x\n", 2001)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "many.txt"), []byte(data), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+			result := tool.RunWithOptions(context.Background(), map[string]any{
+				"path": "many.txt",
+			}, RunOptions{})
+			if result.Status != StatusOK || result.Meta["raw_lines"] != "2000" {
+				t.Fatalf("status=%s raw_lines=%q meta=%#v", result.Status, result.Meta["raw_lines"], result.Meta)
+			}
+			if !strings.Contains(result.Output, "offset=2001") {
+				t.Fatalf("missing default continuation: %q", result.Output[len(result.Output)-200:])
+			}
+		})
+	}
+}
+
+func TestReadMinifiedFileBlankLineAdvancesContinuation(t *testing.T) {
+	for _, partial := range []bool{false, true} {
+		t.Run(map[bool]string{false: "full load", true: "streamed"}[partial], func(t *testing.T) {
+			dir := t.TempDir()
+			data := "\nreachable\n"
+			if partial {
+				data += strings.Repeat("padding\n", 80000)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "blank.txt"), []byte(data), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+			result := tool.RunWithOptions(context.Background(), map[string]any{
+				"path": "blank.txt", "offset": 1, "limit": 1,
+			}, RunOptions{})
+			if result.Status != StatusOK || result.Meta["source_lines_emitted"] != "1" {
+				t.Fatalf("status=%s meta=%#v output=%q", result.Status, result.Meta, result.Output)
+			}
+			if !strings.Contains(result.Output, "offset=2") {
+				t.Fatalf("missing blank-line continuation: %q", result.Output)
+			}
+		})
+	}
+}
+
+func TestReadMinifiedFileReportsSourceByteBudgetContinuation(t *testing.T) {
+	dir := t.TempDir()
+	line := strings.Repeat("x", 2000) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "wide.txt"), []byte(strings.Repeat(line, 400)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+	result := tool.RunWithOptions(context.Background(), map[string]any{
+		"path": "wide.txt", "limit": 400,
+	}, RunOptions{})
+	if result.Status != StatusOK || !result.Truncated {
+		t.Fatalf("status=%s truncated=%v", result.Status, result.Truncated)
+	}
+	if result.Meta["truncation_reason"] != readMinifiedTruncByteBudget {
+		t.Fatalf("meta=%#v", result.Meta)
+	}
+	emitted, err := strconv.Atoi(result.Meta["source_lines_emitted"])
+	if err != nil || emitted < 1 || emitted >= 400 {
+		t.Fatalf("source_lines_emitted=%q err=%v", result.Meta["source_lines_emitted"], err)
+	}
+	want := "offset=" + strconv.Itoa(emitted+1)
+	if !strings.Contains(result.Output, want) {
+		t.Fatalf("missing continuation %q: %q", want, result.Output)
+	}
+}
+
+func TestLoadMinifiedFileHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	reader := bytes.NewReader(bytes.Repeat([]byte("line\n"), readMinifiedMaxLoadBytes))
+
+	_, err := loadMinifiedFile(ctx, reader, int64(reader.Len()), 1, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v want context.Canceled", err)
+	}
+}
+
+func TestReadFileLineWindowPropagatesPeekError(t *testing.T) {
+	wantErr := errors.New("look-ahead failed")
+	reader := &peekErrorReader{wantErr: wantErr}
+	_, err := readFileLineWindow(context.Background(), reader, 1, 1)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err=%v want %v", err, wantErr)
+	}
+}
+
+func TestLoadMinifiedFileBoundsGrownSmallFile(t *testing.T) {
+	data := bytes.Repeat([]byte("line\n"), readMinifiedMaxLoadBytes)
+	reader := &countingReadSeeker{ReadSeeker: bytes.NewReader(data)}
+	loaded, err := loadMinifiedFile(context.Background(), reader, readMinifiedMaxLoadBytes-1, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.partial {
+		t.Fatalf("expected streamed fallback after overflow probe: %+v", loaded)
+	}
+	if reader.bytesRead > 2*(readMinifiedMaxLoadBytes+1)+64*1024 {
+		t.Fatalf("grown file consumed %d bytes", reader.bytesRead)
+	}
+}
+
+func TestLoadMinifiedFileBoundsHugeSingleLine(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 2*readMinifiedMaxWindowBytes)
+	reader := &countingReadSeeker{ReadSeeker: bytes.NewReader(data)}
+	loaded, err := loadMinifiedFile(context.Background(), reader, int64(len(data)), 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.partial || !loaded.window.hitByteLimit {
+		t.Fatalf("expected bounded partial window: %+v", loaded)
+	}
+	if reader.bytesRead > readMinifiedMaxWindowBytes+1+64*1024 {
+		t.Fatalf("single-line stream consumed %d bytes", reader.bytesRead)
+	}
+}
+
+func TestReadFileLineWindowRecognizesExactPageEOF(t *testing.T) {
+	data := bytes.Repeat([]byte("x\n"), readMinifiedMaxWindowBytes/2)
+	window, err := readFileLineWindow(context.Background(), bytes.NewReader(data), 1, int(^uint(0)>>1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if window.hitByteLimit || window.emitted != readMinifiedMaxWindowBytes/2 || window.totalLines != window.emitted {
+		t.Fatalf("window=%+v", window)
+	}
+}
+
+func TestReadMinifiedFileShortCircuitsNULInBoundedContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{name: "full load", content: append(bytes.Repeat([]byte("text "), 100), append([]byte{0}, []byte("tail")...)...)},
+		{name: "streamed page", content: append(bytes.Repeat([]byte("text "), 120), append([]byte{0}, append([]byte("\n"), bytes.Repeat([]byte("padding\n"), 80000)...)...)...)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "binary.txt"), tc.content, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+			result := tool.RunWithOptions(context.Background(), map[string]any{
+				"path": "binary.txt",
+			}, RunOptions{})
+			if result.Status != StatusOK || result.Meta["binary"] != "true" || strings.Contains(result.Output, "text text") {
+				t.Fatalf("expected bounded binary short-circuit: status=%s meta=%#v output=%q", result.Status, result.Meta, result.Output)
+			}
+		})
+	}
+}
+
+func TestReadMinifiedFilePartialLoadDoesNotRecordWholeFileVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "large.txt")
+	if err := os.WriteFile(path, bytes.Repeat([]byte("line\n"), readMinifiedMaxLoadBytes), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tracker := NewFileTracker()
+	tool := NewScopedReadMinifiedFileTool(dir, nil).(optionsAwareTool)
+	result := tool.RunWithOptions(context.Background(), map[string]any{
+		"path": "large.txt", "limit": 1,
+	}, RunOptions{FileTracker: tracker})
+	if result.Status != StatusOK {
+		t.Fatalf("status=%s output=%q", result.Status, result.Output)
+	}
+	if _, tracked := tracker.Version(path); tracked {
+		t.Fatal("partial read recorded a whole-file version")
+	}
+}
+
+func TestReadFileLineWindowPropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := readFileLineWindow(ctx, strings.NewReader("line\n"), 1, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v want context.Canceled", err)
+	}
+}
+
+type countingReadSeeker struct {
+	io.ReadSeeker
+	bytesRead int
+}
+
+func (reader *countingReadSeeker) Read(buffer []byte) (int, error) {
+	n, err := reader.ReadSeeker.Read(buffer)
+	reader.bytesRead += n
+	return n, err
+}
+
+type peekErrorReader struct {
+	returned bool
+	wantErr  error
+}
+
+func (reader *peekErrorReader) Read(buffer []byte) (int, error) {
+	if !reader.returned {
+		reader.returned = true
+		copy(buffer, "line\n")
+		return len("line\n"), nil
+	}
+	return 0, reader.wantErr
 }

--- a/internal/tools/readable_file.go
+++ b/internal/tools/readable_file.go
@@ -1,0 +1,23 @@
+package tools
+
+import (
+	"errors"
+	"os"
+)
+
+func openReadableRegularFile(path string) (*os.File, error) {
+	file, err := openReadableFile(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, errors.New("not a regular file")
+	}
+	return file, nil
+}

--- a/internal/tools/readable_file_unix.go
+++ b/internal/tools/readable_file_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package tools
+
+import (
+	"os"
+	"syscall"
+)
+
+func openReadableFile(path string) (*os.File, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}

--- a/internal/tools/readable_file_windows.go
+++ b/internal/tools/readable_file_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package tools
+
+import "os"
+
+func openReadableFile(path string) (*os.File, error) {
+	return os.Open(path)
+}


### PR DESCRIPTION
## Summary

This PR is the standalone bounded-streaming breakout from the earlier file-reading work. It changes only `read_minified_file` and its line-reader tests.

- Large files are served page-locally without a whole-file hash, line count, or pre-scan.
- Reads honor cancellation and an independent 512 KiB page budget.
- Omitted `limit` defaults to 2,000 lines; explicit positive limits are preserved until the byte budget is reached.
- Partial pages report lower-bound totals and continue from the actual source-line range emitted.
- Full-load reads use a bounded overflow probe, so growth after the initial size snapshot cannot turn into an unbounded `io.ReadAll`.
- Binary classification is bounded and catches NUL bytes in loaded content or the streamed page.
- Partial reads do not record a whole-file tracker observation.

The old `read_file`, path-repair, containment, and heuristic changes are intentionally out of this PR and can land independently.

## Verification

- `go test ./...`
- `go test -race ./internal/tools`
- `make fmt-check`
- `go vet ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `make lint-static`
- `git diff HEAD --check`

`make vulncheck` still reports the repository's existing `GO-2026-6222` issue in `golang.org/x/image@v0.44.0`; no new vulnerability was introduced by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved large-file reading by loading only requested sections when appropriate.
  * Added a default limit of 2,000 lines when no limit is specified.
  * Added clearer reporting for partial results, truncation, line limits, binary files, and repaired paths.
  * Added cancellation support for long-running file reads.

* **Bug Fixes**
  * Improved handling of empty files, oversized lines, blank lines, exact end-of-file ranges, and binary content.
  * Prevented incomplete reads from being recorded as complete file versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->