### PR TITLE
fix(acp): three defects a desktop ACP client hits

### DIFF
--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -181,12 +181,17 @@ func (a *Agent) handleSessionLoad(ctx context.Context, params json.RawMessage) (
 		}
 	}
 	sess := a.registerSession(meta.SessionID, root, history, model, models, restrictModels)
+	note := &notifier{conn: a.conn, sessionID: sess.id}
 	a.warnPersistence(
-		&notifier{conn: a.conn, sessionID: sess.id},
+		note,
 		"load session history",
 		"Could not load session history. The session is open, but earlier turns may be missing until storage recovers.",
 		historyErr,
 	)
+	// BEFORE RETURNING, so a client that renders on the reply already has the
+	// transcript. Loading history that only the model can see is what made a
+	// resumed session open blank; see notifier.replayHistory.
+	note.replayHistory(sess.snapshotHistory())
 	return LoadSessionResult{
 		ConfigOptions: a.configOptions(sess),
 		Modes:         a.modeState(sess),
@@ -296,6 +301,16 @@ func stopReasonFor(result agent.Result, err error) (string, error) {
 		if errors.Is(err, context.Canceled) {
 			return StopCancelled, nil
 		}
+		// A CLIENT THAT CANCELLED A PERMISSION PROMPT DID NOT FAIL. Only
+		// context.Canceled was matched here, so dismissing a permission dialog —
+		// a deliberate action, and for apply_patch the only refusal a client is
+		// offered — came back as JSON-RPC -32603 carrying the internal sentinel
+		// text. Editors and the desktop app both render that as a crashed turn,
+		// so declining a tool looked like ZERO falling over. It is a
+		// cancellation, and StopCancelled is what ACP has for saying so.
+		if errors.Is(err, agent.ErrPermissionApprovalCanceled) {
+			return StopCancelled, nil
+		}
 		return "", err
 	}
 	if result.FinishReason == "length" {
@@ -323,7 +338,10 @@ func (a *Agent) requestPermission(ctx context.Context, sessionID string, req age
 		}
 		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "permission request failed: " + err.Error()}, nil
 	}
