### PR TITLE
fix: bump Go to 1.26.6 for stdlib vulnerability fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Gitlawb/zero
 
-go 1.26.5
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
`make vulncheck` is currently failing on every open PR, with no code change behind it. `govulncheck` reads the live database, so six stdlib advisories landed and immediately turned the check red repo-wide.

```
GO-2026-6218  net/url          quadratic complexity in resolvePath
GO-2026-6090  crypto/tls       unbounded post-handshake messages
GO-2026-6089  net/http         ReadHeaderTimeout skipped on the h2c check
GO-2026-6088  encoding/xml     no recursion depth guard on decode
GO-2026-5972  encoding/asn1    no maximum recursion depth
GO-2026-5026  x/net/idna       ASCII-only punycode labels not rejected
```

All six are fixed in Go 1.26.6. We are on 1.26.5, so this bumps the `go` directive, same as #607 did for GO-2026-5856.

This is worth landing ahead of everything else in flight: `vulncheck` is the first step of both `Security & code health` and `Smoke (windows-latest)`, so it short-circuits the job before lint, vet, test and the binary smoke ever run. Right now those two required checks are red on every PR and are telling us nothing about the code in them.

Verified with the pinned `govulncheck@v1.3.0` in a clean worktree: 1.26.5 reports all six and exits 1, 1.26.6 reports none and exits 0.

The README and docs/INSTALL.md still say "Go 1.26.5+". Left alone here to keep this to the one line that unblocks CI, happy to follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go language version to 1.26.6 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->