### PR TITLE
feat: use Exa as default search provider

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,4 +33,4 @@ Please include, where possible:
   depend on a user explicitly disabling the sandbox (`--skip-permissions-unsafe`), are generally
   out of scope — but please report anything you are unsure about.
 - Zero sends no telemetry. Network calls go to the model/tool providers you configure (and, for
-  keyless web search, to the documented Firecrawl endpoint — see the README).
+  keyless web search, to Exa's hosted MCP endpoint at `https://mcp.exa.ai/mcp`).

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -856,7 +856,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	// A server that could not be reached or validated is skipped, not fatal (one
 	// bad MCP server must not abort startup) — surface each so a missing tool set is
 	// explained rather than silently absent. A built-in default the user never
-	// configured (e.g. keyless Firecrawl with no credentials) is the exception: it
+	// configured (e.g. keyless Exa with no credentials) is the exception: it
 	// was never asked for, so its failure is not worth a startup warning — only
 	// servers the user actually configured warn on failure (issue #552).
 	for _, skipped := range mcpRuntime.Skipped() {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -211,12 +211,12 @@ func TestTUIStartupSuppressesWarningForUnconfiguredDefaultServer(t *testing.T) {
 		},
 		resolveMCPConfig: func(workspaceRoot string, excludeProject bool) (config.MCPConfig, error) {
 			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
-				"firecrawl": config.DefaultMCPServers()["firecrawl"],
+				"exa": config.DefaultMCPServers()["exa"],
 			}}, nil
 		},
 		registerMCPTools: func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
 			return fakeMCPRuntimeWithSkips{skipped: []mcp.SkippedServer{
-				{Name: "firecrawl", Err: errors.New("returned HTTP 401"), UnconfiguredDefault: true},
+				{Name: "exa", Err: errors.New("returned HTTP 401"), UnconfiguredDefault: true},
 			}}, nil
 		},
 		runTUI: func(ctx context.Context, options tui.Options) int {
@@ -227,7 +227,7 @@ func TestTUIStartupSuppressesWarningForUnconfiguredDefaultServer(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
 	}
-	if strings.Contains(stderr.String(), "firecrawl") {
+	if strings.Contains(stderr.String(), "exa") {
 		t.Fatalf("stderr = %q, want no warning for an unconfigured default server", stderr.String())
 	}
 }

--- a/internal/cli/mcp_default_test.go
+++ b/internal/cli/mcp_default_test.go
@@ -9,15 +9,15 @@ import (
 	"github.com/Gitlawb/zero/internal/config"
 )
 
-// `zero mcp disable firecrawl` must work even though firecrawl is a built-in
+// `zero mcp disable exa` must work even though exa is a built-in
 // default that is not written to the user's config file until overridden.
-func TestRunMCPDisableSeededFirecrawlDefault(t *testing.T) {
+func TestRunMCPDisableSeededExaDefault(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
-	// A config with no firecrawl entry — the default lives in code, not the file.
+	// A config with no Exa entry — the default lives in code, not the file.
 	writeMCPCommandRawConfig(t, configPath, `{"activeProvider":"fast"}`)
 
 	var out, errBuf bytes.Buffer
-	code := runWithDeps([]string{"mcp", "disable", "firecrawl", "--json"}, &out, &errBuf, appDeps{
+	code := runWithDeps([]string{"mcp", "disable", "exa", "--json"}, &out, &errBuf, appDeps{
 		userConfigPath: func() (string, error) { return configPath, nil },
 	})
 	if code != exitSuccess {
@@ -31,8 +31,8 @@ func TestRunMCPDisableSeededFirecrawlDefault(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
 		t.Fatalf("decode disable JSON: %v\n%s", err, out.String())
 	}
-	if payload.ServerName != "firecrawl" || !payload.Disabled || !payload.Changed {
-		t.Fatalf("disable payload = %#v, want firecrawl disabled+changed", payload)
+	if payload.ServerName != "exa" || !payload.Disabled || !payload.Changed {
+		t.Fatalf("disable payload = %#v, want exa disabled+changed", payload)
 	}
 
 	// End-to-end: resolving that config now turns the default off.
@@ -40,7 +40,7 @@ func TestRunMCPDisableSeededFirecrawlDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveMCP: %v", err)
 	}
-	if !cfg.Servers["firecrawl"].Disabled {
-		t.Fatal("expected `mcp disable firecrawl` to turn the seeded default off in the resolved config")
+	if !cfg.Servers["exa"].Disabled {
+		t.Fatal("expected `mcp disable exa` to turn the seeded default off in the resolved config")
 	}
 }

--- a/internal/config/mcp_defaults.go
+++ b/internal/config/mcp_defaults.go
@@ -5,22 +5,20 @@ import (
 	"strings"
 )
 
-// DefaultMCPServers returns the MCP servers Zero ships ENABLED by default so web
-// search and scraping work out of the box with no setup and no API key. They are
-// seeded before user/project config is merged (see ResolveMCP), so a user can
-// override any field — for example point firecrawl at a self-hosted instance, or
-// add an API-key header to lift the free-tier limit — or disable it entirely with
+// DefaultMCPServers returns the MCP servers Zero ships ENABLED by default so
+// web search and page fetching work out of the box with no setup and no API
+// key. They are seeded before user/project config is merged (see ResolveMCP),
+// so a user can override any field — for example add an API-key header to lift
+// Exa's anonymous rate limit — or disable it entirely with
 // `zero mcp disable <name>` (which writes `"disabled": true`).
 //
-// Keyless Firecrawl routes requests through firecrawl.dev (1,000 free credits per
-// month, no account). Self-host Firecrawl (AGPL-3.0) for unlimited and private
-// use. Zero only calls it over the network, so Firecrawl's license never reaches
-// into Zero's own code.
+// Exa's hosted MCP server works anonymously with rate limits. Users can add an
+// Exa API key for higher limits.
 func DefaultMCPServers() map[string]MCPServerConfig {
 	return map[string]MCPServerConfig{
-		"firecrawl": {
+		"exa": {
 			Type: "http",
-			URL:  "https://mcp.firecrawl.dev/v2/mcp",
+			URL:  "https://mcp.exa.ai/mcp",
 		},
 	}
 }
@@ -35,13 +33,13 @@ func IsDefaultMCPServer(name string) bool {
 
 // IsUnconfiguredDefault reports whether server is one of Zero's built-in
 // defaults that the user never wrote an entry for in their config — i.e. it is
-// running with whatever Zero ships (e.g. keyless Firecrawl, no credentials).
+// running with whatever Zero ships (e.g. keyless Exa, no credentials).
 //
 // Both conditions below must hold:
 //   - !server.configured: the user's JSON never declared an object for this
 //     server key at all (set by MCPServerConfig.UnmarshalJSON only when it
 //     actually ran for this key). Any explicit action — including a
-//     disable/enable toggle like `zero mcp enable firecrawl` that leaves the
+//     disable/enable toggle like `zero mcp enable exa` that leaves the
 //     resolved value unchanged — sets configured, so it always counts as
 //     user-configured, even though the value comparison below could not tell
 //     the difference on its own.

--- a/internal/config/mcp_defaults.go
+++ b/internal/config/mcp_defaults.go
@@ -57,41 +57,89 @@ func IsUnconfiguredDefault(name string, server MCPServerConfig) bool {
 	return ok && !server.configured && reflect.DeepEqual(def, server)
 }
 
-// legacyDefaultMCPServers maps a built-in default Zero no longer ships to the
-// default that replaced it (retired name -> successor name).
-//
-// A user who ran `zero mcp disable <old default>` made an explicit choice not
-// to open that outbound connection. Renaming the default underneath them must
-// not silently re-open it under the new name — and the reopened server would
-// look like an untouched default, so even the startup warning stays quiet
-// (see IsUnconfiguredDefault and issue #552).
-var legacyDefaultMCPServers = map[string]string{
-	"firecrawl": "exa",
+// retiredDefaultMCPServer describes a built-in default Zero no longer ships.
+type retiredDefaultMCPServer struct {
+	// successor is the default that replaced it.
+	successor string
+	// shipped is the value Zero used to seed for this name. A user entry
+	// written while the default was still shipped may name only an override
+	// (a header, say) and rely on these fields for the rest, so they have to
+	// outlive the default itself.
+	shipped MCPServerConfig
 }
 
-// applyLegacyDefaultDisable carries a user's explicit disable of a retired
-// built-in default onto the default that replaced it, so upgrading Zero never
-// turns a connection back on that the user switched off.
+// retiredDefaultMCPServers maps a retired built-in default to what replaced it
+// and to the value Zero used to ship for it.
+var retiredDefaultMCPServers = map[string]retiredDefaultMCPServer{
+	"firecrawl": {
+		successor: "exa",
+		shipped: MCPServerConfig{
+			Type: "http",
+			URL:  "https://mcp.firecrawl.dev/v2/mcp",
+		},
+	},
+}
+
+// migrateRetiredDefaultMCPServers keeps an upgrade across a default-provider
+// swap from changing what the user's config means. It handles the two ways a
+// rename can break a config written against the old default:
+//
+//   - A user who ran `zero mcp disable <old default>` made an explicit choice
+//     not to open that outbound connection. Without carrying that decision to
+//     the successor, the upgrade re-opens it under the new name — and because
+//     the replacement looks like an untouched default, even the startup
+//     warning stays quiet (see IsUnconfiguredDefault and issue #552).
+//   - A user who customized the old default could name only the field they
+//     were changing, because the seeded default supplied the transport. Once
+//     the default stops being seeded that entry resolves to a server with no
+//     type, url, or command, which fails NormalizeConfig and takes the whole
+//     startup down rather than just that one server.
 //
 // It runs immediately after the user layer merges (see ResolveMCP), which
-// scopes it to user-level disables — the only scope whose disable is sticky.
-// It applies only when the user never declared the successor themselves: an
-// explicit `exa` entry wins whether it enables or disables. Because the
-// carried-over disable is recorded as a user-level decision, the lower-trust
-// project layer cannot lift it, while `zero mcp enable exa` still can (the CLI
-// override scope merges with canReenable=true).
-func applyLegacyDefaultDisable(cfg *MCPConfig) {
-	for legacy, successor := range legacyDefaultMCPServers {
-		retired, ok := cfg.Servers[legacy]
-		if !ok || !retired.disabledSet || !retired.Disabled {
+// scopes it to user-level decisions — the only scope whose disable is sticky.
+// The carried-over disable applies only when the user never declared the
+// successor themselves: an explicit `exa` entry wins whether it enables or
+// disables. Because the disable is recorded as a user-level decision, the
+// lower-trust project layer cannot lift it, while `zero mcp enable exa` still
+// can (the CLI override scope merges with canReenable=true).
+func migrateRetiredDefaultMCPServers(cfg *MCPConfig) {
+	for name, retired := range retiredDefaultMCPServers {
+		entry, ok := cfg.Servers[name]
+		if !ok {
 			continue
 		}
-		replacement, ok := cfg.Servers[successor]
+		if inheritsRetiredTransport(entry) {
+			// Re-seed what Zero used to ship underneath the user's fields, so a
+			// partial entry still resolves to the complete server it named when
+			// it was written. Their own values still win — this only fills the
+			// gap the retired default used to cover.
+			entry = mergeMCPServer(retired.shipped, entry, true)
+			cfg.Servers[name] = entry
+		}
+		if !entry.disabledSet || !entry.Disabled {
+			continue
+		}
+		replacement, ok := cfg.Servers[retired.successor]
 		if !ok || replacement.configured {
 			continue
 		}
 		replacement.Disabled = true
 		replacement.disabledSet = true
-		cfg.Servers[successor] = replacement
+		cfg.Servers[retired.successor] = replacement
 	}
+}
+
+// inheritsRetiredTransport reports whether entry named no transport of its own
+// — no type, url, command, or args — and so relied entirely on the retired
+// default to supply one.
+//
+// Anything else is a complete definition the user owns (a self-hosted url, a
+// stdio command) and must be left alone: grafting the retired default's http
+// type onto an entry that names a command produces a server that is rejected
+// outright, turning a working config into a startup failure.
+func inheritsRetiredTransport(entry MCPServerConfig) bool {
+	return strings.TrimSpace(entry.Type) == "" &&
+		strings.TrimSpace(entry.URL) == "" &&
+		strings.TrimSpace(entry.Command) == "" &&
+		len(entry.Args) == 0
 }

--- a/internal/config/mcp_defaults.go
+++ b/internal/config/mcp_defaults.go
@@ -56,3 +56,42 @@ func IsUnconfiguredDefault(name string, server MCPServerConfig) bool {
 	def, ok := DefaultMCPServers()[strings.TrimSpace(name)]
 	return ok && !server.configured && reflect.DeepEqual(def, server)
 }
+
+// legacyDefaultMCPServers maps a built-in default Zero no longer ships to the
+// default that replaced it (retired name -> successor name).
+//
+// A user who ran `zero mcp disable <old default>` made an explicit choice not
+// to open that outbound connection. Renaming the default underneath them must
+// not silently re-open it under the new name — and the reopened server would
+// look like an untouched default, so even the startup warning stays quiet
+// (see IsUnconfiguredDefault and issue #552).
+var legacyDefaultMCPServers = map[string]string{
+	"firecrawl": "exa",
+}
+
+// applyLegacyDefaultDisable carries a user's explicit disable of a retired
+// built-in default onto the default that replaced it, so upgrading Zero never
+// turns a connection back on that the user switched off.
+//
+// It runs immediately after the user layer merges (see ResolveMCP), which
+// scopes it to user-level disables — the only scope whose disable is sticky.
+// It applies only when the user never declared the successor themselves: an
+// explicit `exa` entry wins whether it enables or disables. Because the
+// carried-over disable is recorded as a user-level decision, the lower-trust
+// project layer cannot lift it, while `zero mcp enable exa` still can (the CLI
+// override scope merges with canReenable=true).
+func applyLegacyDefaultDisable(cfg *MCPConfig) {
+	for legacy, successor := range legacyDefaultMCPServers {
+		retired, ok := cfg.Servers[legacy]
+		if !ok || !retired.disabledSet || !retired.Disabled {
+			continue
+		}
+		replacement, ok := cfg.Servers[successor]
+		if !ok || replacement.configured {
+			continue
+		}
+		replacement.Disabled = true
+		replacement.disabledSet = true
+		cfg.Servers[successor] = replacement
+	}
+}

--- a/internal/config/mcp_defaults_test.go
+++ b/internal/config/mcp_defaults_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestIsDefaultMCPServer(t *testing.T) {
-	if !IsDefaultMCPServer("firecrawl") {
-		t.Fatal("firecrawl should be a built-in default")
+	if !IsDefaultMCPServer("exa") {
+		t.Fatal("exa should be a built-in default")
 	}
-	if IsDefaultMCPServer("  firecrawl  ") == false {
+	if IsDefaultMCPServer("  exa  ") == false {
 		t.Fatal("IsDefaultMCPServer should trim whitespace")
 	}
 	if IsDefaultMCPServer("not-a-default") {
@@ -18,45 +18,45 @@ func TestIsDefaultMCPServer(t *testing.T) {
 	}
 }
 
-func TestResolveMCPSeedsEnabledFirecrawlDefault(t *testing.T) {
+func TestResolveMCPSeedsEnabledExaDefault(t *testing.T) {
 	cfg, err := ResolveMCP(ResolveOptions{})
 	if err != nil {
 		t.Fatalf("ResolveMCP: %v", err)
 	}
-	firecrawl, ok := cfg.Servers["firecrawl"]
+	exa, ok := cfg.Servers["exa"]
 	if !ok {
-		t.Fatal("expected the firecrawl default to be seeded with no user config")
+		t.Fatal("expected the exa default to be seeded with no user config")
 	}
-	if firecrawl.Type != "http" || firecrawl.URL != "https://mcp.firecrawl.dev/v2/mcp" {
-		t.Fatalf("unexpected firecrawl default: %#v", firecrawl)
+	if exa.Type != "http" || exa.URL != "https://mcp.exa.ai/mcp" {
+		t.Fatalf("unexpected exa default: %#v", exa)
 	}
-	if firecrawl.Disabled {
-		t.Fatal("the firecrawl default must be enabled out of the box")
+	if exa.Disabled {
+		t.Fatal("the exa default must be enabled out of the box")
 	}
 }
 
 func TestResolveMCPUserCanDisableDefault(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":true}}}}`), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"exa":{"disabled":true}}}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
 	if err != nil {
 		t.Fatalf("ResolveMCP: %v", err)
 	}
-	if !cfg.Servers["firecrawl"].Disabled {
+	if !cfg.Servers["exa"].Disabled {
 		t.Fatal("a user must be able to disable the default by writing over it")
 	}
 }
 
 func TestIsUnconfiguredDefault(t *testing.T) {
-	if !IsUnconfiguredDefault("firecrawl", DefaultMCPServers()["firecrawl"]) {
-		t.Fatal("an untouched firecrawl default should be reported as unconfigured")
+	if !IsUnconfiguredDefault("exa", DefaultMCPServers()["exa"]) {
+		t.Fatal("an untouched exa default should be reported as unconfigured")
 	}
-	if IsUnconfiguredDefault("firecrawl", MCPServerConfig{Type: "http", URL: "http://localhost:3002/mcp"}) {
+	if IsUnconfiguredDefault("exa", MCPServerConfig{Type: "http", URL: "https://example.com/mcp"}) {
 		t.Fatal("a server overriding the default URL is no longer unconfigured")
 	}
-	if IsUnconfiguredDefault("firecrawl", MCPServerConfig{Type: "http", URL: "https://mcp.firecrawl.dev/v2/mcp", Auth: "bearer"}) {
+	if IsUnconfiguredDefault("exa", MCPServerConfig{Type: "http", URL: "https://mcp.exa.ai/mcp", Auth: "bearer"}) {
 		t.Fatal("a server with credentials added is no longer unconfigured")
 	}
 	if IsUnconfiguredDefault("not-a-default", MCPServerConfig{}) {
@@ -65,68 +65,68 @@ func TestIsUnconfiguredDefault(t *testing.T) {
 }
 
 func TestResolveMCPExplicitReenableIsNotUnconfiguredDefault(t *testing.T) {
-	// `zero mcp enable firecrawl` after a prior disable writes {"disabled":false}
+	// `zero mcp enable exa` after a prior disable writes {"disabled":false}
 	// explicitly. The resolved value is identical to the untouched default (both
 	// enabled, no credentials), but the user DID take an explicit action here, so
 	// IsUnconfiguredDefault must not treat it as untouched (issue #563 review).
 	path := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":false}}}}`), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"exa":{"disabled":false}}}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
 	if err != nil {
 		t.Fatalf("ResolveMCP: %v", err)
 	}
-	firecrawl := cfg.Servers["firecrawl"]
-	if firecrawl.Disabled {
-		t.Fatalf("explicit re-enable should leave the server enabled: %#v", firecrawl)
+	exa := cfg.Servers["exa"]
+	if exa.Disabled {
+		t.Fatalf("explicit re-enable should leave the server enabled: %#v", exa)
 	}
-	if IsUnconfiguredDefault("firecrawl", firecrawl) {
+	if IsUnconfiguredDefault("exa", exa) {
 		t.Fatal("an explicit enable/disable toggle must count as user-configured, even though the resolved value matches the default")
 	}
 }
 
 func TestResolveMCPExplicitRedeclareOfDefaultValuesIsNotUnconfiguredDefault(t *testing.T) {
-	// A user who copies firecrawl's exact default type/url into their config
+	// A user who copies Exa's exact default type/url into their config
 	// (e.g. from an example file, planning to add credentials later) produces a
-	// resolved value byte-identical to DefaultMCPServers()["firecrawl"] — the
+	// resolved value byte-identical to DefaultMCPServers()["exa"] — the
 	// same trap TestResolveMCPExplicitReenableIsNotUnconfiguredDefault covers for
 	// the disabled toggle. IsUnconfiguredDefault must still treat this as
 	// user-configured because the user's JSON declared an entry for it, even
 	// though a plain resolved-value comparison could not tell the difference.
 	path := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"type":"http","url":"https://mcp.firecrawl.dev/v2/mcp"}}}}`), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"exa":{"type":"http","url":"https://mcp.exa.ai/mcp"}}}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
 	if err != nil {
 		t.Fatalf("ResolveMCP: %v", err)
 	}
-	firecrawl := cfg.Servers["firecrawl"]
-	want := DefaultMCPServers()["firecrawl"]
-	if firecrawl.Type != want.Type || firecrawl.URL != want.URL || firecrawl.Disabled != want.Disabled {
-		t.Fatalf("expected the resolved value to match the default's fields exactly: %#v", firecrawl)
+	exa := cfg.Servers["exa"]
+	want := DefaultMCPServers()["exa"]
+	if exa.Type != want.Type || exa.URL != want.URL || exa.Disabled != want.Disabled {
+		t.Fatalf("expected the resolved value to match the default's fields exactly: %#v", exa)
 	}
-	if IsUnconfiguredDefault("firecrawl", firecrawl) {
+	if IsUnconfiguredDefault("exa", exa) {
 		t.Fatal("redeclaring the default's exact values is still an explicit user configuration, not an untouched default")
 	}
 }
 
 func TestResolveMCPUserCanOverrideDefaultURLKeepingOtherFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
-	// Point firecrawl at a self-hosted instance; the default's Type must survive.
-	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"url":"http://localhost:3002/mcp"}}}}`), 0o600); err != nil {
+	// Point Exa at a proxy; the default's Type must survive.
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"exa":{"url":"https://example.com/mcp"}}}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
 	if err != nil {
 		t.Fatalf("ResolveMCP: %v", err)
 	}
-	firecrawl := cfg.Servers["firecrawl"]
-	if firecrawl.URL != "http://localhost:3002/mcp" {
-		t.Fatalf("user override of the default URL did not apply: %#v", firecrawl)
+	exa := cfg.Servers["exa"]
+	if exa.URL != "https://example.com/mcp" {
+		t.Fatalf("user override of the default URL did not apply: %#v", exa)
 	}
-	if firecrawl.Type != "http" {
-		t.Fatalf("override should keep the default's other fields (type), got %#v", firecrawl)
+	if exa.Type != "http" {
+		t.Fatalf("override should keep the default's other fields (type), got %#v", exa)
 	}
 }

--- a/internal/config/mcp_defaults_test.go
+++ b/internal/config/mcp_defaults_test.go
@@ -130,3 +130,98 @@ func TestResolveMCPUserCanOverrideDefaultURLKeepingOtherFields(t *testing.T) {
 		t.Fatalf("override should keep the default's other fields (type), got %#v", exa)
 	}
 }
+
+func TestResolveMCPCarriesLegacyDefaultDisableToSuccessor(t *testing.T) {
+	// Upgrade path: the user disabled the firecrawl default Zero used to ship.
+	// Swapping the default to exa must not re-open an outbound connection they
+	// explicitly switched off.
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":true}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	if !cfg.Servers["exa"].Disabled {
+		t.Fatalf("a prior disable of the retired default must carry to its replacement: %#v", cfg.Servers["exa"])
+	}
+}
+
+func TestResolveMCPExplicitSuccessorBeatsLegacyDefaultDisable(t *testing.T) {
+	// The user disabled the old default but has since explicitly configured exa.
+	// Their newer, explicit choice wins — the migration must not override it.
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":true},"exa":{"disabled":false}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	exa := cfg.Servers["exa"]
+	if exa.Disabled {
+		t.Fatalf("an explicit exa entry must survive the legacy-disable migration: %#v", exa)
+	}
+	if IsUnconfiguredDefault("exa", exa) {
+		t.Fatal("an explicitly configured exa is not an untouched default")
+	}
+}
+
+func TestResolveMCPLegacyDefaultLeftEnabledDoesNotDisableSuccessor(t *testing.T) {
+	// A user who configured firecrawl without disabling it (e.g. added a header)
+	// never opted out of the default search server, so exa stays enabled.
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"headers":{"Authorization":"Bearer k"}}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	if cfg.Servers["exa"].Disabled {
+		t.Fatal("only an explicit disable of the retired default should carry over")
+	}
+}
+
+func TestResolveMCPLegacyDefaultDisableIsLiftableByOverride(t *testing.T) {
+	// The carried-over disable is a user-level decision, not a permanent one:
+	// `zero mcp enable exa` merges through the CLI override scope, which is the
+	// one layer allowed to re-enable.
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":true}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	enabled := MCPServerConfig{Disabled: false, disabledSet: true}
+	cfg, err := ResolveMCP(ResolveOptions{
+		UserConfigPath: path,
+		Overrides:      Overrides{MCP: MCPConfig{Servers: map[string]MCPServerConfig{"exa": enabled}}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	if cfg.Servers["exa"].Disabled {
+		t.Fatalf("an explicit enable must lift the carried-over disable: %#v", cfg.Servers["exa"])
+	}
+}
+
+func TestResolveMCPLegacyDisableSurvivesProjectReenable(t *testing.T) {
+	// The project layer is lower-trust and must not lift the carried-over
+	// user-level disable — the same guard a direct `zero mcp disable exa` gets.
+	dir := t.TempDir()
+	userPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(userPath, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":true}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	projectPath := filepath.Join(dir, "project.json")
+	if err := os.WriteFile(projectPath, []byte(`{"mcp":{"servers":{"exa":{"disabled":false}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: userPath, ProjectConfigPath: projectPath})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	if !cfg.Servers["exa"].Disabled {
+		t.Fatal("project config must not re-enable a server the user disabled")
+	}
+}

--- a/internal/config/mcp_defaults_test.go
+++ b/internal/config/mcp_defaults_test.go
@@ -225,3 +225,69 @@ func TestResolveMCPLegacyDisableSurvivesProjectReenable(t *testing.T) {
 		t.Fatal("project config must not re-enable a server the user disabled")
 	}
 }
+
+func TestResolveMCPKeepsRetiredDefaultTransportForPartialEntry(t *testing.T) {
+	// A user who added an API key to the firecrawl default wrote only the header
+	// — the seeded default supplied the http type and URL. Retiring the default
+	// must not strip those out from under them and leave an unusable server.
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"headers":{"Authorization":"Bearer k"}}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	firecrawl := cfg.Servers["firecrawl"]
+	if firecrawl.Type != "http" || firecrawl.URL != "https://mcp.firecrawl.dev/v2/mcp" {
+		t.Fatalf("a partial entry must keep the retired default's transport: %#v", firecrawl)
+	}
+	if firecrawl.Headers["Authorization"] != "Bearer k" {
+		t.Fatalf("the user's own field must still win: %#v", firecrawl)
+	}
+}
+
+func TestResolveMCPDoesNotGraftRetiredDefaultOntoOwnTransport(t *testing.T) {
+	// A self-hosted firecrawl over stdio is a complete definition the user owns.
+	// Re-seeding the retired http default under it would produce an http server
+	// carrying a command, which NormalizeConfig rejects outright.
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"command":"firecrawl-mcp"}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	firecrawl := cfg.Servers["firecrawl"]
+	if firecrawl.Type != "" || firecrawl.URL != "" {
+		t.Fatalf("an entry naming its own transport must be left alone: %#v", firecrawl)
+	}
+	if firecrawl.Command != "firecrawl-mcp" {
+		t.Fatalf("the user's command must survive: %#v", firecrawl)
+	}
+}
+
+func TestResolveMCPDisabledRetiredEntryStaysReEnableable(t *testing.T) {
+	// The disable carries to exa, and the retired entry itself keeps a usable
+	// transport so a later `zero mcp enable firecrawl` does not resolve to a
+	// server with no type, url, or command.
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":true}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	firecrawl := cfg.Servers["firecrawl"]
+	if !firecrawl.Disabled {
+		t.Fatalf("the retired entry must stay disabled: %#v", firecrawl)
+	}
+	if firecrawl.Type != "http" || firecrawl.URL != "https://mcp.firecrawl.dev/v2/mcp" {
+		t.Fatalf("a disabled retired entry should still carry a usable transport: %#v", firecrawl)
+	}
+	if !cfg.Servers["exa"].Disabled {
+		t.Fatal("the disable must still carry to the successor")
+	}
+}

--- a/internal/config/resolve_mcp_exclude_project_test.go
+++ b/internal/config/resolve_mcp_exclude_project_test.go
@@ -34,7 +34,7 @@ func TestResolveMCPExcludeProjectDropsProjectServers(t *testing.T) {
 		if _, ok := cfg.Servers["user-srv"]; !ok {
 			t.Fatal("the user server must always be present")
 		}
-		if _, ok := cfg.Servers["firecrawl"]; !ok {
+		if _, ok := cfg.Servers["exa"]; !ok {
 			t.Fatal("the built-in default must always be present")
 		}
 	})
@@ -54,7 +54,7 @@ func TestResolveMCPExcludeProjectDropsProjectServers(t *testing.T) {
 		if _, ok := cfg.Servers["user-srv"]; !ok {
 			t.Fatal("the user server must survive when the project layer is dropped")
 		}
-		if _, ok := cfg.Servers["firecrawl"]; !ok {
+		if _, ok := cfg.Servers["exa"]; !ok {
 			t.Fatal("the built-in default must survive when the project layer is dropped")
 		}
 	})

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -194,6 +194,11 @@ func ResolveMCP(options ResolveOptions) (MCPConfig, error) {
 		// server the user disabled (a user-level disable is sticky, but the user
 		// scope itself may lift it).
 		mergeMCPConfig(&cfg.MCP, fileConfig.MCP, true)
+		// A user who disabled the default Zero used to ship never consented to
+		// its replacement. Carry that decision across the rename here, while the
+		// user layer is the only one merged, so it counts as a user-level
+		// disable that the project layer below cannot lift.
+		applyLegacyDefaultDisable(&cfg.MCP)
 	}
 	// Drop the project layer when the workspace is untrusted, so a cloned repo's
 	// ./.zero/config.json cannot register (and spawn) MCP servers. Fail-closed:

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -180,7 +180,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 }
 
 func ResolveMCP(options ResolveOptions) (MCPConfig, error) {
-	// Seed Zero's built-in default MCP servers (e.g. keyless Firecrawl for free,
+	// Seed Zero's built-in default MCP servers (e.g. keyless Exa for free,
 	// no-setup web search/scrape) BEFORE merging user/project config, so the user
 	// can override any field or disable a default by writing over it.
 	cfg := FileConfig{MCP: MCPConfig{Servers: DefaultMCPServers()}}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -194,11 +194,10 @@ func ResolveMCP(options ResolveOptions) (MCPConfig, error) {
 		// server the user disabled (a user-level disable is sticky, but the user
 		// scope itself may lift it).
 		mergeMCPConfig(&cfg.MCP, fileConfig.MCP, true)
-		// A user who disabled the default Zero used to ship never consented to
-		// its replacement. Carry that decision across the rename here, while the
-		// user layer is the only one merged, so it counts as a user-level
-		// disable that the project layer below cannot lift.
-		applyLegacyDefaultDisable(&cfg.MCP)
+		// Reconcile config written against a default Zero has since retired,
+		// here while the user layer is the only one merged — so a carried-over
+		// disable counts as a user-level decision the project layer cannot lift.
+		migrateRetiredDefaultMCPServers(&cfg.MCP)
 	}
 	// Drop the project layer when the workspace is untrusted, so a cloned repo's
 	// ./.zero/config.json cannot register (and spawn) MCP servers. Fail-closed:

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -464,7 +464,7 @@ type MCPServerConfig struct {
 	// fields it set or what values they hold. A built-in default seeded by
 	// DefaultMCPServers() is never unmarshaled from JSON, so it starts false;
 	// any explicit entry in the user/project file — even one that happens to
-	// repeat a default's exact field values (e.g. re-declaring firecrawl's
+	// repeat a default's exact field values (e.g. re-declaring Exa's
 	// default URL) — sets it true. IsUnconfiguredDefault checks this alongside
 	// a resolved-value comparison, so redeclaring default values verbatim still
 	// counts as user-configured.

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -35,7 +35,7 @@ type Server struct {
 	// credential lookup uses it to avoid reusing legacy user tokens by name.
 	ProjectConfigured bool
 	// UnconfiguredDefault is true when this server is one of Zero's built-in
-	// defaults (e.g. keyless Firecrawl) that the user never touched in their
+	// defaults (e.g. keyless Exa) that the user never touched in their
 	// config — no credentials, no overrides. Callers use it to avoid warning
 	// loudly when a server nobody configured fails to connect.
 	UnconfiguredDefault bool

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -1,6 +1,8 @@
 package mcp
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -239,4 +241,49 @@ func TestCopyStringMapTrimsKeysAndPreservesValues(t *testing.T) {
 	if copied["TOKEN"] != "  keep surrounding spaces  " {
 		t.Fatalf("copied[TOKEN] = %q, want value preserved verbatim", copied["TOKEN"])
 	}
+}
+
+// Startup behavior for the firecrawl -> exa default migration: a user who
+// disabled the retired default must end up with no Exa server to connect to,
+// not merely a disabled entry in the resolved config.
+func TestNormalizeConfigSkipsExaAfterLegacyFirecrawlDisable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":true}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ResolveMCP(config.ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	servers, err := NormalizeConfig(cfg)
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	for _, server := range servers {
+		if server.Name == "exa" {
+			t.Fatalf("exa must not be started after the user disabled the default it replaced: %#v", server)
+		}
+	}
+}
+
+// The same path with no legacy disable still starts Exa, so the migration
+// cannot quietly switch off the default for everyone else.
+func TestNormalizeConfigStartsExaWithoutLegacyDisable(t *testing.T) {
+	cfg, err := config.ResolveMCP(config.ResolveOptions{})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	servers, err := NormalizeConfig(cfg)
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	for _, server := range servers {
+		if server.Name == "exa" {
+			if !server.UnconfiguredDefault {
+				t.Fatalf("an untouched exa default should be flagged unconfigured: %#v", server)
+			}
+			return
+		}
+	}
+	t.Fatal("expected the exa default to be started out of the box")
 }

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -90,7 +90,7 @@ func TestNormalizeConfigValidatesTransportBoundaries(t *testing.T) {
 
 func TestNormalizeConfigFlagsUnconfiguredDefault(t *testing.T) {
 	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
-		"firecrawl": config.DefaultMCPServers()["firecrawl"],
+		"exa": config.DefaultMCPServers()["exa"],
 		"web": {
 			Type: "http",
 			URL:  "https://example.com/mcp",
@@ -107,8 +107,8 @@ func TestNormalizeConfigFlagsUnconfiguredDefault(t *testing.T) {
 		byName[server.Name] = server
 	}
 
-	if !byName["firecrawl"].UnconfiguredDefault {
-		t.Fatal("an untouched firecrawl default should be flagged UnconfiguredDefault")
+	if !byName["exa"].UnconfiguredDefault {
+		t.Fatal("an untouched exa default should be flagged UnconfiguredDefault")
 	}
 	if byName["web"].UnconfiguredDefault {
 		t.Fatal("a server the user configured must not be flagged UnconfiguredDefault")

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -287,3 +287,71 @@ func TestNormalizeConfigStartsExaWithoutLegacyDisable(t *testing.T) {
 	}
 	t.Fatal("expected the exa default to be started out of the box")
 }
+
+// The failure path CodeRabbit flagged: a firecrawl entry that named only a
+// header relied on the retired default for its transport. Resolving it must
+// still produce a complete server — an incomplete one fails NormalizeConfig,
+// which takes down every other server's startup with it, not just this one.
+func TestNormalizeConfigResolvesPartialRetiredDefaultEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"headers":{"Authorization":"Bearer k"}}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ResolveMCP(config.ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	servers, err := NormalizeConfig(cfg)
+	if err != nil {
+		t.Fatalf("a header-only legacy entry must not break startup: %v", err)
+	}
+	var firecrawl *Server
+	var sawExa bool
+	for i := range servers {
+		switch servers[i].Name {
+		case "firecrawl":
+			firecrawl = &servers[i]
+		case "exa":
+			sawExa = true
+		}
+	}
+	if firecrawl == nil {
+		t.Fatalf("expected the customized firecrawl server to survive: %#v", servers)
+	}
+	if firecrawl.Type != ServerTypeHTTP || firecrawl.URL != "https://mcp.firecrawl.dev/v2/mcp" {
+		t.Fatalf("firecrawl lost the transport its entry relied on: %#v", *firecrawl)
+	}
+	if firecrawl.Headers["Authorization"] != "Bearer k" {
+		t.Fatalf("firecrawl lost the user's header: %#v", *firecrawl)
+	}
+	if !sawExa {
+		t.Fatal("the new exa default should still start alongside it")
+	}
+}
+
+// The mirror case: an entry that names its own stdio transport must not have
+// the retired http default grafted onto it, which would be rejected outright.
+func TestNormalizeConfigLeavesRetiredEntryWithOwnTransportAlone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"command":"firecrawl-mcp"}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ResolveMCP(config.ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	servers, err := NormalizeConfig(cfg)
+	if err != nil {
+		t.Fatalf("a self-hosted stdio entry must keep working: %v", err)
+	}
+	for _, server := range servers {
+		if server.Name != "firecrawl" {
+			continue
+		}
+		if server.Type != ServerTypeStdio || server.Command != "firecrawl-mcp" {
+			t.Fatalf("the user's own stdio transport was corrupted: %#v", server)
+		}
+		return
+	}
+	t.Fatalf("expected the self-hosted firecrawl server to survive: %#v", servers)
+}

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -153,16 +153,16 @@ func TestRegisterToolsSkipsUnreachableServerAndKeepsOthers(t *testing.T) {
 }
 
 func TestRegisterToolsFlagsUnconfiguredDefaultOnSkip(t *testing.T) {
-	// firecrawl is seeded by config.DefaultMCPServers with no credentials; when a
-	// user never configures it, a connect failure (e.g. the real HTTP 401 from
-	// issue #552) must be recorded as UnconfiguredDefault so callers can avoid
+	// Exa is seeded by config.DefaultMCPServers with no credentials; when a
+	// user never configures it, a connect failure must be recorded as
+	// UnconfiguredDefault so callers can avoid
 	// warning about a server the user never asked for. "custom" is configured by
 	// the user and must NOT be flagged even though it also fails to connect.
 	registry := tools.NewRegistry()
 
 	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
-		"firecrawl": config.DefaultMCPServers()["firecrawl"],
-		"custom":    {Type: "stdio", Command: "custom-mcp"},
+		"exa":    config.DefaultMCPServers()["exa"],
+		"custom": {Type: "stdio", Command: "custom-mcp"},
 	}}, RegisterOptions{
 		ClientFactory: func(_ context.Context, server Server) (ToolClient, error) {
 			return nil, errors.New(server.Name + " connect failed")
@@ -177,12 +177,12 @@ func TestRegisterToolsFlagsUnconfiguredDefaultOnSkip(t *testing.T) {
 	for _, skipped := range runtime.Skipped() {
 		byName[skipped.Name] = skipped
 	}
-	firecrawl, ok := byName["firecrawl"]
+	exa, ok := byName["exa"]
 	if !ok {
-		t.Fatalf("Skipped() = %#v, want an entry for firecrawl", runtime.Skipped())
+		t.Fatalf("Skipped() = %#v, want an entry for exa", runtime.Skipped())
 	}
-	if !firecrawl.UnconfiguredDefault {
-		t.Fatalf("Skipped()[firecrawl] = %#v, want UnconfiguredDefault", firecrawl)
+	if !exa.UnconfiguredDefault {
+		t.Fatalf("Skipped()[exa] = %#v, want UnconfiguredDefault", exa)
 	}
 	custom, ok := byName["custom"]
 	if !ok {


### PR DESCRIPTION
Swaps Zero's built-in default MCP server from keyless Firecrawl to Exa's hosted
endpoint, so out-of-the-box web search and page fetching route through
`https://mcp.exa.ai/mcp`.

## What changed

The substantive change is one default in `internal/config/mcp_defaults.go`:

```diff
-		"firecrawl": {
+		"exa": {
 			Type: "http",
-			URL:  "https://mcp.firecrawl.dev/v2/mcp",
+			URL:  "https://mcp.exa.ai/mcp",
 		},
```

Everything else is comment, doc, and test renaming to match: `internal/cli/app.go`,
`internal/config/resolver.go`, `internal/config/types.go`, `internal/mcp/config.go`,
`SECURITY.md`, plus six test files. 12 files, +78/-80.

The seeding mechanism is untouched — Exa is still merged *before* user/project config,
so any field can be overridden and `zero mcp disable exa` still works.

## Review notes

Flagging four things I noticed while reviewing this branch. None are blockers; the
first two are the ones worth a decision before merge.

**1. No migration path for existing users.** ~~Anyone who already has a `firecrawl`
entry in their config keeps it — it now counts as user-configured — *and* gets `exa`
seeded alongside it. Anyone who previously ran `zero mcp disable firecrawl` gets Exa
enabled anyway, since the disable was recorded against the old key.~~
**Fixed in fc6e0692** (also raised by CodeRabbit). `ResolveMCP` now carries an
explicit user-level disable of a retired default onto its successor, but only when
the user never declared the successor themselves. The project layer cannot lift the
carried-over disable; `zero mcp enable exa` still can.

**2. The default provider is undocumented.** `SECURITY.md` now names the Exa endpoint,
but it dropped the "see the README" pointer it used to carry — and the README and
`docs/` never mentioned Firecrawl or Exa at all. After this change there is no
user-facing page that says which provider keyless web search talks to, or how to add
an API key to lift the anonymous rate limit.

**3. The removed license note carried information the replacement doesn't.** The old
comment explained that Firecrawl is AGPL-3.0, that self-hosting gives unlimited and
private use, and that Zero only calls it over the network so the license never reaches
into Zero's own code. Exa is hosted-only with no self-host option, so the
"point it at your own instance" escape hatch is genuinely gone — the new comment just
says "works anonymously with rate limits" and doesn't tell a reader that.

**4. One stale mention.** `internal/agent/defer_savings_test.go:12` still reads
"Exa/Firecrawl-style search". Harmless — it describes a schema shape, not the default.

## Testing

`go build ./...` plus `go test ./internal/config/... ./internal/mcp/... ./internal/cli/...` — all pass.
The three behavioral migration tests were confirmed to fail with the migration call removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Keyless web search now uses Exa’s hosted MCP service by default.
  - Exa supports rate-limited anonymous access, API key configuration, and custom service URLs.

- **Bug Fixes**
  - Startup warnings and configuration handling now correctly identify unconfigured Exa defaults.
  - Existing settings disabling the former default service continue to be respected unless Exa is explicitly enabled or configured.

- **Documentation**
  - Updated security and configuration guidance to reflect Exa as the default web search provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->