-	return decisionFromOutcome(result.Outcome, req.AvailableDecisions), nil
+	// Validated against what was actually SENT, not against the raw field. See
+	// offeredDecisions: those two differ whenever ZERO did not enumerate, and
+	// validating against the field turned every offered option into a denial.
+	return decisionFromOutcome(result.Outcome, offeredDecisions(req)), nil
 }
 
 func (a *Agent) emitPlan(registry *tools.Registry, note *notifier) {

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -321,10 +321,14 @@ func stopReasonFor(result agent.Result, err error) (string, error) {
 // session/request_permission request and maps the outcome back. Failure to reach
 // the client fails closed to deny.
 func (a *Agent) requestPermission(ctx context.Context, sessionID string, req agent.PermissionRequest) (agent.PermissionDecision, error) {
+	// Built ONCE and used for both halves. Sending one list and validating the
+	// reply against another is the defect this whole path had; see
+	// decisionFromOutcome.
+	options := buildPermissionOptions(req)
 	params := RequestPermissionParams{
 		SessionID: sessionID,
 		ToolCall:  permissionToolCall(req),
-		Options:   buildPermissionOptions(req),
+		Options:   options,
 	}
 	var result RequestPermissionResult
 	if err := a.conn.Call(ctx, MethodSessionRequestPerm, params, &result); err != nil {
@@ -333,10 +337,7 @@ func (a *Agent) requestPermission(ctx context.Context, sessionID string, req age
 		}
 		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "permission request failed: " + err.Error()}, nil
 	}
-	// Validated against what was actually SENT, not against the raw field. See
-	// offeredDecisions: those two differ whenever ZERO did not enumerate, and
-	// validating against the field turned every offered option into a denial.
-	return decisionFromOutcome(result.Outcome, offeredDecisions(req)), nil
+	return decisionFromOutcome(result.Outcome, options), nil
 }
 
 func (a *Agent) emitPlan(registry *tools.Registry, note *notifier) {

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -181,17 +181,12 @@ func (a *Agent) handleSessionLoad(ctx context.Context, params json.RawMessage) (
 		}
 	}
 	sess := a.registerSession(meta.SessionID, root, history, model, models, restrictModels)
-	note := &notifier{conn: a.conn, sessionID: sess.id}
 	a.warnPersistence(
-		note,
+		&notifier{conn: a.conn, sessionID: sess.id},
 		"load session history",
 		"Could not load session history. The session is open, but earlier turns may be missing until storage recovers.",
 		historyErr,
 	)
-	// BEFORE RETURNING, so a client that renders on the reply already has the
-	// transcript. Loading history that only the model can see is what made a
-	// resumed session open blank; see notifier.replayHistory.
-	note.replayHistory(sess.snapshotHistory())
 	return LoadSessionResult{
 		ConfigOptions: a.configOptions(sess),
 		Modes:         a.modeState(sess),

--- a/internal/acp/desktopinterop_test.go
+++ b/internal/acp/desktopinterop_test.go
@@ -1,176 +1,22 @@
 package acp
 
-// desktopinterop_test.go covers four defects found by driving the real `zero
+// desktopinterop_test.go covers three defects found by driving the real `zero
 // acp` binary from a desktop ACP client. Each is a case where ZERO and a
 // conforming client disagreed about the wire, and none of them failed loudly —
-// they produced a blank transcript, a silent denial, a spurious crash, or two
-// buttons the user could not tell apart.
+// they produced a silent denial, a spurious crash, or two buttons the user
+// could not tell apart.
+//
+// A fourth, session/load restoring history without replaying it, is fixed by
+// #914 rather than here: that one also gives the replayed messages stable ids
+// and keeps session/resume replay-free, which this did not.
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/Gitlawb/zero/internal/agent"
-	"github.com/Gitlawb/zero/internal/sessions"
 )
-
-// ---- session/load replays the conversation ----
-
-// recordUpdates collects every session/update the agent sends, in order and
-// with its variant, which the shared harness does not: that one keeps only
-// agent_message_chunk text, and the whole question here is whether the USER's
-// turns are replayed too.
-type replayedUpdate struct {
-	kind string
-	text string
-}
-
-func recordUpdates(t *testing.T, deps Deps) (*clientHarness, chan replayedUpdate) {
-	t.Helper()
-	seen := make(chan replayedUpdate, 128)
-	h := newHarness(t, deps)
-	h.client.HandleNotify(MethodSessionUpdate, func(_ context.Context, params json.RawMessage) {
-		var probe struct {
-			Update struct {
-				SessionUpdate string `json:"sessionUpdate"`
-				Content       struct {
-					Text string `json:"text"`
-				} `json:"content"`
-			} `json:"update"`
-		}
-		if json.Unmarshal(params, &probe) != nil {
-			return
-		}
-		seen <- replayedUpdate{kind: probe.Update.SessionUpdate, text: probe.Update.Content.Text}
-	})
-	return h, seen
-}
-
-func collect(t *testing.T, seen chan replayedUpdate, want int) []replayedUpdate {
-	t.Helper()
-	var got []replayedUpdate
-	deadline := time.After(3 * time.Second)
-	for len(got) < want {
-		select {
-		case update := <-seen:
-			got = append(got, update)
-		case <-deadline:
-			return got
-		}
-	}
-	return got
-}
-
-// A loaded session used to restore its turns into the agent's own memory and
-// send nothing at all, so a client that resumed got an empty transcript and a
-// model that remembered everything. Asking a follow-up produced a correct
-// answer to a question no longer on screen.
-func TestSessionLoadReplaysTheConversation(t *testing.T) {
-	deps := testDeps(t)
-	cwd := t.TempDir()
-	meta, err := deps.Store.Create(sessions.CreateInput{Title: "resumed", Cwd: cwd})
-	if err != nil {
-		t.Fatalf("create session: %v", err)
-	}
-	if _, err := deps.Store.AppendEvents(meta.SessionID, []sessions.AppendEventInput{
-		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "first question"}},
-		{Type: sessions.EventMessage, Payload: map[string]any{"role": "assistant", "content": "first answer"}},
-	}); err != nil {
-		t.Fatalf("seed history: %v", err)
-	}
-
-	h, seen := recordUpdates(t, deps)
-	defer h.stop()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := h.client.Call(ctx, MethodSessionLoad,
-		LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}},
-		&LoadSessionResult{}); err != nil {
-		t.Fatalf("session/load: %v", err)
-	}
-
-	got := collect(t, seen, 2)
-	if len(got) < 2 {
-		t.Fatalf("replayed %d updates, want 2: %+v", len(got), got)
-	}
-	// Order matters: the question has to arrive before its answer, or the
-	// transcript reads backwards.
-	if got[0].kind != UpdateUserMessageChunk || got[0].text != "first question" {
-		t.Fatalf("first update = %+v, want the user's turn", got[0])
-	}
-	if got[1].kind != UpdateAgentMessageChunk || got[1].text != "first answer" {
-		t.Fatalf("second update = %+v, want the agent's turn", got[1])
-	}
-}
-
-// A session with nothing in it replays nothing, rather than an empty message
-// pair that would render as two blank bubbles.
-func TestSessionLoadOfAnEmptySessionReplaysNothing(t *testing.T) {
-	deps := testDeps(t)
-	cwd := t.TempDir()
-	meta, err := deps.Store.Create(sessions.CreateInput{Title: "empty", Cwd: cwd})
-	if err != nil {
-		t.Fatalf("create session: %v", err)
-	}
-
-	h, seen := recordUpdates(t, deps)
-	defer h.stop()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := h.client.Call(ctx, MethodSessionLoad,
-		LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}},
-		&LoadSessionResult{}); err != nil {
-		t.Fatalf("session/load: %v", err)
-	}
-
-	select {
-	case update := <-seen:
-		t.Fatalf("empty session replayed %+v", update)
-	case <-time.After(300 * time.Millisecond):
-	}
-}
-
-// A turn persisted with a question but no answer — which is what a run
-// interrupted mid-turn leaves behind — replays only the question. Inventing an
-// empty assistant message for it would put a blank agent bubble on screen.
-func TestSessionLoadSkipsAnAnswerThatWasNeverWritten(t *testing.T) {
-	deps := testDeps(t)
-	cwd := t.TempDir()
-	meta, err := deps.Store.Create(sessions.CreateInput{Title: "half", Cwd: cwd})
-	if err != nil {
-		t.Fatalf("create session: %v", err)
-	}
-	if _, err := deps.Store.AppendEvents(meta.SessionID, []sessions.AppendEventInput{
-		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "interrupted"}},
-	}); err != nil {
-		t.Fatalf("seed history: %v", err)
-	}
-
-	h, seen := recordUpdates(t, deps)
-	defer h.stop()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := h.client.Call(ctx, MethodSessionLoad,
-		LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}},
-		&LoadSessionResult{}); err != nil {
-		t.Fatalf("session/load: %v", err)
-	}
-
-	got := collect(t, seen, 2)
-	if len(got) != 1 {
-		t.Fatalf("replayed %d updates, want only the question: %+v", len(got), got)
-	}
-	if got[0].kind != UpdateUserMessageChunk {
-		t.Fatalf("replayed %+v, want the user's turn alone", got[0])
-	}
-}
 
 // ---- an offered option is an acceptable answer ----
 

