### PR TITLE
feat(security): path-jail primitive, credential-store locking, worktree git hardening

### DIFF
--- a/internal/credstore/concurrency_test.go
+++ b/internal/credstore/concurrency_test.go
@@ -1,0 +1,246 @@
+package credstore
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func fileStore(t *testing.T, dir string) *Store {
+	t.Helper()
+	store, err := New(Options{Dir: dir, Storage: "file"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return store
+}
+
+// THE REPRODUCTION, kept as the regression. Before the lock this reliably kept
+// 1 of 100: every writer read the same map, added its own provider, and the
+// last rename published a file missing all the others.
+func TestConcurrentSetKeepsEveryKey(t *testing.T) {
+	dir := t.TempDir()
+	store := fileStore(t, dir)
+
+	const n = 100
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := store.Set(fmt.Sprintf("p%03d", i), fmt.Sprintf("k%03d", i)); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := store.Providers()
+	if err != nil {
+		t.Fatalf("Providers: %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("kept %d of %d concurrent writes", len(got), n)
+	}
+	// ...and every value is the one its own writer wrote, not a neighbour's.
+	for i := 0; i < n; i++ {
+		key, ok, err := store.Get(fmt.Sprintf("p%03d", i))
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if !ok || key != fmt.Sprintf("k%03d", i) {
+			t.Fatalf("p%03d = %q (present=%v); a writer's own value must survive", i, key, ok)
+		}
+	}
+}
+
+// DELETE RACES SET, and an unlocked delete loses the other writer's key.
+//
+// A first version of this only checked that keys nobody deleted survived — and
+// every reader sees those, so it passed with the lock removed from Delete. The
+// case that actually breaks is a Delete whose stale read predates a concurrent
+// Set: it writes back a map that never contained the new key, and the Set is
+// gone. So the assertion is on the SETS surviving, not on the bystanders.
+func TestADeleteCannotClobberAConcurrentSet(t *testing.T) {
+	dir := t.TempDir()
+	store := fileStore(t, dir)
+
+	// Throwaway keys for the deleters to remove, written first so a delete
+	// always has something to do.
+	const churn = 40
+	for i := 0; i < churn; i++ {
+		if err := store.Set(fmt.Sprintf("churn%02d", i), "v"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const adds = 60
+	var wg sync.WaitGroup
+	for i := 0; i < adds; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = store.Set(fmt.Sprintf("added%02d", i), "v")
+		}(i)
+	}
+	for i := 0; i < churn; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = store.Delete(fmt.Sprintf("churn%02d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := store.Providers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	survivors := map[string]bool{}
+	for _, name := range got {
+		survivors[name] = true
+	}
+	missing := []string{}
+	for i := 0; i < adds; i++ {
+		name := fmt.Sprintf("added%02d", i)
+		if !survivors[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("%d of %d concurrent Set calls were clobbered by a racing Delete: %v",
+			len(missing), adds, missing)
+	}
+	// ...and every churn key really was removed, so the deletes were not
+	// no-ops that would make the check above vacuous.
+	for i := 0; i < churn; i++ {
+		if survivors[fmt.Sprintf("churn%02d", i)] {
+			t.Fatalf("churn%02d survived; the deletes did nothing and this test proves nothing", i)
+		}
+	}
+}
+
+// ACROSS PROCESSES, which is the case that matters: a plan running with
+// max_workers > 1 spawns child PROCESSES, and an in-process mutex would not
+// have helped any of them. The race detector cannot see this one either — it is
+// two OS processes — so it is driven for real.
+func TestConcurrentSetAcrossProcesses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns processes")
+	}
+	helper := os.Getenv("ZERO_CREDSTORE_HELPER_DIR")
+	if helper != "" {
+		// Child mode: write our slice of the keys and exit.
+		store, err := New(Options{Dir: helper, Storage: "file"})
+		if err != nil {
+			os.Exit(3)
+		}
+		prefix := os.Getenv("ZERO_CREDSTORE_HELPER_PREFIX")
+		for i := 0; i < 25; i++ {
+			if err := store.Set(fmt.Sprintf("%s%02d", prefix, i), "v"); err != nil {
+				os.Exit(4)
+			}
+		}
+		os.Exit(0)
+	}
+
+	dir := t.TempDir()
+	const children = 4
+	var wg sync.WaitGroup
+	failures := make(chan string, children)
+	for c := 0; c < children; c++ {
+		wg.Add(1)
+		go func(c int) {
+			defer wg.Done()
+			cmd := exec.Command(os.Args[0], "-test.run=TestConcurrentSetAcrossProcesses", "-test.v")
+			cmd.Env = append(os.Environ(),
+				"ZERO_CREDSTORE_HELPER_DIR="+dir,
+				fmt.Sprintf("ZERO_CREDSTORE_HELPER_PREFIX=c%d_", c),
+			)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				failures <- fmt.Sprintf("child %d: %v\n%s", c, err, out)
+			}
+		}(c)
+	}
+	wg.Wait()
+	close(failures)
+	for failure := range failures {
+		t.Fatal(failure)
+	}
+
+	store := fileStore(t, dir)
+	got, err := store.Providers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != children*25 {
+		t.Fatalf("kept %d of %d keys written by %d concurrent processes", len(got), children*25, children)
+	}
+}
+
+// The lock lives BESIDE the data file, never on it. write publishes by rename,
+// so a lock taken on the data file would be attached to an inode the next
+// writer has already replaced — every writer would appear to hold it.
+func TestTheLockIsNotTheDataFile(t *testing.T) {
+	dir := t.TempDir()
+	store := fileStore(t, dir)
+	if store.lockPath() == store.file {
+		t.Fatal("the lock is the data file; rename would carry it away")
+	}
+	if !strings.HasPrefix(filepath.Base(store.lockPath()), filepath.Base(store.file)) {
+		t.Fatalf("lock %q is not beside the data file %q", store.lockPath(), store.file)
+	}
+	if err := store.Set("p", "k"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(store.lockPath()); err != nil {
+		t.Fatalf("the lock file was not created: %v", err)
+	}
+	// ...and it survives a write, since the rename replaces only the data file.
+	if err := store.Set("q", "k"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(store.lockPath()); err != nil {
+		t.Fatalf("the lock file did not survive a write: %v", err)
+	}
+}
+
+// The lock is a security boundary, so the path where it CANNOT be taken needs
+// coverage too: an operation that could not lock must report that, never proceed
+// unserialized and never report success. Replacing the credential directory with
+// a regular file makes the lock's MkdirAll fail on every platform.
+func TestOperationsFailWhenTheLockCannotBeAcquired(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "creds")
+	store := fileStore(t, dir)
+	// Where the store expects its directory, put a regular file.
+	if err := os.WriteFile(dir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Set("openai", "sk-test"); err == nil {
+		t.Error("Set reported success although the lock could not be acquired")
+	}
+	if _, err := store.Delete("openai"); err == nil {
+		t.Error("Delete reported success although the lock could not be acquired")
+	}
+	if _, _, err := store.Get("openai"); err == nil {
+		t.Error("Get reported success although the lock could not be acquired")
+	}
+	if _, err := store.Providers(); err == nil {
+		t.Error("Providers reported success although the lock could not be acquired")
+	}
+	// And nothing may have been written through the failed path.
+	if raw, err := os.ReadFile(dir); err != nil || string(raw) != "not a directory" {
+		t.Errorf("the blocking file was modified: %q (err %v)", raw, err)
+	}
+}

--- a/internal/credstore/credstore.go
+++ b/internal/credstore/credstore.go
@@ -9,6 +9,7 @@ package credstore
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -125,14 +126,27 @@ func (s *Store) Backend() string { return s.backend }
 func (s *Store) Encrypted() bool { return s.backend == "keyring" || s.backend == "encrypted-file" }
 
 // Set stores (or overwrites) the API key for provider.
-func (s *Store) Set(provider, key string) error {
+func (s *Store) Set(provider, key string) (err error) {
 	provider = normalizeProvider(provider)
 	if provider == "" {
 		return fmt.Errorf("credstore: provider is required")
 	}
 	if s.backend == "keyring" {
+		// The OS keyring serializes its own writes; the file lock guards the
+		// file backends only.
 		return s.kr.Set(keyringService, keyringPrefix+provider, key)
 	}
+	// READ AND WRITE UNDER ONE LOCK. Separately locking each half would still
+	// lose keys: two writers would each read the same map, each add their own
+	// provider, and the second rename would publish a file missing the first.
+	// Measured before this existed: 1 of 100 concurrent Set calls survived.
+	release, err := s.acquireFileLock(true)
+	if err != nil {
+		return err
+	}
+	// Joined, not chosen between: a release failure annotates the result instead
+	// of masking the write error that actually explains what went wrong.
+	defer func() { err = errors.Join(err, release()) }()
 	data, err := s.read()
 	if err != nil {
 		return err
@@ -142,7 +156,7 @@ func (s *Store) Set(provider, key string) error {
 }
 
 // Get returns the API key for provider and whether one is stored.
-func (s *Store) Get(provider string) (string, bool, error) {
+func (s *Store) Get(provider string) (value string, found bool, err error) {
 	provider = normalizeProvider(provider)
 	if provider == "" {
 		return "", false, nil
@@ -150,6 +164,15 @@ func (s *Store) Get(provider string) (string, bool, error) {
 	if s.backend == "keyring" {
 		return s.kr.Get(keyringService, keyringPrefix+provider)
 	}
+	// A shared lock, so a read serializes against a writer's publish. On unix
+	// the rename is atomic and this only prevents reading an empty file mid-swap;
+	// on Windows an unsynchronized reader holding the file open would block the
+	// writer's rename outright, so readers must coordinate through the same lock.
+	release, err := s.acquireFileLock(false)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { err = errors.Join(err, release()) }()
 	data, err := s.read()
 	if err != nil {
 		return "", false, err
@@ -159,7 +182,7 @@ func (s *Store) Get(provider string) (string, bool, error) {
 }
 
 // Delete removes the API key for provider, reporting whether one existed.
-func (s *Store) Delete(provider string) (bool, error) {
+func (s *Store) Delete(provider string) (existed bool, err error) {
 	provider = normalizeProvider(provider)
 	if provider == "" {
 		return false, nil
@@ -167,6 +190,13 @@ func (s *Store) Delete(provider string) (bool, error) {
 	if s.backend == "keyring" {
 		return s.kr.Delete(keyringService, keyringPrefix+provider)
 	}
+	// The same lock as Set: a delete is a read-modify-write too, and one racing
+	// a set would otherwise resurrect or erase an unrelated provider.
+	release, err := s.acquireFileLock(true)
+	if err != nil {
+		return false, err
+	}
+	defer func() { err = errors.Join(err, release()) }()
 	data, err := s.read()
 	if err != nil {
 		return false, err
@@ -179,17 +209,22 @@ func (s *Store) Delete(provider string) (bool, error) {
 }
 
 // Providers lists providers with a stored key (sorted), for display/audit.
-func (s *Store) Providers() ([]string, error) {
+func (s *Store) Providers() (names []string, err error) {
 	if s.backend == "keyring" {
 		// The OS keyring has no enumerate-by-prefix in our minimal surface; callers
 		// that need a list pass known provider names to Get. Return empty here.
 		return nil, nil
 	}
+	release, err := s.acquireFileLock(false)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = errors.Join(err, release()) }()
 	data, err := s.read()
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, 0, len(data))
+	names = make([]string, 0, len(data))
 	for name := range data {
 		names = append(names, name)
 	}
@@ -263,6 +298,15 @@ func (s *Store) write(data map[string]string) error {
 	}
 	return nil
 }
+
+// lockPath is the advisory lock guarding a read-modify-write of the credential
+// file. Beside the data file, never the data file itself — write publishes by
+// rename and would carry the lock away with the old inode.
+func (s *Store) lockPath() string { return s.file + ".lock" }
+
+// filepathDir is filepath.Dir, named locally so the two platform lock files can
+// share it without either importing path/filepath for one call.
+func filepathDir(path string) string { return filepath.Dir(path) }
 
 func normalizeProvider(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))

--- a/internal/credstore/filelock_unix.go
+++ b/internal/credstore/filelock_unix.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package credstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// acquireFileLock takes an exclusive advisory lock (flock) so a read-modify-write
+// of the credential file is serialized against every other one — across
+// processes AND across goroutines, since flock is held per open file
+// description and two opens in one process contend exactly as two processes do.
+//
+// THE LOCK FILE IS SEPARATE FROM THE DATA FILE, and that is not tidiness. write
+// publishes by os.Rename, which replaces the inode; a lock taken on the data
+// file would be attached to an inode that the next writer has already replaced,
+// so every writer would appear to hold it. The lock lives on a file nothing
+// renames.
+func (s *Store) acquireFileLock(exclusive bool) (func() error, error) {
+	path := s.lockPath()
+	if err := os.MkdirAll(filepathDir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("credstore: lock dir: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("credstore: open lock: %w", err)
+	}
+	// Writers take LOCK_EX; readers take LOCK_SH so they run concurrently with
+	// each other but still serialize against a writer's publish (see Get).
+	how := unix.LOCK_SH
+	if exclusive {
+		how = unix.LOCK_EX
+	}
+	if err := unix.Flock(int(file.Fd()), how); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("credstore: lock: %w", err)
+	}
+	return func() error {
+		// Close alone drops the flock, so the explicit unlock is belt-and-braces —
+		// but its failure is reported rather than swallowed, because a cleanup that
+		// did not complete must not be indistinguishable from one that did. The
+		// callers join this into their result, so it annotates a successful write
+		// instead of masking it.
+		unlockErr := unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		closeErr := file.Close()
+		if err := errors.Join(unlockErr, closeErr); err != nil {
+			return fmt.Errorf("credstore: release lock: %w", err)
+		}
+		return nil
+	}, nil
+}

--- a/internal/credstore/filelock_windows.go
+++ b/internal/credstore/filelock_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package credstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// acquireFileLock takes an exclusive OS lock (LockFileEx) so a read-modify-write
+// of the credential file is serialized, matching the flock behaviour on unix.
+//
+// The lock file is SEPARATE from the data file for the same reason: write
+// publishes by rename, and a lock on the renamed file would be attached to
+// something the next writer has already replaced.
+func (s *Store) acquireFileLock(exclusive bool) (func() error, error) {
+	path := s.lockPath()
+	if err := os.MkdirAll(filepathDir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("credstore: lock dir: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("credstore: open lock: %w", err)
+	}
+	handle := windows.Handle(file.Fd())
+	overlapped := new(windows.Overlapped)
+	// A fixed 1-byte region, blocking (no LOCKFILE_FAIL_IMMEDIATELY) so a
+	// waiter queues rather than failing the operation. Writers pass
+	// LOCKFILE_EXCLUSIVE_LOCK; readers omit it (a shared lock) so they still
+	// serialize against a writer's publish — which matters more on Windows,
+	// where an unsynchronized reader holding the file open blocks the rename.
+	flags := uint32(0)
+	if exclusive {
+		flags = windows.LOCKFILE_EXCLUSIVE_LOCK
+	}
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, overlapped); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("credstore: lock: %w", err)
+	}
+	return func() error {
+		// Reported rather than swallowed, for the same reason as the unix side: a
+		// cleanup that did not complete must not look identical to one that did.
+		// It matters more here — on Windows the handle staying open is what blocks
+		// the next writer's rename, so a failed release has a visible consequence.
+		unlockErr := windows.UnlockFileEx(handle, 0, 1, 0, overlapped)
+		closeErr := file.Close()
+		if err := errors.Join(unlockErr, closeErr); err != nil {
+			return fmt.Errorf("credstore: release lock: %w", err)
+		}
+		return nil
+	}, nil
+}

--- a/internal/pathjail/pathjail.go
+++ b/internal/pathjail/pathjail.go
@@ -1,0 +1,177 @@
+// Package pathjail confines file operations to a directory tree.
+//
+// It exists because the obvious guard does not work. Checking a path with
+// Lstat and then handing the same string to MkdirAll, CreateTemp, Rename or
+// Remove is two independent resolutions with a gap between them, and every
+// operation after the check re-resolves the ANCESTORS as well. A store that
+// verified only its own directory and file was therefore writable outside its
+// tree whenever any component above them was a link: the check passed, and the
+// syscall that followed went somewhere else.
+//
+// On Windows the same guard failed for a second, independent reason. A junction
+// is a reparse point but NOT a symlink, so os.Lstat reports it as ModeIrregular
+// with ModeSymlink clear, and a guard testing only ModeSymlink returns "not a
+// link" when pointed straight at one. Junctions also need no privilege to
+// create, unlike Windows symlinks, so this is reachable by exactly the
+// unprivileged user a workspace guard is meant to contain.
+//
+// The fix for both is to stop naming things by path. Open a handle on the root
+// once and address everything below it relative to that handle, so the kernel
+// resolves each component against an object that cannot be swapped underneath.
+// os.Root is that handle: it refuses any component that would escape, including
+// a Windows reparse point, and it is the same idea the sandbox uses for ACL
+// materialization.
+package pathjail
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrEscapes reports a target that is not inside the root it was confined to.
+// Returned before anything is opened, so a caller cannot act on the path first.
+var ErrEscapes = errors.New("path escapes its root")
+
+// ErrReparse reports a link or reparse point where a real file or directory was
+// required.
+var ErrReparse = errors.New("refusing to write through a link")
+
+// Open confines dir to root and returns a handle on root plus dir expressed
+// relative to it. The caller closes the handle.
+//
+// root is resolved normally, because it is the boundary the caller chose and
+// trusts (a workspace the operator opened, say, which may legitimately sit under
+// a link). Everything BELOW it is resolved against the returned handle and
+// cannot escape.
+func Open(root, dir string) (*os.Root, string, error) {
+	// Only a genuinely EMPTY value is treated as missing; every other spelling is
+	// used verbatim. Testing TrimSpace(...) == "" instead would retarget the very
+	// paths this guards: " " is a legal directory name on unix, so trimming would
+	// reject it as "no root" or silently swap dir for root, which is the same
+	// retargeting bug as trimming "root " down to "root".
+	if root == "" {
+		return nil, "", fmt.Errorf("%w: no root to confine %q to", ErrEscapes, dir)
+	}
+	if dir == "" {
+		dir = root
+	}
+	// Rel before Open, so an escaping target is refused without opening
+	// anything. filepath.Rel is lexical, which is the right test here: it says
+	// what the caller ASKED for, and the handle enforces what actually happens.
+	relative, err := filepath.Rel(root, dir)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: %q against %q: %v", ErrEscapes, dir, root, err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return nil, "", fmt.Errorf("%w: %q is outside %q", ErrEscapes, dir, root)
+	}
+	// The root is created if it is missing, by ordinary pathname, because it is
+	// the boundary the caller declared rather than anything being confined. The
+	// stores this replaced called MkdirAll on the whole tree, so this creates
+	// strictly less by pathname than before, and everything BELOW root is opened
+	// relative to the handle.
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, "", fmt.Errorf("create %s: %w", root, err)
+	}
+	handle, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, "", fmt.Errorf("open %s: %w", root, err)
+	}
+	return handle, relative, nil
+}
+
+// RefuseReparse fails when relative names a link or reparse point.
+//
+// Absent is fine: a name that does not exist yet is what a create is for.
+//
+// This is belt to os.Root's braces. The handle already refuses to traverse a
+// reparse point, so this exists to give the FINAL component a clear error
+// instead of an "escapes from parent" one, and to keep the refusal explicit at
+// the point a reader looks for it.
+//
+// ModeIrregular is tested alongside ModeSymlink deliberately: that is what a
+// Windows junction reports, and a guard checking only ModeSymlink lets one
+// straight through.
+func RefuseReparse(handle *os.Root, relative string) error {
+	// A trailing separator makes os.Root.Lstat resolve the terminal component on
+	// Windows (doInRootAlwaysResolveTerminalSlash), so a junction named with a
+	// trailing slash would be stat'd as its target and wave through as "not a
+	// link". Strip it so the final component itself is the thing inspected.
+	//
+	// os.IsPathSeparator rather than a literal `/\` set, because backslash is a
+	// separator only on Windows: on unix it is an ordinary filename character, and
+	// trimming it would inspect "linked" when asked about a symlink genuinely
+	// named `linked\` — reporting "not a link" for one that is.
+	if trimmed := trimTrailingSeparators(relative); trimmed != "" {
+		relative = trimmed
+	}
+	info, err := handle.Lstat(relative)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("inspect %s: %w", relative, err)
+	}
+	if info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0 {
+		return fmt.Errorf("%w: %s", ErrReparse, relative)
+	}
+	return nil
+}
+
+// trimTrailingSeparators drops the path separators at the end of a name, using
+// the ACTIVE platform's definition of one: `/` and `\` on Windows, `/` only on
+// unix, where a backslash is a legal character in a filename.
+func trimTrailingSeparators(path string) string {
+	end := len(path)
+	for end > 0 && os.IsPathSeparator(path[end-1]) {
+		end--
+	}
+	return path[:end]
+}
+
+// randomBytes fills b with cryptographic randomness. A variable rather than a
+// direct crypto/rand call so a test can force the name collision that exercises
+// the O_EXCL retry below — the branch that matters, and one a real random source
+// will not reach on demand.
+var randomBytes = rand.Read
+
+// CreateTemp makes an O_EXCL temp file named prefix.<random>suffix inside dir,
+// relative to handle, and returns it with its relative path.
+//
+// O_EXCL rather than a fixed name: a link planted at a predictable temp path
+// between the check and the create is the same race this package exists to
+// close, and O_EXCL makes the kernel refuse it rather than us.
+func CreateTemp(handle *os.Root, dir, prefix, suffix string) (*os.File, string, error) {
+	// prefix and suffix are NAME fragments, not path fragments. A separator or a
+	// "."/".." in either would relocate the file out of dir — a prefix of
+	// "../escaped", or a suffix of ".tmp/../evil" that also erases the random
+	// component and with it the O_EXCL unpredictability the file relies on.
+	// Reject them up front so the file lands where dir promises.
+	for _, fragment := range []string{prefix, suffix} {
+		if strings.ContainsAny(fragment, `/\`) || fragment == "." || fragment == ".." {
+			return nil, "", fmt.Errorf("%w: temporary name fragment %q must be a single path component", ErrEscapes, fragment)
+		}
+	}
+	for attempt := 0; attempt < 10; attempt++ {
+		noise := make([]byte, 8)
+		if _, err := randomBytes(noise); err != nil {
+			return nil, "", fmt.Errorf("generate a temporary name: %w", err)
+		}
+		relative := filepath.Join(dir, prefix+"."+hex.EncodeToString(noise)+suffix)
+		file, err := handle.OpenFile(relative, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			return file, relative, nil
+		}
+		if errors.Is(err, fs.ErrExist) {
+			continue
+		}
+		return nil, "", err
+	}
+	return nil, "", errors.New("could not create a temporary file with an unused name")
+}

--- a/internal/pathjail/pathjail_test.go
+++ b/internal/pathjail/pathjail_test.go
@@ -1,0 +1,360 @@
+package pathjail
+
+import (
+	"encoding/hex"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// linkDir points link at target, using whatever kind of link this platform lets
+// an unprivileged process create.
+//
+// On Windows that is a JUNCTION, not a symlink, and the difference is the whole
+// reason this package exists twice over. A symlink needs
+// SeCreateSymbolicLinkPrivilege, which an ordinary account does not hold, so a
+// test written with os.Symlink silently skips on Windows and proves nothing
+// there. A junction needs no privilege at all, so it is both the reachable
+// attack and the only one that can be tested.
+func linkDir(t *testing.T, target, link string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		if out, err := exec.Command("cmd", "/c", "mklink", "/J", link, target).CombinedOutput(); err != nil {
+			t.Skipf("cannot create a junction: %v %s", err, out)
+		}
+		return
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("cannot create a symlink: %v", err)
+	}
+}
+
+// The reported defect: a link in an ANCESTOR of the target, not at the target
+// itself. Every guard that checked only the final directory and file passed
+// this, because the components it checked were genuinely not links; the ones
+// the syscall then traversed were.
+func TestAnAncestorLinkCannotRedirectAWrite(t *testing.T) {
+	base := t.TempDir()
+	outside := filepath.Join(base, "outside")
+	workspace := filepath.Join(base, "workspace")
+	for _, dir := range []string{outside, workspace} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkDir(t, outside, filepath.Join(workspace, ".zero"))
+
+	handle, relative, err := Open(workspace, filepath.Join(workspace, ".zero", "store"))
+	if err != nil {
+		t.Fatalf("Open should confine, not refuse outright: %v", err)
+	}
+	defer handle.Close()
+
+	if err := handle.MkdirAll(relative, 0o700); err == nil {
+		t.Fatal("created a directory through a linked ancestor, so a write can still leave the workspace")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "store")); !os.IsNotExist(err) {
+		t.Errorf("something was created outside the workspace, stat error = %v", err)
+	}
+}
+
+// RefuseReparse has to catch a junction, which is the case os.ModeSymlink alone
+// misses. Asserted through the exported helper rather than by reading the mode,
+// so the test fails if the predicate is ever narrowed back.
+func TestRefuseReparseCatchesAJunctionNotJustASymlink(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "target")
+	inside := filepath.Join(base, "inside")
+	for _, dir := range []string{target, inside} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkDir(t, target, filepath.Join(inside, "linked"))
+
+	handle, relative, err := Open(inside, inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+
+	err = RefuseReparse(handle, filepath.Join(relative, "linked"))
+	if !errors.Is(err, ErrReparse) {
+		t.Fatalf("RefuseReparse(link) = %v, want ErrReparse; on Windows a junction reports ModeIrregular, so a ModeSymlink-only check returns nil here", err)
+	}
+}
+
+// A name that does not exist yet is what a create is for, so it must not be
+// refused. Without this the guard above would be satisfied by refusing
+// everything.
+func TestRefuseReparseAllowsAnAbsentName(t *testing.T) {
+	base := t.TempDir()
+	handle, relative, err := Open(base, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+	if err := RefuseReparse(handle, filepath.Join(relative, "not-there.md")); err != nil {
+		t.Errorf("an absent name was refused: %v", err)
+	}
+	if err := RefuseReparse(handle, relative); err != nil {
+		t.Errorf("an ordinary directory was refused: %v", err)
+	}
+}
+
+// Open refuses a target outside its root before opening anything, so a caller
+// cannot act on the path first.
+func TestOpenRefusesATargetOutsideTheRoot(t *testing.T) {
+	base := t.TempDir()
+	inside := filepath.Join(base, "inside")
+	if err := os.MkdirAll(inside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range []string{
+		filepath.Join(base, "sibling"),
+		filepath.Join(inside, "..", "..", "escape"),
+	} {
+		if _, _, err := Open(inside, target); !errors.Is(err, ErrEscapes) {
+			t.Errorf("Open(%q, %q) = %v, want ErrEscapes", inside, target, err)
+		}
+	}
+	if _, _, err := Open("", filepath.Join(base, "anything")); !errors.Is(err, ErrEscapes) {
+		t.Error("an empty root was accepted; a boundary is not optional")
+	}
+}
+
+// CreateTemp must use O_EXCL and an unpredictable name, so a link planted at a
+// guessable temp path is refused by the kernel rather than followed.
+func TestCreateTempIsExclusiveAndUnpredictable(t *testing.T) {
+	base := t.TempDir()
+	handle, relative, err := Open(base, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+
+	seen := map[string]bool{}
+	for i := 0; i < 8; i++ {
+		file, name, err := CreateTemp(handle, relative, "note", ".tmp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		file.Close()
+		if seen[name] {
+			t.Fatalf("CreateTemp reused the name %q, so two concurrent writes would stomp each other", name)
+		}
+		seen[name] = true
+		if filepath.Ext(name) != ".tmp" {
+			t.Errorf("temp name %q lost its suffix, so a listing may pick it up as real content", name)
+		}
+	}
+}
+
+// A legitimate directory whose name carries a space must be confined as spelled.
+// Trimming it would open a different filesystem object.
+//
+// A LEADING space, deliberately: Win32 normalizes a component's trailing spaces
+// and dots away, so "root " and "root" are one object there and a trailing-space
+// case cannot express the bug on Windows. A leading space survives on every
+// platform, so this runs everywhere rather than being gated to unix.
+// The path is RELATIVE, under t.Chdir, so the leading space sits at the start of
+// the whole string. An absolute filepath.Join(base, " root") would put the space
+// in the middle, where TrimSpace cannot reach it — the test would then pass
+// against the very guard it exists to catch, on every platform.
+func TestOpenPreservesSpaceInPaths(t *testing.T) {
+	base := t.TempDir()
+	t.Chdir(base)
+	const spaced = " root" // the leading space is part of the name
+
+	handle, relative, err := Open(spaced, spaced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+
+	// Write through the handle, then confirm the bytes landed under the spelling
+	// the caller asked for — the property that actually matters, and one
+	// handle.Name() alone would not prove.
+	file, _, err := CreateTemp(handle, relative, "probe", ".tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := file.Name()
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(base, spaced, filepath.Base(name))); err != nil {
+		t.Errorf("a file created through the handle is not under %q: %v — the leading space was trimmed away", spaced, err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "root")); err == nil {
+		t.Error(`a trimmed "root" was created instead of the requested " root"`)
+	}
+}
+
+// A whitespace-only name is a legal directory on unix, so it must be confined as
+// given rather than treated as "no root" or silently swapped for the root.
+func TestOpenAcceptsAWhitespaceOnlyComponent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Win32 normalizes a whitespace-only component away; the name is not expressible there")
+	}
+	// The path must be whitespace-only IN FULL for this to bite, so it has to be
+	// relative: an absolute path ending in " " still has a non-empty TrimSpace and
+	// would sail past the old guard, making the test prove nothing.
+	t.Chdir(t.TempDir())
+	handle, _, err := Open(" ", " ")
+	if err != nil {
+		t.Fatalf("a whitespace-only path was rejected as missing: %v", err)
+	}
+	defer handle.Close()
+	if _, err := os.Stat(" "); err != nil {
+		t.Errorf("the whitespace-only directory was not created as spelled: %v", err)
+	}
+}
+
+// prefix and suffix are name fragments. A separator or traversal in either must
+// be refused, or the file lands outside dir and (for a suffix erasing the random
+// component) loses the O_EXCL unpredictability it depends on.
+func TestCreateTempRejectsPathFragmentsThatEscapeTheDir(t *testing.T) {
+	base := t.TempDir()
+	inside := filepath.Join(base, "inside")
+	if err := os.MkdirAll(inside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// root is base, dir is the subdirectory: a "../escaped" fragment lands in
+	// base — still inside the os.Root, so os.Root does NOT catch it — but outside
+	// the dir CreateTemp promised. This is the case the reviewers reproduced.
+	handle, relative, err := Open(base, inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+	cases := []struct{ prefix, suffix string }{
+		{"../escaped", ".tmp"},
+		{`..\sibling`, ".tmp"},
+		{"note", ".tmp/../evil"},
+		{"note", ".."},
+		{"..", ".tmp"},
+	}
+	for _, c := range cases {
+		if _, _, err := CreateTemp(handle, relative, c.prefix, c.suffix); !errors.Is(err, ErrEscapes) {
+			t.Errorf("CreateTemp(prefix=%q, suffix=%q) = %v, want ErrEscapes", c.prefix, c.suffix, err)
+		}
+	}
+	// Nothing may have leaked into base above the promised dir.
+	entries, _ := os.ReadDir(base)
+	for _, entry := range entries {
+		if entry.Name() != "inside" {
+			t.Errorf("a temp fragment escaped into the parent: %q", entry.Name())
+		}
+	}
+}
+
+// A junction named with a trailing separator must still be refused. On Windows
+// os.Root.Lstat resolves the terminal component when the name ends in a
+// separator, so without trimming it the link is stat'd as its target and waved
+// through.
+func TestRefuseReparseCatchesALinkNamedWithATrailingSeparator(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "target")
+	inside := filepath.Join(base, "inside")
+	for _, dir := range []string{target, inside} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkDir(t, target, filepath.Join(inside, "linked"))
+	handle, relative, err := Open(inside, inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+	name := filepath.Join(relative, "linked") + string(filepath.Separator)
+	if err := RefuseReparse(handle, name); !errors.Is(err, ErrReparse) {
+		t.Fatalf("RefuseReparse(%q) = %v, want ErrReparse", name, err)
+	}
+}
+
+// The O_EXCL retry is the branch that protects an existing file, and a real
+// random source will not collide on demand — so force it. The first two draws
+// return the same bytes: the name is pre-created, CreateTemp must refuse to
+// reuse it, leave its contents alone, and come back with a different name.
+func TestCreateTempRetriesWithoutClobberingAnExistingName(t *testing.T) {
+	base := t.TempDir()
+	handle, relative, err := Open(base, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+
+	draws := [][]byte{
+		{1, 1, 1, 1, 1, 1, 1, 1}, // collides with the pre-created file
+		{1, 1, 1, 1, 1, 1, 1, 1}, // and again, so the retry must keep trying
+		{2, 2, 2, 2, 2, 2, 2, 2}, // finally a free name
+	}
+	previous := randomBytes
+	t.Cleanup(func() { randomBytes = previous })
+	call := 0
+	randomBytes = func(b []byte) (int, error) {
+		copy(b, draws[min(call, len(draws)-1)])
+		call++
+		return len(b), nil
+	}
+
+	taken := filepath.Join(base, "note."+hex.EncodeToString(draws[0])+".tmp")
+	if err := os.WriteFile(taken, []byte("do not clobber me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	file, name, err := CreateTemp(handle, relative, "note", ".tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	if filepath.Base(name) == filepath.Base(taken) {
+		t.Fatalf("CreateTemp returned the name that was already taken (%q), so O_EXCL did not protect it", name)
+	}
+	kept, err := os.ReadFile(taken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(kept) != "do not clobber me" {
+		t.Errorf("the pre-existing file was overwritten: %q", kept)
+	}
+	if call < 2 {
+		t.Errorf("the random source was drawn %d time(s); the collision path never ran", call)
+	}
+}
+
+// On unix a backslash is an ordinary filename character, not a separator, so a
+// link genuinely named `linked\` must still be refused. Trimming backslashes
+// unconditionally would inspect "linked" instead and report "not a link" for one
+// that is.
+func TestRefuseReparseKeepsABackslashInAUnixName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip(`backslash is a separator on Windows, so this name is not expressible there`)
+	}
+	base := t.TempDir()
+	target := filepath.Join(base, "target")
+	inside := filepath.Join(base, "inside")
+	for _, dir := range []string{target, inside} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkDir(t, target, filepath.Join(inside, `linked\`))
+
+	handle, relative, err := Open(inside, inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+
+	name := filepath.Join(relative, `linked\`)
+	if err := RefuseReparse(handle, name); !errors.Is(err, ErrReparse) {
+		t.Fatalf("RefuseReparse(%q) = %v, want ErrReparse — the backslash is part of the name here, not a separator", name, err)
+	}
+}

--- a/internal/worktrees/run_git_test.go
+++ b/internal/worktrees/run_git_test.go
@@ -1,0 +1,97 @@
+package worktrees
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// The constructor every git call goes through must carry the hardening, so a
+// future call site cannot get an unhardened command by using it.
+func TestTheGitConstructorHardens(t *testing.T) {
+	command := newHardenedCommand(context.Background(), t.TempDir(), "git", "status")
+	if command.WaitDelay == 0 {
+		t.Fatal("WaitDelay is unset; a cancelled git can block Wait indefinitely")
+	}
+	if command.Dir == "" {
+		t.Fatal("the working directory was dropped")
+	}
+	// The process-group half is POSIX-only and is asserted in
+	// run_git_unix_test.go, which can name Setpgid at all — this file must
+	// compile on Windows, where it does not exist.
+	if runtime.GOOS != "windows" && command.Cancel == nil {
+		t.Fatal("Cancel is unset; the process group is never signalled")
+	}
+}
+
+// ...and the git runner itself still works, so the hardening did not break the
+// ordinary path.
+func TestHardenedGitStillRuns(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("no git: %v", err)
+	}
+	result, err := defaultRunGit(context.Background(), t.TempDir(), "--version")
+	if err != nil {
+		t.Fatalf("git --version: %v", err)
+	}
+	if result.ExitCode != 0 || result.Stdout == "" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+// EXACTLY ONE PLACE BUILDS A SUBPROCESS IN THIS PACKAGE.
+//
+// Every behavioural test above goes through newHardenedCommand, so all of them
+// pass against a defaultRunGit that quietly builds its own unhardened command —
+// which is the wiring gap this feature has produced five times, and the only one
+// no runtime assertion here can reach: defaultRunGit returns a result, not the
+// command it used.
+//
+// So the invariant is enforced at the SOURCE. This is the small, local form of
+// the AST enforcement the repo-wide hardening sweep would need, applied to the
+// one package a plan reaches.
+func TestOnlyTheHardenedConstructorBuildsSubprocesses(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	offenders := []string{}
+	checked := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		raw, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		checked++
+		for index, line := range strings.Split(string(raw), "\n") {
+			if !strings.Contains(line, "exec.Command") {
+				continue
+			}
+			// The one permitted site is inside newHardenedCommand, which
+			// hardens what it builds.
+			if name == "worktrees.go" && strings.Contains(line, "exec.CommandContext(ctx, name, args...)") {
+				continue
+			}
+			offenders = append(offenders, fmt.Sprintf("%s:%d: %s", name, index+1, strings.TrimSpace(line)))
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no source files were scanned; this test checked nothing")
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("a subprocess is built outside newHardenedCommand, so it is not hardened:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/worktrees/run_git_unix.go
+++ b/internal/worktrees/run_git_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package worktrees
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// worktreeWaitDelay bounds how long Wait blocks for the child's stdout/stderr
+// pipes to drain after the process exits or its context is cancelled, so a
+// leaked grandchild cannot hang the parent past cancel/timeout. Var (not const)
+// so tests can shorten it.
+var worktreeWaitDelay = 2 * time.Second
+
+// hardenWorktreeGit makes a git subprocess killable as a single unit. Setpgid
+// puts the child into its own process group, so on cancel/timeout we signal the
+// whole group (negative pid) — any long-running git subprocess dies with it
+// instead of being orphaned. WaitDelay is the backstop if a grandchild still
+// holds a pipe after the group is killed. Must be called before command.Run.
+func hardenWorktreeGit(command *exec.Cmd) {
+	if command.SysProcAttr == nil {
+		command.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	command.SysProcAttr.Setpgid = true
+	command.WaitDelay = worktreeWaitDelay
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return nil
+		}
+		// Negative pid targets the whole process group led by the child.
+		if err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		return nil
+	}
+}

--- a/internal/worktrees/run_git_unix_test.go
+++ b/internal/worktrees/run_git_unix_test.go
@@ -1,0 +1,120 @@
+//go:build !windows
+
+package worktrees
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// THE HARDENING HAS TO WORK, not merely be configured.
+//
+// A leaked grandchild holding the pipes is what makes an unhardened cancel hang:
+// CommandContext signals the direct child, Wait blocks until the pipes reach
+// EOF, and the grandchild holds them open. So this launches exactly that shape —
+// a shell that spawns a long sleeper inheriting stdout — cancels, and requires
+// the call to return.
+//
+// It goes through newHardenedCommand, the constructor defaultRunGit uses. A test
+// calling hardenWorktreeGit directly would prove three fields are set and prove
+// nothing about whether anything calls it.
+// TestTheGitConstructorSetsAProcessGroup is the POSIX half of the constructor
+// assertion; the portable half lives in run_git_test.go.
+func TestTheGitConstructorSetsAProcessGroup(t *testing.T) {
+	command := newHardenedCommand(context.Background(), t.TempDir(), "git", "status")
+	if command.SysProcAttr == nil || !command.SysProcAttr.Setpgid {
+		t.Fatal("Setpgid is unset; a cancel signals only the direct child")
+	}
+	if command.Cancel == nil {
+		t.Fatal("Cancel is unset; the process group is never signalled")
+	}
+}
+
+func TestACancelledCommandKillsTheWholeProcessGroup(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("no shell: %v", err)
+	}
+	previous := worktreeWaitDelay
+	worktreeWaitDelay = 500 * time.Millisecond
+	t.Cleanup(func() { worktreeWaitDelay = previous })
+
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "grandchild.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// A grandchild that outlives its parent shell and inherits stdout — the
+	// exact shape that hangs an unhardened Wait AND survives a kill aimed at
+	// the direct child only.
+	// pidFile is passed as a positional argument ($1), not interpolated into the
+	// script, so a temp path containing a space or shell metacharacter cannot
+	// break or reshape the command.
+	script := `sleep 60 & echo $! > "$1"; sleep 60`
+	command := newHardenedCommand(ctx, dir, "sh", "-c", script, "sh", pidFile)
+	var sink discardWriter
+	command.Stdout = &sink
+	command.Stderr = &sink
+	if err := command.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Wait for the grandchild to exist before cancelling, or the test proves
+	// nothing about what happens to it.
+	var grandchild int
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(pidFile)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(raw))); convErr == nil && pid > 0 {
+				grandchild = pid
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if grandchild == 0 {
+		// The command is already running; clean it up before failing rather than
+		// leaking the shell and its grandchild. A missed pid is a failure of the
+		// setup this test depends on, not a reason to silently skip the assertion.
+		cancel()
+		_ = command.Wait()
+		t.Fatal("the grandchild never reported its pid")
+	}
+
+	cancel()
+
+	// FIRST: the call must return. An unhardened Wait blocks on the pipes the
+	// grandchild holds open.
+	done := make(chan error, 1)
+	go func() { done <- command.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Wait did not return after cancel; a leaked grandchild is holding the pipes open")
+	}
+
+	// SECOND, and this is the property WaitDelay alone does not give: the
+	// grandchild must be DEAD. Returning promptly while leaving a process
+	// running is the orphan this hardening exists to prevent, and a test that
+	// only checked the return would pass against a cancel aimed at the direct
+	// child alone.
+	alive := false
+	for attempt := 0; attempt < 50; attempt++ {
+		if err := syscall.Kill(grandchild, 0); err != nil {
+			alive = false
+			break
+		}
+		alive = true
+		time.Sleep(20 * time.Millisecond)
+	}
+	if alive {
+		_ = syscall.Kill(grandchild, syscall.SIGKILL)
+		t.Fatalf("grandchild %d survived the cancel; the signal did not reach the process group", grandchild)
+	}
+}

--- a/internal/worktrees/run_git_windows.go
+++ b/internal/worktrees/run_git_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package worktrees
+
+import (
+	"os/exec"
+	"time"
+)
+
+// worktreeWaitDelay bounds how long Wait blocks for the child's stdout/stderr
+// pipes to drain after the process exits or its context is cancelled, so a
+// leaked grandchild cannot hang the parent past cancel/timeout. Var (not const)
+// so tests can shorten it.
+var worktreeWaitDelay = 2 * time.Second
+
+// hardenWorktreeGit sets WaitDelay so a leaked grandchild cannot block Wait
+// indefinitely. Windows lacks POSIX process groups; tree-killing is not wired
+// for this path, so the default Cancel (Process.Kill) plus WaitDelay is used.
+func hardenWorktreeGit(command *exec.Cmd) {
+	command.WaitDelay = worktreeWaitDelay
+}

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -740,12 +740,33 @@ func gitCommonDir(ctx context.Context, runGit GitRunner, dir string) (string, er
 	return filepath.Clean(resolved), nil
 }
 
-func defaultRunGit(ctx context.Context, dir string, args ...string) (CommandResult, error) {
-	command := exec.CommandContext(ctx, "git", args...)
+// newHardenedCommand builds a subprocess that dies as one unit on cancel.
+//
+// Extracted so a test can exercise the SAME constructor defaultRunGit uses. A
+// test that only called hardenWorktreeGit would prove the helper sets three
+// fields and prove nothing about whether anything calls it — which is the
+// wiring gap this feature has produced four times.
+func newHardenedCommand(ctx context.Context, dir string, name string, args ...string) *exec.Cmd {
+	command := exec.CommandContext(ctx, name, args...)
 	command.Dir = dir
 	// Pin C locale so English phrases callers match on (e.g. "already locked"
 	// in lockWorktree) stay parseable under localized git installs.
+	//
+	// Set HERE rather than in defaultRunGit, so every command built through this
+	// constructor is parseable, not just the one path that happened to need it
+	// first.
 	command.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	// Without this a cancelled git is signalled but its Wait can still block on
+	// pipes a grandchild holds open. git is short-lived and rarely forks, so
+	// this is a small risk — but the worktree path is now reached by a plan,
+	// and a plan can be cancelled at any moment by /plans stop or by the run
+	// ending.
+	hardenWorktreeGit(command)
+	return command
+}
+
+func defaultRunGit(ctx context.Context, dir string, args ...string) (CommandResult, error) {
+	command := newHardenedCommand(ctx, dir, "git", args...)
 	// Capture stdout and stderr separately: callers parse Stdout for values
 	// (rev-parse output) and prefer Stderr for error messages. CombinedOutput
 	// merged the two, letting git's stderr warnings pollute parsed output and


### PR DESCRIPTION
## Split 1 of 3 of #829 — the independently-reversible hardening layer

Per @anandh8x's review of #829, splitting the change into focused PRs. This is the base: the security/hardening layer, which has **no dependency on the orchestration work** and carries its own independent rollback domain. The orchestration and durable-memory work stack on top of it.

### What this contains
- **`internal/pathjail`** (new) — `os.Root` handle-relative path confinement: ancestor traversal is confined, the final component is checked for reparse points, unprivileged Windows junctions are covered, and temp files are unpredictable and exclusive. This is the path-containment primitive @anandh8x verified as correct on #829.
- **`internal/credstore`** — cross-process file locking around the credential store.
- **`internal/worktrees`** — git invocation hardening.

`pathjail` has no importers in this PR by design; `internal/memory` (split 2) and `internal/specialist` (split 3) adopt it in the stacked PRs.

### On the split shape
The full seven-way split @anandh8x proposed isn't mechanically achievable as independently-building PRs: the plan subsystem is a single package whose 29 `plan_*.go` files cross-reference each other, and the zeromaxing posture reaches into the shared TUI model — so "plan core", "saved plans", "model routing" and "posture" cannot compile as separate PRs without the module-seam refactor requested separately. The feasible stack is three: **(1) this hardening layer → (2) durable memory → (3) the orchestration remainder**, which together reconstruct #829 byte-for-byte.

### Validation
- `go build ./...` clean.
- `go test ./internal/pathjail/ ./internal/credstore/ ./internal/worktrees/` — all green.
- Rebased on current `main` (`cabfeefc`).

Part of #829.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent credential-store updates from overwriting, resurrecting, or losing credentials.
  * Improved cancellation of Git operations so stalled child processes no longer delay command completion.

* **Security**
  * Strengthened filesystem protections against directory escapes and unsafe links.
  * Added safer temporary-file creation within protected storage locations.

* **Reliability**
  * Improved Git command behavior across Unix and Windows with consistent environments and bounded shutdown waits.
  * Added cross-platform safeguards for credential-store file access and replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->