### PR TITLE
Fix LM studio (local) model discovery.

### DIFF
--- a/internal/providermodeldiscovery/discovery.go
+++ b/internal/providermodeldiscovery/discovery.go
@@ -539,7 +539,8 @@ func mergeLiveModels(provider providercatalog.Descriptor, liveModels []Model, ca
 	hasCatalog := len(byID) > 0
 	// Aggregators publish the live list as the source of truth. Keep live-only
 	// ids even when a remote catalog also loaded, instead of intersecting.
-	preferLive := providermodelcatalog.PublicLiveCatalog(provider.ID) ||
+	preferLive := provider.Local ||
+		providermodelcatalog.PublicLiveCatalog(provider.ID) ||
 		providercatalog.NormalizeID(provider.ID) == "chatgpt"
 	result := make([]Model, 0, len(liveModels))
 	for _, live := range liveModels {

--- a/internal/providermodeldiscovery/discovery_test.go
+++ b/internal/providermodeldiscovery/discovery_test.go
@@ -164,6 +164,29 @@ func TestMergeLiveModelsUsesLiveDefaultsAndReasoningCapability(t *testing.T) {
 	}
 }
 
+func TestMergeLocalModelsKeepsLiveOnlyEntries(t *testing.T) {
+	models := mergeLiveModels(
+		providercatalog.Descriptor{ID: "lmstudio", Local: true},
+		[]Model{
+			{ID: "qwen3-coder-30b", ContextWindow: 32768},
+			{ID: "text-embedding-local"},
+			{ID: "qwen2.5-coder-32b-instruct", Description: "live description"},
+		},
+		[]Model{{ID: "qwen2.5-coder-32b-instruct", Description: "catalog description", ToolCall: true}},
+	)
+
+	if got, want := strings.Join(modelIDs(models), ","), "qwen3-coder-30b,qwen2.5-coder-32b-instruct"; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+	for _, model := range models {
+		if model.ID == "qwen2.5-coder-32b-instruct" {
+			if model.Description != "catalog description" || !model.ToolCall {
+				t.Fatalf("merged catalog metadata = %#v", model)
+			}
+		}
+	}
+}
+
 func TestDiscoverCatalogOpenGatewayUsesLiveListWithoutKey(t *testing.T) {
 	// Catalog and live endpoints return distinct payloads so the merge must keep
 	// live-only ids that are absent from the remote catalog response.

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -502,7 +502,8 @@ func normalizeToolParameters(parameters map[string]any) map[string]any {
 	for key, value := range parameters {
 		normalized[key] = value
 	}
-	if properties, ok := normalized["properties"]; !ok || properties == nil {
+	properties, ok := normalized["properties"].(map[string]any)
+	if !ok || properties == nil {
 		normalized["properties"] = map[string]any{}
 	}
 	return normalized

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -486,12 +486,26 @@ func (provider *Provider) openAIRequest(request zeroruntime.CompletionRequest) c
 				Function: toolFunction{
 					Name:        tool.Name,
 					Description: tool.Description,
-					Parameters:  tool.Parameters,
+					Parameters:  normalizeToolParameters(tool.Parameters),
 				},
 			})
 		}
 	}
 	return mapped
+}
+
+// normalizeToolParameters keeps schemas accepted by strict OpenAI-compatible
+// servers such as LM Studio. No-argument tools still need an object-valued
+// parameters.properties field instead of an omitted field.
+func normalizeToolParameters(parameters map[string]any) map[string]any {
+	normalized := make(map[string]any, len(parameters)+1)
+	for key, value := range parameters {
+		normalized[key] = value
+	}
+	if properties, ok := normalized["properties"]; !ok || properties == nil {
+		normalized["properties"] = map[string]any{}
+	}
+	return normalized
 }
 
 // promptCacheKeyDisabled reports whether the ZERO_DISABLE_PROMPT_CACHE_KEY

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -1546,3 +1546,66 @@ func TestOpenAIRequestPreservesCacheablePrefixAcrossTurns(t *testing.T) {
 		t.Fatalf("wire prompt cache key must remain stable: first=%#v second=%#v", first["prompt_cache_key"], second["prompt_cache_key"])
 	}
 }