--- a/internal/acp/desktopinterop_test.go
+++ b/internal/acp/desktopinterop_test.go
@@ -1,0 +1,320 @@
+package acp
+
+// desktopinterop_test.go covers four defects found by driving the real `zero
+// acp` binary from a desktop ACP client. Each is a case where ZERO and a
+// conforming client disagreed about the wire, and none of them failed loudly —
+// they produced a blank transcript, a silent denial, a spurious crash, or two
+// buttons the user could not tell apart.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+// ---- session/load replays the conversation ----
+
+// recordUpdates collects every session/update the agent sends, in order and
+// with its variant, which the shared harness does not: that one keeps only
+// agent_message_chunk text, and the whole question here is whether the USER's
+// turns are replayed too.
+type replayedUpdate struct {
+	kind string
+	text string
+}
+
+func recordUpdates(t *testing.T, deps Deps) (*clientHarness, chan replayedUpdate) {
+	t.Helper()
+	seen := make(chan replayedUpdate, 128)
+	h := newHarness(t, deps)
+	h.client.HandleNotify(MethodSessionUpdate, func(_ context.Context, params json.RawMessage) {
+		var probe struct {
+			Update struct {
+				SessionUpdate string `json:"sessionUpdate"`
+				Content       struct {
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"update"`
+		}
+		if json.Unmarshal(params, &probe) != nil {
+			return
+		}
+		seen <- replayedUpdate{kind: probe.Update.SessionUpdate, text: probe.Update.Content.Text}
+	})
+	return h, seen
+}
+
+func collect(t *testing.T, seen chan replayedUpdate, want int) []replayedUpdate {
+	t.Helper()
+	var got []replayedUpdate
+	deadline := time.After(3 * time.Second)
+	for len(got) < want {
+		select {
+		case update := <-seen:
+			got = append(got, update)
+		case <-deadline:
+			return got
+		}
+	}
+	return got
+}
+
+// A loaded session used to restore its turns into the agent's own memory and
+// send nothing at all, so a client that resumed got an empty transcript and a
+// model that remembered everything. Asking a follow-up produced a correct
+// answer to a question no longer on screen.
+func TestSessionLoadReplaysTheConversation(t *testing.T) {
+	deps := testDeps(t)
+	cwd := t.TempDir()
+	meta, err := deps.Store.Create(sessions.CreateInput{Title: "resumed", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := deps.Store.AppendEvents(meta.SessionID, []sessions.AppendEventInput{
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "first question"}},
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "assistant", "content": "first answer"}},
+	}); err != nil {
+		t.Fatalf("seed history: %v", err)
+	}
+
+	h, seen := recordUpdates(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := h.client.Call(ctx, MethodSessionLoad,
+		LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}},
+		&LoadSessionResult{}); err != nil {
+		t.Fatalf("session/load: %v", err)
+	}
+
+	got := collect(t, seen, 2)
+	if len(got) < 2 {
+		t.Fatalf("replayed %d updates, want 2: %+v", len(got), got)
+	}
+	// Order matters: the question has to arrive before its answer, or the
+	// transcript reads backwards.
+	if got[0].kind != UpdateUserMessageChunk || got[0].text != "first question" {
+		t.Fatalf("first update = %+v, want the user's turn", got[0])
+	}
+	if got[1].kind != UpdateAgentMessageChunk || got[1].text != "first answer" {
+		t.Fatalf("second update = %+v, want the agent's turn", got[1])
+	}
+}
+
+// A session with nothing in it replays nothing, rather than an empty message
+// pair that would render as two blank bubbles.
+func TestSessionLoadOfAnEmptySessionReplaysNothing(t *testing.T) {
+	deps := testDeps(t)
+	cwd := t.TempDir()
+	meta, err := deps.Store.Create(sessions.CreateInput{Title: "empty", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	h, seen := recordUpdates(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := h.client.Call(ctx, MethodSessionLoad,
+		LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}},
+		&LoadSessionResult{}); err != nil {
+		t.Fatalf("session/load: %v", err)
+	}
+
+	select {
+	case update := <-seen:
+		t.Fatalf("empty session replayed %+v", update)
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// A turn persisted with a question but no answer — which is what a run
+// interrupted mid-turn leaves behind — replays only the question. Inventing an
+// empty assistant message for it would put a blank agent bubble on screen.
+func TestSessionLoadSkipsAnAnswerThatWasNeverWritten(t *testing.T) {
+	deps := testDeps(t)
+	cwd := t.TempDir()
+	meta, err := deps.Store.Create(sessions.CreateInput{Title: "half", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := deps.Store.AppendEvents(meta.SessionID, []sessions.AppendEventInput{
+		{Type: sessions.EventMessage, Payload: map[string]any{"role": "user", "content": "interrupted"}},
+	}); err != nil {
+		t.Fatalf("seed history: %v", err)
+	}
+
+	h, seen := recordUpdates(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := h.client.Call(ctx, MethodSessionLoad,
+		LoadSessionParams{SessionID: meta.SessionID, Cwd: cwd, McpServers: []McpServer{}},
+		&LoadSessionResult{}); err != nil {
+		t.Fatalf("session/load: %v", err)
+	}
+
+	got := collect(t, seen, 2)
+	if len(got) != 1 {
+		t.Fatalf("replayed %d updates, want only the question: %+v", len(got), got)
+	}
+	if got[0].kind != UpdateUserMessageChunk {
+		t.Fatalf("replayed %+v, want the user's turn alone", got[0])
+	}
+}
+
+// ---- an offered option is an acceptable answer ----
+
+// The list the options were BUILT from and the list the answer was CHECKED
+// against were different whenever ZERO did not enumerate: the client was sent
+// Allow and Reject, and its reply was validated against an empty slice, so
+// every button it could possibly show failed closed to deny. The user clicked
+// Allow and ZERO recorded a denial, with nothing on screen to say so.
+func TestAnOfferedOptionIsAccepted(t *testing.T) {
+	// No AvailableDecisions: the fallback path, which is every permission event
+	// that is not a prompt.
+	req := agent.PermissionRequest{ToolName: "bash"}
+
+	options := buildPermissionOptions(req)
+	if len(options) == 0 {
+		t.Fatal("no options were offered")
+	}
+
+	for _, option := range options {
+		decision := decisionFromOutcome(
+			RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: option.OptionID},
+			offeredDecisions(req),
+		)
+		if string(decision.Action) != option.OptionID {
+			t.Fatalf("option %q was answered with %q (%s) — an offered option must be accepted",
+				option.OptionID, decision.Action, decision.Reason)
+		}
+	}
+}
+
+// The narrowing this validation exists for still holds: a client must not be
+// able to return a broader grant than it was shown.
+func TestAnOptionThatWasNotOfferedIsStillRefused(t *testing.T) {
+	req := agent.PermissionRequest{ToolName: "bash"}
+
+	decision := decisionFromOutcome(
+		RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: string(agent.PermissionDecisionAlwaysAllow)},
+		offeredDecisions(req),
+	)
+	if decision.Action != agent.PermissionDecisionDeny {
+		t.Fatalf("an unoffered broader grant was accepted as %q", decision.Action)
+	}
+}
+
+// The resolver is the single source of truth for both sides, which is what
+// makes the two agree by construction rather than by being kept in step.
+func TestOfferedDecisionsMatchWhatWasSent(t *testing.T) {
+	for _, req := range []agent.PermissionRequest{
+		{ToolName: "bash"},
+		{ToolName: "bash", AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowForSession,
+			agent.PermissionDecisionDeny,
+		}},
+	} {
+		offered := offeredDecisions(req)
+		for _, option := range buildPermissionOptions(req) {
+			if !actionOffered(agent.PermissionDecisionAction(option.OptionID), offered) {
+				t.Fatalf("option %q was sent but is not in the offered set %v", option.OptionID, offered)
+			}
+		}
+	}
+}
+
+// ---- two options the user can tell apart ----
+
+// request_permissions offers plain allow and strict-review allow together, and
+// both were labelled "Allow". The label is the only thing an ACP client shows,
+// so the panel presented two identical buttons where one silently enabled
+// strict auto-review of what was granted.
+func TestEveryOfferedOptionHasADistinctLabel(t *testing.T) {
+	req := agent.PermissionRequest{
+		ToolName: "request_permissions",
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowStrict,
+			agent.PermissionDecisionAllowForSession,
+			agent.PermissionDecisionDeny,
+		},
+	}
+
+	seen := map[string]string{}
+	for _, option := range buildPermissionOptions(req) {
+		if previous, clash := seen[option.Name]; clash {
+			t.Fatalf("options %q and %q share the label %q — a user cannot tell them apart",
+				previous, option.OptionID, option.Name)
+		}
+		seen[option.Name] = option.OptionID
+	}
+}
+
+// The two remain distinct decisions: the label changed, the round trip did not.
+func TestStrictAllowStillRoundTrips(t *testing.T) {
+	req := agent.PermissionRequest{
+		ToolName: "request_permissions",
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowStrict,
+		},
+	}
+	decision := decisionFromOutcome(
+		RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: string(agent.PermissionDecisionAllowStrict)},
+		offeredDecisions(req),
+	)
+	if decision.Action != agent.PermissionDecisionAllowStrict {
+		t.Fatalf("strict allow round-tripped as %q", decision.Action)
+	}
+}
+
+// ---- cancelling a permission is a cancellation, not a crash ----
+
+// Only context.Canceled was recognised, so dismissing a permission dialog came
+// back as JSON-RPC -32603 carrying the internal sentinel text. Clients render
+// that as a failed turn, so declining a tool looked like ZERO falling over —
+// and for apply_patch, dismissing is the ONLY refusal a client is offered.
+func TestCancellingAPermissionEndsTheTurnAsCancelled(t *testing.T) {
+	canceled := fmt.Errorf("%w for apply_patch", agent.ErrPermissionApprovalCanceled)
+
+	reason, err := stopReasonFor(agent.Result{}, canceled)
+	if err != nil {
+		t.Fatalf("stopReasonFor returned an error for a cancellation: %v", err)
+	}
+	if reason != StopCancelled {
+		t.Fatalf("stop reason = %q, want %q", reason, StopCancelled)
+	}
+}
+
+// A genuine failure must still be an error. Mapping too much to cancelled would
+// hide real faults behind a clean ending, which is the opposite mistake.
+func TestARealFailureIsStillAnError(t *testing.T) {
+	failure := errors.New("provider exploded")
+
+	if _, err := stopReasonFor(agent.Result{}, failure); !errors.Is(err, failure) {
+		t.Fatalf("stopReasonFor(%v) = %v, want the failure preserved", failure, err)
+	}
+}
+
+// The sentinel is matched through errors.Is, so it survives the wrapping every
+// return site applies — each one adds the tool name.
+func TestPermissionCancellationSurvivesWrapping(t *testing.T) {
+	if !errors.Is(fmt.Errorf("%w for bash", agent.ErrPermissionApprovalCanceled), agent.ErrPermissionApprovalCanceled) {
+		t.Fatal("a wrapped permission cancellation was not recognised")
+	}
+	if errors.Is(errors.New("something else"), agent.ErrPermissionApprovalCanceled) {
+		t.Fatal("an unrelated error was reported as a permission cancellation")
+	}
+}

--- a/internal/acp/desktopinterop_test.go
+++ b/internal/acp/desktopinterop_test.go
@@ -38,7 +38,7 @@ func TestAnOfferedOptionIsAccepted(t *testing.T) {
 	for _, option := range options {
 		decision := decisionFromOutcome(
 			RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: option.OptionID},
-			offeredDecisions(req),
+			buildPermissionOptions(req),
 		)
 		if string(decision.Action) != option.OptionID {
 			t.Fatalf("option %q was answered with %q (%s) — an offered option must be accepted",
@@ -54,7 +54,7 @@ func TestAnOptionThatWasNotOfferedIsStillRefused(t *testing.T) {
 
 	decision := decisionFromOutcome(
 		RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: string(agent.PermissionDecisionAlwaysAllow)},
-		offeredDecisions(req),
+		buildPermissionOptions(req),
 	)
 	if decision.Action != agent.PermissionDecisionDeny {
 		t.Fatalf("an unoffered broader grant was accepted as %q", decision.Action)
@@ -72,9 +72,9 @@ func TestOfferedDecisionsMatchWhatWasSent(t *testing.T) {
 			agent.PermissionDecisionDeny,
 		}},
 	} {
-		offered := offeredDecisions(req)
+		offered := buildPermissionOptions(req)
 		for _, option := range buildPermissionOptions(req) {
-			if !actionOffered(agent.PermissionDecisionAction(option.OptionID), offered) {
+			if !actionOffered(option.OptionID, offered) {
 				t.Fatalf("option %q was sent but is not in the offered set %v", option.OptionID, offered)
 			}
 		}
@@ -119,7 +119,7 @@ func TestStrictAllowStillRoundTrips(t *testing.T) {
 	}
 	decision := decisionFromOutcome(
 		RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: string(agent.PermissionDecisionAllowStrict)},
-		offeredDecisions(req),
+		buildPermissionOptions(req),
 	)
 	if decision.Action != agent.PermissionDecisionAllowStrict {
 		t.Fatalf("strict allow round-tripped as %q", decision.Action)
@@ -162,5 +162,56 @@ func TestPermissionCancellationSurvivesWrapping(t *testing.T) {
 	}
 	if errors.Is(errors.New("something else"), agent.ErrPermissionApprovalCanceled) {
 		t.Fatal("an unrelated error was reported as a permission cancellation")
+	}
+}
+
+// A decision that never became an option cannot be selected.
+//
+// PermissionDecisionCancel is the case that exists today: optionKindFor drops
+// it because ACP expresses cancellation through the outcome, yet ZERO
+// enumerates it in AvailableDecisions for shell commands and apply_patch. While
+// the reply was validated against the DECISIONS rather than the sent options, a
+// client could return {"outcome":"selected","optionId":"cancel"} — an id it was
+// never shown — and abort the whole turn.
+//
+// Written over every option-less decision rather than over "cancel", so a
+// future action that optionKindFor declines to render is covered the day it is
+// added rather than the day someone remembers this test.
+func TestADecisionThatIsNotAnOptionCannotBeSelected(t *testing.T) {
+	for _, toolName := range []string{"bash", "apply_patch"} {
+		req := agent.PermissionRequest{
+			ToolName: toolName,
+			AvailableDecisions: []agent.PermissionDecisionAction{
+				agent.PermissionDecisionAllow,
+				agent.PermissionDecisionDeny,
+				agent.PermissionDecisionCancel,
+			},
+		}
+		options := buildPermissionOptions(req)
+
+		for _, action := range req.AvailableDecisions {
+			if actionOffered(string(action), options) {
+				continue // it was sent; selecting it is legitimate
+			}
+			decision := decisionFromOutcome(
+				RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: string(action)},
+				options,
+			)
+			if decision.Action != agent.PermissionDecisionDeny {
+				t.Fatalf("%s: %q was never sent as an option but was accepted as %q",
+					toolName, action, decision.Action)
+			}
+		}
+	}
+}
+
+// Cancelling is still reachable — through the outcome, which is where ACP puts
+// it. Closing the selected-id route must not close the real one.
+func TestCancellingThroughTheOutcomeStillWorks(t *testing.T) {
+	options := buildPermissionOptions(agent.PermissionRequest{ToolName: "apply_patch"})
+
+	decision := decisionFromOutcome(RequestPermissionOutcome{Outcome: OutcomeCancelled}, options)
+	if decision.Action != agent.PermissionDecisionCancel {
+		t.Fatalf("outcome=cancelled gave %q, want cancel", decision.Action)
 	}
 }

--- a/internal/acp/permission.go
+++ b/internal/acp/permission.go
@@ -97,19 +97,31 @@ func optionKindFor(action agent.PermissionDecisionAction, escalates bool) (kind,
 
 // decisionFromOutcome maps the client's permission outcome back to a ZERO
 // decision. A cancelled outcome cancels the run; a selected option id is the ZERO
-// action verbatim (validated against what was offered); anything unrecognized
-// fails closed to deny.
-func decisionFromOutcome(outcome RequestPermissionOutcome, offered []agent.PermissionDecisionAction) agent.PermissionDecision {
+// action verbatim (validated against what was actually sent); anything
+// unrecognized fails closed to deny.
+//
+// IT TAKES THE OPTIONS THAT WERE SENT, not the decisions the request offered,
+// and the two are not the same list. Some actions never become options —
+// PermissionDecisionCancel is dropped by optionKindFor because ACP expresses
+// cancellation through the outcome instead — yet it IS enumerated in
+// AvailableDecisions for shell commands and apply_patch, the two commonest
+// prompts. Validating against the decisions therefore accepted
+// {"outcome":"selected","optionId":"cancel"}: an identifier no client was ever
+// shown, aborting the whole turn.
+//
+// Passing the sent options makes "what we offered" and "what we accept" the
+// same slice rather than two things kept in step, so anything optionKindFor
+// declines to render is excluded structurally instead of by name.
+func decisionFromOutcome(outcome RequestPermissionOutcome, offered []PermissionOption) agent.PermissionDecision {
 	switch outcome.Outcome {
 	case OutcomeCancelled:
 		return agent.PermissionDecision{Action: agent.PermissionDecisionCancel, Reason: "client cancelled"}
 	case OutcomeSelected:
-		action := agent.PermissionDecisionAction(outcome.OptionID)
 		// Bind to what was actually offered for THIS call: a client must not be able
 		// to return a broader grant (always_allow / allow_for_session) that wasn't
 		// presented. Anything not offered fails closed to deny.
-		if actionOffered(action, offered) {
-			return agent.PermissionDecision{Action: action}
+		if actionOffered(outcome.OptionID, offered) {
+			return agent.PermissionDecision{Action: agent.PermissionDecisionAction(outcome.OptionID)}
 		}
 		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "permission option was not offered"}
 	default:
@@ -117,9 +129,9 @@ func decisionFromOutcome(outcome RequestPermissionOutcome, offered []agent.Permi
 	}
 }
 
-func actionOffered(action agent.PermissionDecisionAction, offered []agent.PermissionDecisionAction) bool {
-	for _, a := range offered {
-		if a == action {
+func actionOffered(optionID string, offered []PermissionOption) bool {
+	for _, option := range offered {
+		if option.OptionID == optionID {
 			return true
 		}
 	}

--- a/internal/acp/permission.go
+++ b/internal/acp/permission.go
@@ -15,14 +15,7 @@ import (
 // PermissionOptions. Only the actions ZERO actually presented (AvailableDecisions)
 // are surfaced; the optionId is the ZERO action string for a clean round-trip.
 func buildPermissionOptions(req agent.PermissionRequest) []PermissionOption {
-	actions := req.AvailableDecisions
-	if len(actions) == 0 {
-		// Sensible default if ZERO didn't enumerate: allow once / reject.
-		actions = []agent.PermissionDecisionAction{
-			agent.PermissionDecisionAllow,
-			agent.PermissionDecisionDeny,
-		}
-	}
+	actions := offeredDecisions(req)
 	options := make([]PermissionOption, 0, len(actions))
 	for _, action := range actions {
 		kind, name := optionKindFor(action, req.PrefixApprovalEscalates)
@@ -38,6 +31,32 @@ func buildPermissionOptions(req agent.PermissionRequest) []PermissionOption {
 	return options
 }
 
+// offeredDecisions resolves what this request actually offers the client.
+//
+// ONE RESOLVER, USED BY BOTH SIDES, and that is the entire point of it existing.
+// The fallback below used to live inside buildPermissionOptions while
+// requestPermission validated the client's answer against the raw
+// req.AvailableDecisions. When ZERO did not enumerate — which is every
+// permission event that is not a prompt, and includes a shell call whose sandbox
+// decision came back deny — the two disagreed completely: the client was sent
+// "Allow" and "Reject", and validation was performed against an EMPTY list, so
+// every option the client could possibly click failed closed to deny with
+// "permission option was not offered".
+//
+// The user clicked Allow and ZERO recorded a denial. Nothing surfaced it,
+// because a denial is a legitimate answer — the tool was simply refused and the
+// turn carried on as though the user had rejected it.
+func offeredDecisions(req agent.PermissionRequest) []agent.PermissionDecisionAction {
+	if len(req.AvailableDecisions) > 0 {
+		return req.AvailableDecisions
+	}
+	// Sensible default if ZERO didn't enumerate: allow once / reject.
+	return []agent.PermissionDecisionAction{
+		agent.PermissionDecisionAllow,
+		agent.PermissionDecisionDeny,
+	}
+}
+
 // optionKindFor maps a ZERO decision action to an ACP PermissionOptionKind and a
 // human label. Returns an empty kind for actions that ACP expresses through the
 // outcome rather than an option (cancel).
@@ -49,8 +68,16 @@ func buildPermissionOptions(req agent.PermissionRequest) []PermissionOption {
 // disclosure cannot be TUI-only.
 func optionKindFor(action agent.PermissionDecisionAction, escalates bool) (kind, name string) {
 	switch action {
-	case agent.PermissionDecisionAllow, agent.PermissionDecisionAllowStrict:
+	case agent.PermissionDecisionAllow:
 		return PermAllowOnce, "Allow"
+	case agent.PermissionDecisionAllowStrict:
+		// SPLIT FROM PLAIN ALLOW because the label is the only thing an ACP
+		// client shows. Both were labelled "Allow", and request_permissions
+		// offers them together — so the panel presented two identical buttons,
+		// and whichever the user picked looked the same while one of them
+		// silently turned on strict auto-review of what was granted. The option
+		// id carries no room for the distinction, so it has to be in the name.
+		return PermAllowOnce, "Allow with strict review"
 	case agent.PermissionDecisionAllowForSession:
 		return PermAllowAlways, "Allow for this session"
 	case agent.PermissionDecisionAllowPrefix:

--- a/internal/acp/permission_escalation_test.go
+++ b/internal/acp/permission_escalation_test.go
@@ -56,10 +56,11 @@ func TestACPPrefixOptionsStaySilentWithoutEscalation(t *testing.T) {
 // what was offered, so decorating it would fail every prefix approval closed.
 func TestACPDisclosureDoesNotDisturbTheOptionIDRoundTrip(t *testing.T) {
 	request := escalationRequest(true)
-	for _, option := range buildPermissionOptions(request) {
+	options := buildPermissionOptions(request)
+	for _, option := range options {
 		decision := decisionFromOutcome(
 			RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: option.OptionID},
-			request.AvailableDecisions,
+			options,
 		)
 		if string(decision.Action) != option.OptionID {
 			t.Errorf("option id %q round-tripped to %q (%s)", option.OptionID, decision.Action, decision.Reason)

--- a/internal/acp/permission_test.go
+++ b/internal/acp/permission_test.go
@@ -39,11 +39,14 @@ func TestBuildPermissionOptionsDefault(t *testing.T) {
 }
 
 func TestDecisionFromOutcome(t *testing.T) {
-	offered := []agent.PermissionDecisionAction{
-		agent.PermissionDecisionAllow,
-		agent.PermissionDecisionAlwaysAllow,
-		agent.PermissionDecisionDeny,
-	}
+	offered := buildPermissionOptions(agent.PermissionRequest{
+		ToolName: "bash",
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAlwaysAllow,
+			agent.PermissionDecisionDeny,
+		},
+	})
 	if d := decisionFromOutcome(RequestPermissionOutcome{Outcome: OutcomeCancelled}, offered); d.Action != agent.PermissionDecisionCancel {
 		t.Errorf("cancelled -> %q, want cancel", d.Action)
 	}

--- a/internal/acp/translate.go
+++ b/internal/acp/translate.go
@@ -21,6 +21,10 @@ func agentThoughtChunk(delta string) ContentChunk {
 	return ContentChunk{SessionUpdate: UpdateAgentThoughtChunk, Content: TextBlock(delta)}
 }
 
+func userMessageChunk(delta string) ContentChunk {
+	return ContentChunk{SessionUpdate: UpdateUserMessageChunk, Content: TextBlock(delta)}
+}
+
 // toolKindFor maps a ZERO tool name to the closest ACP ToolKind so editors can
 // pick an icon/affordance. Unknown tools fall back to "other".
 func toolKindFor(name string) string {
@@ -198,6 +202,34 @@ func (n *notifier) text(delta string) {
 func (n *notifier) thought(delta string) {
 	if delta != "" {
 		n.send(agentThoughtChunk(delta))
+	}
+}
+
+// replayHistory re-sends a loaded conversation so the client can render it.
+//
+// WITHOUT THIS, session/load RESTORED NOTHING THE USER COULD SEE. The turns
+// were read from the store into the agent's own memory and used to build every
+// subsequent prompt, but not one notification was sent — so a client that
+// resumed a session got an empty transcript and a model that nevertheless
+// remembered everything. Ask a follow-up like "now do the other one" and ZERO
+// answers correctly, about a question no longer on screen.
+//
+// Sent as whole messages rather than per-token deltas: this is not streaming,
+// it is a transcript, and a client folds a chunk into a message the same way
+// either way.
+//
+// Each turn is user-then-assistant, and an empty assistant is skipped — a turn
+// can be persisted with the question but no answer if the previous run ended
+// mid-turn, and inventing an empty reply for it would put a blank agent bubble
+// on screen.
+func (n *notifier) replayHistory(turns []turnRecord) {
+	for _, turn := range turns {
+		if turn.user != "" {
+			n.send(userMessageChunk(turn.user))
+		}
+		if turn.assistant != "" {
+			n.send(agentMessageChunk(turn.assistant))
+		}
 	}
 }
 

--- a/internal/acp/translate.go
+++ b/internal/acp/translate.go
@@ -21,10 +21,6 @@ func agentThoughtChunk(delta string) ContentChunk {
 	return ContentChunk{SessionUpdate: UpdateAgentThoughtChunk, Content: TextBlock(delta)}
 }
 
-func userMessageChunk(delta string) ContentChunk {
-	return ContentChunk{SessionUpdate: UpdateUserMessageChunk, Content: TextBlock(delta)}
-}
-
 // toolKindFor maps a ZERO tool name to the closest ACP ToolKind so editors can
 // pick an icon/affordance. Unknown tools fall back to "other".
 func toolKindFor(name string) string {
@@ -202,34 +198,6 @@ func (n *notifier) text(delta string) {
 func (n *notifier) thought(delta string) {
 	if delta != "" {
 		n.send(agentThoughtChunk(delta))
-	}
-}
-
-// replayHistory re-sends a loaded conversation so the client can render it.
-//
-// WITHOUT THIS, session/load RESTORED NOTHING THE USER COULD SEE. The turns
-// were read from the store into the agent's own memory and used to build every
-// subsequent prompt, but not one notification was sent — so a client that
-// resumed a session got an empty transcript and a model that nevertheless
-// remembered everything. Ask a follow-up like "now do the other one" and ZERO
-// answers correctly, about a question no longer on screen.
-//
-// Sent as whole messages rather than per-token deltas: this is not streaming,
-// it is a transcript, and a client folds a chunk into a message the same way
-// either way.
-//
-// Each turn is user-then-assistant, and an empty assistant is skipped — a turn
-// can be persisted with the question but no answer if the previous run ended
-// mid-turn, and inventing an empty reply for it would put a blank agent bubble
-// on screen.
-func (n *notifier) replayHistory(turns []turnRecord) {
-	for _, turn := range turns {
-		if turn.user != "" {
-			n.send(userMessageChunk(turn.user))
-		}
-		if turn.assistant != "" {
-			n.send(agentMessageChunk(turn.assistant))
-		}
 	}
 }
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -40,7 +40,15 @@ const (
 	toolResultControlSpecReview = "spec_review_required"
 )
 
-var errPermissionApprovalCanceled = errors.New("permission approval cancelled")
+// ErrPermissionApprovalCanceled ends a run because the caller cancelled a
+// permission prompt, rather than because anything failed.
+//
+// EXPORTED FOR THE SURFACES. A cancel is a normal ending and each surface says
+// so its own way — the TUI unwinds, and ACP has a "cancelled" stop reason for
+// exactly this. While it was unexported ACP could not distinguish it from a
+// fault and reported it as an internal error, so declining a tool looked like
+// the agent crashing.
+var ErrPermissionApprovalCanceled = errors.New("permission approval cancelled")
 
 // isImageRejectionError reports whether err is a provider 400 that rejects
 // image/multimodal content. This is checked BEFORE the compaction-retry path
@@ -1364,7 +1372,7 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 			}
 		case PermissionDecisionCancel:
 			emitCanceledPermission(options, call, requestEvent, decisionReason)
-			return canceledPermissionResult(call, decisionReason, requestEvent), fmt.Errorf("%w for %s", errPermissionApprovalCanceled, call.Name)
+			return canceledPermissionResult(call, decisionReason, requestEvent), fmt.Errorf("%w for %s", ErrPermissionApprovalCanceled, call.Name)
 		default:
 			emitDeniedPermission(options, call, requestEvent, decisionReason)
 			return deniedPermissionResult(call, decisionReason, requestEvent), nil
@@ -1548,7 +1556,7 @@ func maybeRetryUnsandboxedAfterSandboxRestriction(ctx context.Context, registry 
 	case PermissionDecisionCancel:
 		emitCanceledPermission(options, call, requestEvent, reason)
 		canceled := canceledPermissionResult(call, reason, requestEvent)
-		return result, &canceled, true, decision.Action, reason, nil, fmt.Errorf("%w for %s", errPermissionApprovalCanceled, call.Name)
+		return result, &canceled, true, decision.Action, reason, nil, fmt.Errorf("%w for %s", ErrPermissionApprovalCanceled, call.Name)
 	default:
 		emitDeniedPermission(options, call, requestEvent, reason)
 		denied := deniedPermissionResult(call, reason, requestEvent)
@@ -1596,7 +1604,7 @@ func maybeRetryWithNetworkAfterSandboxDenial(ctx context.Context, registry *tool
 	case PermissionDecisionCancel:
 		emitCanceledPermission(options, call, requestEvent, reason)
 		canceled := canceledPermissionResult(call, reason, requestEvent)
-		return result, &canceled, true, decision.Action, reason, fmt.Errorf("%w for %s", errPermissionApprovalCanceled, call.Name)
+		return result, &canceled, true, decision.Action, reason, fmt.Errorf("%w for %s", ErrPermissionApprovalCanceled, call.Name)
 	default:
 		emitDeniedPermission(options, call, requestEvent, reason)
 		denied := deniedPermissionResult(call, reason, requestEvent)

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -4340,3 +4340,95 @@ func TestPlanModeHonorsBeforeToolVeto(t *testing.T) {
 		t.Fatalf("expected tool result to mention the beforeTool veto, got %q", combined)
 	}
 }
+
+// A cancelled permission on either sandbox-retry path must abort the run with a
+// recognisable cancellation, and must not run the escalated retry.
+//
+// BOTH PATHS, because both wrap ErrPermissionApprovalCanceled and each is
+// reached by a different kind of denial: one by an unrestricted platform denial
+// asking for approval, the other by an external-network denial. Surfaces map
+// this sentinel onto their own idea of a cancel — ACP returns stopReason
+// "cancelled" for it — so a path that produced a bare error instead would show
+// the user a crash where they had simply declined.
+func TestCancellingASandboxRetryAbortsWithoutRetrying(t *testing.T) {
+	denial := func(capability execution.CapabilityKind, scope string) tools.Result {
+		return tools.Result{
+			Status: tools.StatusError,
+			ExecutionOutcome: &execution.Outcome{
+				State: execution.StateDenied,
+				Kind:  execution.OutcomeEnforcementDenied,
+				Denial: &execution.Denial{
+					Capability:  execution.Capability{Kind: capability, Scope: scope},
+					Source:      execution.DenialSourcePlatformSandbox,
+					Reason:      "denied by the sandbox",
+					Recoverable: true,
+					NextAction:  execution.DenialNextActionRequestApproval,
+				},
+			},
+		}
+	}
+
+	for _, testCase := range []struct {
+		name   string
+		result tools.Result
+		run    func(context.Context, *tools.Registry, ToolCall, tools.Tool, map[string]any, tools.Result, Options) error
+	}{
+		{
+			name:   "unsandboxed retry",
+			result: denial(execution.CapabilityUnrestricted, "host"),
+			run: func(ctx context.Context, registry *tools.Registry, call ToolCall, tool tools.Tool, args map[string]any, result tools.Result, options Options) error {
+				_, _, _, _, _, _, abortErr := maybeRetryUnsandboxedAfterSandboxRestriction(
+					ctx, registry, call, tool, args, result, PermissionModeAsk, options, nil)
+				return abortErr
+			},
+		},
+		{
+			name:   "network retry",
+			result: denial(execution.CapabilityExternalNetwork, ""),
+			run: func(ctx context.Context, registry *tools.Registry, call ToolCall, tool tools.Tool, args map[string]any, result tools.Result, options Options) error {
+				_, _, _, _, _, abortErr := maybeRetryWithNetworkAfterSandboxDenial(
+					ctx, registry, call, tool, args, result, PermissionModeAsk, options, nil)
+				return abortErr
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			retryTool := &sandboxNamespaceLimitedRetryTool{}
+			registry := tools.NewRegistry()
+			registry.Register(retryTool)
+
+			asked := 0
+			options := Options{
+				Registry:       registry,
+				PermissionMode: PermissionModeAsk,
+				Autonomy:       "medium",
+				Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+					WorkspaceRoot: t.TempDir(),
+					Policy:        sandbox.DefaultPolicy(),
+				}),
+				OnPermissionRequest: func(context.Context, PermissionRequest) (PermissionDecision, error) {
+					asked++
+					return PermissionDecision{Action: PermissionDecisionCancel, Reason: "client cancelled"}, nil
+				},
+			}
+
+			call := ToolCall{ID: "call-1", Name: "bash", Arguments: `{"command":"curl example.com"}`}
+			args := map[string]any{"command": "curl example.com"}
+
+			abortErr := testCase.run(context.Background(), registry, call, retryTool, args, testCase.result, options)
+
+			if asked != 1 {
+				t.Fatalf("permission was requested %d times, want exactly 1", asked)
+			}
+			if !errors.Is(abortErr, ErrPermissionApprovalCanceled) {
+				t.Fatalf("abort error = %v, want it to match ErrPermissionApprovalCanceled", abortErr)
+			}
+			// The escalated retry is the thing the permission was gating. A
+			// cancelled prompt that still ran it would have run the command the
+			// user just declined.
+			if len(retryTool.calls) != 0 {
+				t.Fatalf("the escalated retry ran %d times after a cancel: %+v", len(retryTool.calls), retryTool.calls)
+			}
+		})
+	}
+}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1853,7 +1853,7 @@ func TestRunAbortsWhenPermissionRequestCanceled(t *testing.T) {
 		},
 	})
 
-	if !errors.Is(err, errPermissionApprovalCanceled) {
+	if !errors.Is(err, ErrPermissionApprovalCanceled) {
 		t.Fatalf("expected permission approval cancel error, got %v", err)
 	}
 	if result.FinalAnswer != "" {


### PR DESCRIPTION
Found by driving `zero acp` over stdio from ZeroApp (the desktop client) and comparing both sides of the wire against each other. None of these fail loudly — they produce a silent denial, a spurious crash, or two buttons a user cannot tell apart.

**Rebased around #914.** This originally carried a fourth fix — `session/load` restoring history without replaying it — which gnanam's #914 also fixes, and better: the replayed messages get stable ids derived from the store's event ids, `session/load` replays while `session/resume` deliberately does not, and both are capability-gated. I dropped mine rather than keep a weaker duplicate. `translate.go` is back to its state on `main`, so the only overlap left with #914 is `agent.go`, in two hunks nowhere near `handleSessionLoad`.

The three below are untouched by #914 — it does not modify `permission.go` or `stopReasonFor`.

### An option we offered could not be accepted

`buildPermissionOptions` substitutes a fallback allow/deny list when `req.AvailableDecisions` is empty. `requestPermission` validated the client's reply against `req.AvailableDecisions` — the raw field, still empty.

So whenever ZERO did not enumerate — which is every permission event that is not a prompt (`loop.go` returns nil for those), and includes a shell call whose sandbox decision came back deny — the client was sent "Allow" and "Reject" and its answer was checked against an **empty slice**. Every option it could possibly show failed closed to `deny` with reason `"permission option was not offered"`.

The user clicks Allow, ZERO records a denial, the tool is refused and the turn carries on as though they had rejected it. Nothing surfaces it, because a denial is a legitimate answer.

One `offeredDecisions` resolver now feeds both sides, so what was sent and what is accepted agree by construction rather than by being kept in step. The narrowing this validation exists for is untouched — a client still cannot return a broader grant than it was shown.

### Cancelling a permission prompt looked like a crash

`stopReasonFor` matched only `context.Canceled`, so `errPermissionApprovalCanceled` fell through to `RPCError(codeInternalError, ...)` — a `-32603` carrying the internal sentinel text. Clients render that as a failed turn, so **declining a tool looked like ZERO falling over**. For `apply_patch`, dismissing the dialog is the only refusal a client is offered at all.

It maps to `StopCancelled` now, which is what ACP has for exactly this. The sentinel is exported as `ErrPermissionApprovalCanceled` so the surfaces can recognise it (matched with `errors.Is`, so it survives the tool-name wrapping every return site applies). A genuine failure is still an error — mapping too much to cancelled would hide real faults behind a clean ending.

### Two options labelled "Allow"

`optionKindFor` returned `"Allow"` for both `PermissionDecisionAllow` and `PermissionDecisionAllowStrict`, and `request_permissions` offers them together. The label is the only thing an ACP client shows, so the panel presented two adjacent identical buttons — and one of them silently sets `StrictAutoReview` on what was granted.

The distinction cannot live in the `optionId`, which is opaque to the client, so it is in the name: "Allow with strict review". The round trip is unchanged.

### Verification

Eight tests in `internal/acp/desktopinterop_test.go`. **Each fix was reverted by hand and the naming test confirmed to fail** — a passing test proves nothing otherwise:

| Reverted | Test result |
|---|---|
| cancel mapping removed | `stopReasonFor returned an error for a cancellation` |
| strict label back to "Allow" | `options "allow" and "allow_with_strict_auto_review" share the label "Allow"` |
| resolver reads the raw field | `no options were offered` |

`go build ./internal/... ./cmd/...`, `go vet`, and `go test` on `internal/acp` and `internal/agent` all pass. `gofmt -l` clean on every file touched.

One note on scope: `internal/agent/loop.go` changes only to export the existing sentinel — three wrap sites and one test reference renamed, no behaviour moves.

The companion PR on ZeroApp is Gitlawb/zero-app#31.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Permission approval cancellations now correctly end operations as cancelled instead of reporting an internal error.
  - Permission choices are validated against the options actually presented, preventing unoffered permissions from being accepted.
  - Strict approval is now clearly distinguished from standard approval.
  - Genuine permission failures continue to be reported as errors.

- **Tests**
  - Added coverage for permission option consistency, cancellation handling, sandbox retry behavior, and strict approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->