### PR TITLE
feat(acp): add standard session list and resume

### DIFF
--- a/docs/HOW_ZERO_WORKS.md
+++ b/docs/HOW_ZERO_WORKS.md
@@ -302,8 +302,9 @@ Conceptually, one requested tool goes through these phases:
    the model can inspect it and decide what to do next.
 6. **Render and persist** — the result is surfaced to the TUI, stream-JSON
    writer, or ACP client. TUI and exec record rich tool/session events for
-   resume/history; ACP currently persists conversational messages and streams
-   tool/permission updates to the client.
+   resume/history; ACP persists conversational messages and completed tool-call
+   starts/results for load replay. Live streaming details and permission
+   exchanges remain client notifications rather than durable history.
 
 Tool success and failure are both informative context. A successful `read_file`
 result gives the model file contents; a failed `edit_file` result gives the model

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -203,7 +203,7 @@ func (a *Agent) handleSessionNew(ctx context.Context, params json.RawMessage) (a
 	if err != nil {
 		return nil, RPCError(codeInternalError, "create session: "+err.Error())
 	}
-	sess := a.registerSession(meta.SessionID, root, nil, model, models, restrictModels)
+	sess, _ := a.registerSession(meta.SessionID, root, nil, model, models, restrictModels)
 	return NewSessionResult{
 		SessionID:     sess.id,
 		ConfigOptions: a.configOptions(sess),
@@ -309,7 +309,13 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 			models = append(models, SessionConfigOptionValue{Value: persistedModel, Name: persistedModel})
 		}
 	}
-	sess := a.registerSession(meta.SessionID, root, history, model, models, restrictModels)
+	sess, existed := a.registerSession(meta.SessionID, root, history, model, models, restrictModels)
+	if existed {
+		_, messages, historyWarning, historyErr = a.refreshSessionHistory(sess)
+		if operation == persistedSessionResume && historyErr != nil {
+			return nil, RPCError(codeInternalError, "restore session history: "+historyErr.Error())
+		}
+	}
 	note := &notifier{conn: a.conn, sessionID: sess.id}
 	if operation == persistedSessionLoad && historyErr == nil {
 		for _, message := range messages {
@@ -325,12 +331,14 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 		"rehydrate session compaction",
 		"Could not apply session compaction. Raw session history was restored instead.",
 		historyWarning,
+		operation == persistedSessionLoad,
 	)
 	a.warnPersistence(
 		note,
 		"load session history",
 		"Could not load session history. The session is open, but earlier turns may be missing until storage recovers.",
 		historyErr,
+		operation == persistedSessionLoad,
 	)
 	return LoadSessionResult{
 		ConfigOptions: a.configOptions(sess),
@@ -488,10 +496,16 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 			note.text("\n\n[zero warning] " + text + "\n")
 		}
 	}
-	// Persist the user message before the agent can emit tool callbacks. Tool
-	// starts and results are appended synchronously from those callbacks, so the
-	// durable log has the same order the client observed and an interrupted call
-	// remains visible after a fresh-process load.
+	// Buffer the complete turn until RunAgent has a valid ACP outcome. A hard run
+	// failure is an aborted turn: neither live history nor durable history may
+	// retain its user/tool prefix under an RPC error. StopCancelled is a valid
+	// outcome and commits through the same boundary below.
+	pendingEvents := make([]sessions.AppendEventInput, 0, 4)
+	queue := func(input sessions.AppendEventInput) {
+		pendingEvents = append(pendingEvents, input)
+	}
+	queue(messageEvent("user", userText))
+
 	var persistenceErr error
 	persistenceFailed := false
 	persist := func(input sessions.AppendEventInput) {
@@ -503,8 +517,6 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 			persistenceFailed = true
 		}
 	}