+
+// TestStreamCompletionSerializesNonMapPropertiesAsEmptyObject locks in the
+// normalizeToolParameters type-assert branch: when a tool's parameters carry a
+// `properties` field whose value is a non-map (e.g., an empty slice), it must
+// be normalized to "properties":{} on the wire, never "properties":[] or
+// "properties":null.
+func TestStreamCompletionSerializesNonMapPropertiesAsEmptyObject(t *testing.T) {
+	var gotBody map[string]any
+	var gotRaw []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		gotRaw = raw
+		if err := json.Unmarshal(raw, &gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `{"choices":[]}`)
+		writeSSE(w, `[DONE]`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{
+		APIKey:  "sk-secret",
+		BaseURL: server.URL + "/",
+		Model:   "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+		Tools: []zeroruntime.ToolDefinition{{
+			Name:        "no_args",
+			Description: "Takes no arguments",
+			Parameters:  map[string]any{"type": "object", "properties": []any{}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if !strings.Contains(string(gotRaw), `"properties":{}`) {
+		t.Fatalf("request body must serialize properties as an empty object, got: %s", gotRaw)
+	}
+	if strings.Contains(string(gotRaw), `"properties":null`) {
+		t.Fatalf("request body must not serialize properties as null, got: %s", gotRaw)
+	}
+	if strings.Contains(string(gotRaw), `"properties":[]`) {
+		t.Fatalf("request body must not serialize properties as an empty array, got: %s", gotRaw)
+	}
+	tools := gotBody["tools"].([]any)
+	tool := tools[0].(map[string]any)
+	functionDefinition := tool["function"].(map[string]any)
+	parameters := functionDefinition["parameters"].(map[string]any)
+	properties, ok := parameters["properties"].(map[string]any)
+	if !ok || len(properties) != 0 {
+		t.Fatalf("parameters.properties = %#v, want empty object", parameters["properties"])
+	}
+}

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -105,6 +105,12 @@ func TestStreamCompletionPostsChatCompletionRequest(t *testing.T) {
 	if tool["type"] != "function" {
 		t.Fatalf("unexpected tool wrapper: %#v", tool)
 	}
+	functionDefinition := tool["function"].(map[string]any)
+	parameters := functionDefinition["parameters"].(map[string]any)
+	properties, ok := parameters["properties"].(map[string]any)
+	if !ok || len(properties) != 0 {
+		t.Fatalf("parameters.properties = %#v, want empty object", parameters["properties"])
+	}
 }
 
 func TestNewRequiresModelButNotAPIKey(t *testing.T) {

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -105,6 +106,66 @@ func TestStreamCompletionPostsChatCompletionRequest(t *testing.T) {
 	if tool["type"] != "function" {
 		t.Fatalf("unexpected tool wrapper: %#v", tool)
 	}
+	functionDefinition := tool["function"].(map[string]any)
+	parameters := functionDefinition["parameters"].(map[string]any)
+	properties, ok := parameters["properties"].(map[string]any)
+	if !ok || len(properties) != 0 {
+		t.Fatalf("parameters.properties = %#v, want empty object", parameters["properties"])
+	}
+}
+
+// TestStreamCompletionSerializesTypedNilPropertiesAsEmptyObject locks in the
+// normalizeToolParameters fix: a tool whose parameters carry a typed-nil
+// properties map must serialize "properties":{} on the wire, never
+// "properties":null, because strict OpenAI-compatible servers (LM Studio)
+// reject the null form.
+func TestStreamCompletionSerializesTypedNilPropertiesAsEmptyObject(t *testing.T) {
+	var gotBody map[string]any
+	var gotRaw []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		gotRaw = raw
+		if err := json.Unmarshal(raw, &gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `{"choices":[]}`)
+		writeSSE(w, `[DONE]`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{
+		APIKey:  "sk-secret",
+		BaseURL: server.URL + "/",
+		Model:   "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+		Tools: []zeroruntime.ToolDefinition{{
+			Name:        "no_args",
+			Description: "Takes no arguments",
+			Parameters:  map[string]any{"type": "object", "properties": map[string]any(nil)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if !strings.Contains(string(gotRaw), `"properties":{}`) {
+		t.Fatalf("request body must serialize properties as an empty object, got: %s", gotRaw)
+	}
+	if strings.Contains(string(gotRaw), `"properties":null`) {
+		t.Fatalf("request body must not serialize properties as null, got: %s", gotRaw)
+	}
+	tools := gotBody["tools"].([]any)
+	tool := tools[0].(map[string]any)
 	functionDefinition := tool["function"].(map[string]any)
 	parameters := functionDefinition["parameters"].(map[string]any)
 	properties, ok := parameters["properties"].(map[string]any)


### PR DESCRIPTION
## Summary

The change fixes issues with discovering models from local LM studio and other local providers, by flipping behaviour of discovered and pre-defined models.

## Linked issue

https://github.com/Gitlawb/zero/issues/917

Fixes #


## Checklist

- [x] The linked issue already has the `issue-approved` label.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] `gofmt` clean.
- [x] Tests added/updated for the change (and run under `-race` where relevant).
- [x] UI changes include screenshots or a short recording where possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local models are now included in available model lists, preserving live-only models and relevant catalog details.
  * OpenAI tool requests now ensure parameter schemas include a valid properties object, including tools without arguments.

* **Bug Fixes**
  * Improved consistency when discovering models and processing tool schemas across supported providers.
  * Prevented malformed tool parameter schemas from being serialized as `null` or arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->