### PR TITLE
chore: bump go directive to 1.26.6 for stdlib security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Gitlawb/zero
 
-go 1.26.5
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
## Summary
`make vulncheck` is failing on open PRs. It is not caused by any of their
changes: govulncheck reports six Go standard-library vulnerabilities against
`go1.26.5`, all fixed in `go1.26.6`. They were published after main's last
green run (the scheduled run at 2026-08-14T03:41 passed), so every branch
now fails the gate and main will too on its next run.

CI resolves its toolchain with `go-version-file: go.mod`, so bumping the
directive is the entire fix. No source changes.

## Changes
- `go.mod`: `go 1.26.5` → `go 1.26.6`.

## Vulnerabilities cleared
| ID | Package | Issue |
|---|---|---|
| GO-2026-6218 | net/url | quadratic complexity in `resolvePath` |
| GO-2026-6090 | crypto/tls | unbounded post-handshake messages |
| GO-2026-6089 | net/http | `ReadHeaderTimeout` not applied to the h2c check |
| GO-2026-6088 | encoding/xml | |
| GO-2026-5972 | encoding/asn1 | |
| GO-2026-5026 | net/http | |

Reachable traces the scanner flagged included
`internal/tools/web_search.go`, `internal/mcp/network_client.go`,
`internal/mcp/oauth.go`, `internal/daemon/protocol.go`, and
`internal/daemon/remote/client.go`.

## Test plan
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...` — **No
  vulnerabilities found** (was 6).
- [x] `go test ./...` — the failures on my Windows box (`fork/exec ...
  Access is denied`, `TempDir RemoveAll cleanup`) reproduce identically on
  unmodified main, so they are local environment issues, not this change.
  CI is the real signal here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go language version to 1.26.6 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->