-	persist(messageEvent("user", userText))
-
 	opts := agent.Options{
 		Cwd:            sess.cwd,
 		SessionID:      sess.id,
@@ -519,11 +531,11 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 		OnText:         note.text,
 		OnReasoning:    note.thought,
 		OnToolCall: func(call agent.ToolCall) {
-			persist(toolCallEvent(call))
+			queue(toolCallEvent(call))
 			note.toolCall(call)
 		},
 		OnToolResult: func(result agent.ToolResult) {
-			persist(toolResultEvent(result))
+			queue(toolResultEvent(result))
 			note.toolResult(result)
 			if result.Name == "update_plan" {
 				a.emitPlan(registry, note)
@@ -537,7 +549,14 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 	agentPrompt := buildPrompt(sess.snapshotHistory(), userText)
 	result, runErr := a.deps.RunAgent(ctx, agentPrompt, provider, opts)
 	if result.FinalAnswer != "" {
-		persist(messageEvent("assistant", result.FinalAnswer))
+		queue(messageEvent("assistant", result.FinalAnswer))
+	}
+	reason, stopErr := stopReasonFor(result, runErr)
+	if stopErr != nil {
+		return "", RPCError(codeInternalError, stopErr.Error())
+	}
+	for _, event := range pendingEvents {
+		persist(event)
 	}
 	sess.appendHistory(turnRecord{user: userText, assistant: result.FinalAnswer})
 	a.warnPersistence(
@@ -545,12 +564,8 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 		"save session history",
 		"Could not save session history. This turn is available in memory, but future resume may miss it until storage recovers.",
 		persistenceErr,
+		true,
 	)
-
-	reason, stopErr := stopReasonFor(result, runErr)
-	if stopErr != nil {
-		return "", RPCError(codeInternalError, stopErr.Error())
-	}
 	return reason, nil
 }
 
@@ -1053,7 +1068,7 @@ func replayMessageID(eventID string) string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
-func (a *Agent) warnPersistence(note *notifier, action string, message string, err error) {
+func (a *Agent) warnPersistence(note *notifier, action string, message string, err error, notify bool) {
 	if err == nil {
 		return
 	}
@@ -1062,7 +1077,7 @@ func (a *Agent) warnPersistence(note *notifier, action string, message string, e
 		sessionID = note.sessionID
 	}
 	log.Printf("zero acp: failed to %s for session %s: %v", action, sessionID, err)
-	if note != nil {
+	if note != nil && notify {
 		note.text("\n\n[zero warning] " + message + "\n")
 	}
 }
@@ -1109,18 +1124,34 @@ func promptImages(blocks []ContentBlock) []zeroruntime.ImageBlock {
 
 // registerSession publishes a session under the agent's lock. If one is already
 // registered for id (e.g. a re-load of an in-flight session) the existing live
-// session is returned unchanged rather than orphaning its turn or resetting its
-// mode/model. history is set BEFORE publishing so no concurrent prompt can read a
-// half-initialized session.
-func (a *Agent) registerSession(id, cwd string, history []turnRecord, model string, models []SessionConfigOptionValue, restrictModels bool) *acpSession {
+// session is returned rather than orphaning its turn or resetting its mode/model.
+// The bool reports that case so persisted activation can re-read and apply disk
+// history under turnMu. history is set BEFORE first publication so no concurrent
+// prompt can read a half-initialized session.
+func (a *Agent) registerSession(id, cwd string, history []turnRecord, model string, models []SessionConfigOptionValue, restrictModels bool) (*acpSession, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if existing := a.sessions[id]; existing != nil {
-		return existing
+		return existing, true
 	}
 	sess := &acpSession{id: id, cwd: cwd, mode: agent.PermissionModeAuto, model: model, models: models, restrictModels: restrictModels, history: history}
 	a.sessions[id] = sess
-	return sess
+	return sess, false
+}
+
+// refreshSessionHistory is the activation apply boundary for an already-live
+// session. The history is read while prompts are excluded, then applied to the
+// same object the prompt path uses. Re-reading here avoids overwriting a turn
+// that committed between activatePersistedSession's pre-publication read and
+// discovering that another activation had already registered the session.
+func (a *Agent) refreshSessionHistory(sess *acpSession) ([]turnRecord, []persistedMessage, error, error) {
+	sess.turnMu.Lock()
+	defer sess.turnMu.Unlock()
+	history, messages, warning, err := a.loadHistory(sess.id)
+	if err == nil {
+		sess.setHistory(history)
+	}
+	return history, messages, warning, err
 }
 
 func (a *Agent) session(id string) *acpSession {
@@ -1200,6 +1231,12 @@ func (s *acpSession) configState() (string, []SessionConfigOptionValue, agent.Pe
 func (s *acpSession) appendHistory(rec turnRecord) {
 	s.mu.Lock()
 	s.history = append(s.history, rec)
+	s.mu.Unlock()
+}
+
+func (s *acpSession) setHistory(history []turnRecord) {
+	s.mu.Lock()
+	s.history = append([]turnRecord(nil), history...)
 	s.mu.Unlock()
 }
 

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 
@@ -220,7 +221,7 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	// ACP session cwd is immutable. Loading history under a different root
 	// would give a conversation from one workspace access to another
 	// workspace's configuration, files, and tools.
-	if root != persistedRoot {
+	if !sameWorkspace(root, persistedRoot) {
 		return nil, RPCError(codeInvalidParams, "session cwd does not match its persisted workspace")
 	}
 	// Load history BEFORE publishing the session so no concurrent prompt observes
@@ -282,7 +283,7 @@ func (a *Agent) handleSessionList(_ context.Context, params json.RawMessage) (an
 	for _, item := range items {
 		if cwd != "" {
 			itemRoot, err := a.deps.ResolveWorkspaceRoot(item.Cwd)
-			if err != nil || itemRoot != cwd {
+			if err != nil || !sameWorkspace(itemRoot, cwd) {
 				continue
 			}
 		}
@@ -920,4 +921,38 @@ func (s *acpSession) snapshotHistory() []turnRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]turnRecord(nil), s.history...)
+}
+
+// sameWorkspace reports whether two resolved roots name the same directory.
+//
+// STRING EQUALITY IS NOT DIRECTORY IDENTITY. ResolveWorkspaceRoot is abs plus
+// filepath.Clean plus a stat: it does not fold case and does not resolve
+// junctions, so one directory reached by two spellings produces two different
+// roots. A session persisted from the TUI was then unresumable from an editor
+// holding a different spelling of the same project folder, and session/list
+// filtered by the other spelling returned nothing — not a failed resume but an
+// invisible one, on exactly the case this feature exists for.
+//
+// filepath.EvalSymlinks is NOT the fix on Windows: it normalises a drive letter
+// but returns a junction path unchanged, so the alias survives it. Junctions need
+// no privilege, so this is ordinary rather than exotic. os.SameFile compares the
+// filesystem's own identity for the two directories, which is the question being
+// asked.
+//
+// The string comparison stays as the fast path, and a stat failure falls back to
+// it rather than widening the match — this gate refuses access to another
+// workspace's files and configuration, so an unanswerable comparison denies.
+func sameWorkspace(left, right string) bool {
+	if left == right {
+		return true
+	}
+	leftInfo, err := os.Stat(left)
+	if err != nil {
+		return false
+	}
+	rightInfo, err := os.Stat(right)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(leftInfo, rightInfo)
 }

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -272,6 +272,20 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	// a half-initialized session (registerSession sets history under the lock and
 	// reuses an already-live session rather than orphaning its in-flight turn).
 	history, messages, historyErr := a.loadHistory(meta.SessionID)
+	// RESUME PROMISES RESTORED CONTEXT, SO A FAILED RESTORATION IS A FAILED
+	// RESUME. historyErr used to do nothing but suppress replay and raise a
+	// warning: the session was registered and reported ready regardless, so a
+	// corrupt record or an unreadable events file left the caller holding a live,
+	// promptable session ID whose next prompt ran as a brand-new conversation
+	// under the old identity. Nothing in the response said so.
+	//
+	// Publication is now gated on restoration for resume. LOAD keeps the
+	// best-effort policy deliberately rather than by inheriting this helper: it
+	// replays what it has and warns about the rest, which is the right trade for
+	// a client rebuilding a transcript it can still scroll. Reported by @jatmn.
+	if !replay && historyErr != nil {
+		return nil, RPCError(codeInternalError, "restore session history: "+historyErr.Error())
+	}
 	model, models, restrictModels, err := a.resolveModelChoices(ctx, root)
 	if err != nil {
 		return nil, RPCError(codeInternalError, "config: "+err.Error())
@@ -286,6 +300,10 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	note := &notifier{conn: a.conn, sessionID: sess.id}
 	if replay && historyErr == nil {
 		for _, message := range messages {
+			if message.tool != nil {
+				note.send(*message.tool)
+				continue
+			}
 			note.send(replayMessageChunk(message.role, replayMessageID(message.eventID), message.content))
 		}
 	}
@@ -771,17 +789,40 @@ func (a *Agent) persistTurn(sess *acpSession, user, assistant string) error {
 	return err
 }
 
+// persistedMessage is one entry of the restored transcript in stored order. It
+// is either a message (role/content) or a tool-call notification (tool), never
+// both: keeping them in ONE ordered slice is what preserves the interleaving a
+// client needs to redraw the conversation as it originally happened.
 type persistedMessage struct {
 	eventID string
 	role    string
 	content string
+	// tool is set for a replayed tool call or its result, and is already in wire
+	// shape — it comes from the same toolCallStart/toolCallResult mapping the
+	// live turn uses, so a replayed tool call renders identically to a fresh one
+	// and there is no second mapping to drift out of sync.
+	tool *ToolCallUpdate
 }
 
 func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage, error) {
 	if a.deps.Store == nil {
 		return nil, nil, nil
 	}
-	events, err := a.deps.Store.ReadEvents(sessionID)
+	// THE EFFECTIVE CONVERSATION, NOT THE RAW LOG. A compacted session keeps its
+	// original prefix on disk alongside an EventCompaction that names the events
+	// it replaced and carries their durable summary. ReadEvents hands back both,
+	// so restoring from it replayed superseded turns AND dropped the summary that
+	// replaced them — resume then seeded the next turn with context the
+	// conversation had already moved past, and load visibly resurrected
+	// transcript entries the user had seen compacted away.
+	//
+	// ReadRehydratedEvents is the projection the TUI and exec paths already use
+	// (internal/tui/session.go, internal/sessions/exec_session.go), so all three
+	// now agree on what the conversation IS. Switching readers alone is not
+	// enough: rehydration substitutes the compaction event in place of the events
+	// it replaced, so a loop that skips everything but EventMessage would drop the
+	// summary exactly as before. It is projected below. Reported by @jatmn.
+	events, err := a.deps.Store.ReadRehydratedEvents(sessionID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -790,6 +831,47 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage,
 	var pendingUser string
 	havePending := false
 	for _, e := range events {
+		if e.Type == sessions.EventCompaction {
+			// The summary stands in for the turns it replaced, so it enters the
+			// history as an assistant message: it is prior context the next turn
+			// must see, and the wire has no separate role for it.
+			raw, marshalErr := json.Marshal(e.Payload)
+			if marshalErr != nil {
+				continue
+			}
+			var payload struct {
+				Summary string `json:"summary"`
+			}
+			if json.Unmarshal(raw, &payload) != nil || strings.TrimSpace(payload.Summary) == "" {
+				continue
+			}
+			messages = append(messages, persistedMessage{
+				eventID: persistedMessageIdentity(sessionID, e),
+				role:    "assistant",
+				content: payload.Summary,
+			})
+			records = append(records, turnRecord{user: pendingUser, assistant: payload.Summary})
+			pendingUser = ""
+			havePending = false
+			continue
+		}
+		// TOOL ACTIVITY IS PART OF THE TRANSCRIPT, NOT DECORATION. A restored
+		// conversation that shows only the prose reads as if the agent asserted
+		// its edits and command output from nowhere: the user sees "I updated
+		// scope.go" with no record that any tool ran. These are collected for
+		// replay only. They deliberately do NOT enter turnRecord, so the prompt
+		// context a resumed turn receives stays byte-identical to what it was —
+		// load and resume continue to consume the SAME effective history, and
+		// only the wire rendering differs. Reported by @jatmn.
+		if e.Type == sessions.EventToolCall || e.Type == sessions.EventToolResult {
+			if upd := replayToolUpdate(e); upd != nil {
+				messages = append(messages, persistedMessage{
+					eventID: persistedMessageIdentity(sessionID, e),
+					tool:    upd,
+				})
+			}
+			continue
+		}
 		if e.Type != sessions.EventMessage {
 			continue
 		}
@@ -823,6 +905,55 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage,
 		records = append(records, turnRecord{user: pendingUser})
 	}
 	return records, messages, nil
+}
+
+// replayToolUpdate rebuilds the ACP notification for one stored tool event.
+//
+// The stored toolCallId is reused verbatim rather than re-derived, because the
+// client pairs a result with its call by that id alone; minting a new one would
+// replay the result as an orphan update against a call the client never saw.
+// Older records wrote the field as "id", so both spellings are accepted — the
+// TUI projection already does the same (internal/tui/session.go).
+//
+// A record that carries no usable id is skipped rather than replayed under a
+// synthesized one: an unpairable update is worse than a missing row.
+func replayToolUpdate(event sessions.Event) *ToolCallUpdate {
+	raw, err := json.Marshal(event.Payload)
+	if err != nil {
+		return nil
+	}
+	var payload struct {
+		Name       string `json:"name"`
+		ToolCallID string `json:"toolCallId"`
+		ID         string `json:"id"`
+		Arguments  string `json:"arguments"`
+		Status     string `json:"status"`
+		Output     string `json:"output"`
+	}
+	if json.Unmarshal(raw, &payload) != nil {
+		return nil
+	}
+	id := payload.ToolCallID
+	if id == "" {
+		id = payload.ID
+	}
+	if id == "" {
+		return nil
+	}
+	if event.Type == sessions.EventToolCall {
+		upd := toolCallStart(agent.ToolCall{ID: id, Name: payload.Name, Arguments: payload.Arguments})
+		// The call already ran; replaying it as in_progress would leave a
+		// permanently spinning row when no result event follows it (a session
+		// killed mid-call). Its own result event supplies the real outcome.
+		upd.Status = ToolStatusCompleted
+		return &upd
+	}
+	status := tools.Status(payload.Status)
+	if status == "" {
+		status = tools.StatusOK
+	}
+	upd := toolCallResult(agent.ToolResult{ToolCallID: id, Name: payload.Name, Status: status, Output: payload.Output})
+	return &upd
 }
 
 func persistedMessageIdentity(sessionID string, event sessions.Event) string {

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -469,6 +469,15 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 			note.text("\n\n[zero warning] " + text + "\n")
 		}
 	}
+	// Persist the user message before the agent can emit tool callbacks. Tool
+	// starts and results are appended synchronously from those callbacks, so the
+	// durable log has the same order the client observed and an interrupted call
+	// remains visible after a fresh-process load.
+	var persistenceErr error
+	persist := func(input sessions.AppendEventInput) {
+		persistenceErr = errors.Join(persistenceErr, a.persistEvent(sess.id, input))
+	}
+	persist(messageEvent("user", userText))
 
 	opts := agent.Options{
 		Cwd:            sess.cwd,
@@ -483,8 +492,12 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 		Images:         images,
 		OnText:         note.text,
 		OnReasoning:    note.thought,
-		OnToolCall:     note.toolCall,
+		OnToolCall: func(call agent.ToolCall) {
+			persist(toolCallEvent(call))
+			note.toolCall(call)
+		},
 		OnToolResult: func(result agent.ToolResult) {
+			persist(toolResultEvent(result))
 			note.toolResult(result)
 			if result.Name == "update_plan" {
 				a.emitPlan(registry, note)
@@ -497,18 +510,20 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 
 	agentPrompt := buildPrompt(sess.snapshotHistory(), userText)
 	result, runErr := a.deps.RunAgent(ctx, agentPrompt, provider, opts)
+	if result.FinalAnswer != "" {
+		persist(messageEvent("assistant", result.FinalAnswer))
+	}
+	sess.appendHistory(turnRecord{user: userText, assistant: result.FinalAnswer})
+	a.warnPersistence(
+		note,
+		"save session history",
+		"Could not save session history. This turn is available in memory, but future resume may miss it until storage recovers.",
+		persistenceErr,
+	)
 
 	reason, stopErr := stopReasonFor(result, runErr)
 	if stopErr != nil {
 		return "", RPCError(codeInternalError, stopErr.Error())
-	}
-	if err := a.persistTurn(sess, userText, result.FinalAnswer); err != nil {
-		a.warnPersistence(
-			note,
-			"save session history",
-			"Could not save session history. This turn is available in memory, but future resume may miss it until storage recovers.",
-			err,
-		)
 	}
 	return reason, nil
 }
@@ -768,25 +783,43 @@ func (a *Agent) configOptions(s *acpSession) []SessionConfigOption {
 
 // ---- persistence + continuity ----
 
-func (a *Agent) persistTurn(sess *acpSession, user, assistant string) error {
-	defer sess.appendHistory(turnRecord{user: user, assistant: assistant})
+func (a *Agent) persistEvent(sessionID string, input sessions.AppendEventInput) error {
 	if a.deps.Store == nil {
 		return nil
 	}
-	events := []sessions.AppendEventInput{
-		{
-			Type:    sessions.EventMessage,
-			Payload: map[string]any{"role": "user", "content": user},
+	_, err := a.deps.Store.AppendEvents(sessionID, []sessions.AppendEventInput{input})
+	return err
+}
+
+func messageEvent(role, content string) sessions.AppendEventInput {
+	return sessions.AppendEventInput{
+		Type:    sessions.EventMessage,
+		Payload: map[string]any{"role": role, "content": content},
+	}
+}
+
+func toolCallEvent(call agent.ToolCall) sessions.AppendEventInput {
+	return sessions.AppendEventInput{
+		Type: sessions.EventToolCall,
+		Payload: map[string]any{
+			"toolCallId": call.ID,
+			"name":       call.Name,
+			"arguments":  call.Arguments,
 		},
 	}
-	if assistant != "" {
-		events = append(events, sessions.AppendEventInput{
-			Type:    sessions.EventMessage,
-			Payload: map[string]any{"role": "assistant", "content": assistant},
-		})
+}
+
+func toolResultEvent(result agent.ToolResult) sessions.AppendEventInput {
+	return sessions.AppendEventInput{
+		Type: sessions.EventToolResult,
+		Payload: map[string]any{
+			"toolCallId":   result.ToolCallID,
+			"name":         result.Name,
+			"status":       result.Status,
+			"output":       result.Output,
+			"changedFiles": append([]string(nil), result.ChangedFiles...),
+		},
 	}
-	_, err := a.deps.Store.AppendEvents(sess.id, events)
-	return err
 }
 
 // persistedMessage is one entry of the restored transcript in stored order. It
@@ -923,12 +956,13 @@ func replayToolUpdate(event sessions.Event) *ToolCallUpdate {
 		return nil
 	}
 	var payload struct {
-		Name       string `json:"name"`
-		ToolCallID string `json:"toolCallId"`
-		ID         string `json:"id"`
-		Arguments  string `json:"arguments"`
-		Status     string `json:"status"`
-		Output     string `json:"output"`
+		Name         string   `json:"name"`
+		ToolCallID   string   `json:"toolCallId"`
+		ID           string   `json:"id"`
+		Arguments    string   `json:"arguments"`
+		Status       string   `json:"status"`
+		Output       string   `json:"output"`
+		ChangedFiles []string `json:"changedFiles"`
 	}
 	if json.Unmarshal(raw, &payload) != nil {
 		return nil
@@ -942,17 +976,19 @@ func replayToolUpdate(event sessions.Event) *ToolCallUpdate {
 	}
 	if event.Type == sessions.EventToolCall {
 		upd := toolCallStart(agent.ToolCall{ID: id, Name: payload.Name, Arguments: payload.Arguments})
-		// The call already ran; replaying it as in_progress would leave a
-		// permanently spinning row when no result event follows it (a session
-		// killed mid-call). Its own result event supplies the real outcome.
-		upd.Status = ToolStatusCompleted
 		return &upd
 	}
 	status := tools.Status(payload.Status)
 	if status == "" {
 		status = tools.StatusOK
 	}
-	upd := toolCallResult(agent.ToolResult{ToolCallID: id, Name: payload.Name, Status: status, Output: payload.Output})
+	upd := toolCallResult(agent.ToolResult{
+		ToolCallID:   id,
+		Name:         payload.Name,
+		Status:       status,
+		Output:       payload.Output,
+		ChangedFiles: append([]string(nil), payload.ChangedFiles...),
+	})
 	return &upd
 }
 

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -154,12 +154,41 @@ func (a *Agent) handleInitialize(_ context.Context, params json.RawMessage) (any
 
 // ---- session lifecycle ----
 
+// requestedWorkspace is the single rule for a cwd that arrived from the client,
+// applied before the value can reach ResolveWorkspaceRoot.
+//
+// THE REQUEST'S OWN CWD IS THE ONLY THING ALLOWED TO PICK A ROOT. Every params
+// type spells cwd as a plain string, so an absent field and an empty one decode
+// to exactly the same "", and the resolver treats "" as "use the directory this
+// process was started in" and joins a relative cwd onto it. Those two defaults
+// meet in the middle: `{"sessionId":"known"}` used to activate a persisted
+// session, and `{}` used to create one, both rooted at wherever the editor
+// happened to spawn `zero acp` — which then becomes the sandbox and file-tool
+// confinement root. The client never named that directory, so it is a root the
+// server invented, and ACP requires an absolute cwd on every method carrying
+// one. Rejecting here is what keeps a missing field from being answered with a
+// guess.
+func requestedWorkspace(cwd string) (string, error) {
+	trimmed := strings.TrimSpace(cwd)
+	if trimmed == "" {
+		return "", RPCError(codeInvalidParams, "cwd is required and must be an absolute path")
+	}
+	if !filepath.IsAbs(trimmed) {
+		return "", RPCError(codeInvalidParams, "cwd must be an absolute path: "+trimmed)
+	}
+	return trimmed, nil
+}
+
 func (a *Agent) handleSessionNew(ctx context.Context, params json.RawMessage) (any, error) {
 	var p NewSessionParams
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, RPCError(codeInvalidParams, "invalid session/new params")
 	}
-	root, err := a.deps.ResolveWorkspaceRoot(p.Cwd)
+	cwd, err := requestedWorkspace(p.Cwd)
+	if err != nil {
+		return nil, err
+	}
+	root, err := a.deps.ResolveWorkspaceRoot(cwd)
 	if err != nil {
 		return nil, RPCError(codeInvalidParams, err.Error())
 	}
@@ -200,6 +229,16 @@ func (a *Agent) handleSessionResume(ctx context.Context, params json.RawMessage)
 // history as ordered session/update notifications; session/resume deliberately
 // does not, which makes it safe for an already-rendered desktop reconnect.
 func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParams, replay bool) (any, error) {
+	// BOTH METHODS, BEFORE ANYTHING IS LOOKED UP. session/resume shares this
+	// params type with session/load, so the wire cannot tell an omitted cwd from
+	// an empty one; the blank case used to be answered with the persisted cwd,
+	// which made {"sessionId":"known"} a complete, successful activation request.
+	// Validating here rather than in one handler is what keeps the two entry
+	// points from drifting apart.
+	cwd, err := requestedWorkspace(p.Cwd)
+	if err != nil {
+		return nil, err
+	}
 	meta, err := a.deps.Store.Get(p.SessionID)
 	if err != nil || meta == nil {
 		return nil, RPCError(codeInvalidParams, "session not found: "+p.SessionID)
@@ -208,10 +247,10 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 		return nil, RPCError(codeInvalidParams, "session has no persisted workspace: "+p.SessionID)
 	}
 	// SAME RULE ON THE WAY IN. Omitting a relative entry from the listing is not
-	// enough: session/resume falls back to meta.Cwd when the client sends no cwd,
-	// so a stored "." resolved against this process's directory and bound the
-	// conversation to it — verified returning no error at all. A workspace that
-	// cannot be identified is not one this session can be restored into.
+	// enough: a stored "." still resolves against this process's directory, so a
+	// client that hands back that same directory as its cwd would be sold the
+	// invented root as a match. A workspace that cannot be identified is not one
+	// this session can be restored into.
 	if !filepath.IsAbs(meta.Cwd) {
 		return nil, RPCError(codeInvalidParams, "session workspace is not an absolute path, so it cannot be identified: "+p.SessionID)
 	}
@@ -219,11 +258,7 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	if err != nil {
 		return nil, RPCError(codeInvalidParams, "persisted session workspace is unavailable: "+err.Error())
 	}
-	cwdInput := p.Cwd
-	if strings.TrimSpace(cwdInput) == "" {
-		cwdInput = meta.Cwd
-	}
-	root, err := a.deps.ResolveWorkspaceRoot(cwdInput)
+	root, err := a.deps.ResolveWorkspaceRoot(cwd)
 	if err != nil {
 		return nil, RPCError(codeInvalidParams, err.Error())
 	}
@@ -280,10 +315,17 @@ func (a *Agent) handleSessionList(_ context.Context, params json.RawMessage) (an
 	if err != nil {
 		return nil, RPCError(codeInternalError, "list sessions: "+err.Error())
 	}
+	// The filter is the one cwd ACP leaves optional, so a blank one means "no
+	// filter" rather than an error — but a relative one is rebased onto this
+	// process's directory exactly like the others, and would then silently answer
+	// about a workspace the client never named.
 	var cwd string
 	if strings.TrimSpace(p.Cwd) != "" {
-		var err error
-		cwd, err = a.deps.ResolveWorkspaceRoot(p.Cwd)
+		filter, err := requestedWorkspace(p.Cwd)
+		if err != nil {
+			return nil, err
+		}
+		cwd, err = a.deps.ResolveWorkspaceRoot(filter)
 		if err != nil {
 			return nil, RPCError(codeInvalidParams, err.Error())
 		}

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -206,6 +207,14 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	if strings.TrimSpace(meta.Cwd) == "" {
 		return nil, RPCError(codeInvalidParams, "session has no persisted workspace: "+p.SessionID)
 	}
+	// SAME RULE ON THE WAY IN. Omitting a relative entry from the listing is not
+	// enough: session/resume falls back to meta.Cwd when the client sends no cwd,
+	// so a stored "." resolved against this process's directory and bound the
+	// conversation to it — verified returning no error at all. A workspace that
+	// cannot be identified is not one this session can be restored into.
+	if !filepath.IsAbs(meta.Cwd) {
+		return nil, RPCError(codeInvalidParams, "session workspace is not an absolute path, so it cannot be identified: "+p.SessionID)
+	}
 	persistedRoot, err := a.deps.ResolveWorkspaceRoot(meta.Cwd)
 	if err != nil {
 		return nil, RPCError(codeInvalidParams, "persisted session workspace is unavailable: "+err.Error())
@@ -292,6 +301,16 @@ func (a *Agent) handleSessionList(_ context.Context, params json.RawMessage) (an
 		// holding a relative path, which was then reported as cwd "." even though
 		// ACP requires SessionInfo.cwd to be absolute.
 		if strings.TrimSpace(item.Cwd) == "" {
+			continue
+		}
+		// A RELATIVE PERSISTED CWD HAS NO RECOVERABLE IDENTITY. Resolving one
+		// rebases it onto wherever this ACP server happens to be running and
+		// advertises that invented absolute path as the session's workspace — so a
+		// conversation created for one project could be resumed against another
+		// project's configuration, files and tools. The original base is not
+		// knowable from the metadata, so the honest answer is to omit the entry
+		// rather than to guess at it.
+		if !filepath.IsAbs(item.Cwd) {
 			continue
 		}
 		itemRoot, err := a.deps.ResolveWorkspaceRoot(item.Cwd)

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -44,11 +44,12 @@ type Deps struct {
 	// ResolveWorkspaceRoot validates + normalizes a client-supplied cwd (must be an
 	// existing directory; never the bare root). It is the file-tool confinement root.
 	ResolveWorkspaceRoot func(cwd string) (string, error)
-	// PersistEvent is an optional test seam for injecting event-store failures.
-	// Production callers leave it nil and use Store.AppendEvents.
-	PersistEvent func(sessionID string, input sessions.AppendEventInput) error
-	Store        *sessions.Store
-	AgentInfo    Implementation
+	// PersistEvents is an optional test seam for injecting event-store failures.
+	// It receives a COMPLETED TURN as one batch, never one event at a time: the
+	// batch is the unit the shared store keeps contiguous (see persistTurn).
+	PersistEvents func(sessionID string, inputs []sessions.AppendEventInput) error
+	Store         *sessions.Store
+	AgentInfo     Implementation
 }
 
 // Workspace is the per-turn execution environment passed to the agent. ACP does
@@ -507,17 +508,6 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 	}
 	queue(messageEvent("user", userText))
 
-	var persistenceErr error
-	persistenceFailed := false
-	persist := func(input sessions.AppendEventInput) {
-		if persistenceFailed {
-			return
-		}
-		if err := a.persistEvent(sess.id, input); err != nil {
-			persistenceErr = errors.Join(persistenceErr, err)
-			persistenceFailed = true
-		}
-	}
 	opts := agent.Options{
 		Cwd:            sess.cwd,
 		SessionID:      sess.id,
@@ -556,9 +546,21 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 	if stopErr != nil {
 		return "", RPCError(codeInternalError, stopErr.Error())
 	}
-	for _, event := range pendingEvents {
-		persist(event)
-	}
+	// ONE BATCH, ONE LOCK. The outcome gate above decides WHETHER the turn is
+	// committed; the store batch decides WHICH RECORDS STAY TOGETHER relative to
+	// other writers, and these are different guarantees. Persisting the buffer
+	// one event per call took and released the store's session lock between
+	// events, so a second ACP instance holding the same session — its turnMu is
+	// its own, only the store is shared — could append its whole turn in the
+	// gap: user A, user B, answer B, answer A. Every write was individually
+	// locked and the log was valid, but a fresh load pairs prose by order and
+	// reconstructed three wrong turns from two right ones. Before this branch,
+	// persistTurn handed the user and assistant events to AppendEvents together;
+	// buffering until the outcome is known was correct, splitting the commit
+	// into singleton writes was not. The store writes a batch under one lock and
+	// one file write, which is the contiguity restored here — not a disk
+	// transaction, and not a promise about crashes mid-fsync. Reported by @jatmn.
+	persistenceErr := a.persistTurn(sess.id, pendingEvents)
 	sess.appendHistory(turnRecord{user: userText, assistant: result.FinalAnswer})
 	a.warnPersistence(
 		note,
@@ -825,14 +827,20 @@ func (a *Agent) configOptions(s *acpSession) []SessionConfigOption {
 
 // ---- persistence + continuity ----
 
-func (a *Agent) persistEvent(sessionID string, input sessions.AppendEventInput) error {
-	if a.deps.PersistEvent != nil {
-		return a.deps.PersistEvent(sessionID, input)
+// persistTurn commits a completed turn's buffered events as one store batch, so
+// no other writer's records can land between them. A failure is the failure of
+// the whole batch: nothing after a failed prerequisite is appended on its own.
+func (a *Agent) persistTurn(sessionID string, inputs []sessions.AppendEventInput) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	if a.deps.PersistEvents != nil {
+		return a.deps.PersistEvents(sessionID, inputs)
 	}
 	if a.deps.Store == nil {
 		return nil
 	}
-	_, err := a.deps.Store.AppendEvents(sessionID, []sessions.AppendEventInput{input})
+	_, err := a.deps.Store.AppendEvents(sessionID, inputs)
 	return err
 }
 

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -2,9 +2,11 @@ package acp
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 	"sync"
@@ -106,6 +108,8 @@ func NewAgent(conn *Conn, deps Deps) *Agent {
 	conn.Handle(MethodInitialize, a.handleInitialize)
 	conn.Handle(MethodSessionNew, a.handleSessionNew)
 	conn.Handle(MethodSessionLoad, a.handleSessionLoad)
+	conn.Handle(MethodSessionList, a.handleSessionList)
+	conn.Handle(MethodSessionResume, a.handleSessionResume)
 	conn.Handle(MethodSessionPrompt, a.handleSessionPrompt)
 	conn.Handle(MethodSessionSetMode, a.handleSetMode)
 	conn.Handle(MethodSessionSetConfigOption, a.handleSetConfigOption)
@@ -134,11 +138,11 @@ func (a *Agent) handleInitialize(_ context.Context, params json.RawMessage) (any
 	return InitializeResult{
 		ProtocolVersion: negotiated,
 		AgentCapabilities: AgentCapabilities{
-			// Only advertise what ZERO actually implements: session/load (loadSession)
-			// and image prompts. session/resume + the session-capability sub-object
-			// are intentionally omitted since there is no resume handler yet.
-			LoadSession:        true,
-			PromptCapabilities: PromptCapabilities{Image: true},
+			// ACP v1 optional methods are advertised as empty capability objects;
+			// clients must gate session/list and session/resume on their presence.
+			LoadSession:         true,
+			PromptCapabilities:  PromptCapabilities{Image: true},
+			SessionCapabilities: &SessionCapabilities{List: &struct{}{}, Resume: &struct{}{}},
 		},
 		AgentInfo: &info,
 		// ZERO owns credentials (BYOK) and does not delegate auth to the editor.
@@ -178,6 +182,22 @@ func (a *Agent) handleSessionLoad(ctx context.Context, params json.RawMessage) (
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, RPCError(codeInvalidParams, "invalid session/load params")
 	}
+	return a.activatePersistedSession(ctx, p, true)
+}
+
+func (a *Agent) handleSessionResume(ctx context.Context, params json.RawMessage) (any, error) {
+	var p ResumeSessionParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, RPCError(codeInvalidParams, "invalid session/resume params")
+	}
+	return a.activatePersistedSession(ctx, p, false)
+}
+
+// activatePersistedSession restores the agent's internal conversation context
+// for both lifecycle methods. session/load additionally replays user-visible
+// history as ordered session/update notifications; session/resume deliberately
+// does not, which makes it safe for an already-rendered desktop reconnect.
+func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParams, replay bool) (any, error) {
 	meta, err := a.deps.Store.Get(p.SessionID)
 	if err != nil || meta == nil {
 		return nil, RPCError(codeInvalidParams, "session not found: "+p.SessionID)
@@ -193,7 +213,7 @@ func (a *Agent) handleSessionLoad(ctx context.Context, params json.RawMessage) (
 	// Load history BEFORE publishing the session so no concurrent prompt observes
 	// a half-initialized session (registerSession sets history under the lock and
 	// reuses an already-live session rather than orphaning its in-flight turn).
-	history, historyErr := a.loadHistory(meta.SessionID)
+	history, messages, historyErr := a.loadHistory(meta.SessionID)
 	model, models, restrictModels, err := a.resolveModelChoices(ctx, root)
 	if err != nil {
 		return nil, RPCError(codeInternalError, "config: "+err.Error())
@@ -205,8 +225,14 @@ func (a *Agent) handleSessionLoad(ctx context.Context, params json.RawMessage) (
 		}
 	}
 	sess := a.registerSession(meta.SessionID, root, history, model, models, restrictModels)
+	note := &notifier{conn: a.conn, sessionID: sess.id}
+	if replay && historyErr == nil {
+		for _, message := range messages {
+			note.send(replayMessageChunk(message.role, replayMessageID(message.eventID), message.content))
+		}
+	}
 	a.warnPersistence(
-		&notifier{conn: a.conn, sessionID: sess.id},
+		note,
 		"load session history",
 		"Could not load session history. The session is open, but earlier turns may be missing until storage recovers.",
 		historyErr,
@@ -215,6 +241,37 @@ func (a *Agent) handleSessionLoad(ctx context.Context, params json.RawMessage) (
 		ConfigOptions: a.configOptions(sess),
 		Modes:         a.modeState(sess),
 	}, nil
+}
+
+func (a *Agent) handleSessionList(_ context.Context, params json.RawMessage) (any, error) {
+	var p ListSessionsParams
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, RPCError(codeInvalidParams, "invalid session/list params")
+		}
+	}
+	if p.Cursor != "" {
+		return nil, RPCError(codeInvalidParams, "invalid session/list cursor")
+	}
+	items, err := a.deps.Store.ListResumable()
+	if err != nil {
+		return nil, RPCError(codeInternalError, "list sessions: "+err.Error())
+	}
+	cwd := strings.TrimSpace(p.Cwd)
+	result := ListSessionsResult{Sessions: make([]SessionInfo, 0, len(items))}
+	for _, item := range items {
+		if cwd != "" && item.Cwd != cwd {
+			continue
+		}
+		result.Sessions = append(result.Sessions, SessionInfo{
+			SessionID: item.SessionID,
+			Title:     item.Title,
+			Cwd:       item.Cwd,
+			UpdatedAt: item.UpdatedAt,
+			Meta:      &SessionInfoMeta{ModelID: item.ModelID, CreatedAt: item.CreatedAt},
+		})
+	}
+	return result, nil
 }
 
 // ---- prompt turn ----
@@ -613,15 +670,22 @@ func (a *Agent) persistTurn(sess *acpSession, user, assistant string) error {
 	return err
 }
 
-func (a *Agent) loadHistory(sessionID string) ([]turnRecord, error) {
+type persistedMessage struct {
+	eventID string
+	role    string
+	content string
+}
+
+func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage, error) {
 	if a.deps.Store == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	events, err := a.deps.Store.ReadEvents(sessionID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var records []turnRecord
+	var messages []persistedMessage
 	var pendingUser string
 	havePending := false
 	for _, e := range events {
@@ -641,12 +705,14 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, error) {
 		}
 		switch msg.Role {
 		case "user":
+			messages = append(messages, persistedMessage{eventID: persistedMessageIdentity(sessionID, e), role: msg.Role, content: msg.Content})
 			if havePending {
 				records = append(records, turnRecord{user: pendingUser})
 			}
 			pendingUser = msg.Content
 			havePending = true
 		case "assistant":
+			messages = append(messages, persistedMessage{eventID: persistedMessageIdentity(sessionID, e), role: msg.Role, content: msg.Content})
 			records = append(records, turnRecord{user: pendingUser, assistant: msg.Content})
 			pendingUser = ""
 			havePending = false
@@ -655,7 +721,26 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, error) {
 	if havePending {
 		records = append(records, turnRecord{user: pendingUser})
 	}
-	return records, nil
+	return records, messages, nil
+}
+
+func persistedMessageIdentity(sessionID string, event sessions.Event) string {
+	if event.ID != "" {
+		return event.ID
+	}
+	return fmt.Sprintf("%s:%d", sessionID, event.Sequence)
+}
+
+// replayMessageID maps ZERO's stable event identity to a standards-shaped UUID
+// without leaking or parsing the event id on the wire. The same stored message
+// receives the same opaque id across loads, which also gives clients an exact
+// chunk boundary when two adjacent persisted messages have the same role.
+func replayMessageID(eventID string) string {
+	sum := sha256.Sum256([]byte("zero-acp-message:" + eventID))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x50
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 func (a *Agent) warnPersistence(note *notifier, action string, message string, err error) {

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -281,23 +281,32 @@ func (a *Agent) handleSessionList(_ context.Context, params json.RawMessage) (an
 	}
 	result := ListSessionsResult{Sessions: make([]SessionInfo, 0, len(items))}
 	for _, item := range items {
-		// A session with no persisted workspace cannot be resumed —
-		// activatePersistedSession refuses it — so advertising it offers the
-		// client something that only fails when taken. Listing is a menu, and
-		// every entry on it has to be orderable.
+		// EVERY ENTRY IS RESOLVED, FILTER OR NO FILTER. Listing is a menu, and
+		// every item on it has to be orderable: activatePersistedSession
+		// resolves the persisted workspace and refuses what it cannot reach, so
+		// anything this loop cannot resolve is something the client would be
+		// offered and then denied.
+		//
+		// Resolving only when a cwd filter was supplied left two shapes through —
+		// a session whose workspace has since been deleted, and a legacy entry
+		// holding a relative path, which was then reported as cwd "." even though
+		// ACP requires SessionInfo.cwd to be absolute.
 		if strings.TrimSpace(item.Cwd) == "" {
 			continue
 		}
-		if cwd != "" {
-			itemRoot, err := a.deps.ResolveWorkspaceRoot(item.Cwd)
-			if err != nil || !sameWorkspace(itemRoot, cwd) {
-				continue
-			}
+		itemRoot, err := a.deps.ResolveWorkspaceRoot(item.Cwd)
+		if err != nil {
+			continue
+		}
+		if cwd != "" && !sameWorkspace(itemRoot, cwd) {
+			continue
 		}
 		result.Sessions = append(result.Sessions, SessionInfo{
 			SessionID: item.SessionID,
 			Title:     item.Title,
-			Cwd:       item.Cwd,
+			// The RESOLVED root, not the stored string: absolute as ACP
+			// requires, and the same value the client will hand back on resume.
+			Cwd:       itemRoot,
 			UpdatedAt: item.UpdatedAt,
 			Meta:      &SessionInfoMeta{ModelID: item.ModelID, CreatedAt: item.CreatedAt},
 		})

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -281,6 +281,13 @@ func (a *Agent) handleSessionList(_ context.Context, params json.RawMessage) (an
 	}
 	result := ListSessionsResult{Sessions: make([]SessionInfo, 0, len(items))}
 	for _, item := range items {
+		// A session with no persisted workspace cannot be resumed —
+		// activatePersistedSession refuses it — so advertising it offers the
+		// client something that only fails when taken. Listing is a menu, and
+		// every entry on it has to be orderable.
+		if strings.TrimSpace(item.Cwd) == "" {
+			continue
+		}
 		if cwd != "" {
 			itemRoot, err := a.deps.ResolveWorkspaceRoot(item.Cwd)
 			if err != nil || !sameWorkspace(itemRoot, cwd) {

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -202,6 +202,13 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	if err != nil || meta == nil {
 		return nil, RPCError(codeInvalidParams, "session not found: "+p.SessionID)
 	}
+	if strings.TrimSpace(meta.Cwd) == "" {
+		return nil, RPCError(codeInvalidParams, "session has no persisted workspace: "+p.SessionID)
+	}
+	persistedRoot, err := a.deps.ResolveWorkspaceRoot(meta.Cwd)
+	if err != nil {
+		return nil, RPCError(codeInvalidParams, "persisted session workspace is unavailable: "+err.Error())
+	}
 	cwdInput := p.Cwd
 	if strings.TrimSpace(cwdInput) == "" {
 		cwdInput = meta.Cwd
@@ -209,6 +216,12 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	root, err := a.deps.ResolveWorkspaceRoot(cwdInput)
 	if err != nil {
 		return nil, RPCError(codeInvalidParams, err.Error())
+	}
+	// ACP session cwd is immutable. Loading history under a different root
+	// would give a conversation from one workspace access to another
+	// workspace's configuration, files, and tools.
+	if root != persistedRoot {
+		return nil, RPCError(codeInvalidParams, "session cwd does not match its persisted workspace")
 	}
 	// Load history BEFORE publishing the session so no concurrent prompt observes
 	// a half-initialized session (registerSession sets history under the lock and
@@ -257,11 +270,21 @@ func (a *Agent) handleSessionList(_ context.Context, params json.RawMessage) (an
 	if err != nil {
 		return nil, RPCError(codeInternalError, "list sessions: "+err.Error())
 	}
-	cwd := strings.TrimSpace(p.Cwd)
+	var cwd string
+	if strings.TrimSpace(p.Cwd) != "" {
+		var err error
+		cwd, err = a.deps.ResolveWorkspaceRoot(p.Cwd)
+		if err != nil {
+			return nil, RPCError(codeInvalidParams, err.Error())
+		}
+	}
 	result := ListSessionsResult{Sessions: make([]SessionInfo, 0, len(items))}
 	for _, item := range items {
-		if cwd != "" && item.Cwd != cwd {
-			continue
+		if cwd != "" {
+			itemRoot, err := a.deps.ResolveWorkspaceRoot(item.Cwd)
+			if err != nil || itemRoot != cwd {
+				continue
+			}
 		}
 		result.Sessions = append(result.Sessions, SessionInfo{
 			SessionID: item.SessionID,

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -44,8 +44,11 @@ type Deps struct {
 	// ResolveWorkspaceRoot validates + normalizes a client-supplied cwd (must be an
 	// existing directory; never the bare root). It is the file-tool confinement root.
 	ResolveWorkspaceRoot func(cwd string) (string, error)
-	Store                *sessions.Store
-	AgentInfo            Implementation
+	// PersistEvent is an optional test seam for injecting event-store failures.
+	// Production callers leave it nil and use Store.AppendEvents.
+	PersistEvent func(sessionID string, input sessions.AppendEventInput) error
+	Store        *sessions.Store
+	AgentInfo    Implementation
 }
 
 // Workspace is the per-turn execution environment passed to the agent. ACP does
@@ -213,7 +216,7 @@ func (a *Agent) handleSessionLoad(ctx context.Context, params json.RawMessage) (
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, RPCError(codeInvalidParams, "invalid session/load params")
 	}
-	return a.activatePersistedSession(ctx, p, true)
+	return a.activatePersistedSession(ctx, p, persistedSessionLoad)
 }
 
 func (a *Agent) handleSessionResume(ctx context.Context, params json.RawMessage) (any, error) {
@@ -221,14 +224,21 @@ func (a *Agent) handleSessionResume(ctx context.Context, params json.RawMessage)
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, RPCError(codeInvalidParams, "invalid session/resume params")
 	}
-	return a.activatePersistedSession(ctx, p, false)
+	return a.activatePersistedSession(ctx, p, persistedSessionResume)
 }
+
+type persistedSessionOperation uint8
+
+const (
+	persistedSessionLoad persistedSessionOperation = iota
+	persistedSessionResume
+)
 
 // activatePersistedSession restores the agent's internal conversation context
 // for both lifecycle methods. session/load additionally replays user-visible
 // history as ordered session/update notifications; session/resume deliberately
 // does not, which makes it safe for an already-rendered desktop reconnect.
-func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParams, replay bool) (any, error) {
+func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParams, operation persistedSessionOperation) (any, error) {
 	// BOTH METHODS, BEFORE ANYTHING IS LOOKED UP. session/resume shares this
 	// params type with session/load, so the wire cannot tell an omitted cwd from
 	// an empty one; the blank case used to be answered with the persisted cwd,
@@ -242,6 +252,9 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	meta, err := a.deps.Store.Get(p.SessionID)
 	if err != nil || meta == nil {
 		return nil, RPCError(codeInvalidParams, "session not found: "+p.SessionID)
+	}
+	if operation == persistedSessionResume && !sessions.IsResumableKind(meta.SessionKind) {
+		return nil, RPCError(codeInvalidParams, "session is not resumable: "+p.SessionID)
 	}
 	if strings.TrimSpace(meta.Cwd) == "" {
 		return nil, RPCError(codeInvalidParams, "session has no persisted workspace: "+p.SessionID)
@@ -271,7 +284,7 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	// Load history BEFORE publishing the session so no concurrent prompt observes
 	// a half-initialized session (registerSession sets history under the lock and
 	// reuses an already-live session rather than orphaning its in-flight turn).
-	history, messages, historyErr := a.loadHistory(meta.SessionID)
+	history, messages, historyWarning, historyErr := a.loadHistory(meta.SessionID)
 	// RESUME PROMISES RESTORED CONTEXT, SO A FAILED RESTORATION IS A FAILED
 	// RESUME. historyErr used to do nothing but suppress replay and raise a
 	// warning: the session was registered and reported ready regardless, so a
@@ -283,7 +296,7 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	// best-effort policy deliberately rather than by inheriting this helper: it
 	// replays what it has and warns about the rest, which is the right trade for
 	// a client rebuilding a transcript it can still scroll. Reported by @jatmn.
-	if !replay && historyErr != nil {
+	if operation == persistedSessionResume && historyErr != nil {
 		return nil, RPCError(codeInternalError, "restore session history: "+historyErr.Error())
 	}
 	model, models, restrictModels, err := a.resolveModelChoices(ctx, root)
@@ -298,7 +311,7 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	}
 	sess := a.registerSession(meta.SessionID, root, history, model, models, restrictModels)
 	note := &notifier{conn: a.conn, sessionID: sess.id}
-	if replay && historyErr == nil {
+	if operation == persistedSessionLoad && historyErr == nil {
 		for _, message := range messages {
 			if message.tool != nil {
 				note.send(*message.tool)
@@ -307,6 +320,12 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 			note.send(replayMessageChunk(message.role, replayMessageID(message.eventID), message.content))
 		}
 	}
+	a.warnPersistence(
+		note,
+		"rehydrate session compaction",
+		"Could not apply session compaction. Raw session history was restored instead.",
+		historyWarning,
+	)
 	a.warnPersistence(
 		note,
 		"load session history",
@@ -474,8 +493,15 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 	// durable log has the same order the client observed and an interrupted call
 	// remains visible after a fresh-process load.
 	var persistenceErr error
+	persistenceFailed := false
 	persist := func(input sessions.AppendEventInput) {
-		persistenceErr = errors.Join(persistenceErr, a.persistEvent(sess.id, input))
+		if persistenceFailed {
+			return
+		}
+		if err := a.persistEvent(sess.id, input); err != nil {
+			persistenceErr = errors.Join(persistenceErr, err)
+			persistenceFailed = true
+		}
 	}
 	persist(messageEvent("user", userText))
 
@@ -784,6 +810,9 @@ func (a *Agent) configOptions(s *acpSession) []SessionConfigOption {
 // ---- persistence + continuity ----
 
 func (a *Agent) persistEvent(sessionID string, input sessions.AppendEventInput) error {
+	if a.deps.PersistEvent != nil {
+		return a.deps.PersistEvent(sessionID, input)
+	}
 	if a.deps.Store == nil {
 		return nil
 	}
@@ -837,9 +866,9 @@ type persistedMessage struct {
 	tool *ToolCallUpdate
 }
 
-func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage, error) {
+func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage, error, error) {
 	if a.deps.Store == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	// THE EFFECTIVE CONVERSATION, NOT THE RAW LOG. A compacted session keeps its
 	// original prefix on disk alongside an EventCompaction that names the events
@@ -856,11 +885,17 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage,
 	// it replaced, so a loop that skips everything but EventMessage would drop the
 	// summary exactly as before. It is projected below. Reported by @jatmn.
 	events, err := a.deps.Store.ReadRehydratedEvents(sessionID)
+	var rehydrateWarning error
 	if err != nil {
-		return nil, nil, err
+		rehydrateWarning = err
+		events, err = a.deps.Store.ReadEvents(sessionID)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	var records []turnRecord
 	var messages []persistedMessage
+	seenToolCalls := make(map[string]struct{})
 	var pendingUser string
 	havePending := false
 	for _, e := range events {
@@ -898,6 +933,13 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage,
 		// only the wire rendering differs. Reported by @jatmn.
 		if e.Type == sessions.EventToolCall || e.Type == sessions.EventToolResult {
 			if upd := replayToolUpdate(e); upd != nil {
+				if e.Type == sessions.EventToolResult {
+					if _, ok := seenToolCalls[upd.ToolCallID]; !ok {
+						continue
+					}
+				} else {
+					seenToolCalls[upd.ToolCallID] = struct{}{}
+				}
 				messages = append(messages, persistedMessage{
 					eventID: persistedMessageIdentity(sessionID, e),
 					tool:    upd,
@@ -937,7 +979,7 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage,
 	if havePending {
 		records = append(records, turnRecord{user: pendingUser})
 	}
-	return records, messages, nil
+	return records, messages, rehydrateWarning, nil
 }
 
 // replayToolUpdate rebuilds the ACP notification for one stored tool event.

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -284,7 +284,8 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	// Load history BEFORE publishing the session so no concurrent prompt observes
 	// a half-initialized session (registerSession sets history under the lock and
 	// reuses an already-live session rather than orphaning its in-flight turn).
-	history, messages, historyWarning, historyErr := a.loadHistory(meta.SessionID)
+	requireHistoryLog := operation == persistedSessionResume && meta.EventCount > 0
+	history, messages, historyWarning, historyErr := a.loadHistory(meta.SessionID, requireHistoryLog)
 	// RESUME PROMISES RESTORED CONTEXT, SO A FAILED RESTORATION IS A FAILED
 	// RESUME. historyErr used to do nothing but suppress replay and raise a
 	// warning: the session was registered and reported ready regardless, so a
@@ -311,7 +312,7 @@ func (a *Agent) activatePersistedSession(ctx context.Context, p LoadSessionParam
 	}
 	sess, existed := a.registerSession(meta.SessionID, root, history, model, models, restrictModels)
 	if existed {
-		_, messages, historyWarning, historyErr = a.refreshSessionHistory(sess)
+		_, messages, historyWarning, historyErr = a.refreshSessionHistory(sess, requireHistoryLog)
 		if operation == persistedSessionResume && historyErr != nil {
 			return nil, RPCError(codeInternalError, "restore session history: "+historyErr.Error())
 		}
@@ -881,7 +882,7 @@ type persistedMessage struct {
 	tool *ToolCallUpdate
 }
 
-func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage, error, error) {
+func (a *Agent) loadHistory(sessionID string, requireHistoryLog bool) ([]turnRecord, []persistedMessage, error, error) {
 	if a.deps.Store == nil {
 		return nil, nil, nil, nil
 	}
@@ -899,18 +900,21 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage,
 	// enough: rehydration substitutes the compaction event in place of the events
 	// it replaced, so a loop that skips everything but EventMessage would drop the
 	// summary exactly as before. It is projected below. Reported by @jatmn.
-	events, err := a.deps.Store.ReadRehydratedEvents(sessionID)
+	events, eventLogPresent, err := a.deps.Store.ReadRehydratedEventsWithPresence(sessionID)
 	var rehydrateWarning error
 	if err != nil {
 		rehydrateWarning = err
-		events, err = a.deps.Store.ReadEvents(sessionID)
+		events, eventLogPresent, err = a.deps.Store.ReadEventsWithPresence(sessionID)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 	}
+	if requireHistoryLog && !eventLogPresent {
+		return nil, nil, nil, fmt.Errorf("zero session %s event log is missing", sessionID)
+	}
 	var records []turnRecord
 	var messages []persistedMessage
-	seenToolCalls := make(map[string]struct{})
+	activeToolCalls := make(map[string]string)
 	var pendingUser string
 	havePending := false
 	for _, e := range events {
@@ -948,12 +952,18 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage,
 		// only the wire rendering differs. Reported by @jatmn.
 		if e.Type == sessions.EventToolCall || e.Type == sessions.EventToolResult {
 			if upd := replayToolUpdate(e); upd != nil {
+				rawID := upd.ToolCallID
 				if e.Type == sessions.EventToolResult {
-					if _, ok := seenToolCalls[upd.ToolCallID]; !ok {
+					replayID, ok := activeToolCalls[rawID]
+					if !ok {
 						continue
 					}
+					upd.ToolCallID = replayID
+					delete(activeToolCalls, rawID)
 				} else {
-					seenToolCalls[upd.ToolCallID] = struct{}{}
+					replayID := replayToolCallID(persistedMessageIdentity(sessionID, e))
+					activeToolCalls[rawID] = replayID
+					upd.ToolCallID = replayID
 				}
 				messages = append(messages, persistedMessage{
 					eventID: persistedMessageIdentity(sessionID, e),
@@ -999,11 +1009,11 @@ func (a *Agent) loadHistory(sessionID string) ([]turnRecord, []persistedMessage,
 
 // replayToolUpdate rebuilds the ACP notification for one stored tool event.
 //
-// The stored toolCallId is reused verbatim rather than re-derived, because the
-// client pairs a result with its call by that id alone; minting a new one would
-// replay the result as an orphan update against a call the client never saw.
-// Older records wrote the field as "id", so both spellings are accepted — the
-// TUI projection already does the same (internal/tui/session.go).
+// The stored toolCallId is returned here as a correlation key. loadHistory maps
+// each call occurrence to a stable session-wide replay identity and applies that
+// identity to its result. Older records wrote the field as "id", so both
+// spellings are accepted — the TUI projection already does the same
+// (internal/tui/session.go).
 //
 // A record that carries no usable id is skipped rather than replayed under a
 // synthesized one: an unpairable update is worse than a missing row.
@@ -1061,7 +1071,15 @@ func persistedMessageIdentity(sessionID string, event sessions.Event) string {
 // receives the same opaque id across loads, which also gives clients an exact
 // chunk boundary when two adjacent persisted messages have the same role.
 func replayMessageID(eventID string) string {
-	sum := sha256.Sum256([]byte("zero-acp-message:" + eventID))
+	return replayOpaqueID("message", eventID)
+}
+
+func replayToolCallID(eventID string) string {
+	return replayOpaqueID("tool-call", eventID)
+}
+
+func replayOpaqueID(kind, eventID string) string {
+	sum := sha256.Sum256([]byte("zero-acp-" + kind + ":" + eventID))
 	b := sum[:16]
 	b[6] = (b[6] & 0x0f) | 0x50
 	b[8] = (b[8] & 0x3f) | 0x80
@@ -1144,10 +1162,10 @@ func (a *Agent) registerSession(id, cwd string, history []turnRecord, model stri
 // same object the prompt path uses. Re-reading here avoids overwriting a turn
 // that committed between activatePersistedSession's pre-publication read and
 // discovering that another activation had already registered the session.
-func (a *Agent) refreshSessionHistory(sess *acpSession) ([]turnRecord, []persistedMessage, error, error) {
+func (a *Agent) refreshSessionHistory(sess *acpSession, requireHistoryLog bool) ([]turnRecord, []persistedMessage, error, error) {
 	sess.turnMu.Lock()
 	defer sess.turnMu.Unlock()
-	history, messages, warning, err := a.loadHistory(sess.id)
+	history, messages, warning, err := a.loadHistory(sess.id, requireHistoryLog)
 	if err == nil {
 		sess.setHistory(history)
 	}

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1583,10 +1583,12 @@ func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
 	if _, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{
 		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "read the file"}},
 		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "read_file", "toolCallId": "call-77", "arguments": `{"path":"scope.go"}`}},
-		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "read_file", "toolCallId": "call-77", "status": "ok", "output": "package sandbox"}},
+		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "read_file", "toolCallId": "call-77", "status": "ok", "output": "package sandbox", "changedFiles": []string{"scope.go", "scope_test.go"}}},
 		// An older record spells the id "id" rather than "toolCallId".
 		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "bash", "id": "call-88", "arguments": `{"command":"go build"}`}},
 		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "bash", "id": "call-88", "status": "error", "output": "build failed"}},
+		// A start with no result is an interrupted call, not a completed one.
+		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "grep", "toolCallId": "call-99", "arguments": `{"pattern":"TODO"}`}},
 		// No id at all: unpairable, so it must be skipped rather than replayed.
 		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "orphan", "arguments": "{}"}},
 	}); err != nil {
@@ -1601,18 +1603,28 @@ func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
 	}
 	type want struct {
 		kind, id, status string
+		locations        []string
 	}
 	wants := []want{
-		{UpdateToolCall, "call-77", ToolStatusCompleted},
-		{UpdateToolCallUpdate, "call-77", ToolStatusCompleted},
-		{UpdateToolCall, "call-88", ToolStatusCompleted},
-		{UpdateToolCallUpdate, "call-88", ToolStatusFailed},
+		{UpdateToolCall, "call-77", ToolStatusInProgress, nil},
+		{UpdateToolCallUpdate, "call-77", ToolStatusCompleted, []string{"scope.go", "scope_test.go"}},
+		{UpdateToolCall, "call-88", ToolStatusInProgress, nil},
+		{UpdateToolCallUpdate, "call-88", ToolStatusFailed, nil},
+		{UpdateToolCall, "call-99", ToolStatusInProgress, nil},
 	}
 	for i, w := range wants {
 		select {
 		case update := <-loader.tools:
 			if update.SessionUpdate != w.kind || update.ToolCallID != w.id || update.Status != w.status {
 				t.Fatalf("tool update %d = %+v, want %s/%s/%s", i, update, w.kind, w.id, w.status)
+			}
+			if len(update.Locations) != len(w.locations) {
+				t.Fatalf("tool update %d locations = %+v, want %v", i, update.Locations, w.locations)
+			}
+			for j, path := range w.locations {
+				if update.Locations[j].Path != path {
+					t.Fatalf("tool update %d location %d = %+v, want %q", i, j, update.Locations[j], path)
+				}
 			}
 		case <-ctx.Done():
 			t.Fatalf("tool update %d never arrived", i)
@@ -1634,6 +1646,92 @@ func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
 	case update := <-resumer.tools:
 		t.Fatalf("session/resume replayed tool activity: %+v", update)
 	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// Drive the callback-to-store boundary through session/prompt rather than
+// seeding replay-shaped events by hand. A fresh agent must then reconstruct the
+// same call/result pair and changed-file locations from the durable log.
+func TestACPPromptPersistsToolActivityForFreshLoad(t *testing.T) {
+	deps := testDeps(t)
+	deps.RunAgent = func(_ context.Context, _ string, _ zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+		call := agent.ToolCall{ID: "call-live", Name: "edit_file", Arguments: `{"path":"a.go"}`}
+		result := agent.ToolResult{
+			ToolCallID:   call.ID,
+			Name:         call.Name,
+			Status:       tools.StatusOK,
+			Output:       "updated",
+			ChangedFiles: []string{"a.go", "b.go"},
+		}
+		opts.OnToolCall(call)
+		opts.OnToolResult(result)
+		return agent.Result{FinalAnswer: "done"}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	workspace := t.TempDir()
+	writer := newHarness(t, deps)
+	var created NewSessionResult
+	if err := writer.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: workspace}, &created); err != nil {
+		t.Fatalf("session/new: %v", err)
+	}
+	if err := writer.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: created.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "edit the files"}},
+	}, &PromptResult{}); err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+	writer.stop()
+
+	events, err := deps.Store.ReadEvents(created.SessionID)
+	if err != nil {
+		t.Fatalf("read persisted prompt events: %v", err)
+	}
+	wantTypes := []sessions.EventType{
+		sessions.EventMessage,
+		sessions.EventToolCall,
+		sessions.EventToolResult,
+		sessions.EventMessage,
+	}
+	if len(events) != len(wantTypes) {
+		t.Fatalf("persisted %d events, want %d: %+v", len(events), len(wantTypes), events)
+	}
+	for i, want := range wantTypes {
+		if events[i].Type != want {
+			t.Fatalf("event %d type = %s, want %s", i, events[i].Type, want)
+		}
+	}
+	rawResult, err := json.Marshal(events[2].Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var storedResult struct {
+		ToolCallID   string   `json:"toolCallId"`
+		ChangedFiles []string `json:"changedFiles"`
+	}
+	if err := json.Unmarshal(rawResult, &storedResult); err != nil {
+		t.Fatal(err)
+	}
+	if storedResult.ToolCallID != "call-live" || strings.Join(storedResult.ChangedFiles, ",") != "a.go,b.go" {
+		t.Fatalf("stored tool result = %+v", storedResult)
+	}
+
+	loader := newHarness(t, deps)
+	defer loader.stop()
+	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("fresh session/load: %v", err)
+	}
+	start := <-loader.tools
+	result := <-loader.tools
+	if start.SessionUpdate != UpdateToolCall || start.ToolCallID != "call-live" || start.Status != ToolStatusInProgress {
+		t.Fatalf("replayed tool start = %+v", start)
+	}
+	if result.SessionUpdate != UpdateToolCallUpdate || result.ToolCallID != "call-live" || result.Status != ToolStatusCompleted {
+		t.Fatalf("replayed tool result = %+v", result)
+	}
+	if len(result.Locations) != 2 || result.Locations[0].Path != "a.go" || result.Locations[1].Path != "b.go" {
+		t.Fatalf("replayed tool locations = %+v", result.Locations)
 	}
 }
 

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -100,6 +100,7 @@ func testDeps(t *testing.T) Deps {
 // clientHarness wires a client Conn to an Agent over in-memory pipes and collects
 // session/update text chunks.
 type clientHarness struct {
+	agent         *Agent
 	client        *Conn
 	updates       chan string
 	notifications chan ContentChunk
@@ -118,7 +119,7 @@ func newHarness(t *testing.T, deps Deps) *clientHarness {
 	client := NewConn(br, bw)
 	a := NewAgent(agentConn, deps)
 
-	h := &clientHarness{client: client, updates: make(chan string, 128), notifications: make(chan ContentChunk, 128), tools: make(chan ToolCallUpdate, 128)}
+	h := &clientHarness{agent: a, client: client, updates: make(chan string, 128), notifications: make(chan ContentChunk, 128), tools: make(chan ToolCallUpdate, 128)}
 	client.HandleNotify(MethodSessionUpdate, func(_ context.Context, params json.RawMessage) {
 		// Decode the discriminator ALONE first. ContentChunk and ToolCallUpdate
 		// disagree on the shape of "content" (a block vs an array of them), so
@@ -891,6 +892,88 @@ func TestACPPromptWarnsWhenTurnPersistenceFails(t *testing.T) {
 	}
 }
 
+func TestACPHardTurnFailureDoesNotCommitHistory(t *testing.T) {
+	deps := testDeps(t)
+	deps.RunAgent = func(_ context.Context, _ string, _ zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+		call := agent.ToolCall{ID: "failed-call", Name: "read_file", Arguments: `{"path":"a.go"}`}
+		opts.OnToolCall(call)
+		opts.OnToolResult(agent.ToolResult{ToolCallID: call.ID, Name: call.Name, Status: tools.StatusOK, Output: "content"})
+		return agent.Result{FinalAnswer: "partial answer"}, errors.New("injected hard run failure")
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var created NewSessionResult
+	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: t.TempDir()}, &created); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("failed question")},
+	}, &PromptResult{}); err == nil {
+		t.Fatal("hard RunAgent failure was reported as a successful turn")
+	}
+
+	sess := h.agent.session(created.SessionID)
+	if sess == nil || len(sess.snapshotHistory()) != 0 {
+		t.Fatalf("failed turn changed live history: %+v", sess)
+	}
+	events, err := deps.Store.ReadEvents(created.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("failed turn changed durable history: %+v", events)
+	}
+	loader := newHarness(t, deps)
+	defer loader.stop()
+	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{
+		SessionID: created.SessionID, Cwd: sess.cwd,
+	}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("fresh session/load: %v", err)
+	}
+	loaded := loader.agent.session(created.SessionID)
+	if loaded == nil || len(loaded.snapshotHistory()) != 0 {
+		t.Fatalf("fresh load disagreed with the uncommitted turn: %+v", loaded)
+	}
+}
+
+func TestACPCancelledTurnCommitsAtOutcomeBoundary(t *testing.T) {
+	deps := testDeps(t)
+	deps.RunAgent = func(context.Context, string, zeroruntime.Provider, agent.Options) (agent.Result, error) {
+		return agent.Result{}, context.Canceled
+	}
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var created NewSessionResult
+	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: t.TempDir()}, &created); err != nil {
+		t.Fatal(err)
+	}
+	var result PromptResult
+	if err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("cancelled question")},
+	}, &result); err != nil {
+		t.Fatalf("cancelled turn returned an RPC error: %v", err)
+	}
+	if result.StopReason != StopCancelled {
+		t.Fatalf("stop reason = %q, want %q", result.StopReason, StopCancelled)
+	}
+	sess := h.agent.session(created.SessionID)
+	if got := sess.snapshotHistory(); len(got) != 1 || got[0].user != "cancelled question" {
+		t.Fatalf("cancelled turn was not committed to live history: %+v", got)
+	}
+	events, err := deps.Store.ReadEvents(created.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Type != sessions.EventMessage {
+		t.Fatalf("cancelled turn was not committed to durable history: %+v", events)
+	}
+}
+
 func TestACPLoadWarnsWhenHistoryReadFails(t *testing.T) {
 	deps := testDeps(t)
 	cwd := t.TempDir()
@@ -915,6 +998,79 @@ func TestACPLoadWarnsWhenHistoryReadFails(t *testing.T) {
 	})
 	if !strings.Contains(got, "Could not load session history") {
 		t.Fatalf("streamed text = %q, want load warning", got)
+	}
+}
+
+func TestACPSameConnectionReloadRefreshesRecoveredHistory(t *testing.T) {
+	deps := testDeps(t)
+	cwd := t.TempDir()
+	meta, err := deps.Store.Create(sessions.CreateInput{Title: "ACP session", Cwd: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	eventsPath := filepath.Join(deps.Store.RootDir, meta.SessionID, sessions.EventsFile)
+	if err := os.WriteFile(eventsPath, []byte("{bad json}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prompts := make(chan string, 1)
+	deps.RunAgent = func(_ context.Context, prompt string, _ zeroruntime.Provider, _ agent.Options) (agent.Result, error) {
+		prompts <- prompt
+		return agent.Result{FinalAnswer: "continued"}, nil
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	params := LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd}
+	if err := h.client.Call(ctx, MethodSessionLoad, params, &LoadSessionResult{}); err != nil {
+		t.Fatalf("initial best-effort load: %v", err)
+	}
+	select {
+	case <-h.notifications: // discard the expected best-effort load warning
+	case <-ctx.Done():
+		t.Fatal("initial best-effort load did not surface its warning")
+	}
+	if err := os.WriteFile(eventsPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.AppendEvents(meta.SessionID, []sessions.AppendEventInput{
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "recovered question"}},
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "assistant", "content": "recovered answer"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.client.Call(ctx, MethodSessionLoad, params, &LoadSessionResult{}); err != nil {
+		t.Fatalf("load after storage repair: %v", err)
+	}
+	for index, want := range []struct {
+		kind string
+		text string
+	}{
+		{UpdateUserMessageChunk, "recovered question"},
+		{UpdateAgentMessageChunk, "recovered answer"},
+	} {
+		select {
+		case update := <-h.notifications:
+			if update.SessionUpdate != want.kind || update.Content.Text != want.text {
+				t.Fatalf("replayed history %d = %+v, want %s %q", index, update, want.kind, want.text)
+			}
+		case <-ctx.Done():
+			t.Fatalf("replayed history %d never arrived", index)
+		}
+	}
+	if err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: meta.SessionID, Prompt: []ContentBlock{TextBlock("continue")},
+	}, &PromptResult{}); err != nil {
+		t.Fatalf("prompt after repaired reload: %v", err)
+	}
+	select {
+	case prompt := <-prompts:
+		if !strings.Contains(prompt, "recovered question") || !strings.Contains(prompt, "recovered answer") {
+			t.Fatalf("same-connection reload discarded recovered history:\n%s", prompt)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
 	}
 }
 
@@ -1933,6 +2089,11 @@ func TestACPCompactionFailureFallsBackToRawHistory(t *testing.T) {
 		SessionID: created.SessionID, Cwd: workspace,
 	}, &ResumeSessionResult{}); err != nil {
 		t.Fatalf("session/resume: %v", err)
+	}
+	select {
+	case update := <-resumer.notifications:
+		t.Fatalf("session/resume emitted transcript-shaped fallback warning: %+v", update)
+	case <-time.After(100 * time.Millisecond):
 	}
 	if err := resumer.client.Call(ctx, MethodSessionPrompt, PromptParams{
 		SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("continue")},

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -196,6 +196,7 @@ func TestACPEndToEndPrompt(t *testing.T) {
 
 func TestACPListsOnlyResumableSessionMetadata(t *testing.T) {
 	deps := testDeps(t)
+	deps.ResolveWorkspaceRoot = func(cwd string) (string, error) { return filepath.Clean(cwd), nil }
 	workspaceA := t.TempDir()
 	workspaceB := t.TempDir()
 	for _, input := range []sessions.CreateInput{
@@ -238,6 +239,21 @@ func TestACPListsOnlyResumableSessionMetadata(t *testing.T) {
 	if len(filtered.Sessions) != 1 || filtered.Sessions[0].SessionID != "desktop-b" {
 		t.Fatalf("filtered sessions = %+v, want only desktop-b", filtered.Sessions)
 	}
+
+	var equivalent ListSessionsResult
+	equivalentPath := workspaceB + string(os.PathSeparator) + "."
+	if err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{Cwd: equivalentPath}, &equivalent); err != nil {
+		t.Fatalf("equivalent-path session/list: %v", err)
+	}
+	if len(equivalent.Sessions) != 1 || equivalent.Sessions[0].SessionID != "desktop-b" {
+		t.Fatalf("equivalent-path sessions = %+v, want only desktop-b", equivalent.Sessions)
+	}
+
+	err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{Cursor: "not-issued"}, &ListSessionsResult{})
+	var rpcErr *rpcError
+	if !errors.As(err, &rpcErr) || rpcErr.Code != codeInvalidParams {
+		t.Fatalf("invalid cursor error = %v, want invalid params", err)
+	}
 }
 
 func TestACPLoadReplaysHistoryAndResumeDoesNot(t *testing.T) {
@@ -265,6 +281,7 @@ func TestACPLoadReplaysHistoryAndResumeDoesNot(t *testing.T) {
 	wantKinds := []string{UpdateUserMessageChunk, UpdateAgentMessageChunk, UpdateUserMessageChunk}
 	wantText := []string{"first user", "first answer", "second user"}
 	seenIDs := map[string]bool{}
+	firstLoadIDs := make([]string, 0, len(wantKinds))
 	for i := range wantKinds {
 		select {
 		case update := <-loader.notifications:
@@ -275,11 +292,27 @@ func TestACPLoadReplaysHistoryAndResumeDoesNot(t *testing.T) {
 				t.Fatalf("history update %d has missing/duplicate message id %q", i, update.MessageID)
 			}
 			seenIDs[update.MessageID] = true
+			firstLoadIDs = append(firstLoadIDs, update.MessageID)
 		case <-ctx.Done():
 			t.Fatalf("history update %d was not replayed", i)
 		}
 	}
 	loader.stop()
+	secondLoader := newHarness(t, deps)
+	if err := secondLoader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("second session/load: %v", err)
+	}
+	for i, wantID := range firstLoadIDs {
+		select {
+		case update := <-secondLoader.notifications:
+			if update.MessageID != wantID {
+				t.Fatalf("second load message id %d = %q, want stable %q", i, update.MessageID, wantID)
+			}
+		case <-ctx.Done():
+			t.Fatalf("second load history update %d was not replayed", i)
+		}
+	}
+	secondLoader.stop()
 
 	resumer := newHarness(t, deps)
 	defer resumer.stop()
@@ -290,6 +323,38 @@ func TestACPLoadReplaysHistoryAndResumeDoesNot(t *testing.T) {
 	case update := <-resumer.notifications:
 		t.Fatalf("session/resume replayed history: %+v", update)
 	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestACPLoadAndResumeStayBoundToThePersistedWorkspace(t *testing.T) {
+	deps := testDeps(t)
+	workspaceA := t.TempDir()
+	workspaceB := t.TempDir()
+	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "workspace-bound", Cwd: workspaceA})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, method := range []string{MethodSessionLoad, MethodSessionResume} {
+		err := h.client.Call(ctx, method, LoadSessionParams{SessionID: created.SessionID, Cwd: workspaceB, McpServers: []McpServer{}}, &LoadSessionResult{})
+		var rpcErr *rpcError
+		if !errors.As(err, &rpcErr) || rpcErr.Code != codeInvalidParams || !strings.Contains(rpcErr.Message, "persisted workspace") {
+			t.Fatalf("%s with mismatched cwd error = %v, want persisted-workspace invalid params", method, err)
+		}
+	}
+
+	missing, err := deps.Store.Create(sessions.CreateInput{SessionID: "workspace-missing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = h.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: missing.SessionID, Cwd: workspaceA, McpServers: []McpServer{}}, &ResumeSessionResult{})
+	var rpcErr *rpcError
+	if !errors.As(err, &rpcErr) || rpcErr.Code != codeInvalidParams || !strings.Contains(rpcErr.Message, "no persisted workspace") {
+		t.Fatalf("resume with missing persisted cwd error = %v, want invalid params", err)
 	}
 }
 

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1222,14 +1222,22 @@ func TestResumeRefusesARelativePersistedWorkspace(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// No cwd at all: the request that used to succeed by rebasing.
-	var out LoadSessionResult
-	if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: "relative-ws"}, &out); err == nil {
-		t.Error("resuming a relative persisted workspace succeeded; the session was rebound to the ACP process directory")
-	}
-	// And an unrelated workspace must not be accepted as its home either.
+	// BOTH ACTIVATING METHODS, not just one. session/load and session/resume are
+	// separate entry points that today share activatePersistedSession — so a test
+	// through either passes while the guard holds. Naming both here is what keeps
+	// that true: if resume is ever given its own path, this fails rather than
+	// silently covering half the surface it claims to.
 	elsewhere := t.TempDir()
-	if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: "relative-ws", Cwd: elsewhere}, &out); err == nil {
-		t.Errorf("resuming a relative persisted workspace into %q succeeded", elsewhere)
+	var out LoadSessionResult
+	for _, method := range []string{MethodSessionLoad, MethodSessionResume} {
+		// No cwd at all: the request that used to succeed by rebasing onto
+		// whatever directory this process happens to be running in.
+		if err := h.client.Call(ctx, method, LoadSessionParams{SessionID: "relative-ws"}, &out); err == nil {
+			t.Errorf("%s of a relative persisted workspace succeeded; the session was rebound to the ACP process directory", method)
+		}
+		// And an unrelated workspace must not be accepted as its home either.
+		if err := h.client.Call(ctx, method, ResumeSessionParams{SessionID: "relative-ws", Cwd: elsewhere}, &out); err == nil {
+			t.Errorf("%s of a relative persisted workspace into %q succeeded", method, elsewhere)
+		}
 	}
 }

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1722,8 +1722,18 @@ func TestACPPromptPersistsToolActivityForFreshLoad(t *testing.T) {
 	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace}, &LoadSessionResult{}); err != nil {
 		t.Fatalf("fresh session/load: %v", err)
 	}
-	start := <-loader.tools
-	result := <-loader.tools
+	nextReplay := func(label string) ToolCallUpdate {
+		t.Helper()
+		select {
+		case update := <-loader.tools:
+			return update
+		case <-ctx.Done():
+			t.Fatalf("replayed %s never arrived: %v", label, ctx.Err())
+			return ToolCallUpdate{}
+		}
+	}
+	start := nextReplay("tool start")
+	result := nextReplay("tool result")
 	if start.SessionUpdate != UpdateToolCall || start.ToolCallID != "call-live" || start.Status != ToolStatusInProgress {
 		t.Fatalf("replayed tool start = %+v", start)
 	}

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -97,9 +97,10 @@ func testDeps(t *testing.T) Deps {
 // clientHarness wires a client Conn to an Agent over in-memory pipes and collects
 // session/update text chunks.
 type clientHarness struct {
-	client  *Conn
-	updates chan string
-	stop    func()
+	client        *Conn
+	updates       chan string
+	notifications chan ContentChunk
+	stop          func()
 }
 
 func newHarness(t *testing.T, deps Deps) *clientHarness {
@@ -110,18 +111,16 @@ func newHarness(t *testing.T, deps Deps) *clientHarness {
 	client := NewConn(br, bw)
 	a := NewAgent(agentConn, deps)
 
-	h := &clientHarness{client: client, updates: make(chan string, 128)}
+	h := &clientHarness{client: client, updates: make(chan string, 128), notifications: make(chan ContentChunk, 128)}
 	client.HandleNotify(MethodSessionUpdate, func(_ context.Context, params json.RawMessage) {
 		var probe struct {
-			Update struct {
-				SessionUpdate string `json:"sessionUpdate"`
-				Content       struct {
-					Text string `json:"text"`
-				} `json:"content"`
-			} `json:"update"`
+			Update ContentChunk `json:"update"`
 		}
 		if json.Unmarshal(params, &probe) != nil {
 			return
+		}
+		if probe.Update.SessionUpdate == UpdateAgentMessageChunk || probe.Update.SessionUpdate == UpdateUserMessageChunk {
+			h.notifications <- probe.Update
 		}
 		if probe.Update.SessionUpdate == UpdateAgentMessageChunk {
 			h.updates <- probe.Update.Content.Text
@@ -154,7 +153,8 @@ func TestACPEndToEndPrompt(t *testing.T) {
 	if initRes.ProtocolVersion != ProtocolVersion {
 		t.Fatalf("protocol version = %d", initRes.ProtocolVersion)
 	}
-	if !initRes.AgentCapabilities.LoadSession || !initRes.AgentCapabilities.PromptCapabilities.Image {
+	if !initRes.AgentCapabilities.LoadSession || !initRes.AgentCapabilities.PromptCapabilities.Image ||
+		initRes.AgentCapabilities.SessionCapabilities == nil || initRes.AgentCapabilities.SessionCapabilities.List == nil || initRes.AgentCapabilities.SessionCapabilities.Resume == nil {
 		t.Fatalf("unexpected capabilities: %+v", initRes.AgentCapabilities)
 	}
 
@@ -191,6 +191,105 @@ func TestACPEndToEndPrompt(t *testing.T) {
 	// The streamed agent_message_chunk(s) should carry the assistant text.
 	if got := drainText(t, h.updates); !strings.Contains(got, "Hello from ZERO") {
 		t.Fatalf("streamed text = %q, want it to contain the assistant message", got)
+	}
+}
+
+func TestACPListsOnlyResumableSessionMetadata(t *testing.T) {
+	deps := testDeps(t)
+	workspaceA := t.TempDir()
+	workspaceB := t.TempDir()
+	for _, input := range []sessions.CreateInput{
+		{SessionID: "desktop-a", Title: "First", Cwd: workspaceA, ModelID: "model-a"},
+		{SessionID: "desktop-b", Title: "Second", Cwd: workspaceB, ModelID: "model-b"},
+		{SessionID: "child-run", SessionKind: sessions.SessionKindChild, Title: "Internal child", Cwd: workspaceA},
+	} {
+		if _, err := deps.Store.Create(input); err != nil {
+			t.Fatalf("create %s: %v", input.SessionID, err)
+		}
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var all ListSessionsResult
+	if err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{}, &all); err != nil {
+		t.Fatalf("session/list: %v", err)
+	}
+	if len(all.Sessions) != 2 {
+		t.Fatalf("all sessions = %+v, want two resumable sessions", all.Sessions)
+	}
+	byID := make(map[string]SessionInfo, len(all.Sessions))
+	for _, item := range all.Sessions {
+		byID[item.SessionID] = item
+	}
+	if _, found := byID["child-run"]; found {
+		t.Fatal("agent-owned child session leaked into the desktop session picker")
+	}
+	if got := byID["desktop-a"]; got.Title != "First" || got.Cwd != workspaceA || got.Meta == nil || got.Meta.ModelID != "model-a" || got.Meta.CreatedAt == "" || got.UpdatedAt == "" {
+		t.Fatalf("desktop-a summary = %+v", got)
+	}
+
+	var filtered ListSessionsResult
+	if err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{Cwd: workspaceB}, &filtered); err != nil {
+		t.Fatalf("filtered session/list: %v", err)
+	}
+	if len(filtered.Sessions) != 1 || filtered.Sessions[0].SessionID != "desktop-b" {
+		t.Fatalf("filtered sessions = %+v, want only desktop-b", filtered.Sessions)
+	}
+}
+
+func TestACPLoadReplaysHistoryAndResumeDoesNot(t *testing.T) {
+	deps := testDeps(t)
+	workspace := t.TempDir()
+	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "replay-session", Title: "Replay", Cwd: workspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "first user"}},
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "assistant", "content": "first answer"}},
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "second user"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	loader := newHarness(t, deps)
+	var loaded LoadSessionResult
+	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &loaded); err != nil {
+		t.Fatalf("session/load: %v", err)
+	}
+	wantKinds := []string{UpdateUserMessageChunk, UpdateAgentMessageChunk, UpdateUserMessageChunk}
+	wantText := []string{"first user", "first answer", "second user"}
+	seenIDs := map[string]bool{}
+	for i := range wantKinds {
+		select {
+		case update := <-loader.notifications:
+			if update.SessionUpdate != wantKinds[i] || update.Content.Text != wantText[i] {
+				t.Fatalf("history update %d = %+v", i, update)
+			}
+			if update.MessageID == "" || seenIDs[update.MessageID] {
+				t.Fatalf("history update %d has missing/duplicate message id %q", i, update.MessageID)
+			}
+			seenIDs[update.MessageID] = true
+		case <-ctx.Done():
+			t.Fatalf("history update %d was not replayed", i)
+		}
+	}
+	loader.stop()
+
+	resumer := newHarness(t, deps)
+	defer resumer.stop()
+	if err := resumer.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &ResumeSessionResult{}); err != nil {
+		t.Fatalf("session/resume: %v", err)
+	}
+	select {
+	case update := <-resumer.notifications:
+		t.Fatalf("session/resume replayed history: %+v", update)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -103,7 +103,11 @@ type clientHarness struct {
 	client        *Conn
 	updates       chan string
 	notifications chan ContentChunk
-	stop          func()
+	// tools carries replayed and live tool-call notifications. They are a
+	// different wire shape from a message chunk, so decoding them into
+	// ContentChunk would silently blank every field the assertions need.
+	tools chan ToolCallUpdate
+	stop  func()
 }
 
 func newHarness(t *testing.T, deps Deps) *clientHarness {
@@ -114,8 +118,30 @@ func newHarness(t *testing.T, deps Deps) *clientHarness {
 	client := NewConn(br, bw)
 	a := NewAgent(agentConn, deps)
 
-	h := &clientHarness{client: client, updates: make(chan string, 128), notifications: make(chan ContentChunk, 128)}
+	h := &clientHarness{client: client, updates: make(chan string, 128), notifications: make(chan ContentChunk, 128), tools: make(chan ToolCallUpdate, 128)}
 	client.HandleNotify(MethodSessionUpdate, func(_ context.Context, params json.RawMessage) {
+		// Decode the discriminator ALONE first. ContentChunk and ToolCallUpdate
+		// disagree on the shape of "content" (a block vs an array of them), so
+		// decoding straight into ContentChunk makes every tool_call_update fail
+		// to unmarshal and vanish — which reads exactly like a notification that
+		// was never sent.
+		var kind struct {
+			Update struct {
+				SessionUpdate string `json:"sessionUpdate"`
+			} `json:"update"`
+		}
+		if json.Unmarshal(params, &kind) != nil {
+			return
+		}
+		if kind.Update.SessionUpdate == UpdateToolCall || kind.Update.SessionUpdate == UpdateToolCallUpdate {
+			var toolProbe struct {
+				Update ToolCallUpdate `json:"update"`
+			}
+			if json.Unmarshal(params, &toolProbe) == nil {
+				h.tools <- toolProbe.Update
+			}
+			return
+		}
 		var probe struct {
 			Update ContentChunk `json:"update"`
 		}
@@ -1447,5 +1473,231 @@ func TestSessionListRejectsARelativeCwdFilter(t *testing.T) {
 	}
 	if len(out.Sessions) != 1 || out.Sessions[0].SessionID != "persisted" {
 		t.Errorf("unfiltered session/list = %+v, want the one persisted session", out.Sessions)
+	}
+}
+
+// A COMPACTED SESSION MUST RESUME AS THE CONVERSATION IT BECAME, NOT THE ONE IT
+// WAS. This session's first three turns were compacted into one summary. Reading
+// the raw log would replay those superseded turns and drop the summary; reading
+// the rehydrated view without projecting EventCompaction would drop the summary
+// and the turns both. Load and resume must agree, so both are asserted.
+func TestACPCompactedHistoryReplacesCompactedTurnsWithTheirSummary(t *testing.T) {
+	deps := testDeps(t)
+	workspace := t.TempDir()
+	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "compacted-session", Title: "Compacted", Cwd: workspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appended, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "compacted question"}},
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "assistant", "content": "compacted answer"}},
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "surviving question"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(appended) != 3 {
+		t.Fatalf("appended %d events, want 3", len(appended))
+	}
+	const summary = "Earlier: the user asked about scope roots and got an answer."
+	if _, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{{
+		Type: sessions.EventCompaction,
+		Payload: map[string]any{
+			"summary":      summary,
+			"preserveLast": 1,
+			"compactableEvents": []map[string]any{
+				{"id": appended[0].ID, "sequence": appended[0].Sequence},
+				{"id": appended[1].ID, "sequence": appended[1].Sequence},
+			},
+		},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	loader := newHarness(t, deps)
+	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("session/load: %v", err)
+	}
+	wantKinds := []string{UpdateAgentMessageChunk, UpdateUserMessageChunk}
+	wantText := []string{summary, "surviving question"}
+	for i := range wantKinds {
+		select {
+		case update := <-loader.notifications:
+			if update.SessionUpdate != wantKinds[i] || update.Content.Text != wantText[i] {
+				t.Fatalf("replayed update %d = %+v, want %s %q", i, update, wantKinds[i], wantText[i])
+			}
+		case <-ctx.Done():
+			t.Fatalf("replayed update %d never arrived", i)
+		}
+	}
+	// The compacted-away turns must NOT also be replayed after the summary.
+	select {
+	case update := <-loader.notifications:
+		t.Fatalf("a compacted-away turn was replayed: %+v", update)
+	case <-time.After(150 * time.Millisecond):
+	}
+	loader.stop()
+
+	// Resume takes the same history. Its prompt context is what proves it: the
+	// summary must be in there and the compacted originals must not, so the
+	// prompt the agent loop actually receives is captured rather than inferred.
+	prompts := make(chan string, 4)
+	realRun := deps.RunAgent
+	deps.RunAgent = func(ctx context.Context, prompt string, provider zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+		prompts <- prompt
+		return realRun(ctx, prompt, provider, opts)
+	}
+	resumer := newHarness(t, deps)
+	defer resumer.stop()
+	if err := resumer.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &ResumeSessionResult{}); err != nil {
+		t.Fatalf("session/resume: %v", err)
+	}
+	if err := resumer.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: created.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "carry on"}},
+	}, &PromptResult{}); err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+	prompt := <-prompts
+	if !strings.Contains(prompt, summary) {
+		t.Fatalf("resumed prompt lost the compaction summary:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "compacted answer") {
+		t.Fatalf("resumed prompt replayed a compacted-away turn:\n%s", prompt)
+	}
+}
+
+// Tool activity is part of the transcript a client redraws on session/load, and
+// a result is only renderable if it pairs with its call by the SAME id. Resume
+// stays replay-free.
+func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
+	deps := testDeps(t)
+	workspace := t.TempDir()
+	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "tool-replay-session", Title: "Tools", Cwd: workspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "read the file"}},
+		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "read_file", "toolCallId": "call-77", "arguments": `{"path":"scope.go"}`}},
+		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "read_file", "toolCallId": "call-77", "status": "ok", "output": "package sandbox"}},
+		// An older record spells the id "id" rather than "toolCallId".
+		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "bash", "id": "call-88", "arguments": `{"command":"go build"}`}},
+		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "bash", "id": "call-88", "status": "error", "output": "build failed"}},
+		// No id at all: unpairable, so it must be skipped rather than replayed.
+		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "orphan", "arguments": "{}"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	loader := newHarness(t, deps)
+	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("session/load: %v", err)
+	}
+	type want struct {
+		kind, id, status string
+	}
+	wants := []want{
+		{UpdateToolCall, "call-77", ToolStatusCompleted},
+		{UpdateToolCallUpdate, "call-77", ToolStatusCompleted},
+		{UpdateToolCall, "call-88", ToolStatusCompleted},
+		{UpdateToolCallUpdate, "call-88", ToolStatusFailed},
+	}
+	for i, w := range wants {
+		select {
+		case update := <-loader.tools:
+			if update.SessionUpdate != w.kind || update.ToolCallID != w.id || update.Status != w.status {
+				t.Fatalf("tool update %d = %+v, want %s/%s/%s", i, update, w.kind, w.id, w.status)
+			}
+		case <-ctx.Done():
+			t.Fatalf("tool update %d never arrived", i)
+		}
+	}
+	select {
+	case update := <-loader.tools:
+		t.Fatalf("an unpairable tool call was replayed: %+v", update)
+	case <-time.After(150 * time.Millisecond):
+	}
+	loader.stop()
+
+	resumer := newHarness(t, deps)
+	defer resumer.stop()
+	if err := resumer.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &ResumeSessionResult{}); err != nil {
+		t.Fatalf("session/resume: %v", err)
+	}
+	select {
+	case update := <-resumer.tools:
+		t.Fatalf("session/resume replayed tool activity: %+v", update)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// sessionCapabilities is omitempty. The positive case is asserted above; this is
+// the other half — an agent that does NOT support list/resume must omit the key
+// entirely rather than send a null a client could read as "supported". Raised by
+// CodeRabbit.
+func TestSessionCapabilitiesAreOmittedWhenUnset(t *testing.T) {
+	encoded, err := json.Marshal(AgentCapabilities{LoadSession: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["sessionCapabilities"]; ok {
+		t.Fatalf("unset sessionCapabilities was still serialized: %s", encoded)
+	}
+}
+
+// A RESUME THAT CANNOT RESTORE ITS CONTEXT MUST FAIL, NOT SUCCEED QUIETLY.
+// Resume's entire contract is "carry on from where this left off". If the events
+// file is unreadable, the old behaviour registered the session anyway and
+// returned success: the client held a live session ID under the old identity
+// whose next prompt ran as a fresh conversation. Nothing on the wire said so.
+//
+// Load keeps the best-effort policy deliberately — it replays what it can and
+// warns — so both halves are asserted here to keep the two from being
+// accidentally unified again.
+func TestACPResumeFailsWhenHistoryCannotBeRestored(t *testing.T) {
+	deps := testDeps(t)
+	cwd := t.TempDir()
+	meta, err := deps.Store.Create(sessions.CreateInput{Title: "ACP session", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	eventsPath := filepath.Join(deps.Store.RootDir, meta.SessionID, sessions.EventsFile)
+	if err := os.WriteFile(eventsPath, []byte("{bad json}\n"), 0o600); err != nil {
+		t.Fatalf("write corrupt events: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resumer := newHarness(t, deps)
+	defer resumer.stop()
+	err = resumer.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}}, &ResumeSessionResult{})
+	if err == nil {
+		t.Fatal("session/resume reported success despite unreadable history")
+	}
+	// And the session must not have been published: a prompt against it has to
+	// be refused, not silently answered with no context.
+	if err := resumer.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: meta.SessionID,
+		Prompt:    []ContentBlock{TextBlock("carry on")},
+	}, &PromptResult{}); err == nil {
+		t.Fatal("a session whose resume failed was still promptable")
+	}
+
+	// Load is the deliberate exception and still opens.
+	loader := newHarness(t, deps)
+	defer loader.stop()
+	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("session/load must stay best-effort, got: %v", err)
 	}
 }

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1782,14 +1782,14 @@ func TestACPCompactedHistoryReplacesCompactedTurnsWithTheirSummary(t *testing.T)
 // Tool activity is part of the transcript a client redraws on session/load, and
 // a result is only renderable if it pairs with its call by the SAME id. Resume
 // stays replay-free.
-func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
+func TestACPLoadReplaysToolCallsPairedByTheirStoredOccurrence(t *testing.T) {
 	deps := testDeps(t)
 	workspace := t.TempDir()
 	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "tool-replay-session", Title: "Tools", Cwd: workspace})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{
+	appended, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{
 		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "read the file"}},
 		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "read_file", "toolCallId": "call-77", "arguments": `{"path":"scope.go"}`}},
 		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "read_file", "toolCallId": "call-77", "status": "ok", "output": "package sandbox", "changedFiles": []string{"scope.go", "scope_test.go"}}},
@@ -1802,7 +1802,8 @@ func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
 		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "orphan", "arguments": "{}"}},
 		// An identified result is still unpairable when its start is absent.
 		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "orphan", "toolCallId": "missing-call", "status": "ok", "output": "must not replay"}},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1817,11 +1818,11 @@ func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
 		locations        []string
 	}
 	wants := []want{
-		{UpdateToolCall, "call-77", ToolStatusInProgress, nil},
-		{UpdateToolCallUpdate, "call-77", ToolStatusCompleted, []string{"scope.go", "scope_test.go"}},
-		{UpdateToolCall, "call-88", ToolStatusInProgress, nil},
-		{UpdateToolCallUpdate, "call-88", ToolStatusFailed, nil},
-		{UpdateToolCall, "call-99", ToolStatusInProgress, nil},
+		{UpdateToolCall, replayToolCallID(appended[1].ID), ToolStatusInProgress, nil},
+		{UpdateToolCallUpdate, replayToolCallID(appended[1].ID), ToolStatusCompleted, []string{"scope.go", "scope_test.go"}},
+		{UpdateToolCall, replayToolCallID(appended[3].ID), ToolStatusInProgress, nil},
+		{UpdateToolCallUpdate, replayToolCallID(appended[3].ID), ToolStatusFailed, nil},
+		{UpdateToolCall, replayToolCallID(appended[5].ID), ToolStatusInProgress, nil},
 	}
 	for i, w := range wants {
 		select {
@@ -1857,6 +1858,63 @@ func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
 	case update := <-resumer.tools:
 		t.Fatalf("session/resume replayed tool activity: %+v", update)
 	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestACPLoadDisambiguatesRepeatedStoredToolIDs(t *testing.T) {
+	deps := testDeps(t)
+	workspace := t.TempDir()
+	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "repeated-tool-ids", Cwd: workspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{
+		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "read_file", "toolCallId": "gemini_tool_1", "arguments": `{"path":"a.go"}`}},
+		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "read_file", "toolCallId": "gemini_tool_1", "status": "ok", "output": "alpha"}},
+		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "grep", "toolCallId": "gemini_tool_1", "arguments": `{"pattern":"TODO"}`}},
+		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "grep", "toolCallId": "gemini_tool_1", "status": "error", "output": "not found"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	load := func() []ToolCallUpdate {
+		t.Helper()
+		h := newHarness(t, deps)
+		defer h.stop()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{
+			SessionID: created.SessionID, Cwd: workspace,
+		}, &LoadSessionResult{}); err != nil {
+			t.Fatalf("session/load: %v", err)
+		}
+		updates := make([]ToolCallUpdate, 0, 4)
+		for len(updates) < 4 {
+			select {
+			case update := <-h.tools:
+				updates = append(updates, update)
+			case <-ctx.Done():
+				t.Fatalf("received %d tool updates, want four", len(updates))
+			}
+		}
+		return updates
+	}
+
+	first := load()
+	if first[0].ToolCallID == "" || first[0].ToolCallID != first[1].ToolCallID {
+		t.Fatalf("first call/result pairing = %q/%q", first[0].ToolCallID, first[1].ToolCallID)
+	}
+	if first[2].ToolCallID == "" || first[2].ToolCallID != first[3].ToolCallID {
+		t.Fatalf("second call/result pairing = %q/%q", first[2].ToolCallID, first[3].ToolCallID)
+	}
+	if first[0].ToolCallID == first[2].ToolCallID {
+		t.Fatalf("separate invocations reused replay identity %q", first[0].ToolCallID)
+	}
+	second := load()
+	for index := range first {
+		if second[index].ToolCallID != first[index].ToolCallID {
+			t.Fatalf("load two identity %d = %q, want stable %q", index, second[index].ToolCallID, first[index].ToolCallID)
+		}
 	}
 }
 
@@ -1945,10 +2003,11 @@ func TestACPPromptPersistsToolActivityForFreshLoad(t *testing.T) {
 	}
 	start := nextReplay("tool start")
 	result := nextReplay("tool result")
-	if start.SessionUpdate != UpdateToolCall || start.ToolCallID != "call-live" || start.Status != ToolStatusInProgress {
+	replayID := replayToolCallID(events[1].ID)
+	if start.SessionUpdate != UpdateToolCall || start.ToolCallID != replayID || start.Status != ToolStatusInProgress {
 		t.Fatalf("replayed tool start = %+v", start)
 	}
-	if result.SessionUpdate != UpdateToolCallUpdate || result.ToolCallID != "call-live" || result.Status != ToolStatusCompleted {
+	if result.SessionUpdate != UpdateToolCallUpdate || result.ToolCallID != replayID || result.Status != ToolStatusCompleted {
 		t.Fatalf("replayed tool result = %+v", result)
 	}
 	if len(result.Locations) != 2 || result.Locations[0].Path != "a.go" || result.Locations[1].Path != "b.go" {
@@ -2028,7 +2087,7 @@ func TestACPPersistenceStopsAtFirstFailedEventDependency(t *testing.T) {
 			}
 			select {
 			case update := <-loader.tools:
-				if tc.failAt != 3 || update.SessionUpdate != UpdateToolCall || update.ToolCallID != "call-prefix" || update.Status != ToolStatusInProgress {
+				if tc.failAt != 3 || update.SessionUpdate != UpdateToolCall || update.ToolCallID != replayToolCallID(events[1].ID) || update.Status != ToolStatusInProgress {
 					t.Fatalf("replayed tool update = %+v", update)
 				}
 			case <-time.After(100 * time.Millisecond):
@@ -2172,5 +2231,47 @@ func TestACPResumeFailsWhenHistoryCannotBeRestored(t *testing.T) {
 	defer loader.stop()
 	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}}, &LoadSessionResult{}); err != nil {
 		t.Fatalf("session/load must stay best-effort, got: %v", err)
+	}
+}
+
+func TestACPResumeRejectsMissingPopulatedEventLog(t *testing.T) {
+	deps := testDeps(t)
+	cwd := t.TempDir()
+	populated, err := deps.Store.Create(sessions.CreateInput{SessionID: "missing-populated-log", Cwd: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.AppendEvent(populated.SessionID, sessions.AppendEventInput{
+		Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "retain me"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(deps.Store.RootDir, populated.SessionID, sessions.EventsFile)); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := h.client.Call(ctx, MethodSessionResume, ResumeSessionParams{
+		SessionID: populated.SessionID, Cwd: cwd,
+	}, &ResumeSessionResult{}); err == nil {
+		t.Fatal("session/resume accepted missing populated history")
+	}
+	if err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: populated.SessionID, Prompt: []ContentBlock{TextBlock("must stay closed")},
+	}, &PromptResult{}); err == nil {
+		t.Fatal("failed missing-history resume became promptable")
+	}
+
+	empty, err := deps.Store.Create(sessions.CreateInput{SessionID: "valid-empty-log", Cwd: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.client.Call(ctx, MethodSessionResume, ResumeSessionParams{
+		SessionID: empty.SessionID, Cwd: cwd,
+	}, &ResumeSessionResult{}); err != nil {
+		t.Fatalf("session/resume rejected valid empty history: %v", err)
 	}
 }

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -258,7 +259,12 @@ func TestACPListsOnlyResumableSessionMetadata(t *testing.T) {
 	if _, found := byID["child-run"]; found {
 		t.Fatal("agent-owned child session leaked into the desktop session picker")
 	}
-	if got := byID["desktop-a"]; got.Title != "First" || got.Cwd != workspaceA || got.Meta == nil || got.Meta.ModelID != "model-a" || got.Meta.CreatedAt == "" || got.UpdatedAt == "" {
+	// The fixture's spelling is the INPUT; the resolver's is the OUTPUT the
+	// listing promises. Under a TMPDIR carrying a ".." component t.TempDir()
+	// keeps that spelling while the test resolver cleans it, and comparing the
+	// two representations failed a correct result. Expected values describe the
+	// output contract. Reported by @jatmn.
+	if got := byID["desktop-a"]; got.Title != "First" || got.Cwd != filepath.Clean(workspaceA) || got.Meta == nil || got.Meta.ModelID != "model-a" || got.Meta.CreatedAt == "" || got.UpdatedAt == "" {
 		t.Fatalf("desktop-a summary = %+v", got)
 	}
 
@@ -2015,92 +2021,214 @@ func TestACPPromptPersistsToolActivityForFreshLoad(t *testing.T) {
 	}
 }
 
-func TestACPPersistenceStopsAtFirstFailedEventDependency(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		failAt    int
-		wantTypes []sessions.EventType
-	}{
-		{name: "user message", failAt: 1},
-		{name: "tool call", failAt: 2, wantTypes: []sessions.EventType{sessions.EventMessage}},
-		{name: "tool result", failAt: 3, wantTypes: []sessions.EventType{sessions.EventMessage, sessions.EventToolCall}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			deps := testDeps(t)
-			attempts := 0
-			deps.PersistEvent = func(sessionID string, input sessions.AppendEventInput) error {
-				attempts++
-				if attempts == tc.failAt {
-					return errors.New("injected append failure")
-				}
-				_, err := deps.Store.AppendEvents(sessionID, []sessions.AppendEventInput{input})
-				return err
-			}
-			deps.RunAgent = func(_ context.Context, _ string, _ zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
-				call := agent.ToolCall{ID: "call-prefix", Name: "read_file", Arguments: `{"path":"a.go"}`}
-				opts.OnToolCall(call)
-				opts.OnToolResult(agent.ToolResult{
-					ToolCallID: call.ID, Name: call.Name, Status: tools.StatusOK, Output: "content",
-				})
-				return agent.Result{FinalAnswer: "done"}, nil
-			}
+// A COMPLETED TURN IS ONE STORE BATCH; ITS FAILURE IS ONE FAILURE. Persistence
+// used to append the buffered turn one event per call, so a failure part-way
+// left a durable prefix and the rule was "never append a dependent suffix after
+// a failed prerequisite". With the turn committed as a single batch there is
+// no suffix to protect: nothing of the turn is durable, the turn still reports
+// its real outcome, the warning is raised, and a fresh load finds no history.
+func TestACPPersistenceFailureCommitsNothingOfTheTurn(t *testing.T) {
+	deps := testDeps(t)
+	batches := 0
+	deps.PersistEvents = func(sessionID string, inputs []sessions.AppendEventInput) error {
+		batches++
+		return errors.New("injected append failure")
+	}
+	deps.RunAgent = func(_ context.Context, _ string, _ zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+		call := agent.ToolCall{ID: "call-prefix", Name: "read_file", Arguments: `{"path":"a.go"}`}
+		opts.OnToolCall(call)
+		opts.OnToolResult(agent.ToolResult{ToolCallID: call.ID, Name: call.Name, Status: tools.StatusOK, Output: "content"})
+		return agent.Result{FinalAnswer: "done"}, nil
+	}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			workspace := t.TempDir()
-			writer := newHarness(t, deps)
-			var created NewSessionResult
-			if err := writer.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: workspace}, &created); err != nil {
-				t.Fatal(err)
-			}
-			if err := writer.client.Call(ctx, MethodSessionPrompt, PromptParams{
-				SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("read it")},
-			}, &PromptResult{}); err != nil {
-				t.Fatalf("session/prompt: %v", err)
-			}
-			writer.stop()
-			if attempts != tc.failAt {
-				t.Fatalf("append attempts = %d, want persistence to stop at %d", attempts, tc.failAt)
-			}
-			events, err := deps.Store.ReadEvents(created.SessionID)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(events) != len(tc.wantTypes) {
-				t.Fatalf("durable events = %+v, want prefix %v", events, tc.wantTypes)
-			}
-			for i, want := range tc.wantTypes {
-				if events[i].Type != want {
-					t.Fatalf("durable event %d = %s, want %s", i, events[i].Type, want)
-				}
-			}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	workspace := t.TempDir()
+	writer := newHarness(t, deps)
+	var created NewSessionResult
+	if err := writer.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: workspace}, &created); err != nil {
+		t.Fatal(err)
+	}
+	var result PromptResult
+	if err := writer.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("read it")},
+	}, &result); err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+	if result.StopReason != StopEndTurn {
+		t.Fatalf("stopReason = %q, want %q: a persistence failure is not a failed turn", result.StopReason, StopEndTurn)
+	}
+	got := drainTextUntil(t, writer.updates, func(text string) bool {
+		return strings.Contains(text, "Could not save session history")
+	})
+	if !strings.Contains(got, "Could not save session history") {
+		t.Fatalf("streamed text = %q, want persistence warning", got)
+	}
+	writer.stop()
+	if batches != 1 {
+		t.Fatalf("persistence attempts = %d, want the whole turn offered once as one batch", batches)
+	}
+	events, err := deps.Store.ReadEvents(created.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("durable events = %+v, want none: a failed batch must not leave a partial turn", events)
+	}
 
-			// Reopen through a fresh ACP instance: the durable prefix may contain
-			// an in-progress call, but never its orphan result or an assistant
-			// answer whose prerequisite write failed.
-			loader := newHarness(t, deps)
-			defer loader.stop()
-			if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{
-				SessionID: created.SessionID, Cwd: workspace,
-			}, &LoadSessionResult{}); err != nil {
-				t.Fatalf("fresh session/load: %v", err)
-			}
-			select {
-			case update := <-loader.tools:
-				if tc.failAt != 3 || update.SessionUpdate != UpdateToolCall || update.ToolCallID != replayToolCallID(events[1].ID) || update.Status != ToolStatusInProgress {
-					t.Fatalf("replayed tool update = %+v", update)
-				}
-			case <-time.After(100 * time.Millisecond):
-				if tc.failAt == 3 {
-					t.Fatal("persisted tool-call prefix was not replayed")
-				}
-			}
-			select {
-			case update := <-loader.tools:
-				t.Fatalf("dependent tool suffix was replayed: %+v", update)
-			case <-time.After(100 * time.Millisecond):
-			}
-		})
+	// A fresh instance loads the session and replays nothing: no orphan call,
+	// no answer whose prerequisite never landed.
+	loader := newHarness(t, deps)
+	defer loader.stop()
+	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{
+		SessionID: created.SessionID, Cwd: workspace,
+	}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("fresh session/load: %v", err)
+	}
+	select {
+	case update := <-loader.tools:
+		t.Fatalf("a tool update from the failed turn was replayed: %+v", update)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TWO INSTANCES, ONE STORE: EACH TURN'S RECORDS STAY TOGETHER. An ACP
+// instance's turnMu serializes prompts within that instance only; two
+// instances that loaded the same session share nothing but the store, so the
+// store batch is the only thing standing between their turns. When the turn
+// was committed one event per call, another writer could land between two of
+// them and a fresh load paired user A with nothing and answer A with nothing.
+//
+// The seam here does not batch anything itself: it OBSERVES what production
+// hands it — the complete buffered turn — holds both writers at the commit
+// boundary until each has arrived, and then delegates to the real
+// Store.AppendEvents batch under the real session lock. Reverting persistTurn
+// to singleton writes fails this deterministically: the seam then sees
+// one-event batches, before any interleaving has to be provoked at all.
+func TestACPCompletedTurnsFromTwoInstancesStayContiguous(t *testing.T) {
+	deps := testDeps(t)
+	workspace := t.TempDir()
+	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "shared-session", Title: "Shared", Cwd: workspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const writers = 2
+	var mu sync.Mutex
+	arrived := 0
+	release := make(chan struct{})
+	deps.PersistEvents = func(sessionID string, inputs []sessions.AppendEventInput) error {
+		// The whole turn, or the contiguity guarantee is already gone.
+		if len(inputs) != 4 {
+			t.Errorf("persist batch carried %d events, want the complete 4-event turn", len(inputs))
+		}
+		mu.Lock()
+		arrived++
+		if arrived == writers {
+			close(release)
+		}
+		mu.Unlock()
+		<-release
+		_, err := deps.Store.AppendEvents(sessionID, inputs)
+		return err
+	}
+	deps.RunAgent = func(_ context.Context, prompt string, _ zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+		who := "A"
+		if strings.Contains(prompt, "prompt B") {
+			who = "B"
+		}
+		call := agent.ToolCall{ID: "call-" + who, Name: "read_file", Arguments: `{"path":"` + who + `.go"}`}
+		opts.OnToolCall(call)
+		opts.OnToolResult(agent.ToolResult{ToolCallID: call.ID, Name: call.Name, Status: tools.StatusOK, Output: "content " + who})
+		return agent.Result{FinalAnswer: "answer " + who}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	instanceA := newHarness(t, deps)
+	defer instanceA.stop()
+	instanceB := newHarness(t, deps)
+	defer instanceB.stop()
+	for _, h := range []*clientHarness{instanceA, instanceB} {
+		if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &LoadSessionResult{}); err != nil {
+			t.Fatalf("session/load: %v", err)
+		}
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for _, turn := range []struct {
+		h      *clientHarness
+		prompt string
+	}{{instanceA, "prompt A"}, {instanceB, "prompt B"}} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- turn.h.client.Call(ctx, MethodSessionPrompt, PromptParams{
+				SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock(turn.prompt)},
+			}, &PromptResult{})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("session/prompt: %v", err)
+		}
+	}
+
+	events, err := deps.Store.ReadEvents(created.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 8 {
+		t.Fatalf("durable events = %d, want 8", len(events))
+	}
+	// Each turn is a contiguous 4-record group in stored order.
+	for start := 0; start < 8; start += 4 {
+		group := events[start : start+4]
+		user := payloadString(group[0].Payload, "content")
+		who := strings.TrimPrefix(user, "prompt ")
+		if group[0].Type != sessions.EventMessage || group[1].Type != sessions.EventToolCall ||
+			group[2].Type != sessions.EventToolResult || group[3].Type != sessions.EventMessage {
+			t.Fatalf("group at %d has types %s %s %s %s", start, group[0].Type, group[1].Type, group[2].Type, group[3].Type)
+		}
+		if payloadString(group[1].Payload, "toolCallId") != "call-"+who ||
+			payloadString(group[2].Payload, "toolCallId") != "call-"+who ||
+			payloadString(group[3].Payload, "content") != "answer "+who {
+			t.Fatalf("another writer's records landed inside turn %s: %+v", who, group)
+		}
+	}
+
+	// A fresh instance restores two correctly paired turns from that log.
+	deps.PersistEvents = nil
+	fresh := newHarness(t, deps)
+	defer fresh.stop()
+	if err := fresh.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("fresh session/load: %v", err)
+	}
+	prompts := make(chan string, 1)
+	realRun := deps.RunAgent
+	_ = realRun
+	deps.RunAgent = func(ctx context.Context, prompt string, provider zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+		prompts <- prompt
+		return agent.Result{FinalAnswer: "ok"}, nil
+	}
+	seeded := newHarness(t, deps)
+	defer seeded.stop()
+	if err := seeded.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: created.SessionID, Cwd: workspace, McpServers: []McpServer{}}, &ResumeSessionResult{}); err != nil {
+		t.Fatalf("session/resume: %v", err)
+	}
+	if err := seeded.client.Call(ctx, MethodSessionPrompt, PromptParams{SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("carry on")}}, &PromptResult{}); err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+	prompt := <-prompts
+	for _, who := range []string{"A", "B"} {
+		if !strings.Contains(prompt, "prompt "+who) || !strings.Contains(prompt, "answer "+who) {
+			t.Fatalf("restored prompt lost turn %s:\n%s", who, prompt)
+		}
+	}
+	if strings.Contains(prompt, "content A") || strings.Contains(prompt, "content B") {
+		t.Fatalf("historical tool output entered the model prompt:\n%s", prompt)
 	}
 }
 
@@ -2274,4 +2402,19 @@ func TestACPResumeRejectsMissingPopulatedEventLog(t *testing.T) {
 	}, &ResumeSessionResult{}); err != nil {
 		t.Fatalf("session/resume rejected valid empty history: %v", err)
 	}
+}
+
+// payloadString reads one string field from a stored event's payload, which is
+// raw JSON once it has been read back from disk.
+func payloadString(payload any, key string) string {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	var decoded map[string]any
+	if json.Unmarshal(raw, &decoded) != nil {
+		return ""
+	}
+	value, _ := decoded[key].(string)
+	return value
 }

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1186,6 +1186,16 @@ func TestSessionListResolvesEveryWorkspace(t *testing.T) {
 	if _, listedLive := seen["live-ws"]; !listedLive {
 		t.Error("a usable session was dropped while filtering unusable ones")
 	}
+	// THE RELATIVE ENTRY IS RETAINED, not quietly dropped. Resolving every item
+	// could have been "fixed" by discarding anything not already absolute, which
+	// would pass the absolute-path check below while losing a resumable session —
+	// so presence is asserted separately from spelling.
+	relative, listedRelative := seen["relative-ws"]
+	if !listedRelative {
+		t.Error("a session with a resolvable relative workspace was dropped rather than normalised")
+	} else if !filepath.IsAbs(relative) {
+		t.Errorf("the relative entry was listed as %q; it must be normalised to an absolute path", relative)
+	}
 	// EVERY reported cwd is absolute, which is the contract clients rely on.
 	for id, cwd := range seen {
 		if !filepath.IsAbs(cwd) {

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -910,4 +911,166 @@ func drainTextUntil(t *testing.T, ch <-chan string, done func(string) bool) stri
 			return b.String()
 		}
 	}
+}
+
+// normalisingResolver reproduces what ResolveWorkspaceRoot actually does — abs,
+// Clean, and a stat that the path exists — WITHOUT resolving symlinks or folding
+// case, which is the behaviour that makes two spellings of one directory produce
+// two different roots.
+//
+// The package's own testDeps resolver is the identity function. Under it the
+// workspace guard degenerates to "are these two strings different", fed two
+// unrelated temp directories, so it can only ever answer yes: the rejection
+// direction is pinned and the acceptance direction is asserted nowhere.
+func normalisingResolver(t *testing.T) func(string) (string, error) {
+	t.Helper()
+	return func(cwd string) (string, error) {
+		absolute, err := filepath.Abs(cwd)
+		if err != nil {
+			return "", err
+		}
+		absolute = filepath.Clean(absolute)
+		info, err := os.Stat(absolute)
+		if err != nil {
+			return "", err
+		}
+		if !info.IsDir() {
+			return "", errors.New("workspace is not a directory")
+		}
+		return absolute, nil
+	}
+}
+
+// ONE DIRECTORY UNDER TWO SPELLINGS IS ONE WORKSPACE.
+//
+// A session persisted from the TUI has to stay resumable from an editor holding
+// a different spelling of the same project folder — the two processes most
+// likely to disagree about spelling, and the case this feature exists for. It
+// failed closed, so it blocked legitimate resumes rather than admitting foreign
+// ones, but session/list filtered by the other spelling returned nothing, which
+// makes it an invisible failure rather than a reported one.
+func TestACPResumesAcrossTwoSpellingsOfOneWorkspace(t *testing.T) {
+	real := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(real, alias); err != nil {
+		t.Skipf("cannot create a directory alias here: %v", err)
+	}
+	// The premise: the resolver really does produce two different strings.
+	resolve := normalisingResolver(t)
+	realRoot, err := resolve(real)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot, err := resolve(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if realRoot == aliasRoot {
+		t.Skipf("this filesystem folds the alias away (%q == %q); the guard cannot be exercised", realRoot, aliasRoot)
+	}
+
+	deps := testDeps(t)
+	deps.ResolveWorkspaceRoot = resolve
+	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "aliased-workspace", Cwd: real})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// ACCEPTANCE: resume and load under the OTHER spelling must both work.
+	for _, method := range []string{MethodSessionLoad, MethodSessionResume} {
+		var result LoadSessionResult
+		if err := h.client.Call(ctx, method, LoadSessionParams{SessionID: created.SessionID, Cwd: alias, McpServers: []McpServer{}}, &result); err != nil {
+			t.Errorf("%s under an alias of the persisted workspace failed: %v", method, err)
+		}
+	}
+
+	// And session/list filtered by the alias must still find it.
+	var listed ListSessionsResult
+	if err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{Cwd: alias}, &listed); err != nil {
+		t.Fatalf("session/list: %v", err)
+	}
+	found := false
+	for _, item := range listed.Sessions {
+		if item.SessionID == created.SessionID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("session/list filtered by an alias of its own workspace returned %d sessions without it", len(listed.Sessions))
+	}
+
+	// REJECTION still holds: a genuinely different directory is refused.
+	other := t.TempDir()
+	err = h.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: created.SessionID, Cwd: other, McpServers: []McpServer{}}, &ResumeSessionResult{})
+	var rpcErr *rpcError
+	if !errors.As(err, &rpcErr) || rpcErr.Code != codeInvalidParams {
+		t.Errorf("resume from an unrelated workspace = %v, want invalid params", err)
+	}
+}
+
+// THE WIRE KEYS ARE AN EXTERNAL CONTRACT, not internal names.
+//
+// Nothing pinned them, so renaming a Go field — or dropping an omitempty —
+// would break every client and leave the suite green. These are the keys this
+// feature adds to the protocol; a change here is a change to what editors
+// consume.
+func TestSessionWireKeysAreStable(t *testing.T) {
+	marshalled := func(v any) map[string]any {
+		t.Helper()
+		raw, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out map[string]any
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+	has := func(where string, got map[string]any, want ...string) {
+		t.Helper()
+		for _, key := range want {
+			if _, ok := got[key]; !ok {
+				t.Errorf("%s is missing the wire key %q; got %v", where, key, keysOf(got))
+			}
+		}
+	}
+
+	has("SessionInfo", marshalled(SessionInfo{
+		SessionID: "s1", Cwd: "/w", Title: "t", UpdatedAt: "now",
+		Meta: &SessionInfoMeta{ModelID: "m", CreatedAt: "then"},
+	}), "sessionId", "cwd", "title", "updatedAt", "_meta")
+
+	has("SessionInfoMeta", marshalled(SessionInfoMeta{ModelID: "m", CreatedAt: "then"}),
+		"modelId", "createdAt")
+
+	has("ListSessionsResult", marshalled(ListSessionsResult{
+		Sessions: []SessionInfo{}, NextCursor: "c",
+	}), "sessions", "nextCursor")
+
+	has("ListSessionsParams", marshalled(ListSessionsParams{Cwd: "/w", Cursor: "c"}),
+		"cwd", "cursor")
+
+	// sessionCapabilities is omitempty, so it must appear when SET — a client
+	// discovers list/resume support through it.
+	has("AgentCapabilities", marshalled(AgentCapabilities{
+		LoadSession:         true,
+		SessionCapabilities: &SessionCapabilities{List: &struct{}{}, Resume: &struct{}{}},
+	}), "loadSession", "promptCapabilities", "sessionCapabilities")
+
+	capabilities := marshalled(SessionCapabilities{List: &struct{}{}, Resume: &struct{}{}})
+	has("SessionCapabilities", capabilities, "list", "resume")
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1040,6 +1040,59 @@ func TestACPResumesAcrossTwoSpellingsOfOneWorkspace(t *testing.T) {
 	}
 }
 
+func TestACPResumeAppliesStandaloneSessionKindPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		kind sessions.SessionKind
+		want bool
+	}{
+		{name: "regular", kind: "", want: true},
+		{name: "fork", kind: sessions.SessionKindFork, want: true},
+		{name: "child", kind: sessions.SessionKindChild},
+		{name: "side", kind: sessions.SessionKindSide},
+		{name: "spec draft", kind: sessions.SessionKindSpecDraft},
+		{name: "spec impl", kind: sessions.SessionKindSpecImpl},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := testDeps(t)
+			workspace := t.TempDir()
+			created, err := deps.Store.Create(sessions.CreateInput{
+				SessionID: "kind-policy", Cwd: workspace, SessionKind: tc.kind,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			h := newHarness(t, deps)
+			defer h.stop()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			err = h.client.Call(ctx, MethodSessionResume, ResumeSessionParams{
+				SessionID: created.SessionID, Cwd: workspace,
+			}, &ResumeSessionResult{})
+			if tc.want {
+				if err != nil {
+					t.Fatalf("session/resume: %v", err)
+				}
+				return
+			}
+			var rpcErr *rpcError
+			if !errors.As(err, &rpcErr) || rpcErr.Code != codeInvalidParams {
+				t.Fatalf("session/resume = %v, want invalid params", err)
+			}
+			if err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{
+				SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("must stay closed")},
+			}, &PromptResult{}); err == nil {
+				t.Fatal("rejected subordinate session became promptable")
+			}
+			if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{
+				SessionID: created.SessionID, Cwd: workspace,
+			}, &LoadSessionResult{}); err != nil {
+				t.Fatalf("session/load should retain render-only access: %v", err)
+			}
+		})
+	}
+}
+
 // THE WIRE KEYS ARE AN EXTERNAL CONTRACT, not internal names.
 //
 // Nothing pinned them, so renaming a Go field — or dropping an omitempty —
