### PR TITLE
fix(modelregistry): expose reasoning effort for DeepSeek V4 models

### DIFF
--- a/internal/modelregistry/catalog.go
+++ b/internal/modelregistry/catalog.go
@@ -231,6 +231,12 @@ func reasoningEffortsForModelName(name string) []ReasoningEffort {
 		// the gateway's translation concern — unknown fields are ignored, so the
 		// worst case is a silent no-op rather than a 400.
 		return []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}
+	case strings.Contains(n, "deepseek"):
+		// DeepSeek V4 (deepseek-v4-flash / deepseek-v4-pro) exposes thinking-mode
+		// effort control through the OpenAI-compatible reasoning_effort parameter.
+		// The API accepts low/high/max and maps medium/xhigh onto high, so only
+		// the three distinct tiers are advertised.
+		return []ReasoningEffort{ReasoningEffortLow, ReasoningEffortHigh, ReasoningEffortMax}
 	default:
 		return nil
 	}

--- a/internal/modelregistry/effort_fallback_test.go
+++ b/internal/modelregistry/effort_fallback_test.go
@@ -20,6 +20,10 @@ func TestReasoningEffortsFallbackForGPT5AndOSeries(t *testing.T) {
 		{"hy3", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
 		{"hunyuan-t1", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}},
 		{"openai/o3-mini", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh}}, // github-style vendor/ id
+		{"deepseek-v4-flash", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortHigh, ReasoningEffortMax}},
+		{"deepseek-v4-pro", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortHigh, ReasoningEffortMax}},
+		{"deepseek-reasoner", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortHigh, ReasoningEffortMax}},
+		{"deepseek-chat", []ReasoningEffort{ReasoningEffortLow, ReasoningEffortHigh, ReasoningEffortMax}},
 		{"gpt-4.1", nil}, // non-reasoning, registered: stays empty
 		{"gpt-4o-mini", nil},
 		{"ollama/llama3.1", nil},


### PR DESCRIPTION
## Problem

`/effort` in the TUI only offers **auto** for DeepSeek V4 models (`deepseek-v4-flash`, `deepseek-v4-pro`) served from the official `https://api.deepseek.com/v1` endpoint. `low` / `high` / `max` never appear, and setting them by hand is rejected with "Active model does not expose reasoning effort controls."

## Root cause

`reasoningEffortsForModelName` in `internal/modelregistry/catalog.go` only recognizes `gpt-5*` / `codex` / `o-series` / `hunyuan` model names. DeepSeek falls through to `default: return nil`, so `Registry.ReasoningEfforts` returns an empty set and the `/effort` picker collapses to just `auto`.

## Evidence that DeepSeek supports effort

DeepSeek's official [Thinking Mode docs](https://api-docs.deepseek.com/guides/thinking_mode) state that `deepseek-v4-flash` / `deepseek-v4-pro` accept the OpenAI-compatible `reasoning_effort` parameter with values `low` / `high` / `max` (`medium` and `xhigh` are mapped onto `high`). Thinking mode is enabled by default with a default effort of `high`.

## Change

Advertise `{low, high, max}` for the `deepseek` model family so the `/effort` picker and the Ctrl+T effort ring work, and add fallback test coverage for `deepseek-v4-flash`, `deepseek-v4-pro`, `deepseek-reasoner`, and `deepseek-chat`.

## Verification

- `go test ./internal/modelregistry/...` passes (new cases included)
- `go test ./internal/providers/openai/...` passes
- `internal/cli` failures (`TestRunAddDirDispatchForwardsGrantIntoExecScope`, `TestExecScopeReRegistrationSwapsCoreToolsByName`, `TestRunSandboxCheckJSONDeniesOutOfWorkspaceWrite`) are pre-existing sandbox-environment failures — they fail identically on a clean checkout of `main` (`d7ac85c`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning-effort support for DeepSeek models, including low, high, and max levels.

* **Tests**
  * Added coverage to verify supported reasoning-effort options across DeepSeek model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->