### PR TITLE
docs(agents): record the normalize-before-match blocker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,14 @@ These classes drive multi-round reviews. Fix them before requesting review:
   final-component-only no-follow is insufficient. On multi-step setup, roll back
   only what this run created; never destroy pre-existing resources you did
   not create; never report success when cleanup or unlock failed.
+- **Normalize before matching:** Any transform that REMOVES bytes without
+  leaving a gap is also a reassembler, so it has to run before whatever matches
+  on the result. Redacting by shape and then stripping control bytes lets a
+  credential split by a NUL, an ESC or a C1 byte pass the patterns as two
+  fragments and be rejoined on the way out; comparing a path against a form
+  produced by the same resolver the kernel just used makes a redirect agree with
+  itself. Strip, decode, or canonicalize first, then match. The unsplit value
+  passing is not evidence, so the test needs a split case.
 - **Atomic shared state:** Write a complete temporary file, then atomically
   replace the destination so concurrent readers never see a partial write.
   Exclusive create or a write lock alone is not enough for readers. Serialize


### PR DESCRIPTION
Adds one bullet to section 4, Common Review Blockers.

Three changes hit this class in a fortnight, each written by someone who was being careful about precisely the thing that caught them, which is why it seems worth writing down rather than catching a fourth time in review.

**The rule:** a transform that removes bytes without leaving a gap is also a reassembler, so it has to run before whatever matches on the result.

It showed up in two shapes.

*Redaction ordering.* Secrets are matched by shape, so a credential split by a NUL, an ESC or a C1 byte does not look like a key. Strip the control bytes afterwards and the fragments become the credential again, on the way to a transcript line or a picker row. That was #835 (an MCP failure reason) and #878 (the imported-transcript chokepoint). In both cases the unsplit value redacted correctly, which is exactly why it survived review: every test used unsplit values.

*Path comparison.* Asking where a handle landed and comparing it against a value produced by the same resolver the kernel just used means the two agree precisely when a redirect happened. That was #808, where junctions were rejected only by an accident of Go's mode bits (a junction is `ModeIrregular`, not `ModeSymlink`, so `EvalSymlinks` declines it) and directory symlinks were not rejected at all.

The last sentence of the bullet is the part I would keep if only one survived: **the unsplit value passing is not evidence.** That is what made this invisible three times.

No code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security review guidance requiring byte-removing transformations to occur before matching.
  * Documented protections against encoding, canonicalization, path normalization, and split-credential bypasses.
  * Added guidance for regression tests covering split-input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->