@@ -1591,6 +1644,8 @@ func TestACPLoadReplaysToolCallsPairedByTheirStoredID(t *testing.T) {
 		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "grep", "toolCallId": "call-99", "arguments": `{"pattern":"TODO"}`}},
 		// No id at all: unpairable, so it must be skipped rather than replayed.
 		{Type: sessions.EventToolCall, Payload: map[string]any{"name": "orphan", "arguments": "{}"}},
+		// An identified result is still unpairable when its start is absent.
+		{Type: sessions.EventToolResult, Payload: map[string]any{"name": "orphan", "toolCallId": "missing-call", "status": "ok", "output": "must not replay"}},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1742,6 +1797,155 @@ func TestACPPromptPersistsToolActivityForFreshLoad(t *testing.T) {
 	}
 	if len(result.Locations) != 2 || result.Locations[0].Path != "a.go" || result.Locations[1].Path != "b.go" {
 		t.Fatalf("replayed tool locations = %+v", result.Locations)
+	}
+}
+
+func TestACPPersistenceStopsAtFirstFailedEventDependency(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		failAt    int
+		wantTypes []sessions.EventType
+	}{
+		{name: "user message", failAt: 1},
+		{name: "tool call", failAt: 2, wantTypes: []sessions.EventType{sessions.EventMessage}},
+		{name: "tool result", failAt: 3, wantTypes: []sessions.EventType{sessions.EventMessage, sessions.EventToolCall}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := testDeps(t)
+			attempts := 0
+			deps.PersistEvent = func(sessionID string, input sessions.AppendEventInput) error {
+				attempts++
+				if attempts == tc.failAt {
+					return errors.New("injected append failure")
+				}
+				_, err := deps.Store.AppendEvents(sessionID, []sessions.AppendEventInput{input})
+				return err
+			}
+			deps.RunAgent = func(_ context.Context, _ string, _ zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+				call := agent.ToolCall{ID: "call-prefix", Name: "read_file", Arguments: `{"path":"a.go"}`}
+				opts.OnToolCall(call)
+				opts.OnToolResult(agent.ToolResult{
+					ToolCallID: call.ID, Name: call.Name, Status: tools.StatusOK, Output: "content",
+				})
+				return agent.Result{FinalAnswer: "done"}, nil
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			workspace := t.TempDir()
+			writer := newHarness(t, deps)
+			var created NewSessionResult
+			if err := writer.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: workspace}, &created); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.client.Call(ctx, MethodSessionPrompt, PromptParams{
+				SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("read it")},
+			}, &PromptResult{}); err != nil {
+				t.Fatalf("session/prompt: %v", err)
+			}
+			writer.stop()
+			if attempts != tc.failAt {
+				t.Fatalf("append attempts = %d, want persistence to stop at %d", attempts, tc.failAt)
+			}
+			events, err := deps.Store.ReadEvents(created.SessionID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(events) != len(tc.wantTypes) {
+				t.Fatalf("durable events = %+v, want prefix %v", events, tc.wantTypes)
+			}
+			for i, want := range tc.wantTypes {
+				if events[i].Type != want {
+					t.Fatalf("durable event %d = %s, want %s", i, events[i].Type, want)
+				}
+			}
+
+			// Reopen through a fresh ACP instance: the durable prefix may contain
+			// an in-progress call, but never its orphan result or an assistant
+			// answer whose prerequisite write failed.
+			loader := newHarness(t, deps)
+			defer loader.stop()
+			if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{
+				SessionID: created.SessionID, Cwd: workspace,
+			}, &LoadSessionResult{}); err != nil {
+				t.Fatalf("fresh session/load: %v", err)
+			}
+			select {
+			case update := <-loader.tools:
+				if tc.failAt != 3 || update.SessionUpdate != UpdateToolCall || update.ToolCallID != "call-prefix" || update.Status != ToolStatusInProgress {
+					t.Fatalf("replayed tool update = %+v", update)
+				}
+			case <-time.After(100 * time.Millisecond):
+				if tc.failAt == 3 {
+					t.Fatal("persisted tool-call prefix was not replayed")
+				}
+			}
+			select {
+			case update := <-loader.tools:
+				t.Fatalf("dependent tool suffix was replayed: %+v", update)
+			case <-time.After(100 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestACPCompactionFailureFallsBackToRawHistory(t *testing.T) {
+	deps := testDeps(t)
+	workspace := t.TempDir()
+	created, err := deps.Store.Create(sessions.CreateInput{SessionID: "bad-compaction", Cwd: workspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.AppendEvents(created.SessionID, []sessions.AppendEventInput{
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "raw question"}},
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "assistant", "content": "raw answer"}},
+		// JSON-valid but semantically invalid: rehydration rejects the missing summary.
+		{Type: sessions.EventCompaction, Payload: map[string]any{}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	loader := newHarness(t, deps)
+	if err := loader.client.Call(ctx, MethodSessionLoad, LoadSessionParams{
+		SessionID: created.SessionID, Cwd: workspace,
+	}, &LoadSessionResult{}); err != nil {
+		t.Fatalf("session/load: %v", err)
+	}
+	loadedText := drainTextUntil(t, loader.updates, func(text string) bool {
+		return strings.Contains(text, "raw answer") && strings.Contains(text, "Raw session history was restored")
+	})
+	if !strings.Contains(loadedText, "raw answer") || !strings.Contains(loadedText, "Raw session history was restored") {
+		t.Fatalf("load output = %q", loadedText)
+	}
+	loader.stop()
+
+	prompts := make(chan string, 1)
+	realRun := deps.RunAgent
+	deps.RunAgent = func(ctx context.Context, prompt string, provider zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+		prompts <- prompt
+		return realRun(ctx, prompt, provider, opts)
+	}
+	resumer := newHarness(t, deps)
+	defer resumer.stop()
+	if err := resumer.client.Call(ctx, MethodSessionResume, ResumeSessionParams{
+		SessionID: created.SessionID, Cwd: workspace,
+	}, &ResumeSessionResult{}); err != nil {
+		t.Fatalf("session/resume: %v", err)
+	}
+	if err := resumer.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: created.SessionID, Prompt: []ContentBlock{TextBlock("continue")},
+	}, &PromptResult{}); err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+	select {
+	case prompt := <-prompts:
+		if !strings.Contains(prompt, "raw question") || !strings.Contains(prompt, "raw answer") {
+			t.Fatalf("resumed prompt lost raw fallback history:\n%s", prompt)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
 	}
 }
 

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -952,9 +954,7 @@ func normalisingResolver(t *testing.T) func(string) (string, error) {
 func TestACPResumesAcrossTwoSpellingsOfOneWorkspace(t *testing.T) {
 	real := t.TempDir()
 	alias := filepath.Join(t.TempDir(), "alias")
-	if err := os.Symlink(real, alias); err != nil {
-		t.Skipf("cannot create a directory alias here: %v", err)
-	}
+	directoryAlias(t, real, alias)
 	// The premise: the resolver really does produce two different strings.
 	resolve := normalisingResolver(t)
 	realRoot, err := resolve(real)
@@ -1073,4 +1073,71 @@ func keysOf(m map[string]any) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// directoryAlias makes `alias` a second name for `target`.
+//
+// A JUNCTION ON WINDOWS, not a symlink. os.Symlink needs a privilege an ordinary
+// Windows session does not hold, so a test built on it SKIPS there — and Windows
+// is where junctions exist and where this bug came from. The guard would have
+// been verified only on the two platforms that never had the problem. mklink /J
+// needs no privilege, which is also how the defect was found.
+func directoryAlias(t *testing.T, target, alias string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		if out, err := exec.Command("cmd", "/c", "mklink", "/J", alias, target).CombinedOutput(); err != nil {
+			t.Skipf("cannot create a junction: %v %s", err, out)
+		}
+		return
+	}
+	if err := os.Symlink(target, alias); err != nil {
+		t.Skipf("cannot create a directory alias here: %v", err)
+	}
+}
+
+// A SESSION WITH NO PERSISTED WORKSPACE IS NOT RESUMABLE, SO IT IS NOT LISTED.
+//
+// activatePersistedSession refuses a session whose Cwd is empty, but the listing
+// advertised it anyway — offering the client a menu entry that only fails when
+// taken. Both halves are asserted together, because the listing is only correct
+// relative to what resume will accept.
+func TestSessionListOmitsSessionsWithoutAWorkspace(t *testing.T) {
+	deps := testDeps(t)
+	workspace := t.TempDir()
+	usable, err := deps.Store.Create(sessions.CreateInput{SessionID: "has-cwd", Cwd: workspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.Create(sessions.CreateInput{SessionID: "no-cwd"}); err != nil {
+		t.Fatal(err)
+	}
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var listed ListSessionsResult
+	if err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{}, &listed); err != nil {
+		t.Fatal(err)
+	}
+	sawUsable := false
+	for _, item := range listed.Sessions {
+		if item.SessionID == "no-cwd" {
+			t.Errorf("session/list advertised a session with no persisted workspace")
+		}
+		if item.SessionID == usable.SessionID {
+			sawUsable = true
+		}
+	}
+	if !sawUsable {
+		t.Errorf("session/list dropped a usable session while filtering; got %d", len(listed.Sessions))
+	}
+
+	// The other half of the contract: resuming the omitted one really does fail,
+	// which is why omitting it is right rather than merely tidy.
+	err = h.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: "no-cwd", Cwd: workspace, McpServers: []McpServer{}}, &ResumeSessionResult{})
+	var rpcErr *rpcError
+	if !errors.As(err, &rpcErr) || !strings.Contains(rpcErr.Message, "persisted workspace") {
+		t.Errorf("resume of a workspace-less session = %v, want a persisted-workspace error", err)
+	}
 }

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1141,3 +1141,55 @@ func TestSessionListOmitsSessionsWithoutAWorkspace(t *testing.T) {
 		t.Errorf("resume of a workspace-less session = %v, want a persisted-workspace error", err)
 	}
 }
+
+// EVERY LISTED SESSION IS ONE THE CLIENT CAN ACTUALLY TAKE.
+//
+// Resolving the persisted workspace only when a cwd filter was supplied left two
+// shapes on the menu that resume then refuses: a session whose workspace has
+// since been deleted, and a legacy entry holding a relative path — reported as
+// cwd "." although ACP requires SessionInfo.cwd to be absolute.
+func TestSessionListResolvesEveryWorkspace(t *testing.T) {
+	deps := testDeps(t)
+	deps.ResolveWorkspaceRoot = normalisingResolver(t)
+
+	gone := t.TempDir()
+	if _, err := deps.Store.Create(sessions.CreateInput{SessionID: "gone-ws", Cwd: gone}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(gone); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.Create(sessions.CreateInput{SessionID: "relative-ws", Cwd: "."}); err != nil {
+		t.Fatal(err)
+	}
+	live := t.TempDir()
+	if _, err := deps.Store.Create(sessions.CreateInput{SessionID: "live-ws", Cwd: live}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var listed ListSessionsResult
+	if err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{}, &listed); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[string]string{}
+	for _, item := range listed.Sessions {
+		seen[item.SessionID] = item.Cwd
+	}
+	if _, listedGone := seen["gone-ws"]; listedGone {
+		t.Error("a session whose workspace no longer exists was advertised; resume would refuse it")
+	}
+	if _, listedLive := seen["live-ws"]; !listedLive {
+		t.Error("a usable session was dropped while filtering unusable ones")
+	}
+	// EVERY reported cwd is absolute, which is the contract clients rely on.
+	for id, cwd := range seen {
+		if !filepath.IsAbs(cwd) {
+			t.Errorf("session %s was listed with a relative cwd %q; ACP requires an absolute path", id, cwd)
+		}
+	}
+}

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -382,8 +382,9 @@ func TestACPModelConfigOptionsCatalogSelectionAndLoad(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	workspace := t.TempDir()
 	var created NewSessionResult
-	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: t.TempDir()}, &created); err != nil {
+	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: workspace}, &created); err != nil {
 		t.Fatalf("session/new: %v", err)
 	}
 	option := created.ConfigOptions[0]
@@ -413,7 +414,7 @@ func TestACPModelConfigOptionsCatalogSelectionAndLoad(t *testing.T) {
 	h = newHarness(t, deps)
 	defer h.stop()
 	var loaded LoadSessionResult
-	if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID}, &loaded); err != nil {
+	if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace}, &loaded); err != nil {
 		t.Fatalf("session/load: %v", err)
 	}
 	if len(loaded.ConfigOptions) != 2 || loaded.ConfigOptions[0].CurrentValue != "gpt-5.4-mini" {
@@ -464,8 +465,9 @@ func TestACPCustomProviderAllowsUnadvertisedModel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	workspace := t.TempDir()
 	var created NewSessionResult
-	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: t.TempDir()}, &created); err != nil {
+	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: workspace}, &created); err != nil {
 		t.Fatalf("session/new: %v", err)
 	}
 	var selected SetSessionConfigOptionResult
@@ -481,7 +483,7 @@ func TestACPCustomProviderAllowsUnadvertisedModel(t *testing.T) {
 	h = newHarness(t, deps)
 	defer h.stop()
 	var loaded LoadSessionResult
-	if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID}, &loaded); err != nil {
+	if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: created.SessionID, Cwd: workspace}, &loaded); err != nil {
 		t.Fatalf("session/load: %v", err)
 	}
 	option := loaded.ConfigOptions[0]
@@ -1207,10 +1209,10 @@ func TestSessionListResolvesEveryWorkspace(t *testing.T) {
 
 func TestResumeRefusesARelativePersistedWorkspace(t *testing.T) {
 	// OMITTING THE ENTRY FROM THE LISTING IS NOT THE WHOLE FIX. A client can ask
-	// to resume any id it already knows, and session/resume falls back to the
-	// persisted cwd when the request carries none — so a stored "." was resolved
-	// against this process's directory and the session bound to it, with no error
-	// returned at all. Both doors need the same lock.
+	// to resume any id it already knows, and a stored "." still resolves against
+	// this process's directory — so a request naming that directory would be told
+	// it matched, and the conversation bound to a workspace it never belonged to.
+	// Both doors need the same lock.
 	deps := testDeps(t)
 	deps.ResolveWorkspaceRoot = normalisingResolver(t)
 	if _, err := deps.Store.Create(sessions.CreateInput{SessionID: "relative-ws", Cwd: "."}); err != nil {
@@ -1222,6 +1224,14 @@ func TestResumeRefusesARelativePersistedWorkspace(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	// The directory the stored "." rebases onto. Naming it explicitly is what
+	// makes this test reach the persisted-cwd guard: a request with no cwd is now
+	// refused earlier, for a different reason, and would pass either way.
+	here, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// BOTH ACTIVATING METHODS, not just one. session/load and session/resume are
 	// separate entry points that today share activatePersistedSession — so a test
 	// through either passes while the guard holds. Naming both here is what keeps
@@ -1230,14 +1240,212 @@ func TestResumeRefusesARelativePersistedWorkspace(t *testing.T) {
 	elsewhere := t.TempDir()
 	var out LoadSessionResult
 	for _, method := range []string{MethodSessionLoad, MethodSessionResume} {
-		// No cwd at all: the request that used to succeed by rebasing onto
-		// whatever directory this process happens to be running in.
-		if err := h.client.Call(ctx, method, LoadSessionParams{SessionID: "relative-ws"}, &out); err == nil {
-			t.Errorf("%s of a relative persisted workspace succeeded; the session was rebound to the ACP process directory", method)
+		// The invented root offered back as the answer: without the guard the two
+		// sides agree, because both were produced by resolving "." here.
+		err := h.client.Call(ctx, method, LoadSessionParams{SessionID: "relative-ws", Cwd: here}, &out)
+		var rpcErr *rpcError
+		if !errors.As(err, &rpcErr) || !strings.Contains(rpcErr.Message, "not an absolute path") {
+			t.Errorf("%s of a relative persisted workspace into the ACP process directory %q = %v, want a persisted-workspace error", method, here, err)
 		}
 		// And an unrelated workspace must not be accepted as its home either.
 		if err := h.client.Call(ctx, method, ResumeSessionParams{SessionID: "relative-ws", Cwd: elsewhere}, &out); err == nil {
 			t.Errorf("%s of a relative persisted workspace into %q succeeded", method, elsewhere)
 		}
+	}
+}
+
+// processDirectoryResolver mirrors internal/cli/exec.go resolveWorkspaceRoot,
+// the resolver the real ACP surface is wired with: a blank cwd becomes the
+// directory the process was started in, a relative one is joined onto it. base
+// stands in for that directory so the test never depends on where `go test`
+// happens to run.
+func processDirectoryResolver(t *testing.T, base string) func(string) (string, error) {
+	t.Helper()
+	return func(cwd string) (string, error) {
+		resolved := strings.TrimSpace(cwd)
+		if resolved == "" {
+			resolved = base
+		} else if !filepath.IsAbs(resolved) {
+			resolved = filepath.Join(base, resolved)
+		}
+		resolved = filepath.Clean(resolved)
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return "", err
+		}
+		if !info.IsDir() {
+			return "", errors.New("workspace is not a directory")
+		}
+		return resolved, nil
+	}
+}
+
+// A REQUEST THAT NAMES NO WORKSPACE ACTIVATES NOTHING.
+//
+// ResumeSessionParams is an alias for LoadSessionParams, and cwd is a plain
+// string on both, so JSON decoding cannot tell an omitted field from an empty
+// one. The blank case used to be answered with the persisted cwd, which made
+// {"sessionId":"known"} — a request carrying no workspace at all — a complete
+// and successful activation. A relative cwd was worse than useless rather than
+// rejected: it was joined onto whatever directory the editor spawned `zero acp`
+// in, so it could agree with the persisted root by accident and hand the session
+// over anyway.
+//
+// The cases go over the wire as raw JSON on purpose. Marshalling a Go struct
+// always emits "cwd":"" and would never exercise the absent field, which is
+// where the defect lives.
+func TestActivationRequiresAnAbsoluteRequestWorkspace(t *testing.T) {
+	deps := testDeps(t)
+	processDir := t.TempDir()
+	workspace := filepath.Join(processDir, "project")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	deps.ResolveWorkspaceRoot = processDirectoryResolver(t, processDir)
+	if _, err := deps.Store.Create(sessions.CreateInput{SessionID: "persisted", Cwd: workspace}); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name    string
+		params  json.RawMessage
+		message string
+	}{
+		// The finding: cwd absent from the wire entirely.
+		{"omitted", json.RawMessage(`{"sessionId":"persisted","mcpServers":[]}`), "cwd is required and must be an absolute path"},
+		{"empty", json.RawMessage(`{"sessionId":"persisted","cwd":"","mcpServers":[]}`), "cwd is required and must be an absolute path"},
+		{"whitespace", json.RawMessage(`{"sessionId":"persisted","cwd":"   ","mcpServers":[]}`), "cwd is required and must be an absolute path"},
+		// "project" resolves onto processDir and MATCHES the persisted root, so
+		// this is the relative case that used to be accepted, not merely mis-erroring.
+		{"relative", json.RawMessage(`{"sessionId":"persisted","cwd":"project","mcpServers":[]}`), "cwd must be an absolute path: project"},
+		{"dot relative", json.RawMessage(`{"sessionId":"persisted","cwd":"./project","mcpServers":[]}`), "cwd must be an absolute path: ./project"},
+	}
+
+	// BOTH ACTIVATING METHODS. They share activatePersistedSession today; naming
+	// both keeps this honest if resume is ever given its own path.
+	for _, method := range []string{MethodSessionLoad, MethodSessionResume} {
+		for _, tc := range cases {
+			t.Run(method+"/"+tc.name, func(t *testing.T) {
+				h := newHarness(t, deps)
+				defer h.stop()
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				var out LoadSessionResult
+				err := h.client.Call(ctx, method, tc.params, &out)
+				var rpcErr *rpcError
+				if !errors.As(err, &rpcErr) {
+					t.Fatalf("%s %s = %v, want a JSON-RPC error", method, tc.params, err)
+				}
+				if rpcErr.Code != codeInvalidParams {
+					t.Errorf("%s %s error code = %d, want %d", method, tc.params, rpcErr.Code, codeInvalidParams)
+				}
+				if rpcErr.Message != tc.message {
+					t.Errorf("%s %s error = %q, want %q", method, tc.params, rpcErr.Message, tc.message)
+				}
+				// AND THE SESSION IS NOT LIVE. The error alone would not prove it:
+				// activation publishes the session before it returns, so a refusal
+				// that still registered would leave session/prompt and session/set_mode
+				// working on a workspace the client never named.
+				modeErr := h.client.Call(ctx, MethodSessionSetMode,
+					SetSessionModeParams{SessionID: "persisted", ModeID: string(agent.PermissionModeAuto)},
+					&SetSessionModeResult{})
+				if !errors.As(modeErr, &rpcErr) || rpcErr.Message != "unknown session: persisted" {
+					t.Errorf("after a refused %s the session was live: set_mode = %v, want %q", method, modeErr, "unknown session: persisted")
+				}
+			})
+		}
+	}
+
+	// The same request with the workspace spelled out is what the client is
+	// expected to send, and it still works.
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var out LoadSessionResult
+	if err := h.client.Call(ctx, MethodSessionResume, ResumeSessionParams{SessionID: "persisted", Cwd: workspace, McpServers: []McpServer{}}, &out); err != nil {
+		t.Fatalf("session/resume with an absolute cwd: %v", err)
+	}
+}
+
+// session/new roots a BRAND NEW session, and its sandbox and file-tool
+// confinement, at the client's cwd. The same absent-field decoding applied
+// there: {"mcpServers":[]} created a session rooted at the ACP process's own
+// directory and persisted that invented path as the session's workspace.
+func TestSessionNewRequiresAnAbsoluteWorkspace(t *testing.T) {
+	deps := testDeps(t)
+	processDir := t.TempDir()
+	deps.ResolveWorkspaceRoot = processDirectoryResolver(t, processDir)
+	if err := os.MkdirAll(filepath.Join(processDir, "project"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, tc := range []struct {
+		params  json.RawMessage
+		message string
+	}{
+		{json.RawMessage(`{"mcpServers":[]}`), "cwd is required and must be an absolute path"},
+		{json.RawMessage(`{"cwd":"","mcpServers":[]}`), "cwd is required and must be an absolute path"},
+		{json.RawMessage(`{"cwd":"project","mcpServers":[]}`), "cwd must be an absolute path: project"},
+	} {
+		var created NewSessionResult
+		err := h.client.Call(ctx, MethodSessionNew, tc.params, &created)
+		var rpcErr *rpcError
+		if !errors.As(err, &rpcErr) || rpcErr.Code != codeInvalidParams || rpcErr.Message != tc.message {
+			t.Errorf("session/new %s = %v, want invalid params %q", tc.params, err, tc.message)
+		}
+		if created.SessionID != "" {
+			t.Errorf("session/new %s created session %q despite refusing the request", tc.params, created.SessionID)
+		}
+	}
+
+	listed, err := deps.Store.ListResumable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 0 {
+		t.Errorf("refused session/new requests persisted %d session(s); the first is rooted at %q", len(listed), listed[0].Cwd)
+	}
+}
+
+// The cwd filter is the one ACP leaves optional, so blank still means "no
+// filter" — but a relative one would be rebased onto the ACP process directory
+// and answer about a workspace the client never named.
+func TestSessionListRejectsARelativeCwdFilter(t *testing.T) {
+	deps := testDeps(t)
+	processDir := t.TempDir()
+	workspace := filepath.Join(processDir, "project")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	deps.ResolveWorkspaceRoot = processDirectoryResolver(t, processDir)
+	if _, err := deps.Store.Create(sessions.CreateInput{SessionID: "persisted", Cwd: workspace}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var out ListSessionsResult
+	err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{Cwd: "project"}, &out)
+	var rpcErr *rpcError
+	if !errors.As(err, &rpcErr) || rpcErr.Code != codeInvalidParams || rpcErr.Message != "cwd must be an absolute path: project" {
+		t.Errorf("session/list with a relative cwd filter = %v, want invalid params %q", err, "cwd must be an absolute path: project")
+	}
+
+	// Omitting the filter is still legal, and still lists the session.
+	if err := h.client.Call(ctx, MethodSessionList, ListSessionsParams{}, &out); err != nil {
+		t.Fatalf("session/list without a filter: %v", err)
+	}
+	if len(out.Sessions) != 1 || out.Sessions[0].SessionID != "persisted" {
+		t.Errorf("unfiltered session/list = %+v, want the one persisted session", out.Sessions)
 	}
 }

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1186,20 +1186,50 @@ func TestSessionListResolvesEveryWorkspace(t *testing.T) {
 	if _, listedLive := seen["live-ws"]; !listedLive {
 		t.Error("a usable session was dropped while filtering unusable ones")
 	}
-	// THE RELATIVE ENTRY IS RETAINED, not quietly dropped. Resolving every item
-	// could have been "fixed" by discarding anything not already absolute, which
-	// would pass the absolute-path check below while losing a resumable session —
-	// so presence is asserted separately from spelling.
-	relative, listedRelative := seen["relative-ws"]
-	if !listedRelative {
-		t.Error("a session with a resolvable relative workspace was dropped rather than normalised")
-	} else if !filepath.IsAbs(relative) {
-		t.Errorf("the relative entry was listed as %q; it must be normalised to an absolute path", relative)
+	// THE RELATIVE ENTRY IS DROPPED. An earlier revision of this test asserted the
+	// opposite — that "." be normalised and kept — which reads as the generous
+	// choice but resolves the stored path against whatever directory this ACP
+	// server was started in. That does not recover the session's workspace; it
+	// invents one, and then advertises the invention as fact, so a conversation
+	// created for one project becomes resumable against another project's files,
+	// configuration and tools. The original base is not knowable from the
+	// metadata, so no entry is the only honest answer.
+	if invented, listedRelative := seen["relative-ws"]; listedRelative {
+		t.Errorf("a relative persisted workspace was listed as %q, rebased onto the current process directory", invented)
 	}
 	// EVERY reported cwd is absolute, which is the contract clients rely on.
 	for id, cwd := range seen {
 		if !filepath.IsAbs(cwd) {
 			t.Errorf("session %s was listed with a relative cwd %q; ACP requires an absolute path", id, cwd)
 		}
+	}
+}
+
+func TestResumeRefusesARelativePersistedWorkspace(t *testing.T) {
+	// OMITTING THE ENTRY FROM THE LISTING IS NOT THE WHOLE FIX. A client can ask
+	// to resume any id it already knows, and session/resume falls back to the
+	// persisted cwd when the request carries none — so a stored "." was resolved
+	// against this process's directory and the session bound to it, with no error
+	// returned at all. Both doors need the same lock.
+	deps := testDeps(t)
+	deps.ResolveWorkspaceRoot = normalisingResolver(t)
+	if _, err := deps.Store.Create(sessions.CreateInput{SessionID: "relative-ws", Cwd: "."}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// No cwd at all: the request that used to succeed by rebasing.
+	var out LoadSessionResult
+	if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: "relative-ws"}, &out); err == nil {
+		t.Error("resuming a relative persisted workspace succeeded; the session was rebound to the ACP process directory")
+	}
+	// And an unrelated workspace must not be accepted as its home either.
+	elsewhere := t.TempDir()
+	if err := h.client.Call(ctx, MethodSessionLoad, LoadSessionParams{SessionID: "relative-ws", Cwd: elsewhere}, &out); err == nil {
+		t.Errorf("resuming a relative persisted workspace into %q succeeded", elsewhere)
 	}
 }

--- a/internal/acp/jsonrpc.go
+++ b/internal/acp/jsonrpc.go
@@ -89,6 +89,13 @@ type Conn struct {
 
 	handlers  map[string]HandlerFunc
 	notifiers map[string]NotifyFunc
+	// Notifications for one method are an ordered stream: session/update in
+	// particular is stateful, so dispatching every frame in an unrelated
+	// goroutine can make a later chunk overtake an earlier one. Different
+	// methods retain independent tails, keeping session/cancel responsive while
+	// an update handler is busy.
+	notifyMu    sync.Mutex
+	notifyTails map[string]chan struct{}
 
 	mu      sync.Mutex
 	nextID  int64
@@ -106,11 +113,12 @@ type Conn struct {
 // lifetime.
 func NewConn(r io.Reader, w io.Writer) *Conn {
 	return &Conn{
-		rawReader: r,
-		w:         w,
-		handlers:  make(map[string]HandlerFunc),
-		notifiers: make(map[string]NotifyFunc),
-		pending:   make(map[int64]chan rpcMessage),
+		rawReader:   r,
+		w:           w,
+		handlers:    make(map[string]HandlerFunc),
+		notifiers:   make(map[string]NotifyFunc),
+		notifyTails: make(map[string]chan struct{}),
+		pending:     make(map[int64]chan rpcMessage),
 	}
 }
 
@@ -303,11 +311,7 @@ func (c *Conn) handleLine(ctx context.Context, line []byte) {
 		}(msg)
 	case msg.isNotify():
 		if fn := c.notifiers[msg.Method]; fn != nil {
-			c.wg.Add(1)
-			go func(m rpcMessage) {
-				defer c.wg.Done()
-				fn(ctx, m.Params)
-			}(msg)
+			c.dispatchNotification(ctx, msg, fn)
 		}
 	default:
 		// Malformed frame; reply only if we can identify a request id.
@@ -315,6 +319,35 @@ func (c *Conn) handleLine(ctx context.Context, line []byte) {
 			c.writeError(msg.ID, &rpcError{Code: codeInvalidRequest, Message: "invalid request"})
 		}
 	}
+}
+
+// dispatchNotification preserves wire order within one method without making
+// unrelated notification methods wait for each other. The read loop installs
+// each tail before starting its goroutine, so goroutine scheduling cannot
+// reorder the chain it observes.
+func (c *Conn) dispatchNotification(ctx context.Context, msg rpcMessage, fn NotifyFunc) {
+	c.notifyMu.Lock()
+	previous := c.notifyTails[msg.Method]
+	done := make(chan struct{})
+	c.notifyTails[msg.Method] = done
+	c.notifyMu.Unlock()
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		defer func() {
+			close(done)
+			c.notifyMu.Lock()
+			if c.notifyTails[msg.Method] == done {
+				delete(c.notifyTails, msg.Method)
+			}
+			c.notifyMu.Unlock()
+		}()
+		if previous != nil {
+			<-previous
+		}
+		fn(ctx, msg.Params)
+	}()
 }
 
 func (c *Conn) dispatchRequest(ctx context.Context, msg rpcMessage) {

--- a/internal/acp/jsonrpc_test.go
+++ b/internal/acp/jsonrpc_test.go
@@ -360,6 +360,86 @@ func TestConnNotification(t *testing.T) {
 	}
 }
 
+func TestConnNotificationsForOneMethodStayInWireOrder(t *testing.T) {
+	a, b, stop := connPair(t)
+	defer stop()
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	delivered := make(chan int, 2)
+	b.HandleNotify("update", func(_ context.Context, params json.RawMessage) {
+		var in struct{ Sequence int }
+		_ = json.Unmarshal(params, &in)
+		if in.Sequence == 1 {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		delivered <- in.Sequence
+	})
+
+	if err := a.Notify("update", map[string]int{"Sequence": 1}); err != nil {
+		t.Fatalf("first notify: %v", err)
+	}
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first notification did not start")
+	}
+	if err := a.Notify("update", map[string]int{"Sequence": 2}); err != nil {
+		t.Fatalf("second notify: %v", err)
+	}
+	select {
+	case sequence := <-delivered:
+		t.Fatalf("notification %d overtook the blocked first notification", sequence)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(releaseFirst)
+	for want := 1; want <= 2; want++ {
+		select {
+		case got := <-delivered:
+			if got != want {
+				t.Fatalf("notification order = ...,%d; want %d", got, want)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("notification %d was not delivered", want)
+		}
+	}
+}
+
+func TestConnDifferentNotificationMethodsStayConcurrent(t *testing.T) {
+	a, b, stop := connPair(t)
+	defer stop()
+
+	updateStarted := make(chan struct{})
+	releaseUpdate := make(chan struct{})
+	cancelDelivered := make(chan struct{})
+	b.HandleNotify("update", func(context.Context, json.RawMessage) {
+		close(updateStarted)
+		<-releaseUpdate
+	})
+	b.HandleNotify("cancel", func(context.Context, json.RawMessage) {
+		close(cancelDelivered)
+	})
+
+	if err := a.Notify("update", nil); err != nil {
+		t.Fatalf("update notify: %v", err)
+	}
+	select {
+	case <-updateStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("update notification did not start")
+	}
+	if err := a.Notify("cancel", nil); err != nil {
+		t.Fatalf("cancel notify: %v", err)
+	}
+	select {
+	case <-cancelDelivered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("different notification method was blocked behind update")
+	}
+	close(releaseUpdate)
+}
+
 func TestConnMethodNotFound(t *testing.T) {
 	a, _, stop := connPair(t)
 	defer stop()

--- a/internal/acp/translate.go
+++ b/internal/acp/translate.go
@@ -19,6 +19,14 @@ func agentMessageChunk(delta string) ContentChunk {
 	return ContentChunk{SessionUpdate: UpdateAgentMessageChunk, Content: TextBlock(delta)}
 }
 
+func replayMessageChunk(role, messageID, text string) ContentChunk {
+	update := UpdateAgentMessageChunk
+	if role == "user" {
+		update = UpdateUserMessageChunk
+	}
+	return ContentChunk{SessionUpdate: update, MessageID: messageID, Content: TextBlock(text)}
+}
+
 func agentThoughtChunk(delta string) ContentChunk {
 	return ContentChunk{SessionUpdate: UpdateAgentThoughtChunk, Content: TextBlock(delta)}
 }

--- a/internal/acp/types.go
+++ b/internal/acp/types.go
@@ -12,6 +12,8 @@ const (
 	MethodAuthenticate           = "authenticate"
 	MethodSessionNew             = "session/new"
 	MethodSessionLoad            = "session/load"
+	MethodSessionList            = "session/list"
+	MethodSessionResume          = "session/resume"
 	MethodSessionPrompt          = "session/prompt"
 	MethodSessionCancel          = "session/cancel" // notification
 	MethodSessionUpdate          = "session/update" // notification (agent -> client)
@@ -62,8 +64,16 @@ type PromptCapabilities struct {
 }
 
 type AgentCapabilities struct {
-	LoadSession        bool               `json:"loadSession"`
-	PromptCapabilities PromptCapabilities `json:"promptCapabilities"`
+	LoadSession         bool                 `json:"loadSession"`
+	PromptCapabilities  PromptCapabilities   `json:"promptCapabilities"`
+	SessionCapabilities *SessionCapabilities `json:"sessionCapabilities,omitempty"`
+}
+
+// Empty capability objects are presence flags in ACP v1. Pointers preserve
+// the wire distinction between an advertised `{}` and an omitted capability.
+type SessionCapabilities struct {
+	List   *struct{} `json:"list,omitempty"`
+	Resume *struct{} `json:"resume,omitempty"`
 }
 
 type AuthMethod struct {
@@ -140,6 +150,35 @@ type LoadSessionResult struct {
 	Modes         *SessionModeState     `json:"modes,omitempty"`
 }
 
+// ListSessionsParams and the following types implement ACP v1 session/list.
+// Transcript contents stay behind session/load; this method returns metadata
+// only and leaves the optional pagination cursor opaque.
+type ListSessionsParams struct {
+	Cwd    string `json:"cwd,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+type SessionInfoMeta struct {
+	ModelID   string `json:"modelId,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+}
+
+type SessionInfo struct {
+	SessionID string           `json:"sessionId"`
+	Cwd       string           `json:"cwd"`
+	Title     string           `json:"title,omitempty"`
+	UpdatedAt string           `json:"updatedAt,omitempty"`
+	Meta      *SessionInfoMeta `json:"_meta,omitempty"`
+}
+
+type ListSessionsResult struct {
+	Sessions   []SessionInfo `json:"sessions"`
+	NextCursor string        `json:"nextCursor,omitempty"`
+}
+
+type ResumeSessionParams = LoadSessionParams
+type ResumeSessionResult = LoadSessionResult
+
 // ---- prompt turn ----
 
 type PromptParams struct {
@@ -174,6 +213,7 @@ type SessionNotification struct {
 // ContentBlock under "content"; the variant is set via SessionUpdate.
 type ContentChunk struct {
 	SessionUpdate string       `json:"sessionUpdate"`
+	MessageID     string       `json:"messageId,omitempty"`
 	Content       ContentBlock `json:"content"`
 }
 

--- a/internal/acp/types.go
+++ b/internal/acp/types.go
@@ -127,9 +127,14 @@ type McpServer struct {
 }
 
 type NewSessionParams struct {
-	Cwd                   string      `json:"cwd"`
-	McpServers            []McpServer `json:"mcpServers"`
-	AdditionalDirectories []string    `json:"additionalDirectories,omitempty"`
+	Cwd        string      `json:"cwd"`
+	McpServers []McpServer `json:"mcpServers"`
+	// AdditionalDirectories is declared by the protocol and consumed nowhere in
+	// this repo yet. When it is wired up it must go through requestedWorkspace
+	// like Cwd does: these are client-supplied paths with no absoluteness rule of
+	// their own, which is the same shape as the resume-cwd hole that made
+	// {"sessionId":"known"} activate a session against this process's directory.
+	AdditionalDirectories []string `json:"additionalDirectories,omitempty"`
 }
 
 type NewSessionResult struct {
@@ -176,6 +181,10 @@ type ListSessionsResult struct {
 	NextCursor string        `json:"nextCursor,omitempty"`
 }
 
+// session/resume takes session/load's wire shape, so its cwd is a plain string
+// too and an omitted one decodes exactly like an empty one. Sharing the type is
+// safe only because activatePersistedSession requires an absolute cwd from the
+// request itself — nothing downstream may supply a default for either method.
 type ResumeSessionParams = LoadSessionParams
 type ResumeSessionResult = LoadSessionResult
 

--- a/internal/sessions/replay.go
+++ b/internal/sessions/replay.go
@@ -226,11 +226,20 @@ func CompactionPayloadFromPlan(summary string, plan CompactionPlan) (CompactionP
 }
 
 func (store *Store) ReadRehydratedEvents(sessionID string) ([]Event, error) {
-	events, err := store.ReadEvents(sessionID)
+	events, _, err := store.ReadRehydratedEventsWithPresence(sessionID)
+	return events, err
+}
+
+// ReadRehydratedEventsWithPresence carries the underlying event-log presence
+// through compaction projection without changing ReadRehydratedEvents' existing
+// empty-on-missing contract.
+func (store *Store) ReadRehydratedEventsWithPresence(sessionID string) ([]Event, bool, error) {
+	events, present, err := store.ReadEventsWithPresence(sessionID)
 	if err != nil {
-		return nil, err
+		return nil, present, err
 	}
-	return RehydrateEvents(events)
+	rehydrated, err := RehydrateEvents(events)
+	return rehydrated, present, err
 }
 
 func (store *Store) ReadReplayEvents(sessionID string) ([]Event, error) {

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -813,15 +813,24 @@ func (store *Store) UpdateModel(sessionID string, modelID string) (Metadata, err
 }
 
 func (store *Store) ReadEvents(sessionID string) ([]Event, error) {
+	events, _, err := store.ReadEventsWithPresence(sessionID)
+	return events, err
+}
+
+// ReadEventsWithPresence preserves the distinction between an intentionally
+// empty event log and a missing one. Most readers accept both as empty history,
+// but activation protocols that promise to restore previously populated
+// context need the stronger signal.
+func (store *Store) ReadEventsWithPresence(sessionID string) ([]Event, bool, error) {
 	if !ValidSessionID(sessionID) {
-		return nil, fmt.Errorf("invalid zero session id %q", sessionID)
+		return nil, false, fmt.Errorf("invalid zero session id %q", sessionID)
 	}
 	data, err := os.ReadFile(store.eventsPath(sessionID))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return []Event{}, nil
+			return []Event{}, false, nil
 		}
-		return nil, fmt.Errorf("read zero session events: %w", err)
+		return nil, false, fmt.Errorf("read zero session events: %w", err)
 	}
 	// A genuine torn tail is an INCOMPLETE final write — a crash mid-append leaves
 	// the last line without its terminating newline. If the file ends with a
@@ -851,11 +860,11 @@ func (store *Store) ReadEvents(sessionID string) ([]Event, error) {
 			if index == lastNonEmpty && tornTailPossible {
 				break
 			}
-			return nil, fmt.Errorf("invalid json in zero session %s %s at line %d: %w", sessionID, EventsFile, index+1, err)
+			return nil, true, fmt.Errorf("invalid json in zero session %s %s at line %d: %w", sessionID, EventsFile, index+1, err)
 		}
 		events = append(events, event)
 	}
-	return events, nil
+	return events, true, nil
 }
 
 func (store *Store) timestamp() string {


### PR DESCRIPTION
## Summary

- advertise and implement optional ACP v1 session/list and session/resume capabilities
- replay persisted user/assistant history during session/load with stable message IDs
- keep session/resume replay-free for reconnecting clients that already retain transcript state
- list resumable sessions only, with optional cwd filtering and ACP metadata

## Verification

- go test ./internal/acp
- go vet ./internal/acp
- make fmt-check
- make lint-static
- make vulncheck
- real ZeroApp ACP conformance: initialize, session/list, and session/load passed

## Integration

ZeroApp consumes these capabilities through a separate follow-up PR. session/list and session/resume remain capability-gated for compatibility with older ACP v1 clients and servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for listing and resuming saved sessions.
  * Added workspace filtering, pagination, session metadata, and resolved absolute paths to session listings.
  * Session listing and resumption capabilities are now advertised during initialization.
  * Loading a session replays saved history with stable message IDs, compaction summaries, and tool activity.
  * Live sessions now preserve user messages, tool activity, and assistant responses incrementally.

* **Bug Fixes**
  * Session loading and resuming validate workspace identity and require absolute paths.
  * Invalid, deleted, unavailable, relative, or workspace-less sessions are excluded from listings.
  * Resume fails when history cannot be restored, while loading remains best-effort.
  * Notifications of the same type remain ordered, while different types can be processed concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->