### PR TITLE
perf: reduce startup and turn overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,13 @@ go run ./cmd/zero-perf-bench
 
 Experimental: `ZERO_OPENAI_TURN_SESSION=1` enables the optimized OpenAI turn
 session (background connection prewarm + request-prefix telemetry) for headless
-`zero exec` runs against official OpenAI profiles. Off by default; `0`/`false`
-disable. A/B-benchmark it by running the same `zero-perf-bench` suite with the
-variable unset and set.
+`zero exec` runs against official OpenAI profiles. Off by default; `0`, `false`,
+or `off` disable it. A/B-benchmark it by running the same `zero-perf-bench` suite
+with the variable unset and set.
+
+Native ChatGPT Responses sessions are enabled by default. Set
+`ZERO_CHATGPT_TURN_SESSION=0`, `false`, or `off` to restore stateless HTTP/SSE
+transport.
 
 ### Code Quality and Security Checks
 

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,11 @@ module github.com/Gitlawb/zero
 
 go 1.26.6
 
+replace charm.land/bubbletea/v2 => github.com/anandh8x/bubbletea/v2 v2.0.10-0.20260820073754-bdad7c1db558
+
 require (
 	charm.land/bubbles/v2 v2.1.1
-	charm.land/bubbletea/v2 v2.0.8
+	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/alecthomas/chroma/v2 v2.27.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/Gitlawb/zero
 
 go 1.26.6
 
-replace charm.land/bubbletea/v2 => github.com/anandh8x/bubbletea/v2 v2.0.10-0.20260820073754-bdad7c1db558
-
 require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.9

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
 charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
-charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
-charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
 charm.land/lipgloss/v2 v2.0.5/go.mod h1:9oqhxt4yxIMe6q5A4kHr44DremZk7J9UNh74GlWa5nc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -12,6 +10,8 @@ github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r
 github.com/alecthomas/chroma/v2 v2.27.0/go.mod h1:NjJ3ciIgrqBNeIkWZ4e46nseoLDslxU1LmfCoL+wcY8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/anandh8x/bubbletea/v2 v2.0.10-0.20260820073754-bdad7c1db558 h1:LaEENulSSjn7i60wfHAWY8vhvTBfBCdVeGRYHvKn3pQ=
+github.com/anandh8x/bubbletea/v2 v2.0.10-0.20260820073754-bdad7c1db558/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
@@ -64,8 +64,6 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20260611194520-c48552f49976 h1:X8Hz2ImujgbmetVuW+w2YkyZChE3cBpZi2P158rTG9M=
 golang.org/x/exp v0.0.0-20260611194520-c48552f49976/go.mod h1:vnf4pv9iKZXY58sQE1L86zmNWJ4159e1RkcWiLCkeEY=
-golang.org/x/image v0.44.0 h1:+tDekMZED9+LrtB3G5xzRggpVh9CARjZqROla3R3R+I=
-golang.org/x/image v0.44.0/go.mod h1:V8K3KE9KKKE+pLpQDOeN18w9oacNSvy1tDOirTu4xtY=
 golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
 golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
 charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
+charm.land/bubbletea/v2 v2.0.9 h1:DpJCMWKgzQK8SJv4zbKKFHAI10ymWy/evClPFk0k0f8=
+charm.land/bubbletea/v2 v2.0.9/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
 charm.land/lipgloss/v2 v2.0.5/go.mod h1:9oqhxt4yxIMe6q5A4kHr44DremZk7J9UNh74GlWa5nc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -10,8 +12,6 @@ github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r
 github.com/alecthomas/chroma/v2 v2.27.0/go.mod h1:NjJ3ciIgrqBNeIkWZ4e46nseoLDslxU1LmfCoL+wcY8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/anandh8x/bubbletea/v2 v2.0.10-0.20260820073754-bdad7c1db558 h1:LaEENulSSjn7i60wfHAWY8vhvTBfBCdVeGRYHvKn3pQ=
-github.com/anandh8x/bubbletea/v2 v2.0.10-0.20260820073754-bdad7c1db558/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -144,6 +144,7 @@ func estimateToolDefTokens(tools []zeroruntime.ToolDefinition) int {
 	for _, tool := range tools {
 		total += ApproxTextTokens(tool.Name)
 		total += ApproxTextTokens(tool.Description)
+		total += ApproxTextTokens(string(tool.Type))
 		if len(tool.Parameters) > 0 {
 			if encoded, err := json.Marshal(tool.Parameters); err == nil {
 				total += ApproxTextTokens(string(encoded))

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -149,6 +149,11 @@ func estimateToolDefTokens(tools []zeroruntime.ToolDefinition) int {
 				total += ApproxTextTokens(string(encoded))
 			}
 		}
+		if tool.Format != nil {
+			total += ApproxTextTokens(tool.Format.Type)
+			total += ApproxTextTokens(tool.Format.Syntax)
+			total += ApproxTextTokens(tool.Format.Definition)
+		}
 		total += 4 // per-tool overhead
 	}
 	return total

--- a/internal/agent/compaction_projection.go
+++ b/internal/agent/compaction_projection.go
@@ -126,8 +126,11 @@ func capCompactionBrief(brief string) (string, bool) {
 
 func compactionToolCallLine(call zeroruntime.ToolCall) string {
 	detail := ""
+	if call.Freeform && call.Name == "apply_patch" {
+		detail = strings.Join(patchPaths(call.Arguments), ", ")
+	}
 	var arguments map[string]any
-	if json.Unmarshal([]byte(strings.TrimSpace(call.Arguments)), &arguments) == nil {
+	if detail == "" && json.Unmarshal([]byte(strings.TrimSpace(call.Arguments)), &arguments) == nil {
 		for _, key := range []string{"file_path", "path", "url", "query", "pattern", "prompt", "description", "question"} {
 			if value, ok := arguments[key].(string); ok && strings.TrimSpace(value) != "" {
 				detail = value

--- a/internal/agent/compaction_projection_test.go
+++ b/internal/agent/compaction_projection_test.go
@@ -73,6 +73,7 @@ func TestProjectCompactionInputRetainsAskUserExchangeAndSemanticArguments(t *tes
 		{Role: zeroruntime.MessageRoleTool, ToolCallID: "ask", Content: "Which database should remain?: Postgres only; do not touch MySQL."},
 		{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
 			{ID: "patch", Name: "apply_patch", Arguments: `{"patch":"*** Begin Patch\n*** Update File: internal/db.go\n*** End Patch"}`},
+			{ID: "raw-patch", Name: "apply_patch", Freeform: true, Arguments: "*** Begin Patch\n*** Update File: internal/api.go\n*** Add File: internal/config.go\n*** End Patch\n"},
 			{ID: "fetch", Name: "web_fetch", Arguments: `{"url":"https://example.com/spec"}`},
 			{ID: "task", Name: "task", Arguments: `{"prompt":"Inspect the Windows implementation"}`},
 		}},
@@ -80,7 +81,7 @@ func TestProjectCompactionInputRetainsAskUserExchangeAndSemanticArguments(t *tes
 	}
 
 	content := projectCompactionInput(messages).messages[0].Content
-	for _, want := range []string{"Which database should remain?", "Postgres only; do not touch MySQL", "internal/db.go", "https://example.com/spec", "Inspect the Windows implementation"} {
+	for _, want := range []string{"Which database should remain?", "Postgres only; do not touch MySQL", "internal/db.go", "internal/api.go", "internal/config.go", "https://example.com/spec", "Inspect the Windows implementation"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("projection missing %q: %q", want, content)
 		}

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -275,6 +275,11 @@ func TestEstimateToolDefTokensCountsDefinitions(t *testing.T) {
 	if estimateToolDefTokens(one) <= 0 {
 		t.Fatal("a tool definition (name + description + schema) should estimate > 0 tokens")
 	}
+	typed := append([]zeroruntime.ToolDefinition(nil), one...)
+	typed[0].Type = zeroruntime.ToolDefinitionFreeform
+	if estimateToolDefTokens(typed) <= estimateToolDefTokens(one) {
+		t.Fatal("a non-empty tool type must increase the estimated request cost")
+	}
 	two := append(append([]zeroruntime.ToolDefinition{}, one...), zeroruntime.ToolDefinition{
 		Name:        "write_file",
 		Description: "Write contents to a file in the workspace.",

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -280,6 +280,22 @@ func TestEstimateToolDefTokensCountsDefinitions(t *testing.T) {
 	if estimateToolDefTokens(typed) <= estimateToolDefTokens(one) {
 		t.Fatal("a non-empty tool type must increase the estimated request cost")
 	}
+	for _, test := range []struct {
+		name   string
+		format zeroruntime.ToolDefinitionFormat
+	}{
+		{name: "type", format: zeroruntime.ToolDefinitionFormat{Type: "grammar"}},
+		{name: "syntax", format: zeroruntime.ToolDefinitionFormat{Syntax: "lark"}},
+		{name: "definition", format: zeroruntime.ToolDefinitionFormat{Definition: "start: WORD"}},
+	} {
+		t.Run("format "+test.name, func(t *testing.T) {
+			formatted := append([]zeroruntime.ToolDefinition(nil), one...)
+			formatted[0].Format = &test.format
+			if estimateToolDefTokens(formatted) <= estimateToolDefTokens(one) {
+				t.Fatalf("a non-empty format %s must increase the estimated request cost", test.name)
+			}
+		})
+	}
 	two := append(append([]zeroruntime.ToolDefinition{}, one...), zeroruntime.ToolDefinition{
 		Name:        "write_file",
 		Description: "Write contents to a file in the workspace.",

--- a/internal/agent/context_planner.go
+++ b/internal/agent/context_planner.go
@@ -102,6 +102,10 @@ func copyToolDefinitions(toolDefs []zeroruntime.ToolDefinition) []zeroruntime.To
 	for index, definition := range toolDefs {
 		copied[index] = definition
 		copied[index].Parameters = copySchemaMap(definition.Parameters)
+		if definition.Format != nil {
+			format := *definition.Format
+			copied[index].Format = &format
+		}
 	}
 	return copied
 }

--- a/internal/agent/context_planner_test.go
+++ b/internal/agent/context_planner_test.go
@@ -15,6 +15,7 @@ func TestContextPlannerPreservesProviderRequest(t *testing.T) {
 	}
 	toolDefs := []zeroruntime.ToolDefinition{{
 		Name: "read_file", Description: "Read a file",
+		Format: &zeroruntime.ToolDefinitionFormat{Type: "grammar", Syntax: "lark", Definition: "start: PATH"},
 		Parameters: map[string]any{
 			"type":       "object",
 			"required":   []string{"path"},
@@ -53,10 +54,12 @@ func TestContextPlannerPreservesProviderRequest(t *testing.T) {
 	toolDefs[0].Parameters["required"].([]string)[0] = "other"
 	toolDefs[0].Parameters["properties"].(map[string]any)["path"].(map[string]any)["type"] = "integer"
 	toolDefs[0].Parameters["anyOf"].([]any)[0].(map[string]any)["type"] = "array"
+	toolDefs[0].Format.Definition = "changed"
 	if plan.Request.Messages[1].Content != "inspect this" || plan.Request.Messages[1].Images[0].Data[0] != 1 {
 		t.Fatalf("planned messages alias caller state: %#v", plan.Request.Messages[1])
 	}
 	if plan.Request.Tools[0].Name != "read_file" ||
+		plan.Request.Tools[0].Format == nil || plan.Request.Tools[0].Format.Definition != "start: PATH" ||
 		plan.Request.Tools[0].Parameters["required"].([]string)[0] != "path" ||
 		plan.Request.Tools[0].Parameters["properties"].(map[string]any)["path"].(map[string]any)["type"] != "string" ||
 		plan.Request.Tools[0].Parameters["anyOf"].([]any)[0].(map[string]any)["type"] != "object" {

--- a/internal/agent/freeform_tool_test.go
+++ b/internal/agent/freeform_tool_test.go
@@ -48,3 +48,50 @@ func TestUnknownFreeformToolFailsClosed(t *testing.T) {
 		t.Fatalf("unknown freeform status = %s, want error", result.Status)
 	}
 }
+
+func TestDeniedFreeformApplyPatchDoesNotWrite(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewScopedApplyPatchTool(root, nil))
+	patch := "*** Begin Patch\n*** Add File: denied.txt\n+must not exist\n*** End Patch\n"
+
+	result, err := executeToolCall(context.Background(), registry, zeroruntime.ToolCall{
+		ID:        "call-1",
+		Name:      "apply_patch",
+		Arguments: patch,
+		Freeform:  true,
+	}, PermissionModeAsk, Options{
+		Cwd: root,
+		OnPermissionRequest: func(context.Context, PermissionRequest) (PermissionDecision, error) {
+			return PermissionDecision{Action: PermissionDecisionDeny, Reason: "test denial"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if result.Status != tools.StatusError {
+		t.Fatalf("denied freeform status = %s, want error", result.Status)
+	}
+	if _, err := os.Stat(filepath.Join(root, "denied.txt")); !os.IsNotExist(err) {
+		t.Fatalf("denied freeform patch changed the workspace: %v", err)
+	}
+}
+
+func TestHistorySafeToolCallsPreservesRawFreeformArguments(t *testing.T) {
+	raw := "*** Begin Patch\n*** Update File: internal/main.go\n@@\n-old\n+new\n*** End Patch\n"
+	safe := historySafeToolCalls([]ToolCall{{
+		ID: "call-1", ProviderCallID: "provider-1", Name: "apply_patch", Arguments: raw, Freeform: true,
+	}})
+	if len(safe) != 1 || safe[0].Arguments != raw || safe[0].ProviderCallID != "provider-1" || !safe[0].Freeform {
+		t.Fatalf("freeform history changed raw call: %#v", safe)
+	}
+}
+
+func TestAbortedToolResultPreservesProviderCallID(t *testing.T) {
+	messages := appendAbortedToolResults(nil, []ToolCall{{
+		ID: "call-1", ProviderCallID: "provider-1", Name: "read_file",
+	}})
+	if len(messages) != 1 || messages[0].ToolCallID != "call-1" || messages[0].ToolCallProviderID != "provider-1" || !messages[0].IsError {
+		t.Fatalf("aborted tool result lost provider identity: %#v", messages)
+	}
+}

--- a/internal/agent/freeform_tool_test.go
+++ b/internal/agent/freeform_tool_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestFreeformApplyPatchUsesExistingToolExecutionPath(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewScopedApplyPatchTool(root, nil))
+	patch := "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n"
+
+	result, err := executeToolCall(context.Background(), registry, zeroruntime.ToolCall{
+		ID:        "call-1",
+		Name:      "apply_patch",
+		Arguments: patch,
+		Freeform:  true,
+	}, PermissionModeUnsafe, Options{Cwd: root, FileTracker: tools.NewFileTracker()})
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if result.Status != tools.StatusOK {
+		t.Fatalf("freeform apply_patch status = %s: %s", result.Status, result.Output)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "hello.txt"))
+	if err != nil {
+		t.Fatalf("read patched file: %v", err)
+	}
+	if string(content) != "hello\n" {
+		t.Fatalf("patched content = %q, want hello newline", content)
+	}
+}
+
+func TestUnknownFreeformToolFailsClosed(t *testing.T) {
+	result, err := executeToolCall(context.Background(), tools.NewRegistry(), zeroruntime.ToolCall{
+		ID: "call-1", Name: "unknown", Arguments: "raw", Freeform: true,
+	}, PermissionModeUnsafe, Options{})
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if result.Status != tools.StatusError {
+		t.Fatalf("unknown freeform status = %s, want error", result.Status)
+	}
+}

--- a/internal/agent/freeform_tool_test.go
+++ b/internal/agent/freeform_tool_test.go
@@ -111,6 +111,135 @@ func TestFreeformApplyPatchSupportsGrantedExtraRoot(t *testing.T) {
 	}
 }
 
+func TestFreeformApplyPatchRejectsMixedWorkspaceAndExtraRoots(t *testing.T) {
+	for _, extraHasMatchingPath := range []bool{false, true} {
+		name := "extra target missing"
+		if extraHasMatchingPath {
+			name = "extra target exists"
+		}
+		t.Run(name, func(t *testing.T) {
+			workspace := t.TempDir()
+			extra := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(workspace, "src"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			workspaceTarget := filepath.Join(workspace, "src", "a.go")
+			if err := os.WriteFile(workspaceTarget, []byte("old\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			extraTarget := filepath.Join(extra, "src", "a.go")
+			if extraHasMatchingPath {
+				if err := os.MkdirAll(filepath.Dir(extraTarget), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(extraTarget, []byte("old\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			scope, err := sandbox.NewScope(workspace, []string{extra})
+			if err != nil {
+				t.Fatal(err)
+			}
+			registry := tools.NewRegistry()
+			registry.Register(tools.NewScopedApplyPatchTool(workspace, scope))
+			extraCreated := filepath.Join(extra, "b.go")
+			patch := strings.Join([]string{
+				"*** Begin Patch",
+				"*** Update File: src/a.go",
+				"@@",
+				"-old",
+				"+new",
+				"*** Add File: " + extraCreated,
+				"+extra",
+				"*** End Patch",
+			}, "\n")
+
+			result, err := executeToolCall(context.Background(), registry, zeroruntime.ToolCall{
+				ID: "call-1", Name: "apply_patch", Arguments: patch, Freeform: true,
+			}, PermissionModeUnsafe, Options{Cwd: workspace, FileTracker: tools.NewFileTracker()})
+			if err != nil {
+				t.Fatalf("executeToolCall: %v", err)
+			}
+			if result.Status != tools.StatusError || !strings.Contains(result.Output, "mixes workspace-relative paths with an extra write root") {
+				t.Fatalf("mixed-root patch result = %s: %s", result.Status, result.Output)
+			}
+			if content, err := os.ReadFile(workspaceTarget); err != nil || string(content) != "old\n" {
+				t.Fatalf("workspace target changed: content=%q err=%v", content, err)
+			}
+			if extraHasMatchingPath {
+				if content, err := os.ReadFile(extraTarget); err != nil || string(content) != "old\n" {
+					t.Fatalf("extra-root target changed: content=%q err=%v", content, err)
+				}
+			}
+			if _, err := os.Stat(extraCreated); !os.IsNotExist(err) {
+				t.Fatalf("mixed-root patch created extra file: %v", err)
+			}
+		})
+	}
+}
+
+func TestFreeformApplyPatchAcceptsOneSemanticRoot(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		useExtraRoot bool
+	}{
+		{name: "workspace"},
+		{name: "extra root", useExtraRoot: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			extra := t.TempDir()
+			scope, err := sandbox.NewScope(workspace, []string{extra})
+			if err != nil {
+				t.Fatal(err)
+			}
+			root := workspace
+			if test.useExtraRoot {
+				root = extra
+			}
+			if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(root, "src", "a.go")
+			if err := os.WriteFile(target, []byte("old\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			updatePath := target
+			if !test.useExtraRoot {
+				updatePath = filepath.Join("src", "a.go")
+			}
+			created := filepath.Join(root, "b.go")
+			patch := strings.Join([]string{
+				"*** Begin Patch",
+				"*** Update File: " + updatePath,
+				"@@",
+				"-old",
+				"+new",
+				"*** Add File: " + created,
+				"+created",
+				"*** End Patch",
+			}, "\n")
+			registry := tools.NewRegistry()
+			registry.Register(tools.NewScopedApplyPatchTool(workspace, scope))
+			result, err := executeToolCall(context.Background(), registry, zeroruntime.ToolCall{
+				ID: "call-1", Name: "apply_patch", Arguments: patch, Freeform: true,
+			}, PermissionModeUnsafe, Options{Cwd: workspace, FileTracker: tools.NewFileTracker()})
+			if err != nil {
+				t.Fatalf("executeToolCall: %v", err)
+			}
+			if result.Status != tools.StatusOK {
+				t.Fatalf("single-root patch status = %s: %s", result.Status, result.Output)
+			}
+			if content, err := os.ReadFile(target); err != nil || string(content) != "new\n" {
+				t.Fatalf("updated content=%q err=%v", content, err)
+			}
+			if content, err := os.ReadFile(created); err != nil || string(content) != "created\n" {
+				t.Fatalf("created content=%q err=%v", content, err)
+			}
+		})
+	}
+}
+
 func TestFreeformApplyPatchRejectsAbsolutePathOutsideGrantedRoots(t *testing.T) {
 	root := t.TempDir()
 	granted := t.TempDir()

--- a/internal/agent/freeform_tool_test.go
+++ b/internal/agent/freeform_tool_test.go
@@ -4,11 +4,29 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
+
+type customApplyPatchTool struct {
+	calls int
+}
+
+func (*customApplyPatchTool) Name() string        { return "apply_patch" }
+func (*customApplyPatchTool) Description() string { return "custom JSON tool" }
+func (*customApplyPatchTool) Parameters() tools.Schema {
+	return tools.Schema{Type: "object", Properties: map[string]tools.PropertySchema{"value": {Type: "string"}}}
+}
+func (*customApplyPatchTool) Safety() tools.Safety {
+	return tools.Safety{Permission: tools.PermissionAllow, SideEffect: tools.SideEffectRead}
+}
+func (tool *customApplyPatchTool) Run(context.Context, map[string]any) tools.Result {
+	tool.calls++
+	return tools.Result{Status: tools.StatusOK}
+}
 
 func TestFreeformApplyPatchUsesExistingToolExecutionPath(t *testing.T) {
 	root := t.TempDir()
@@ -46,6 +64,25 @@ func TestUnknownFreeformToolFailsClosed(t *testing.T) {
 	}
 	if result.Status != tools.StatusError {
 		t.Fatalf("unknown freeform status = %s, want error", result.Status)
+	}
+}
+
+func TestCustomApplyPatchCannotUseFreeformContract(t *testing.T) {
+	custom := &customApplyPatchTool{}
+	registry := tools.NewRegistry()
+	registry.Register(custom)
+
+	result, err := executeToolCall(context.Background(), registry, zeroruntime.ToolCall{
+		ID: "call-1", Name: "apply_patch", Arguments: "raw patch", Freeform: true,
+	}, PermissionModeUnsafe, Options{})
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "Unsupported freeform tool call") {
+		t.Fatalf("custom freeform apply_patch result = %#v, want unsupported error", result)
+	}
+	if custom.calls != 0 {
+		t.Fatalf("custom apply_patch executed %d times", custom.calls)
 	}
 }
 

--- a/internal/agent/freeform_tool_test.go
+++ b/internal/agent/freeform_tool_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -52,6 +53,71 @@ func TestFreeformApplyPatchUsesExistingToolExecutionPath(t *testing.T) {
 	}
 	if string(content) != "hello\n" {
 		t.Fatalf("patched content = %q, want hello newline", content)
+	}
+}
+
+func TestFreeformApplyPatchSupportsGrantedExtraRoot(t *testing.T) {
+	root := t.TempDir()
+	extra := t.TempDir()
+	scope, err := sandbox.NewScope(root, []string{extra})
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewScopedApplyPatchTool(root, scope))
+	target := filepath.Join(extra, "hello.txt")
+	patch := "*** Begin Patch\n*** Add File: " + target + "\n+hello\n*** End Patch\n"
+
+	result, err := executeToolCall(context.Background(), registry, zeroruntime.ToolCall{
+		ID: "call-1", Name: "apply_patch", Arguments: patch, Freeform: true,
+	}, PermissionModeUnsafe, Options{Cwd: root, FileTracker: tools.NewFileTracker()})
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if result.Status != tools.StatusOK {
+		t.Fatalf("freeform extra-root apply_patch status = %s: %s", result.Status, result.Output)
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read extra-root patched file: %v", err)
+	}
+	if string(content) != "hello\n" {
+		t.Fatalf("patched content = %q, want hello newline", content)
+	}
+}
+
+func TestFreeformApplyPatchRejectsAbsolutePathOutsideGrantedRoots(t *testing.T) {
+	root := t.TempDir()
+	granted := t.TempDir()
+	outside, err := os.MkdirTemp(".", ".zero-ungranted-patch-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(outside) })
+	outside, err = filepath.Abs(outside)
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	scope, err := sandbox.NewScope(root, []string{granted})
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewScopedApplyPatchTool(root, scope))
+	target := filepath.Join(outside, "blocked.txt")
+	patch := "*** Begin Patch\n*** Add File: " + target + "\n+blocked\n*** End Patch\n"
+
+	result, err := executeToolCall(context.Background(), registry, zeroruntime.ToolCall{
+		ID: "call-1", Name: "apply_patch", Arguments: patch, Freeform: true,
+	}, PermissionModeUnsafe, Options{Cwd: root})
+	if err != nil {
+		t.Fatalf("executeToolCall: %v", err)
+	}
+	if result.Status != tools.StatusError {
+		t.Fatalf("ungranted absolute patch status = %s, want error: %s", result.Status, result.Output)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("ungranted absolute patch created target: %v", err)
 	}
 }
 

--- a/internal/agent/freeform_tool_test.go
+++ b/internal/agent/freeform_tool_test.go
@@ -17,6 +17,30 @@ type customApplyPatchTool struct {
 	calls int
 }
 
+type fixedPathScope struct {
+	roots []string
+}
+
+func (scope fixedPathScope) Roots() []string {
+	return append([]string(nil), scope.roots...)
+}
+
+func newFixedPathScope(t *testing.T, roots ...string) fixedPathScope {
+	t.Helper()
+	resolved := make([]string, 0, len(roots))
+	for _, root := range roots {
+		absolute, err := filepath.Abs(root)
+		if err != nil {
+			t.Fatalf("Abs(%q): %v", root, err)
+		}
+		if physical, err := filepath.EvalSymlinks(absolute); err == nil {
+			absolute = physical
+		}
+		resolved = append(resolved, absolute)
+	}
+	return fixedPathScope{roots: resolved}
+}
+
 func (*customApplyPatchTool) Name() string        { return "apply_patch" }
 func (*customApplyPatchTool) Description() string { return "custom JSON tool" }
 func (*customApplyPatchTool) Parameters() tools.Schema {
@@ -90,19 +114,8 @@ func TestFreeformApplyPatchSupportsGrantedExtraRoot(t *testing.T) {
 func TestFreeformApplyPatchRejectsAbsolutePathOutsideGrantedRoots(t *testing.T) {
 	root := t.TempDir()
 	granted := t.TempDir()
-	outside, err := os.MkdirTemp(".", ".zero-ungranted-patch-")
-	if err != nil {
-		t.Fatalf("MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(outside) })
-	outside, err = filepath.Abs(outside)
-	if err != nil {
-		t.Fatalf("Abs: %v", err)
-	}
-	scope, err := sandbox.NewScope(root, []string{granted})
-	if err != nil {
-		t.Fatalf("NewScope: %v", err)
-	}
+	outside := t.TempDir()
+	scope := newFixedPathScope(t, root, granted)
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewScopedApplyPatchTool(root, scope))
 	target := filepath.Join(outside, "blocked.txt")
@@ -128,23 +141,12 @@ func TestPreparedFreeformPatchRejectsIntermediateSymlinkSwap(t *testing.T) {
 	}
 	root := t.TempDir()
 	extra := t.TempDir()
-	outside, err := os.MkdirTemp(".", ".zero-patch-swap-outside-")
-	if err != nil {
-		t.Fatalf("MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(outside) })
-	outside, err = filepath.Abs(outside)
-	if err != nil {
-		t.Fatalf("Abs: %v", err)
-	}
+	outside := t.TempDir()
 	intermediate := filepath.Join(extra, "nested")
 	if err := os.Mkdir(intermediate, 0o755); err != nil {
 		t.Fatalf("Mkdir: %v", err)
 	}
-	scope, err := sandbox.NewScope(root, []string{extra})
-	if err != nil {
-		t.Fatalf("NewScope: %v", err)
-	}
+	scope := newFixedPathScope(t, root, extra)
 	tool := tools.NewScopedApplyPatchTool(root, scope)
 	target := filepath.Join(intermediate, "blocked.txt")
 	patch := "*** Begin Patch\n*** Add File: " + target + "\n+blocked\n*** End Patch\n"

--- a/internal/agent/freeform_tool_test.go
+++ b/internal/agent/freeform_tool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -118,6 +119,52 @@ func TestFreeformApplyPatchRejectsAbsolutePathOutsideGrantedRoots(t *testing.T) 
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
 		t.Fatalf("ungranted absolute patch created target: %v", err)
+	}
+}
+
+func TestPreparedFreeformPatchRejectsIntermediateSymlinkSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating directory symlinks requires privileges on Windows")
+	}
+	root := t.TempDir()
+	extra := t.TempDir()
+	outside, err := os.MkdirTemp(".", ".zero-patch-swap-outside-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(outside) })
+	outside, err = filepath.Abs(outside)
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	intermediate := filepath.Join(extra, "nested")
+	if err := os.Mkdir(intermediate, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	scope, err := sandbox.NewScope(root, []string{extra})
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	tool := tools.NewScopedApplyPatchTool(root, scope)
+	target := filepath.Join(intermediate, "blocked.txt")
+	patch := "*** Begin Patch\n*** Add File: " + target + "\n+blocked\n*** End Patch\n"
+	args, err := tools.PrepareFreeformApplyPatchArguments(tool, patch)
+	if err != nil {
+		t.Fatalf("PrepareFreeformApplyPatchArguments: %v", err)
+	}
+
+	if err := os.Remove(intermediate); err != nil {
+		t.Fatalf("Remove intermediate: %v", err)
+	}
+	if err := os.Symlink(outside, intermediate); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	result := tool.Run(context.Background(), args)
+	if result.Status != tools.StatusError {
+		t.Fatalf("symlink-swapped patch status = %s, want error: %s", result.Status, result.Output)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "blocked.txt")); !os.IsNotExist(err) {
+		t.Fatalf("symlink-swapped patch wrote outside root: %v", err)
 	}
 }
 

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -33,11 +33,11 @@ const (
 	// knows before spending more tool turns.
 	toolOnlyProgressReminderAt = 6
 
-	// planReminderTurn is the turn (1-based) by the end of which a multi-step
-	// task should have called update_plan; if it hasn't, a one-time reminder is
-	// injected. Set to 3 (not 2) so short, legitimate two-step tasks finish
-	// without a spurious planning nag.
-	planReminderTurn = 3
+	// planReminderTurn and planReminderToolThreshold keep bounded implementation
+	// work plan-free while still nudging a genuinely sustained run that has not
+	// established any structured progress. Both thresholds must be met.
+	planReminderTurn          = 7
+	planReminderToolThreshold = 7
 
 	// planToolName is the planning tool the loop watches for by name.
 	planToolName = "update_plan"
@@ -597,7 +597,7 @@ func (state *guardState) planReminder(turn int) string {
 	if !state.notCalledReminderSent &&
 		!state.planEverCalled &&
 		turn >= planReminderTurn &&
-		state.totalToolCalls >= 1 {
+		state.totalToolCalls >= planReminderToolThreshold {
 		state.notCalledReminderSent = true
 		return planNotCalledReminder()
 	}

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -591,9 +591,8 @@ func (state *guardState) planReminder(turn int) string {
 		return planStaleReminder(state.toolCallsSincePlanUpdate)
 	}
 
-	// NOT-CALLED reminder: by the end of planReminderTurn the model should have
-	// called update_plan if it's doing a multi-step task (>=1 other tool call).
-	// One-shot for the whole run.
+	// NOT-CALLED reminder: once both the turn and tool-call thresholds are met,
+	// sustained work should have called update_plan. One-shot for the whole run.
 	if !state.notCalledReminderSent &&
 		!state.planEverCalled &&
 		turn >= planReminderTurn &&

--- a/internal/agent/guardrails_test.go
+++ b/internal/agent/guardrails_test.go
@@ -304,6 +304,16 @@ func TestRunDoesNotInjectPlanReminderForBoundedToolSequence(t *testing.T) {
 	}
 }
 
+func TestPlanReminderWaitsForTurnThresholdAfterEnoughToolCalls(t *testing.T) {
+	state := guardState{totalToolCalls: 7}
+	if got := state.planReminder(6); got != "" {
+		t.Fatalf("planReminder(6) = %q, want no reminder before turn threshold", got)
+	}
+	if state.notCalledReminderSent {
+		t.Fatal("early turn marked the not-called reminder as sent")
+	}
+}
+
 func repeatedReadTurns(count int) [][]zeroruntime.StreamEvent {
 	turns := make([][]zeroruntime.StreamEvent, 0, count)
 	for range count {

--- a/internal/agent/guardrails_test.go
+++ b/internal/agent/guardrails_test.go
@@ -262,14 +262,7 @@ func TestRunInjectsPlanNotCalledReminderForMultiStepTask(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewScopedReadFileTool(root, nil))
 
-	provider := &mockProvider{
-		turns: [][]zeroruntime.StreamEvent{
-			toolTurn("call-1", "read_file", `{"path":"notes.txt"}`), // turn 1: other tool call
-			toolTurn("call-2", "read_file", `{"path":"notes.txt"}`), // turn 2: still no update_plan
-			toolTurn("call-3", "read_file", `{"path":"notes.txt"}`), // turn 3: reminder fires here
-			textTurn("done"),
-		},
-	}
+	provider := &mockProvider{turns: append(repeatedReadTurns(planReminderToolThreshold), textTurn("done"))}
 
 	result, err := Run(context.Background(), "go", provider, Options{
 		Registry: registry,
@@ -285,6 +278,33 @@ func TestRunInjectsPlanNotCalledReminderForMultiStepTask(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("expected exactly one not-called plan reminder, got %d", count)
 	}
+}
+
+func TestRunDoesNotInjectPlanReminderForBoundedToolSequence(t *testing.T) {
+	root := t.TempDir()
+	writeAgentTestFile(t, root+"/notes.txt", "alpha")
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewScopedReadFileTool(root, nil))
+
+	provider := &mockProvider{turns: append(repeatedReadTurns(planReminderToolThreshold-1), textTurn("done"))}
+	result, err := Run(context.Background(), "go", provider, Options{Registry: registry, MaxTurns: 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	if count := countUserMessagesContaining(result.Messages, planNotCalledReminderMarker); count != 0 {
+		t.Fatalf("bounded tool sequence must not draw a plan reminder, got %d", count)
+	}
+}
+
+func repeatedReadTurns(count int) [][]zeroruntime.StreamEvent {
+	turns := make([][]zeroruntime.StreamEvent, 0, count)
+	for range count {
+		turns = append(turns, toolTurn("call", "read_file", `{"path":"notes.txt"}`))
+	}
+	return turns
 }
 
 func TestRunDoesNotInjectPlanReminderForTrivialTask(t *testing.T) {

--- a/internal/agent/guardrails_test.go
+++ b/internal/agent/guardrails_test.go
@@ -257,12 +257,16 @@ func TestRunDoesNotCountDroppedToolCallTurnsAsEmpty(t *testing.T) {
 }
 
 func TestRunInjectsPlanNotCalledReminderForMultiStepTask(t *testing.T) {
+	const expectedThreshold = 7
+	if planReminderToolThreshold != expectedThreshold {
+		t.Fatalf("plan reminder tool threshold = %d, want %d", planReminderToolThreshold, expectedThreshold)
+	}
 	root := t.TempDir()
 	writeAgentTestFile(t, root+"/notes.txt", "alpha")
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewScopedReadFileTool(root, nil))
 
-	provider := &mockProvider{turns: append(repeatedReadTurns(planReminderToolThreshold), textTurn("done"))}
+	provider := &mockProvider{turns: append(repeatedReadTurns(expectedThreshold), textTurn("done"))}
 
 	result, err := Run(context.Background(), "go", provider, Options{
 		Registry: registry,
@@ -281,12 +285,13 @@ func TestRunInjectsPlanNotCalledReminderForMultiStepTask(t *testing.T) {
 }
 
 func TestRunDoesNotInjectPlanReminderForBoundedToolSequence(t *testing.T) {
+	const expectedThreshold = 7
 	root := t.TempDir()
 	writeAgentTestFile(t, root+"/notes.txt", "alpha")
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewScopedReadFileTool(root, nil))
 
-	provider := &mockProvider{turns: append(repeatedReadTurns(planReminderToolThreshold-1), textTurn("done"))}
+	provider := &mockProvider{turns: append(repeatedReadTurns(expectedThreshold-1), textTurn("done"))}
 	result, err := Run(context.Background(), "go", provider, Options{Registry: registry, MaxTurns: 12})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -3224,11 +3224,15 @@ func cachedRuntimeToolDefinition(defCache map[string]zeroruntime.ToolDefinition,
 // runtimeToolDefinition renders a tool's advertised definition (name, description,
 // JSON-schema parameters) as sent to the provider.
 func runtimeToolDefinition(tool tools.Tool) zeroruntime.ToolDefinition {
-	return zeroruntime.ToolDefinition{
+	definition := zeroruntime.ToolDefinition{
 		Name:        tool.Name(),
 		Description: tool.Description(),
 		Parameters:  schemaToRuntimeMap(tool.Parameters()),
 	}
+	if tools.IsBuiltInApplyPatch(tool) {
+		definition.Type = zeroruntime.ToolDefinitionFreeform
+	}
+	return definition
 }
 
 func ToolVisible(tool tools.Tool, permissionMode PermissionMode, enabledTools []string, disabledTools []string) bool {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -697,11 +697,12 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 				turnRequestedModel = toolResult.RequestedModel
 			}
 			messages = append(messages, zeroruntime.Message{
-				Role:         zeroruntime.MessageRoleTool,
-				Content:      toolResult.ModelOutput(),
-				ToolCallID:   toolResult.ToolCallID,
-				IsError:      toolResult.Status == tools.StatusError,
-				ChangedFiles: append([]string(nil), toolResult.ChangedFiles...),
+				Role:               zeroruntime.MessageRoleTool,
+				Content:            toolResult.ModelOutput(),
+				ToolCallID:         toolResult.ToolCallID,
+				ToolCallProviderID: call.ProviderCallID,
+				IsError:            toolResult.Status == tools.StatusError,
+				ChangedFiles:       append([]string(nil), toolResult.ChangedFiles...),
 			})
 			// Images ride a following USER message rather than the tool result
 			// above. Every provider drops images on a tool-role message —
@@ -1035,6 +1036,9 @@ func historySafeToolCalls(calls []ToolCall) []ToolCall {
 	safe := make([]ToolCall, len(calls))
 	for i, call := range calls {
 		safe[i] = call
+		if call.Freeform {
+			continue
+		}
 		args := strings.TrimSpace(call.Arguments)
 		switch {
 		case args == "":
@@ -1119,7 +1123,17 @@ func decodeToolArguments(arguments string, v any) error {
 
 func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCall, permissionMode PermissionMode, options Options) (ToolResult, error) {
 	args := map[string]any{}
-	if call.Arguments != "" {
+	if call.Freeform {
+		if call.Name != "apply_patch" {
+			return ToolResult{
+				ToolCallID: call.ID,
+				Name:       call.Name,
+				Status:     tools.StatusError,
+				Output:     "Error: Unsupported freeform tool call for " + call.Name + ".",
+			}, nil
+		}
+		args["patch"] = call.Arguments
+	} else if call.Arguments != "" {
 		if err := decodeToolArguments(call.Arguments, &args); err != nil {
 			return ToolResult{
 				ToolCallID: call.ID,
@@ -3369,10 +3383,11 @@ func loadedToolsFromResult(meta map[string]string) []string {
 func appendAbortedToolResults(messages []Message, remaining []ToolCall) []Message {
 	for _, call := range remaining {
 		messages = append(messages, zeroruntime.Message{
-			Role:       zeroruntime.MessageRoleTool,
-			Content:    abortedToolResultNotice,
-			ToolCallID: call.ID,
-			IsError:    true,
+			Role:               zeroruntime.MessageRoleTool,
+			Content:            abortedToolResultNotice,
+			ToolCallID:         call.ID,
+			ToolCallProviderID: call.ProviderCallID,
+			IsError:            true,
 		})
 	}
 	return messages

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -141,6 +141,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			}
 			options.Trace.Counter(trace.CounterInputTokens, int64(usage.InputTokens))
 			options.Trace.Counter(trace.CounterCachedInputTokens, int64(usage.CachedInputTokens))
+			options.Trace.Counter(trace.CounterCacheWriteTokens, int64(usage.CacheWriteTokens))
 			options.Trace.Counter(trace.CounterOutputTokens, int64(usage.OutputTokens))
 		}
 	}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1134,7 +1134,16 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 				Output:     "Error: Unsupported freeform tool call for " + call.Name + ".",
 			}, nil
 		}
-		args["patch"] = call.Arguments
+		prepared, err := tools.PrepareFreeformApplyPatchArguments(tool, call.Arguments)
+		if err != nil {
+			return ToolResult{
+				ToolCallID: call.ID,
+				Name:       call.Name,
+				Status:     tools.StatusError,
+				Output:     "Error: Invalid freeform apply_patch input: " + err.Error(),
+			}, nil
+		}
+		args = prepared
 	} else if call.Arguments != "" {
 		if err := decodeToolArguments(call.Arguments, &args); err != nil {
 			return ToolResult{

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1123,9 +1123,10 @@ func decodeToolArguments(arguments string, v any) error {
 }
 
 func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCall, permissionMode PermissionMode, options Options) (ToolResult, error) {
+	tool, toolFound := registry.Get(call.Name)
 	args := map[string]any{}
 	if call.Freeform {
-		if call.Name != "apply_patch" {
+		if !toolFound || !tools.IsBuiltInApplyPatch(tool) {
 			return ToolResult{
 				ToolCallID: call.ID,
 				Name:       call.Name,
@@ -1162,7 +1163,6 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 			DenialReason: DenialFiltered,
 		}, nil
 	}
-	tool, toolFound := registry.Get(call.Name)
 	if (permissionMode == PermissionModeSpecDraft || permissionMode == PermissionModePlan) && toolFound && !ToolAdvertised(tool, permissionMode) {
 		modeName := string(permissionMode)
 		return ToolResult{

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -4096,7 +4096,7 @@ func TestRunDoesNotFlagCleanToolOutput(t *testing.T) {
 // caller's callback AND stamps token counters, and the run completes.
 func TestRunTracingWrapperStampsUsage(t *testing.T) {
 	provider := &mockProvider{turns: [][]zeroruntime.StreamEvent{{
-		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 100, CachedInputTokens: 20, OutputTokens: 40}},
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{PromptTokens: 100, CachedInputTokens: 20, CacheWriteTokens: 10, CompletionTokens: 40}},
 		{Type: zeroruntime.StreamEventText, Content: "done"},
 		{Type: zeroruntime.StreamEventDone},
 	}}}
@@ -4134,6 +4134,9 @@ func TestRunTracingWrapperStampsUsage(t *testing.T) {
 	}
 	if got := tr.Counter(trace.CounterCachedInputTokens); got != 20 {
 		t.Fatalf("cached input token counter = %d, want 20", got)
+	}
+	if got := tr.Counter(trace.CounterCacheWriteTokens); got != 10 {
+		t.Fatalf("cache-write token counter = %d, want 10", got)
 	}
 	if got := tr.Counter(trace.CounterOutputTokens); got != 40 {
 		t.Fatalf("output token counter = %d, want 40", got)

--- a/internal/agent/partition_cache_test.go
+++ b/internal/agent/partition_cache_test.go
@@ -31,6 +31,19 @@ func (t countingSchemaTool) Run(_ context.Context, _ map[string]any) tools.Resul
 	return tools.Result{Status: tools.StatusOK}
 }
 
+func TestRuntimeToolDefinitionMarksOnlyBuiltInApplyPatchFreeform(t *testing.T) {
+	builtIn := runtimeToolDefinition(tools.NewScopedApplyPatchTool(t.TempDir(), nil))
+	if builtIn.Type != zeroruntime.ToolDefinitionFreeform {
+		t.Fatalf("built-in apply_patch type = %q, want freeform", builtIn.Type)
+	}
+
+	calls := 0
+	custom := runtimeToolDefinition(countingSchemaTool{name: "apply_patch", calls: &calls})
+	if custom.Type != "" {
+		t.Fatalf("custom apply_patch type = %q, want legacy function shape", custom.Type)
+	}
+}
+
 // The cache renders a tool's schema once and reuses it across calls, and its
 // output is identical to the uncached path.
 func TestPartitionToolsCacheRendersOnceAndMatchesUncached(t *testing.T) {

--- a/internal/agent/prompt_fingerprint.go
+++ b/internal/agent/prompt_fingerprint.go
@@ -58,12 +58,18 @@ func toolSubstrings(exposed []zeroruntime.ToolDefinition) (toolsSubstr, schemaSu
 	for _, def := range exposed {
 		writeLengthPrefixed(&toolsSB, def.Name)
 		writeLengthPrefixed(&toolsSB, def.Description)
+		writeLengthPrefixed(&toolsSB, string(def.Type))
 		// Parameters is rendered to a canonical JSON string per tool. The
 		// schema-render cache in internal/agent (used by partitionToolsCached)
 		// guarantees the same render is byte-identical across turns for the
 		// same tool, so this substring is a stable hash input.
 		writeLengthPrefixed(&schemaSB, def.Name)
 		writeLengthPrefixed(&schemaSB, canonicalSchemaString(def.Parameters))
+		if def.Format != nil {
+			writeLengthPrefixed(&schemaSB, def.Format.Type)
+			writeLengthPrefixed(&schemaSB, def.Format.Syntax)
+			writeLengthPrefixed(&schemaSB, def.Format.Definition)
+		}
 	}
 	return toolsSB.String(), schemaSB.String()
 }

--- a/internal/agent/prompt_fingerprint_test.go
+++ b/internal/agent/prompt_fingerprint_test.go
@@ -73,6 +73,38 @@ func TestComputePrefixFingerprintSchemaChangeChangesSchemaHash(t *testing.T) {
 	}
 }
 
+func TestComputePrefixFingerprintIncludesToolTypeAndFormat(t *testing.T) {
+	opts := Options{Cwd: t.TempDir(), SystemPrompt: "core"}
+	base := zeroruntime.ToolDefinition{Name: "apply_patch", Description: "Patch files"}
+	baseFingerprint := ComputePrefixFingerprint(opts, []zeroruntime.ToolDefinition{base})
+
+	typed := base
+	typed.Type = zeroruntime.ToolDefinitionFreeform
+	if got := ComputePrefixFingerprint(opts, []zeroruntime.ToolDefinition{typed}); got.ToolsHash == baseFingerprint.ToolsHash {
+		t.Fatal("ToolsHash must change when tool Type changes")
+	}
+
+	formatCases := []struct {
+		name   string
+		format zeroruntime.ToolDefinitionFormat
+	}{
+		{name: "type", format: zeroruntime.ToolDefinitionFormat{Type: "grammar"}},
+		{name: "syntax", format: zeroruntime.ToolDefinitionFormat{Syntax: "lark"}},
+		{name: "definition", format: zeroruntime.ToolDefinitionFormat{Definition: "start: PATCH"}},
+		{name: "empty", format: zeroruntime.ToolDefinitionFormat{}},
+	}
+	for _, test := range formatCases {
+		t.Run(test.name, func(t *testing.T) {
+			withFormat := base
+			withFormat.Format = &test.format
+			got := ComputePrefixFingerprint(opts, []zeroruntime.ToolDefinition{withFormat})
+			if got.SchemaHash == baseFingerprint.SchemaHash {
+				t.Fatalf("SchemaHash must change for %s format input", test.name)
+			}
+		})
+	}
+}
+
 // TestComputePrefixFingerprintSystemPromptChangeChangesBaseHash asserts the
 // most common drift path: a system-prompt edit (e.g. an agent.md update, a
 // model addendum change) must move the base-instructions hash, which moves

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -81,14 +81,15 @@ work.
 
 ## Testing gate (mandatory)
 
-- After any change to code, verify after edits by running the project's
-  validators before you summarize or commit: tests, type-checks, linters, and/or
-  the build, as appropriate. Scope them to the change while iterating; reserve
-  full-suite runs for milestones. Combine compatible validators into one command
-  when that preserves useful diagnostics. Run the final validator set once after
-  the last edit; rerun it only after another change or a failure that needs proof.
-- If you are unsure which validators apply, search the repo (Makefile, package
-  manifests, CI config) to find them.
+- After code changes, verify after edits with the project's documented
+  validators: tests, type-checks, linters, and/or build as appropriate. Scope
+  iteration checks; reserve full-suite runs for milestones. Combine compatible
+  validators into one command when diagnostics stay useful. Run the final set
+  once after the last edit; rerun only after another change or a failure needing
+  proof.
+- If unsure which build, validation, or release entry points apply, search the
+  repo (Makefile, package manifests, CI config) and use them instead of inventing
+  a parallel flow.
 - Never claim a task is done, and never commit, while validators are failing. If
   they fail, fix the cause and rerun; do not paper over it. If you could not run
   a validator, say so explicitly rather than implying success.

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -30,12 +30,14 @@ work.
    read-before-edit discipline: inspect the target file and nearby callers,
    tests, or config before you modify behavior. Never edit a file you have not
    read.
-2. **Plan.** Use update_plan for implementation or investigation that has at
-   least three meaningful dependent steps, then keep it current at milestones.
-   Mark completed work and the next in-progress step together when practical;
-   do not spend separate turns updating it after every file or command. Keep at
-   most one item in_progress. Skip plans for simple lookups, explanations, code
-   navigation, and other short tasks. Never create a plan after the work is
+2. **Plan.** Use update_plan when work spans multiple components or independent
+   workstreams, has sequencing uncertainty, or needs sustained tracking across
+   many tool calls. Skip update_plan for bounded changes in one component even
+   when the natural workflow is inspect, implement, and verify. When a plan is
+   useful, keep it current only when the overall phase materially changes; do
+   not spend separate turns updating it after every file or command. Mark
+   completed work and the next in-progress step together when practical, and
+   keep at most one item in_progress. Never create a plan after the work is
    already complete merely to describe what you did.
 3. **Implement.** Make focused changes that match the surrounding code's style,
    naming, and conventions. Prefer the smallest change that fully solves the
@@ -55,9 +57,11 @@ work.
   write_file, apply_patch - over shelling out to
   cat/sed/awk/python for file operations.
   They are safer, reviewable, and produce clean diffs.
-- Prefer read_minified_file when initially exploring source code; it preserves
-  code while removing comments and redundant whitespace. Use read_file when
-  exact text, comments, or line numbers are needed.
+- Prefer read_minified_file only while exploring large or unfamiliar source when
+  no exact edit is yet likely. For a small file or a likely edit target, use
+  read_file directly. Do not read the same file first with read_minified_file and
+  then again with read_file unless the initial inspection reveals a new need for
+  exact text, comments, or line numbers.
 - Keep edits focused and reviewable. A single patch may update several related
   files when they form one coherent change; do not hide unrelated edits in a
   bulk shell or script rewrite.
@@ -69,7 +73,9 @@ work.
 - Solve the problem as posed, not a more general version of it. Add no
   speculative abstraction, configurability, or handling for cases that cannot
   occur, and nothing the user did not ask for. A small diff can still be
-  over-built; if a 200-line solution could be 50, rewrite it.
+  over-built; if a 200-line solution could be 50, rewrite it. Once the required
+  behavior passes validation, stop rather than adding optional cleanup,
+  assertions, or refactors.
 - Preserve behavior you were not asked to change. Do not delete or rewrite code
   you did not author unless the task requires it; if you must, say so.
 
@@ -78,12 +84,17 @@ work.
 - After any change to code, verify after edits by running the project's
   validators before you summarize or commit: tests, type-checks, linters, and/or
   the build, as appropriate. Scope them to the change while iterating; reserve
-  full-suite runs for milestones.
+  full-suite runs for milestones. Combine compatible validators into one command
+  when that preserves useful diagnostics. Run the final validator set once after
+  the last edit; rerun it only after another change or a failure that needs proof.
 - If you are unsure which validators apply, search the repo (Makefile, package
   manifests, CI config) to find them.
 - Never claim a task is done, and never commit, while validators are failing. If
   they fail, fix the cause and rerun; do not paper over it. If you could not run
   a validator, say so explicitly rather than implying success.
+- Treat a successful native patch result as confirmation of the applied edit. Do
+  not reread files solely to confirm it; reread only when the next change needs
+  exact content or the patch/result was ambiguous.
 
 ## Tool use
 
@@ -141,6 +152,8 @@ work.
 - Default to concise, skimmable output. Lead with the answer or the result.
 - Use GitHub-flavored Markdown: headings to structure longer replies, fenced
   code blocks for code, and `inline code` for file paths, commands, symbols, and
-  short snippets. Reference code as `file:line` so it is clickable.
+  short snippets. Reference code with clickable file paths; include line numbers
+  when already known or materially useful. Do not make extra tool calls solely
+  to discover line numbers for the final summary.
 - Report outcomes faithfully: if tests failed, show it; if a step was skipped,
   say so; when something is done and verified, state it plainly without hedging.

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -152,8 +152,8 @@ work.
 - Default to concise, skimmable output. Lead with the answer or the result.
 - Use GitHub-flavored Markdown: headings to structure longer replies, fenced
   code blocks for code, and `inline code` for file paths, commands, symbols, and
-  short snippets. Reference code with clickable file paths; include line numbers
-  when already known or materially useful. Do not make extra tool calls solely
-  to discover line numbers for the final summary.
+  short snippets. Reference code with file paths; include line numbers when
+  already known or materially useful. Do not make extra tool calls solely to
+  discover line numbers for the final summary.
 - Report outcomes faithfully: if tests failed, show it; if a step was skipped,
   say so; when something is done and verified, state it plainly without hedging.

--- a/internal/agent/system_prompt_models.go
+++ b/internal/agent/system_prompt_models.go
@@ -61,7 +61,9 @@ const openAIPromptAddendum = `<model_guidance>
   commands, and symbols.
 - Strongly prefer the native file tools (read_file, list_directory, grep, glob,
   write_file, apply_patch) over shelling out to cat/sed/awk/python for
-  file work. Make one tool call per file; do not batch file writes into a script.
+  file work. When native apply_patch is available, call it directly; never run
+  apply_patch through exec_command. One coherent native patch may update related
+  files; do not batch file writes into a shell script.
 - Persist until the task is fully handled this turn: gather context, implement,
   run the validators, and report — do not stop at a partial result.
 </model_guidance>`

--- a/internal/agent/system_prompt_models_test.go
+++ b/internal/agent/system_prompt_models_test.go
@@ -29,6 +29,9 @@ func TestBuildSystemPromptAppendsModelAddendum(t *testing.T) {
 	if got := buildSystemPrompt(Options{Model: "gpt-5"}); !strings.Contains(got, openAIPromptAddendum) {
 		t.Fatalf("expected the OpenAI addendum in the gpt-5 prompt")
 	}
+	if got := strings.Join(strings.Fields(strings.ToLower(buildSystemPrompt(Options{Model: "gpt-5"}))), " "); !strings.Contains(got, "never run apply_patch through exec_command") {
+		t.Fatalf("OpenAI prompt must route edits through the native patch tool:\n%s", got)
+	}
 	// Claude is aligned with the core prompt and gets no family addendum now that
 	// comment discipline is universal; it must not pick up another family's block.
 	claude := buildSystemPrompt(Options{Model: "claude-opus-4-6"})

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestCoreSystemPromptIncludesCodingQualityRules(t *testing.T) {
-	prompt := strings.ToLower(buildSystemPrompt(Options{}))
+	prompt := strings.Join(strings.Fields(strings.ToLower(buildSystemPrompt(Options{}))), " ")
 
 	for _, want := range []string{
 		"read-before-edit",
@@ -44,6 +44,12 @@ func TestCoreSystemPromptIncludesCodingQualityRules(t *testing.T) {
 		"do not recognize",
 		"scaled to the work",
 		"comment density",
+		"skip update_plan for bounded changes in one component",
+		"do not read the same file first with read_minified_file and then again with read_file",
+		"combine compatible validators into one command",
+		"do not reread files solely to confirm",
+		"once the required behavior passes validation, stop",
+		"do not make extra tool calls solely to discover line numbers",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("expected core system prompt to include %q, got:\n%s", want, buildSystemPrompt(Options{}))

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -50,6 +50,7 @@ func TestCoreSystemPromptIncludesCodingQualityRules(t *testing.T) {
 		"skip update_plan for bounded changes in one component",
 		"do not read the same file first with read_minified_file and then again with read_file",
 		"combine compatible validators into one command",
+		"instead of inventing a parallel flow",
 		"do not reread files solely to confirm",
 		"once the required behavior passes validation, stop",
 		"do not make extra tool calls solely to discover line numbers",

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -30,6 +30,9 @@ func TestMain(m *testing.M) {
 
 func TestCoreSystemPromptIncludesCodingQualityRules(t *testing.T) {
 	prompt := strings.Join(strings.Fields(strings.ToLower(buildSystemPrompt(Options{}))), " ")
+	if strings.Contains(prompt, "clickable file paths") {
+		t.Fatalf("system prompt must not claim inline-code file paths are clickable: %s", prompt)
+	}
 
 	for _, want := range []string{
 		"read-before-edit",

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -975,8 +975,17 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		RecapsEnabled:        resolved.Preferences.RecapsEnabled(),
 		Provider:             provider,
 		NewProvider:          deps.newProvider,
-		ProbeProviderHealth:  deps.probeProviderHealth,
-		UserAgent:            userAgent(),
+		NewTurnSessionProvider: func(profile config.ProviderProfile, provider zeroruntime.Provider) zeroruntime.TurnSessionProvider {
+			if provider == nil {
+				return nil
+			}
+			if optimized, ok := providers.OptimizedTurnSessions(profile, provider, providers.Options{}); ok {
+				return optimized
+			}
+			return providers.DefaultTurnSessions(profile, provider, providers.Options{})
+		},
+		ProbeProviderHealth: deps.probeProviderHealth,
+		UserAgent:           userAgent(),
 		PrepareRunCompletionWarning: func() {
 			scratchBaseline = scratchFileSnapshot(workspaceRoot)
 		},

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -839,9 +839,10 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		mcpTokenStore = nil
 		err = nil
 	}
+	criticalMCPConfig, optionalMCPConfig := splitMCPStartupConfig(mcpConfig)
 	mcpRuntime := mcpToolRuntime(noopMCPRuntime{})
-	if len(mcpConfig.Servers) > 0 {
-		mcpRuntime, err = deps.registerMCPTools(context.Background(), registry, mcpConfig, mcp.RegisterOptions{
+	if len(criticalMCPConfig.Servers) > 0 {
+		mcpRuntime, err = deps.registerMCPTools(context.Background(), registry, criticalMCPConfig, mcp.RegisterOptions{
 			PermissionStore: mcpPermissionStore,
 			Autonomy:        mcp.AutonomyLow,
 			Execution:       executionRunner,
@@ -909,11 +910,35 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	}
 	// Activate deferred MCP-tool loading for the interactive run only when the
 	// VISIBLE deferred-eligible count meets the resolved threshold, matching exec.
-	// The registry is complete (core + specialist + MCP + plugins) here, so the
-	// count is accurate; below threshold this is a no-op and the surface is
-	// unchanged. The interactive surface applies no operator tool filters, so
-	// enabled/disabled are nil — matching the AgentOptions below.
+	// This first pass covers every prompt-critical tool. Optional built-in MCP
+	// defaults re-run the same gate after publishing their atomic batch, so a
+	// later catalog generation cannot miss its loader. The interactive surface
+	// applies no operator tool filters, so enabled/disabled are nil — matching the
+	// AgentOptions below.
 	registerToolSearchIfEligible(registry, resolved.Tools.DeferThreshold, permissionMode, nil, nil)
+	var optionalMCPRuntime *optionalMCPStartup
+	var awaitToolReadiness func(context.Context)
+	if len(optionalMCPConfig.Servers) > 0 {
+		optionalMCPRuntime = startOptionalMCP(
+			context.Background(),
+			registry,
+			optionalMCPConfig,
+			mcp.RegisterOptions{
+				PermissionStore: mcpPermissionStore,
+				Autonomy:        mcp.AutonomyLow,
+				Execution:       executionRunner,
+				WorkspaceRoot:   workspaceRoot,
+			},
+			deps.registerMCPTools,
+			func() {
+				registerToolSearchIfEligible(registry, resolved.Tools.DeferThreshold, permissionMode, nil, nil)
+			},
+		)
+		defer closeMCPRuntime(stderr, optionalMCPRuntime)
+		awaitToolReadiness = func(ctx context.Context) {
+			optionalMCPRuntime.Await(ctx, optionalMCPPromptGrace)
+		}
+	}
 	lastKnownMCPConfig := mcpConfig
 	fileTracker := tools.NewFileTracker()
 	var scratchBaseline scratchFileBaseline
@@ -959,6 +984,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 			return scratchFileWarning(workspaceRoot, scratchBaseline)
 		},
 		Registry:           registry,
+		AwaitToolReadiness: awaitToolReadiness,
 		SessionStore:       sessionStore,
 		PeerService:        peerService,
 		SandboxStore:       sandboxStore,

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -842,16 +842,17 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	criticalMCPConfig, optionalMCPConfig := splitMCPStartupConfig(mcpConfig)
 	mcpRuntime := mcpToolRuntime(noopMCPRuntime{})
 	if len(criticalMCPConfig.Servers) > 0 {
-		mcpRuntime, err = deps.registerMCPTools(context.Background(), registry, criticalMCPConfig, mcp.RegisterOptions{
+		runtime, registerErr := deps.registerMCPTools(context.Background(), registry, criticalMCPConfig, mcp.RegisterOptions{
 			PermissionStore: mcpPermissionStore,
 			Autonomy:        mcp.AutonomyLow,
 			Execution:       executionRunner,
 			WorkspaceRoot:   workspaceRoot,
 		})
-	}
-	if err != nil {
-		closeMCPRuntime(stderr, mcpRuntime)
-		return writeAppError(stderr, err.Error(), 1)
+		if registerErr != nil {
+			closeMCPRuntime(stderr, runtime)
+			return writeAppError(stderr, registerErr.Error(), 1)
+		}
+		mcpRuntime = runtime
 	}
 	defer closeMCPRuntime(stderr, mcpRuntime)
 	// A server that could not be reached or validated is skipped, not fatal (one

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -850,7 +850,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		})
 		if registerErr != nil {
 			closeMCPRuntime(stderr, runtime)
-			return writeAppError(stderr, registerErr.Error(), 1)
+			return writeAppError(stderr, redaction.ErrorMessage(registerErr, redaction.Options{}), 1)
 		}
 		mcpRuntime = runtime
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -486,6 +486,68 @@ func TestRunNoArgsLaunchesTUIWithMCPState(t *testing.T) {
 	}
 }
 
+func TestRunNoArgsPaintsBeforeOptionalDefaultMCPIsReady(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	userConfigPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	permissionStore, err := mcp.NewPermissionStore(mcp.StoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-permissions.json")})
+	if err != nil {
+		t.Fatalf("NewPermissionStore() error = %v", err)
+	}
+	tokenStore, err := mcp.NewTokenStore(mcp.TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-oauth.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd:          func() (string, error) { return cwd, nil },
+		userConfigPath: func() (string, error) { return userConfigPath, nil },
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 8}, nil
+		},
+		resolveMCPConfig: func(string, bool) (config.MCPConfig, error) {
+			return config.MCPConfig{Servers: config.DefaultMCPServers()}, nil
+		},
+		newMCPStore:      func() (*mcp.PermissionStore, error) { return permissionStore, nil },
+		newMCPTokenStore: func() (*mcp.TokenStore, error) { return tokenStore, nil },
+		registerMCPTools: func(_ context.Context, registry *tools.Registry, cfg config.MCPConfig, _ mcp.RegisterOptions) (mcpToolRuntime, error) {
+			if _, ok := cfg.Servers["firecrawl"]; !ok || len(cfg.Servers) != 1 {
+				t.Fatalf("optional MCP config = %#v, want only firecrawl", cfg.Servers)
+			}
+			close(started)
+			<-release
+			registry.Register(cliFakeMCPRegistryTool{})
+			return noopMCPRuntime{}, nil
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("optional MCP initialization did not start")
+			}
+			if options.AwaitToolReadiness == nil {
+				t.Fatal("TUI did not receive optional tool readiness barrier")
+			}
+			if _, ok := options.Registry.Get("mcp_docs_lookup"); ok {
+				t.Fatal("optional MCP tool was published before registration completed")
+			}
+			close(release)
+			options.AwaitToolReadiness(ctx)
+			if _, ok := options.Registry.Get("mcp_docs_lookup"); !ok {
+				t.Fatal("optional MCP tool was not visible after readiness completed")
+			}
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+}
+
 func TestTUIMCPCommandUsesLastGoodConfigOnRefreshError(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -514,8 +514,8 @@ func TestRunNoArgsPaintsBeforeOptionalDefaultMCPIsReady(t *testing.T) {
 		newMCPStore:      func() (*mcp.PermissionStore, error) { return permissionStore, nil },
 		newMCPTokenStore: func() (*mcp.TokenStore, error) { return tokenStore, nil },
 		registerMCPTools: func(_ context.Context, registry *tools.Registry, cfg config.MCPConfig, _ mcp.RegisterOptions) (mcpToolRuntime, error) {
-			if _, ok := cfg.Servers["firecrawl"]; !ok || len(cfg.Servers) != 1 {
-				t.Fatalf("optional MCP config = %#v, want only firecrawl", cfg.Servers)
+			if _, ok := cfg.Servers["exa"]; !ok || len(cfg.Servers) != 1 {
+				t.Fatalf("optional MCP config = %#v, want only exa", cfg.Servers)
 			}
 			close(started)
 			<-release

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
 	"github.com/Gitlawb/zero/internal/update"
@@ -627,6 +628,7 @@ func TestRunNoArgsClosesPartialMCPRuntimeWhenRegistrationFails(t *testing.T) {
 		t.Fatalf("NewTokenStore() error = %v", err)
 	}
 	runtimeClosed := false
+	secret := "sk-proj-" + strings.Repeat("a", 23) + "0"
 
 	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) {
@@ -653,7 +655,7 @@ func TestRunNoArgsClosesPartialMCPRuntimeWhenRegistrationFails(t *testing.T) {
 			return closeFunc(func() error {
 				runtimeClosed = true
 				return nil
-			}), errors.New("register mcp tools failed")
+			}), fmt.Errorf("register mcp tools failed: %s", secret)
 		},
 		runTUI: func(ctx context.Context, options tui.Options) int {
 			t.Fatal("TUI should not launch after MCP registration fails")
@@ -666,6 +668,12 @@ func TestRunNoArgsClosesPartialMCPRuntimeWhenRegistrationFails(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "register mcp tools failed") {
 		t.Fatalf("stderr missing registration error: %s", stderr.String())
+	}
+	if strings.Contains(stderr.String(), secret) {
+		t.Fatalf("stderr leaked MCP registration secret: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), redaction.RedactedSecret) {
+		t.Fatalf("stderr missing redaction marker: %s", stderr.String())
 	}
 	if !runtimeClosed {
 		t.Fatal("partial MCP runtime was not closed after registration error")

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -502,6 +502,7 @@ func TestRunNoArgsPaintsBeforeOptionalDefaultMCPIsReady(t *testing.T) {
 	}
 	started := make(chan struct{})
 	release := make(chan struct{})
+	configResult := make(chan error, 1)
 
 	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
 		getwd:          func() (string, error) { return cwd, nil },
@@ -515,9 +516,11 @@ func TestRunNoArgsPaintsBeforeOptionalDefaultMCPIsReady(t *testing.T) {
 		newMCPStore:      func() (*mcp.PermissionStore, error) { return permissionStore, nil },
 		newMCPTokenStore: func() (*mcp.TokenStore, error) { return tokenStore, nil },
 		registerMCPTools: func(_ context.Context, registry *tools.Registry, cfg config.MCPConfig, _ mcp.RegisterOptions) (mcpToolRuntime, error) {
+			var configErr error
 			if _, ok := cfg.Servers["exa"]; !ok || len(cfg.Servers) != 1 {
-				t.Fatalf("optional MCP config = %#v, want only exa", cfg.Servers)
+				configErr = fmt.Errorf("optional MCP config = %#v, want only exa", cfg.Servers)
 			}
+			configResult <- configErr
 			close(started)
 			<-release
 			registry.Register(cliFakeMCPRegistryTool{})
@@ -546,6 +549,9 @@ func TestRunNoArgsPaintsBeforeOptionalDefaultMCPIsReady(t *testing.T) {
 
 	if exitCode != 0 {
 		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if configErr := <-configResult; configErr != nil {
+		t.Fatal(configErr)
 	}
 }
 

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -939,6 +939,9 @@ func registerToolSearchIfEligible(registry *tools.Registry, deferThreshold int, 
 	if deferThreshold <= 0 {
 		return
 	}
+	if _, registered := registry.Get(tools.ToolSearchToolName); registered {
+		return
+	}
 	if deferredEligibleCount(registry, permissionMode, enabledTools, disabledTools) < deferThreshold {
 		return
 	}

--- a/internal/cli/exec_writer.go
+++ b/internal/cli/exec_writer.go
@@ -267,23 +267,29 @@ func streamJSONPermissionEventType(event agent.PermissionEvent) streamjson.Event
 func (writer *execEventWriter) usage(usage agent.Usage) {
 	if writer.format == execOutputJSON {
 		writer.writeJSON(map[string]any{
-			"type":              "usage",
-			"prompt_tokens":     usage.PromptTokens,
-			"completion_tokens": usage.CompletionTokens,
-			"total_tokens":      usage.TotalTokens(),
+			"type":                "usage",
+			"prompt_tokens":       usage.PromptTokens,
+			"completion_tokens":   usage.CompletionTokens,
+			"cached_input_tokens": usage.CachedInputTokens,
+			"cache_write_tokens":  usage.CacheWriteTokens,
+			"total_tokens":        usage.TotalTokens(),
 		})
 		return
 	}
 	if writer.format == execOutputStreamJSON {
 		promptTokens := usage.EffectiveInputTokens()
 		completionTokens := usage.EffectiveOutputTokens()
+		cachedInputTokens := usage.CachedInputTokens
+		cacheWriteTokens := usage.CacheWriteTokens
 		totalTokens := usage.TotalTokens()
 		writer.writeStreamJSON(streamjson.Event{
-			Type:             streamjson.EventUsage,
-			RunID:            writer.runID,
-			PromptTokens:     &promptTokens,
-			CompletionTokens: &completionTokens,
-			TotalTokens:      &totalTokens,
+			Type:              streamjson.EventUsage,
+			RunID:             writer.runID,
+			PromptTokens:      &promptTokens,
+			CompletionTokens:  &completionTokens,
+			CachedInputTokens: &cachedInputTokens,
+			CacheWriteTokens:  &cacheWriteTokens,
+			TotalTokens:       &totalTokens,
 		})
 	}
 }

--- a/internal/cli/exec_writer_test.go
+++ b/internal/cli/exec_writer_test.go
@@ -52,3 +52,39 @@ func TestExecWriterPropagatesToolResultTruncation(t *testing.T) {
 		})
 	}
 }
+
+func TestExecWriterPropagatesCacheUsage(t *testing.T) {
+	for _, format := range []execOutputFormat{execOutputJSON, execOutputStreamJSON} {
+		t.Run(string(format), func(t *testing.T) {
+			var stdout bytes.Buffer
+			writer := execEventWriter{
+				stdout:       &stdout,
+				format:       format,
+				runID:        "run_usage",
+				streamedText: &strings.Builder{},
+			}
+			writer.usage(agent.Usage{
+				InputTokens:       100,
+				OutputTokens:      20,
+				PromptTokens:      100,
+				CompletionTokens:  20,
+				CachedInputTokens: 60,
+				CacheWriteTokens:  10,
+			})
+			if writer.err != nil {
+				t.Fatalf("usage: %v", writer.err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &payload); err != nil {
+				t.Fatalf("decode output %q: %v", stdout.String(), err)
+			}
+			cachedKey, writeKey := "cached_input_tokens", "cache_write_tokens"
+			if format == execOutputStreamJSON {
+				cachedKey, writeKey = "cachedInputTokens", "cacheWriteTokens"
+			}
+			if payload[cachedKey] != float64(60) || payload[writeKey] != float64(10) {
+				t.Fatalf("cache usage missing from payload: %#v", payload)
+			}
+		})
+	}
+}

--- a/internal/cli/mcp_startup.go
+++ b/internal/cli/mcp_startup.go
@@ -10,7 +10,10 @@ import (
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
-const optionalMCPPromptGrace = time.Second
+const (
+	optionalMCPPromptGrace = time.Second
+	optionalMCPCloseGrace  = 250 * time.Millisecond
+)
 
 // splitMCPStartupConfig keeps explicitly configured servers on the
 // prompt-critical path. Only unchanged built-in defaults may initialize after
@@ -38,8 +41,9 @@ type optionalMCPStartup struct {
 	mu      sync.Mutex
 	runtime mcpToolRuntime
 
-	closeOnce sync.Once
-	closeErr  error
+	closeOnce        sync.Once
+	runtimeCloseOnce sync.Once
+	closeErr         error
 }
 
 func startOptionalMCP(
@@ -103,17 +107,39 @@ func (startup *optionalMCPStartup) Close() error {
 	}
 	startup.closeOnce.Do(func() {
 		startup.cancel()
-		<-startup.done
+		reaped := make(chan struct{})
+		go func() {
+			defer close(reaped)
+			<-startup.done
+			startup.closeRuntime()
+		}()
+		timer := time.NewTimer(optionalMCPCloseGrace)
+		defer timer.Stop()
+		select {
+		case <-reaped:
+		case <-timer.C:
+		}
+	})
+	startup.mu.Lock()
+	defer startup.mu.Unlock()
+	return startup.closeErr
+}
+
+func (startup *optionalMCPStartup) closeRuntime() {
+	startup.runtimeCloseOnce.Do(func() {
 		startup.mu.Lock()
 		runtime := startup.runtime
 		startup.mu.Unlock()
-		if runtime != nil {
-			if err := runtime.Close(); err != nil && startup.closeErr == nil {
-				startup.closeErr = err
-			}
+		if runtime == nil {
+			return
 		}
+		err := runtime.Close()
+		startup.mu.Lock()
+		if err != nil && startup.closeErr == nil {
+			startup.closeErr = err
+		}
+		startup.mu.Unlock()
 	})
-	return startup.closeErr
 }
 
 func (startup *optionalMCPStartup) Skipped() []mcp.SkippedServer {

--- a/internal/cli/mcp_startup.go
+++ b/internal/cli/mcp_startup.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+const optionalMCPPromptGrace = time.Second
+
+// splitMCPStartupConfig keeps explicitly configured servers on the
+// prompt-critical path. Only unchanged built-in defaults may initialize after
+// first paint; their failure was already intentionally silent.
+func splitMCPStartupConfig(cfg config.MCPConfig) (critical config.MCPConfig, optional config.MCPConfig) {
+	critical.Servers = map[string]config.MCPServerConfig{}
+	optional.Servers = map[string]config.MCPServerConfig{}
+	for name, server := range cfg.Servers {
+		if server.Disabled {
+			continue
+		}
+		if config.IsUnconfiguredDefault(name, server) {
+			optional.Servers[name] = server
+			continue
+		}
+		critical.Servers[name] = server
+	}
+	return critical, optional
+}
+
+type optionalMCPStartup struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu      sync.Mutex
+	runtime mcpToolRuntime
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func startOptionalMCP(
+	parent context.Context,
+	registry *tools.Registry,
+	cfg config.MCPConfig,
+	options mcp.RegisterOptions,
+	register func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error),
+	onReady func(),
+) *optionalMCPStartup {
+	ctx, cancel := context.WithCancel(parent)
+	startup := &optionalMCPStartup{cancel: cancel, done: make(chan struct{})}
+	go func() {
+		runtime, err := register(ctx, registry, cfg, options)
+		if err == nil && onReady != nil {
+			onReady()
+		}
+		startup.mu.Lock()
+		startup.runtime = runtime
+		startup.mu.Unlock()
+		close(startup.done)
+	}()
+	return startup
+}
+
+// Await gives optional tools one bounded opportunity to join the next turn's
+// immutable registry snapshot. A timeout leaves this turn on the existing core
+// tool set; a later turn observes the completed generation.
+func (startup *optionalMCPStartup) Await(ctx context.Context, timeout time.Duration) bool {
+	if startup == nil {
+		return true
+	}
+	select {
+	case <-startup.done:
+		return true
+	default:
+	}
+	if timeout <= 0 {
+		select {
+		case <-startup.done:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-startup.done:
+		return true
+	case <-timer.C:
+		return false
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (startup *optionalMCPStartup) Close() error {
+	if startup == nil {
+		return nil
+	}
+	startup.closeOnce.Do(func() {
+		startup.cancel()
+		<-startup.done
+		startup.mu.Lock()
+		runtime := startup.runtime
+		startup.mu.Unlock()
+		if runtime != nil {
+			if err := runtime.Close(); err != nil && startup.closeErr == nil {
+				startup.closeErr = err
+			}
+		}
+	})
+	return startup.closeErr
+}
+
+func (startup *optionalMCPStartup) Skipped() []mcp.SkippedServer {
+	return nil
+}

--- a/internal/cli/mcp_startup_test.go
+++ b/internal/cli/mcp_startup_test.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestSplitMCPStartupConfigDefersOnlyUnconfiguredDefaults(t *testing.T) {
+	defaults := config.DefaultMCPServers()
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"firecrawl": defaults["firecrawl"],
+		"docs":      {Type: "http", URL: "https://docs.example.test/mcp"},
+		"disabled":  {Type: "http", URL: "https://disabled.example.test/mcp", Disabled: true},
+	}}
+
+	critical, optional := splitMCPStartupConfig(cfg)
+	if _, ok := critical.Servers["docs"]; !ok || len(critical.Servers) != 1 {
+		t.Fatalf("critical servers = %#v, want only docs", critical.Servers)
+	}
+	if _, ok := optional.Servers["firecrawl"]; !ok || len(optional.Servers) != 1 {
+		t.Fatalf("optional servers = %#v, want only firecrawl", optional.Servers)
+	}
+}
+
+func TestOptionalMCPAwaitTimesOutThenObservesPublishedTools(t *testing.T) {
+	registry := tools.NewRegistry()
+	release := make(chan struct{})
+	started := make(chan struct{})
+	startup := startOptionalMCP(
+		context.Background(),
+		registry,
+		config.MCPConfig{Servers: config.DefaultMCPServers()},
+		mcp.RegisterOptions{},
+		func(ctx context.Context, registry *tools.Registry, _ config.MCPConfig, _ mcp.RegisterOptions) (mcpToolRuntime, error) {
+			close(started)
+			select {
+			case <-release:
+				registry.RegisterBatch([]tools.Tool{tools.NewScopedReadFileTool(t.TempDir(), nil)})
+				return noopMCPRuntime{}, nil
+			case <-ctx.Done():
+				return noopMCPRuntime{}, ctx.Err()
+			}
+		},
+		nil,
+	)
+	defer func() { _ = startup.Close() }()
+	<-started
+
+	if startup.Await(t.Context(), time.Millisecond) {
+		t.Fatal("optional startup unexpectedly completed before release")
+	}
+	if got := len(registry.All()); got != 0 {
+		t.Fatalf("registry published tools before readiness: %d", got)
+	}
+	close(release)
+	if !startup.Await(t.Context(), time.Second) {
+		t.Fatal("optional startup did not complete after release")
+	}
+	if _, ok := registry.Get("read_file"); !ok {
+		t.Fatal("completed optional startup did not publish its tool batch")
+	}
+}
+
+func TestOptionalMCPCloseCancelsBlockedStartup(t *testing.T) {
+	started := make(chan struct{})
+	startup := startOptionalMCP(
+		context.Background(),
+		tools.NewRegistry(),
+		config.MCPConfig{Servers: config.DefaultMCPServers()},
+		mcp.RegisterOptions{},
+		func(ctx context.Context, _ *tools.Registry, _ config.MCPConfig, _ mcp.RegisterOptions) (mcpToolRuntime, error) {
+			close(started)
+			<-ctx.Done()
+			return noopMCPRuntime{}, nil
+		},
+		nil,
+	)
+	<-started
+	if err := startup.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}

--- a/internal/cli/mcp_startup_test.go
+++ b/internal/cli/mcp_startup_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,20 +11,32 @@ import (
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
+type closeTrackingMCPRuntime struct {
+	closed chan struct{}
+	err    error
+}
+
+func (runtime *closeTrackingMCPRuntime) Close() error {
+	close(runtime.closed)
+	return runtime.err
+}
+
+func (*closeTrackingMCPRuntime) Skipped() []mcp.SkippedServer { return nil }
+
 func TestSplitMCPStartupConfigDefersOnlyUnconfiguredDefaults(t *testing.T) {
 	defaults := config.DefaultMCPServers()
 	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
-		"firecrawl": defaults["firecrawl"],
-		"docs":      {Type: "http", URL: "https://docs.example.test/mcp"},
-		"disabled":  {Type: "http", URL: "https://disabled.example.test/mcp", Disabled: true},
+		"exa":      defaults["exa"],
+		"docs":     {Type: "http", URL: "https://docs.example.test/mcp"},
+		"disabled": {Type: "http", URL: "https://disabled.example.test/mcp", Disabled: true},
 	}}
 
 	critical, optional := splitMCPStartupConfig(cfg)
 	if _, ok := critical.Servers["docs"]; !ok || len(critical.Servers) != 1 {
 		t.Fatalf("critical servers = %#v, want only docs", critical.Servers)
 	}
-	if _, ok := optional.Servers["firecrawl"]; !ok || len(optional.Servers) != 1 {
-		t.Fatalf("optional servers = %#v, want only firecrawl", optional.Servers)
+	if _, ok := optional.Servers["exa"]; !ok || len(optional.Servers) != 1 {
+		t.Fatalf("optional servers = %#v, want only exa", optional.Servers)
 	}
 }
 
@@ -66,6 +79,28 @@ func TestOptionalMCPAwaitTimesOutThenObservesPublishedTools(t *testing.T) {
 	}
 }
 
+func TestOptionalMCPFailedRegistrationSkipsReadinessCallback(t *testing.T) {
+	readyCalls := 0
+	startup := startOptionalMCP(
+		context.Background(),
+		tools.NewRegistry(),
+		config.MCPConfig{Servers: config.DefaultMCPServers()},
+		mcp.RegisterOptions{},
+		func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return noopMCPRuntime{}, errors.New("connect failed")
+		},
+		func() { readyCalls++ },
+	)
+	defer func() { _ = startup.Close() }()
+
+	if !startup.Await(t.Context(), time.Second) {
+		t.Fatal("failed optional startup did not settle")
+	}
+	if readyCalls != 0 {
+		t.Fatalf("readiness callback ran after failed registration: %d", readyCalls)
+	}
+}
+
 func TestOptionalMCPCloseCancelsBlockedStartup(t *testing.T) {
 	started := make(chan struct{})
 	startup := startOptionalMCP(
@@ -83,5 +118,70 @@ func TestOptionalMCPCloseCancelsBlockedStartup(t *testing.T) {
 	<-started
 	if err := startup.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestOptionalMCPCloseReturnsRuntimeErrorWithinGrace(t *testing.T) {
+	closeErr := errors.New("close failed")
+	runtime := &closeTrackingMCPRuntime{closed: make(chan struct{}), err: closeErr}
+	startup := startOptionalMCP(
+		context.Background(),
+		tools.NewRegistry(),
+		config.MCPConfig{Servers: config.DefaultMCPServers()},
+		mcp.RegisterOptions{},
+		func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return runtime, nil
+		},
+		nil,
+	)
+	if !startup.Await(t.Context(), time.Second) {
+		t.Fatal("optional startup did not settle")
+	}
+	if err := startup.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("Close() error = %v, want %v", err, closeErr)
+	}
+}
+
+func TestOptionalMCPCloseBoundsRegistrationThatIgnoresCancellation(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	runtime := &closeTrackingMCPRuntime{closed: make(chan struct{})}
+	startup := startOptionalMCP(
+		context.Background(),
+		tools.NewRegistry(),
+		config.MCPConfig{Servers: config.DefaultMCPServers()},
+		mcp.RegisterOptions{},
+		func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			close(started)
+			<-release
+			return runtime, nil
+		},
+		nil,
+	)
+	<-started
+
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- startup.Close() }()
+	select {
+	case err := <-closeResult:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked on registration after cancellation")
+	}
+
+	close(release)
+	released = true
+	select {
+	case <-runtime.closed:
+	case <-time.After(time.Second):
+		t.Fatal("late optional MCP runtime was not closed")
 	}
 }

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -176,9 +176,11 @@ func RegisterTools(ctx context.Context, registry *tools.Registry, cfg config.MCP
 			staged = append(staged, tool)
 		}
 	}
-	for _, tool := range staged {
-		registry.Register(tool)
+	registered := make([]tools.Tool, 0, len(staged))
+	for index := range staged {
+		registered = append(registered, staged[index])
 	}
+	registry.RegisterBatch(registered)
 	return runtime, nil
 }
 

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -70,6 +70,62 @@ func TestRegisterToolsAddsPromptGatedMCPTools(t *testing.T) {
 	}
 }
 
+func TestRegisterToolsPublishesServerToolsInOneGeneration(t *testing.T) {
+	registry := tools.NewRegistry()
+	before := registry.Snapshot().Generation
+	client := &fakeToolClient{listed: []RemoteTool{
+		{Name: "lookup", Description: "Lookup documentation"},
+		{Name: "search", Description: "Search documentation"},
+	}}
+	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp"},
+	}}, RegisterOptions{ClientFactory: func(context.Context, Server) (ToolClient, error) {
+		return client, nil
+	}})
+	if err != nil {
+		t.Fatalf("RegisterTools() error = %v", err)
+	}
+	defer runtime.Close()
+
+	after := registry.Snapshot()
+	if after.Generation != before+1 {
+		t.Fatalf("registry generation = %d, want %d", after.Generation, before+1)
+	}
+	for _, name := range []string{"mcp_docs_lookup", "mcp_docs_search"} {
+		if _, ok := registry.Get(name); !ok {
+			t.Fatalf("expected %s to be published in the batch", name)
+		}
+	}
+}
+
+func TestRegisterToolsPublishesNoneWhenServerToolValidationFails(t *testing.T) {
+	registry := tools.NewRegistry()
+	before := registry.Snapshot().Generation
+	client := &fakeToolClient{listed: []RemoteTool{
+		{Name: "lookup", Description: "Lookup documentation"},
+		{Name: "", Description: "Invalid nameless tool"},
+	}}
+	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp"},
+	}}, RegisterOptions{ClientFactory: func(context.Context, Server) (ToolClient, error) {
+		return client, nil
+	}})
+	if err != nil {
+		t.Fatalf("RegisterTools() error = %v", err)
+	}
+	defer runtime.Close()
+
+	if got := registry.Snapshot().Generation; got != before {
+		t.Fatalf("registry generation = %d, want unchanged %d", got, before)
+	}
+	if _, ok := registry.Get("mcp_docs_lookup"); ok {
+		t.Fatal("valid prefix of rejected server batch was published")
+	}
+	if skipped := runtime.Skipped(); len(skipped) != 1 || skipped[0].Name != "docs" || skipped[0].Err == nil {
+		t.Fatalf("Skipped() = %#v, want one validation failure for docs", skipped)
+	}
+}
+
 func TestRegisterToolsMarksPersistentlyApprovedToolsAllow(t *testing.T) {
 	store, err := NewPermissionStore(StoreOptions{
 		FilePath: filepath.Join(t.TempDir(), "permissions.json"),

--- a/internal/perfbench/turn_bench.go
+++ b/internal/perfbench/turn_bench.go
@@ -191,6 +191,7 @@ type TurnBenchResult struct {
 type TurnBenchTotals struct {
 	InputTokens       int64 `json:"inputTokens"`
 	CachedInputTokens int64 `json:"cachedInputTokens"`
+	CacheWriteTokens  int64 `json:"cacheWriteTokens"`
 	OutputTokens      int64 `json:"outputTokens"`
 	ModelRequests     int64 `json:"modelRequests"`
 	ToolCalls         int64 `json:"toolCalls"`
@@ -479,6 +480,7 @@ func topLatencySources(perSpan map[string]SpanStats, top int) []LatencySource {
 func aggregateTotals(totals *TurnBenchTotals, tr *trace.TurnTrace) {
 	totals.InputTokens += tr.Counter(trace.CounterInputTokens)
 	totals.CachedInputTokens += tr.Counter(trace.CounterCachedInputTokens)
+	totals.CacheWriteTokens += tr.Counter(trace.CounterCacheWriteTokens)
 	totals.OutputTokens += tr.Counter(trace.CounterOutputTokens)
 	totals.ModelRequests += tr.Counter(trace.CounterModelRequests)
 	totals.ToolCalls += tr.Counter(trace.CounterToolCalls)
@@ -531,8 +533,9 @@ func FormatTurnBenchSummary(result TurnBenchResult) string {
 			lines = append(lines, fmt.Sprintf("  %-18s %10s  %5.1f%%", src.Span, FormatMetric(src.TotalMs, "ms"), src.Share*100))
 		}
 	}
-	lines = append(lines, fmt.Sprintf("totals: in=%d (cached %d) out=%d | requests=%d tools=%d retries=%d reconnects=%d compactions=%d",
-		result.Totals.InputTokens, result.Totals.CachedInputTokens, result.Totals.OutputTokens,
+	lines = append(lines, fmt.Sprintf("totals: in=%d (cache-read %d, cache-write %d, uncached %d) out=%d | requests=%d tools=%d retries=%d reconnects=%d compactions=%d",
+		result.Totals.InputTokens, result.Totals.CachedInputTokens, result.Totals.CacheWriteTokens,
+		maxInt64(0, result.Totals.InputTokens-result.Totals.CachedInputTokens-result.Totals.CacheWriteTokens), result.Totals.OutputTokens,
 		result.Totals.ModelRequests, result.Totals.ToolCalls, result.Totals.Retries,
 		result.Totals.Reconnects, result.Totals.Compactions))
 	for _, class := range sortedClasses(result.PerClass) {
@@ -543,6 +546,13 @@ func FormatTurnBenchSummary(result TurnBenchResult) string {
 			class, tier, summary.Passed, summary.Verified, summary.LatencyOnly, median))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func maxInt64(left, right int64) int64 {
+	if left > right {
+		return left
+	}
+	return right
 }
 
 // classTier returns the oracle tier label a class was classified into, so the

--- a/internal/perfbench/turn_bench.go
+++ b/internal/perfbench/turn_bench.go
@@ -535,7 +535,7 @@ func FormatTurnBenchSummary(result TurnBenchResult) string {
 	}
 	lines = append(lines, fmt.Sprintf("totals: in=%d (cache-read %d, cache-write %d, uncached %d) out=%d | requests=%d tools=%d retries=%d reconnects=%d compactions=%d",
 		result.Totals.InputTokens, result.Totals.CachedInputTokens, result.Totals.CacheWriteTokens,
-		maxInt64(0, result.Totals.InputTokens-result.Totals.CachedInputTokens-result.Totals.CacheWriteTokens), result.Totals.OutputTokens,
+		uncachedInputTokens(result.Totals), result.Totals.OutputTokens,
 		result.Totals.ModelRequests, result.Totals.ToolCalls, result.Totals.Retries,
 		result.Totals.Reconnects, result.Totals.Compactions))
 	for _, class := range sortedClasses(result.PerClass) {
@@ -548,11 +548,21 @@ func FormatTurnBenchSummary(result TurnBenchResult) string {
 	return strings.Join(lines, "\n")
 }
 
-func maxInt64(left, right int64) int64 {
-	if left > right {
-		return left
+func uncachedInputTokens(totals TurnBenchTotals) int64 {
+	remaining := totals.InputTokens
+	if remaining <= 0 {
+		return 0
 	}
-	return right
+	for _, cached := range []int64{totals.CachedInputTokens, totals.CacheWriteTokens} {
+		if cached <= 0 {
+			continue
+		}
+		if cached >= remaining {
+			return 0
+		}
+		remaining -= cached
+	}
+	return remaining
 }
 
 // classTier returns the oracle tier label a class was classified into, so the

--- a/internal/perfbench/turn_bench_test.go
+++ b/internal/perfbench/turn_bench_test.go
@@ -338,6 +338,34 @@ func TestFormatTurnBenchSummaryNamesTopSources(t *testing.T) {
 	}
 }
 
+func TestUncachedInputTokensClampsInconsistentTotals(t *testing.T) {
+	tests := []struct {
+		name   string
+		totals TurnBenchTotals
+		want   int64
+	}{
+		{name: "normal", totals: TurnBenchTotals{InputTokens: 100, CachedInputTokens: 30, CacheWriteTokens: 20}, want: 50},
+		{name: "cached exceeds input", totals: TurnBenchTotals{InputTokens: 100, CachedInputTokens: 120}, want: 0},
+		{name: "write exceeds remainder", totals: TurnBenchTotals{InputTokens: 100, CachedInputTokens: 20, CacheWriteTokens: 90}, want: 0},
+		{name: "overflowing inconsistent counters", totals: TurnBenchTotals{CachedInputTokens: 1<<63 - 1, CacheWriteTokens: 1<<63 - 1}, want: 0},
+		{name: "negative cache counters ignored", totals: TurnBenchTotals{InputTokens: 100, CachedInputTokens: -20, CacheWriteTokens: -10}, want: 100},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := uncachedInputTokens(test.totals); got != test.want {
+				t.Fatalf("uncachedInputTokens(%+v) = %d, want %d", test.totals, got, test.want)
+			}
+		})
+	}
+	summary := FormatTurnBenchSummary(TurnBenchResult{Totals: TurnBenchTotals{
+		CachedInputTokens: 1<<63 - 1,
+		CacheWriteTokens:  1<<63 - 1,
+	}})
+	if !strings.Contains(summary, "uncached 0") {
+		t.Fatalf("summary did not clamp inconsistent cache totals:\n%s", summary)
+	}
+}
+
 func TestLoadBaselineManifest(t *testing.T) {
 	path := filepath.Join("manifests", "baseline.json")
 	set, err := LoadTaskSet(path)

--- a/internal/perfbench/turn_bench_test.go
+++ b/internal/perfbench/turn_bench_test.go
@@ -348,6 +348,7 @@ func TestUncachedInputTokensClampsInconsistentTotals(t *testing.T) {
 		{name: "cached exceeds input", totals: TurnBenchTotals{InputTokens: 100, CachedInputTokens: 120}, want: 0},
 		{name: "write exceeds remainder", totals: TurnBenchTotals{InputTokens: 100, CachedInputTokens: 20, CacheWriteTokens: 90}, want: 0},
 		{name: "overflowing inconsistent counters", totals: TurnBenchTotals{CachedInputTokens: 1<<63 - 1, CacheWriteTokens: 1<<63 - 1}, want: 0},
+		{name: "overflowing counters with input", totals: TurnBenchTotals{InputTokens: 100, CachedInputTokens: 1<<63 - 1, CacheWriteTokens: 1<<63 - 1}, want: 0},
 		{name: "negative cache counters ignored", totals: TurnBenchTotals{InputTokens: 100, CachedInputTokens: -20, CacheWriteTokens: -10}, want: 100},
 	}
 	for _, test := range tests {

--- a/internal/perfbench/turn_bench_test.go
+++ b/internal/perfbench/turn_bench_test.go
@@ -74,6 +74,7 @@ func TestRunTurnBenchAggregation(t *testing.T) {
 		"t3": cannedTrace(150, 20, 1500),
 		"t4": cannedTrace(300, 10, 1000),
 	}
+	canned["t1"].Counters = append(canned["t1"].Counters, trace.Counter{Name: trace.CounterCacheWriteTokens, Value: 125})
 	cfg := TurnBenchConfig{
 		Model:      "fake-model",
 		Iterations: 1,
@@ -154,6 +155,9 @@ func TestRunTurnBenchAggregation(t *testing.T) {
 	}
 	if result.Totals.InputTokens != 5500 {
 		t.Fatalf("inputTokens = %d, want 5500", result.Totals.InputTokens)
+	}
+	if result.Totals.CacheWriteTokens != 125 {
+		t.Fatalf("cacheWriteTokens = %d, want 125", result.Totals.CacheWriteTokens)
 	}
 	if result.Totals.OutputTokens != 2750 {
 		t.Fatalf("outputTokens = %d, want 2750", result.Totals.OutputTokens)

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -72,15 +72,19 @@ const (
 
 // responsesRequest is the wire shape POSTed to {baseURL}/responses.
 type responsesRequest struct {
-	Model           string              `json:"model"`
-	Instructions    string              `json:"instructions"`
-	Input           []inputItem         `json:"input"`
-	Stream          bool                `json:"stream"`
-	Store           bool                `json:"store"`
-	MaxOutputTokens int                 `json:"max_output_tokens,omitempty"`
-	Tools           []responsesTool     `json:"tools,omitempty"`
-	Reasoning       *responsesReasoning `json:"reasoning,omitempty"`
-	ServiceTier     string              `json:"service_tier,omitempty"`
+	Type               string              `json:"type,omitempty"`
+	Model              string              `json:"model"`
+	Instructions       string              `json:"instructions"`
+	PreviousResponseID string              `json:"previous_response_id,omitempty"`
+	Input              []inputItem         `json:"input"`
+	Stream             bool                `json:"stream"`
+	Store              bool                `json:"store"`
+	ParallelToolCalls  bool                `json:"parallel_tool_calls"`
+	MaxOutputTokens    int                 `json:"max_output_tokens,omitempty"`
+	Tools              []responsesTool     `json:"tools,omitempty"`
+	Reasoning          *responsesReasoning `json:"reasoning,omitempty"`
+	ServiceTier        string              `json:"service_tier,omitempty"`
+	PromptCacheKey     string              `json:"prompt_cache_key,omitempty"`
 }
 
 // responsesReasoning carries the reasoning controls for the Responses API. The
@@ -187,6 +191,7 @@ type errorPayload struct {
 // response.output_item.done.
 type toolCallBuilder struct {
 	ID        string
+	CallID    string
 	Name      string
 	Arguments strings.Builder
 	started   bool
@@ -197,13 +202,46 @@ type toolCallBuilder struct {
 // event has been emitted. It is the Responses-API equivalent of the
 // chat-completions toolState in provider.go.
 type responsesState struct {
-	toolCalls map[string]*toolCallBuilder
-	usage     *usagePayload
-	done      bool
+	toolCalls  map[string]*toolCallBuilder
+	toolOrder  []string
+	text       strings.Builder
+	responseID string
+	usage      *usagePayload
+	emitted    bool
+	done       bool
 }
 
 func newResponsesState() *responsesState {
 	return &responsesState{toolCalls: map[string]*toolCallBuilder{}}
+}
+
+func (state *responsesState) outputInputItems() []inputItem {
+	items := make([]inputItem, 0, len(state.toolOrder)+1)
+	if state.text.Len() > 0 {
+		items = append(items, inputItem{
+			Type:    "message",
+			Role:    "assistant",
+			Content: []contentItem{{Type: "output_text", Text: state.text.String()}},
+		})
+	}
+	for _, key := range state.toolOrder {
+		builder := state.toolCalls[key]
+		if builder == nil || builder.ID == "" || builder.Name == "" {
+			continue
+		}
+		callID := builder.CallID
+		if callID == "" {
+			callID = builder.ID
+		}
+		items = append(items, inputItem{
+			Type:      "function_call",
+			ID:        builder.ID,
+			CallID:    callID,
+			Name:      builder.Name,
+			Arguments: builder.Arguments.String(),
+		})
+	}
+	return items
 }
 
 // buildResponsesRequest converts a runtime CompletionRequest into the
@@ -215,9 +253,11 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 		return nil, errors.New("codex provider: model is required")
 	}
 	req := &responsesRequest{
-		Model:           p.inner.model,
-		Stream:          true,
-		MaxOutputTokens: p.inner.maxTokens,
+		Model:             p.inner.model,
+		Stream:            true,
+		ParallelToolCalls: true,
+		MaxOutputTokens:   p.inner.maxTokens,
+		PromptCacheKey:    request.PromptCacheKey,
 	}
 	instructions := []string{}
 	for _, msg := range request.Messages {
@@ -500,12 +540,17 @@ func (p *CodexProvider) emitResponsesEvent(
 		// the runtime. response.incomplete is folded into a length finish at
 		// scan-end (state.done stays false so the wrapper emits the
 		// StreamEventDone with FinishReasonLength).
+		if event.Response != nil && event.Response.ID != "" {
+			state.responseID = event.Response.ID
+		}
 		return true
 	case responsesEventOutputItemAdded:
 		p.handleOutputItemAdded(ctx, &event, state, events)
 		return true
 	case responsesEventOutputTextDelta:
 		if event.Delta != "" {
+			state.emitted = true
+			state.text.WriteString(event.Delta)
 			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
 				Type:    zeroruntime.StreamEventText,
 				Content: event.Delta,
@@ -517,6 +562,7 @@ func (p *CodexProvider) emitResponsesEvent(
 		// phase shows progress (and keeps the activity clock fresh) instead of
 		// looking like a hang. Requested via reasoning.summary="auto".
 		if event.Delta != "" {
+			state.emitted = true
 			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
 				Type:    zeroruntime.StreamEventReasoning,
 				Content: event.Delta,
@@ -575,17 +621,27 @@ func (p *CodexProvider) handleOutputItemAdded(
 		if key == "" {
 			return
 		}
-		builder := &toolCallBuilder{
-			ID:   key,
-			Name: event.Item.Name,
+		builder, exists := state.toolCalls[key]
+		if !exists {
+			builder = &toolCallBuilder{ID: key}
+			state.toolCalls[key] = builder
+			state.toolOrder = append(state.toolOrder, key)
 		}
-		state.toolCalls[key] = builder
-		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
-			Type:       zeroruntime.StreamEventToolCallStart,
-			ToolCallID: key,
-			ToolName:   event.Item.Name,
-		})
-		builder.started = true
+		if event.Item.CallID != "" {
+			builder.CallID = event.Item.CallID
+		}
+		if event.Item.Name != "" {
+			builder.Name = event.Item.Name
+		}
+		state.emitted = true
+		if !builder.started {
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+				Type:       zeroruntime.StreamEventToolCallStart,
+				ToolCallID: key,
+				ToolName:   builder.Name,
+			})
+			builder.started = true
+		}
 	}
 }
 
@@ -612,8 +668,10 @@ func (p *CodexProvider) handleFunctionArgsDelta(
 		// response.output_item.done carries the final name.
 		builder = &toolCallBuilder{ID: key}
 		state.toolCalls[key] = builder
+		state.toolOrder = append(state.toolOrder, key)
 	}
 	builder.Arguments.WriteString(event.Delta)
+	state.emitted = true
 	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
 		Type:              zeroruntime.StreamEventToolCallDelta,
 		ToolCallID:        key,
@@ -643,9 +701,13 @@ func (p *CodexProvider) handleOutputItemDone(
 	if !ok {
 		builder = &toolCallBuilder{ID: key}
 		state.toolCalls[key] = builder
+		state.toolOrder = append(state.toolOrder, key)
 	}
 	if event.Item.Name != "" {
 		builder.Name = event.Item.Name
+	}
+	if event.Item.CallID != "" {
+		builder.CallID = event.Item.CallID
 	}
 	if event.Item.Arguments != "" && builder.Arguments.Len() == 0 {
 		builder.Arguments.WriteString(event.Item.Arguments)
@@ -664,6 +726,7 @@ func (p *CodexProvider) handleOutputItemDone(
 		ToolName:   builder.Name,
 	})
 	builder.ended = true
+	state.emitted = true
 }
 
 // handleTerminalResponse emits the final usage + done event for a
@@ -693,6 +756,7 @@ func (p *CodexProvider) handleTerminalResponse(
 		return false
 	}
 	state.usage = event.Response.Usage
+	state.responseID = event.Response.ID
 	if event.Response.Usage != nil {
 		usage := zeroruntime.Usage{
 			InputTokens:  event.Response.Usage.InputTokens,
@@ -735,7 +799,7 @@ func (p *CodexProvider) handleTerminalResponse(
 		state.done = true
 		return false
 	}
-	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone, ResponseID: event.Response.ID})
 	state.done = true
 	return false
 }

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -340,8 +340,7 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 	req.Instructions = strings.Join(instructions, "\n\n")
 	for _, tool := range request.Tools {
 		definition := tool
-		if definition.Name == "apply_patch" && definition.Type == "" {
-			definition.Type = zeroruntime.ToolDefinitionFreeform
+		if definition.Name == "apply_patch" && definition.Type == zeroruntime.ToolDefinitionFreeform {
 			definition.Description = "The apply_patch tool edits files from a raw structured patch. Do not wrap the patch in JSON."
 			definition.Format = &zeroruntime.ToolDefinitionFormat{Type: "grammar", Syntax: "lark", Definition: applyPatchLarkGrammar}
 		}

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -62,6 +62,7 @@ const (
 	responsesEventReasoningDelta    = "response.reasoning_summary_text.delta"
 	responsesEventOutputTextDone    = "response.output_text.done"
 	responsesEventFunctionArgsDelta = "response.function_call_arguments.delta"
+	responsesEventCustomInputDelta  = "response.custom_tool_call_input.delta"
 	responsesEventContentPartDone   = "response.content_part.done"
 	responsesEventOutputItemDone    = "response.output_item.done"
 	responsesEventCompleted         = "response.completed"
@@ -69,6 +70,22 @@ const (
 	responsesEventError             = "response.error"
 	responsesEventIncomplete        = "response.incomplete"
 )
+
+const applyPatchLarkGrammar = `start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+%import common.LF`
 
 // responsesRequest is the wire shape POSTed to {baseURL}/responses.
 type responsesRequest struct {
@@ -109,6 +126,7 @@ type inputItem struct {
 	CallID    string `json:"call_id,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments,omitempty"`
+	Input     string `json:"input,omitempty"`
 	// function_call_output fields
 	Output any `json:"output,omitempty"`
 }
@@ -122,10 +140,11 @@ type contentItem struct {
 }
 
 type responsesTool struct {
-	Type        string         `json:"type"`
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	Parameters  map[string]any `json:"parameters,omitempty"`
+	Type        string                            `json:"type"`
+	Name        string                            `json:"name"`
+	Description string                            `json:"description,omitempty"`
+	Parameters  map[string]any                    `json:"parameters,omitempty"`
+	Format      *zeroruntime.ToolDefinitionFormat `json:"format,omitempty"`
 }
 
 // responsesEvent is the decoded form of one Responses SSE data payload.
@@ -136,6 +155,7 @@ type responsesEvent struct {
 	Delta string `json:"delta,omitempty"`
 	// item payloads (response.output_item.added / done)
 	ItemID string `json:"item_id,omitempty"`
+	CallID string `json:"call_id,omitempty"`
 	// OutputIndex is a *int so a real 0 (the first output) is distinguishable from
 	// "absent" — a plain int defaulting to 0 dropped a no-item_id call's args (M1).
 	OutputIndex *int         `json:"output_index,omitempty"`
@@ -154,6 +174,7 @@ type itemPayload struct {
 	CallID    string `json:"call_id,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments,omitempty"`
+	Input     string `json:"input,omitempty"`
 	Status    string `json:"status,omitempty"`
 }
 
@@ -194,6 +215,7 @@ type toolCallBuilder struct {
 	CallID    string
 	Name      string
 	Arguments strings.Builder
+	Freeform  bool
 	started   bool
 	ended     bool
 }
@@ -233,13 +255,22 @@ func (state *responsesState) outputInputItems() []inputItem {
 		if callID == "" {
 			callID = builder.ID
 		}
-		items = append(items, inputItem{
-			Type:      "function_call",
-			ID:        builder.ID,
-			CallID:    callID,
-			Name:      builder.Name,
-			Arguments: builder.Arguments.String(),
-		})
+		itemType := "function_call"
+		if builder.Freeform {
+			itemType = "custom_tool_call"
+		}
+		item := inputItem{
+			Type:   itemType,
+			ID:     builder.ID,
+			CallID: callID,
+			Name:   builder.Name,
+		}
+		if builder.Freeform {
+			item.Input = builder.Arguments.String()
+		} else {
+			item.Arguments = builder.Arguments.String()
+		}
+		items = append(items, item)
 	}
 	return items
 }
@@ -260,6 +291,7 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 		PromptCacheKey:    request.PromptCacheKey,
 	}
 	instructions := []string{}
+	customCallIDs := map[string]string{}
 	for _, msg := range request.Messages {
 		switch msg.Role {
 		case zeroruntime.MessageRoleSystem:
@@ -274,13 +306,31 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 				return nil, err
 			}
 			req.Input = append(req.Input, items...)
+			for _, call := range msg.ToolCalls {
+				if call.Freeform && call.ID != "" {
+					callID := call.ProviderCallID
+					if callID == "" {
+						callID = call.ID
+					}
+					customCallIDs[call.ID] = callID
+				}
+			}
 		case zeroruntime.MessageRoleTool:
 			if msg.ToolCallID == "" {
 				return nil, fmt.Errorf("codex provider: tool message missing tool call id")
 			}
+			outputType := "function_call_output"
+			callID := msg.ToolCallProviderID
+			if callID == "" {
+				callID = msg.ToolCallID
+			}
+			if customID, custom := customCallIDs[msg.ToolCallID]; custom {
+				outputType = "custom_tool_call_output"
+				callID = customID
+			}
 			req.Input = append(req.Input, inputItem{
-				Type:   "function_call_output",
-				CallID: msg.ToolCallID,
+				Type:   outputType,
+				CallID: callID,
 				Output: msg.Content,
 			})
 		default:
@@ -289,12 +339,26 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 	}
 	req.Instructions = strings.Join(instructions, "\n\n")
 	for _, tool := range request.Tools {
-		req.Tools = append(req.Tools, responsesTool{
-			Type:        "function",
-			Name:        tool.Name,
-			Description: tool.Description,
-			Parameters:  tool.Parameters,
-		})
+		definition := tool
+		if definition.Name == "apply_patch" && definition.Type == "" {
+			definition.Type = zeroruntime.ToolDefinitionFreeform
+			definition.Description = "The apply_patch tool edits files from a raw structured patch. Do not wrap the patch in JSON."
+			definition.Format = &zeroruntime.ToolDefinitionFormat{Type: "grammar", Syntax: "lark", Definition: applyPatchLarkGrammar}
+		}
+		wireTool := responsesTool{
+			Type:        string(definition.Type),
+			Name:        definition.Name,
+			Description: definition.Description,
+			Parameters:  definition.Parameters,
+			Format:      definition.Format,
+		}
+		if wireTool.Type == "" {
+			wireTool.Type = string(zeroruntime.ToolDefinitionFunction)
+		}
+		if wireTool.Type == string(zeroruntime.ToolDefinitionFreeform) {
+			wireTool.Parameters = nil
+		}
+		req.Tools = append(req.Tools, wireTool)
 	}
 	// Codex / o-series reasoning models take the effort tier nested under
 	// `reasoning` on the Responses API (the chat-completions `reasoning_effort`
@@ -352,13 +416,26 @@ func (p *CodexProvider) assistantInputItems(msg zeroruntime.Message) ([]inputIte
 		if tc.Name == "" {
 			return nil, errors.New("codex provider: assistant tool call missing name")
 		}
-		items = append(items, inputItem{
-			Type:      "function_call",
-			ID:        tc.ID,
-			CallID:    tc.ID,
-			Name:      tc.Name,
-			Arguments: tc.Arguments,
-		})
+		callID := tc.ProviderCallID
+		if callID == "" {
+			callID = tc.ID
+		}
+		itemType := "function_call"
+		if tc.Freeform {
+			itemType = "custom_tool_call"
+		}
+		item := inputItem{
+			Type:   itemType,
+			ID:     tc.ID,
+			CallID: callID,
+			Name:   tc.Name,
+		}
+		if tc.Freeform {
+			item.Input = tc.Arguments
+		} else {
+			item.Arguments = tc.Arguments
+		}
+		items = append(items, item)
 	}
 	return items, nil
 }
@@ -570,7 +647,10 @@ func (p *CodexProvider) emitResponsesEvent(
 		}
 		return true
 	case responsesEventFunctionArgsDelta:
-		p.handleFunctionArgsDelta(ctx, &event, state, events)
+		p.handleToolInputDelta(ctx, &event, state, events, false)
+		return true
+	case responsesEventCustomInputDelta:
+		p.handleToolInputDelta(ctx, &event, state, events, true)
 		return true
 	case responsesEventOutputItemDone:
 		p.handleOutputItemDone(ctx, &event, state, events)
@@ -616,14 +696,14 @@ func (p *CodexProvider) handleOutputItemAdded(
 		return
 	}
 	switch event.Item.Type {
-	case "function_call":
+	case "function_call", "custom_tool_call":
 		key := p.toolCallKey(event)
 		if key == "" {
 			return
 		}
 		builder, exists := state.toolCalls[key]
 		if !exists {
-			builder = &toolCallBuilder{ID: key}
+			builder = &toolCallBuilder{ID: key, Freeform: event.Item.Type == "custom_tool_call"}
 			state.toolCalls[key] = builder
 			state.toolOrder = append(state.toolOrder, key)
 		}
@@ -633,12 +713,18 @@ func (p *CodexProvider) handleOutputItemAdded(
 		if event.Item.Name != "" {
 			builder.Name = event.Item.Name
 		}
+		builder.Freeform = builder.Freeform || event.Item.Type == "custom_tool_call"
+		if builder.Freeform && event.Item.Input != "" && builder.Arguments.Len() == 0 {
+			builder.Arguments.WriteString(event.Item.Input)
+		}
 		state.emitted = true
 		if !builder.started {
 			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
-				Type:       zeroruntime.StreamEventToolCallStart,
-				ToolCallID: key,
-				ToolName:   builder.Name,
+				Type:               zeroruntime.StreamEventToolCallStart,
+				ToolCallID:         key,
+				ToolCallProviderID: builder.CallID,
+				ToolName:           builder.Name,
+				ToolCallFreeform:   builder.Freeform,
 			})
 			builder.started = true
 		}
@@ -649,11 +735,12 @@ func (p *CodexProvider) handleOutputItemAdded(
 // to the in-flight builder and emits StreamEventToolCallDelta. The
 // Codex backend uses either `item_id` or `output_index` to attribute
 // the delta; we honor both.
-func (p *CodexProvider) handleFunctionArgsDelta(
+func (p *CodexProvider) handleToolInputDelta(
 	ctx context.Context,
 	event *responsesEvent,
 	state *responsesState,
 	events chan<- zeroruntime.StreamEvent,
+	freeform bool,
 ) {
 	key := p.toolCallKey(event)
 	if key == "" {
@@ -666,9 +753,13 @@ func (p *CodexProvider) handleFunctionArgsDelta(
 		// an intermediate proxy). Treat the delta as the start of a new
 		// tool call with no known name yet — the eventual
 		// response.output_item.done carries the final name.
-		builder = &toolCallBuilder{ID: key}
+		builder = &toolCallBuilder{ID: key, Freeform: freeform}
 		state.toolCalls[key] = builder
 		state.toolOrder = append(state.toolOrder, key)
+	}
+	builder.Freeform = builder.Freeform || freeform
+	if event.CallID != "" && builder.CallID == "" {
+		builder.CallID = event.CallID
 	}
 	builder.Arguments.WriteString(event.Delta)
 	state.emitted = true
@@ -690,7 +781,7 @@ func (p *CodexProvider) handleOutputItemDone(
 	state *responsesState,
 	events chan<- zeroruntime.StreamEvent,
 ) {
-	if event.Item == nil || event.Item.Type != "function_call" {
+	if event.Item == nil || (event.Item.Type != "function_call" && event.Item.Type != "custom_tool_call") {
 		return
 	}
 	key := p.toolCallKey(event)
@@ -699,7 +790,7 @@ func (p *CodexProvider) handleOutputItemDone(
 	}
 	builder, ok := state.toolCalls[key]
 	if !ok {
-		builder = &toolCallBuilder{ID: key}
+		builder = &toolCallBuilder{ID: key, Freeform: event.Item.Type == "custom_tool_call"}
 		state.toolCalls[key] = builder
 		state.toolOrder = append(state.toolOrder, key)
 	}
@@ -709,14 +800,21 @@ func (p *CodexProvider) handleOutputItemDone(
 	if event.Item.CallID != "" {
 		builder.CallID = event.Item.CallID
 	}
-	if event.Item.Arguments != "" && builder.Arguments.Len() == 0 {
-		builder.Arguments.WriteString(event.Item.Arguments)
+	builder.Freeform = builder.Freeform || event.Item.Type == "custom_tool_call"
+	finalInput := event.Item.Arguments
+	if builder.Freeform {
+		finalInput = event.Item.Input
+	}
+	if finalInput != "" && builder.Arguments.Len() == 0 {
+		builder.Arguments.WriteString(finalInput)
 	}
 	if !builder.started {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
-			Type:       zeroruntime.StreamEventToolCallStart,
-			ToolCallID: key,
-			ToolName:   builder.Name,
+			Type:               zeroruntime.StreamEventToolCallStart,
+			ToolCallID:         key,
+			ToolCallProviderID: builder.CallID,
+			ToolName:           builder.Name,
+			ToolCallFreeform:   builder.Freeform,
 		})
 		builder.started = true
 	}
@@ -817,6 +915,9 @@ func (p *CodexProvider) toolCallKey(event *responsesEvent) string {
 	}
 	if event.Item != nil && event.Item.CallID != "" {
 		return event.Item.CallID
+	}
+	if event.CallID != "" {
+		return event.CallID
 	}
 	if event.OutputIndex != nil {
 		// output_index is present (a *int distinguishes a real 0 — the first output

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -198,7 +198,8 @@ type outputDetails struct {
 }
 
 type inputDetails struct {
-	CachedTokens int `json:"cached_tokens"`
+	CachedTokens     int `json:"cached_tokens"`
+	CacheWriteTokens int `json:"cache_write_tokens"`
 }
 
 type errorPayload struct {
@@ -861,6 +862,7 @@ func (p *CodexProvider) handleTerminalResponse(
 		}
 		if event.Response.Usage.InputTokensDetails != nil {
 			usage.CachedInputTokens = event.Response.Usage.InputTokensDetails.CachedTokens
+			usage.CacheWriteTokens = event.Response.Usage.InputTokensDetails.CacheWriteTokens
 		}
 		if event.Response.Usage.OutputTokensDetails != nil {
 			usage.ReasoningTokens = event.Response.Usage.OutputTokensDetails.ReasoningTokens

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -342,7 +342,7 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 	for _, tool := range request.Tools {
 		definition := tool
 		if definition.Name == "apply_patch" && definition.Type == zeroruntime.ToolDefinitionFreeform {
-			definition.Description = "The apply_patch tool edits files from a raw structured patch. Do not wrap the patch in JSON."
+			definition.Description = "The apply_patch tool edits files from a raw structured patch. Use absolute file paths in patch headers to target a granted extra write root. Do not wrap the patch in JSON."
 			definition.Format = &zeroruntime.ToolDefinitionFormat{Type: "grammar", Syntax: "lark", Definition: applyPatchLarkGrammar}
 		}
 		wireTool := responsesTool{

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -596,6 +596,18 @@ func (p *CodexProvider) emitResponsesEvent(
 		state.done = true
 		return false
 	}
+	return p.emitParsedResponsesEvent(ctx, &event, state, events)
+}
+
+// emitParsedResponsesEvent converts one already-decoded Responses event into
+// zero or more runtime events. WebSocket sessions use this path to avoid
+// decoding each frame twice; the SSE path retains emitResponsesEvent above.
+func (p *CodexProvider) emitParsedResponsesEvent(
+	ctx context.Context,
+	event *responsesEvent,
+	state *responsesState,
+	events chan<- zeroruntime.StreamEvent,
+) bool {
 	if event.Type == "" {
 		// A payload that parses as JSON but carries no `type` field is a
 		// malformed Responses event — the type is the discriminator that
@@ -622,7 +634,7 @@ func (p *CodexProvider) emitResponsesEvent(
 		}
 		return true
 	case responsesEventOutputItemAdded:
-		p.handleOutputItemAdded(ctx, &event, state, events)
+		p.handleOutputItemAdded(ctx, event, state, events)
 		return true
 	case responsesEventOutputTextDelta:
 		if event.Delta != "" {
@@ -647,16 +659,16 @@ func (p *CodexProvider) emitResponsesEvent(
 		}
 		return true
 	case responsesEventFunctionArgsDelta:
-		p.handleToolInputDelta(ctx, &event, state, events, false)
+		p.handleToolInputDelta(ctx, event, state, events, false)
 		return true
 	case responsesEventCustomInputDelta:
-		p.handleToolInputDelta(ctx, &event, state, events, true)
+		p.handleToolInputDelta(ctx, event, state, events, true)
 		return true
 	case responsesEventOutputItemDone:
-		p.handleOutputItemDone(ctx, &event, state, events)
+		p.handleOutputItemDone(ctx, event, state, events)
 		return true
 	case responsesEventCompleted, responsesEventFailed:
-		return p.handleTerminalResponse(ctx, &event, state, events)
+		return p.handleTerminalResponse(ctx, event, state, events)
 	case responsesEventError:
 		message := event.Message
 		if event.Code != "" {

--- a/internal/providers/openai/codex_session.go
+++ b/internal/providers/openai/codex_session.go
@@ -210,10 +210,12 @@ func (session *codexTurnSession) streamWebSocket(
 	for {
 		readCtx := ctx
 		cancel := func() {}
-		if timeout := session.provider.inner.streamIdleTimeout; timeout > 0 {
-			readCtx, cancel = context.WithTimeout(ctx, timeout)
+		idleTimeout := session.provider.inner.streamIdleTimeout
+		if idleTimeout > 0 {
+			readCtx, cancel = context.WithTimeout(ctx, idleTimeout)
 		}
 		messageType, data, err := connection.Read(readCtx)
+		readTimedOut := errors.Is(readCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil
 		cancel()
 		if err != nil {
 			session.disableWebSocket(connection)
@@ -224,9 +226,13 @@ func (session *codexTurnSession) streamWebSocket(
 				session.forwardHTTP(ctx, runtimeRequest, events)
 				return
 			}
+			errorMessage := err.Error()
+			if readTimedOut {
+				errorMessage = providerio.StreamTimeoutMessage(providerio.ErrStreamIdle, idleTimeout)
+			}
 			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
 				Type:  zeroruntime.StreamEventError,
-				Error: session.provider.redact("provider stream error: " + err.Error()),
+				Error: session.provider.redact("provider stream error: " + errorMessage),
 			})
 			return
 		}
@@ -275,7 +281,10 @@ func (session *codexTurnSession) streamWebSocket(
 func (session *codexTurnSession) forwardHTTP(ctx context.Context, request zeroruntime.CompletionRequest, events chan<- zeroruntime.StreamEvent) {
 	stream, err := session.provider.StreamCompletion(ctx, request)
 	if err != nil {
-		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: err.Error()})
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: session.provider.redact(err.Error()),
+		})
 		return
 	}
 	for event := range stream {

--- a/internal/providers/openai/codex_session.go
+++ b/internal/providers/openai/codex_session.go
@@ -1,0 +1,375 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+	"github.com/Gitlawb/zero/internal/trace"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+const (
+	responsesWebSocketBetaHeader = "OpenAI-Beta"
+	responsesWebSocketBetaValue  = "responses_websockets=2026-02-06"
+	responsesWebSocketRequest    = "response.create"
+	previousResponseNotFoundCode = "previous_response_not_found"
+	webSocketConnectionLimitCode = "websocket_connection_limit_reached"
+	responsesWebSocketReadLimit  = 16 << 20
+)
+
+// NewCodexTurnSessionProvider enables one Responses WebSocket connection for
+// each agent run. The session falls back to the existing HTTP/SSE provider when
+// the endpoint cannot upgrade or loses its response chain.
+func NewCodexTurnSessionProvider(provider *CodexProvider, caps zeroruntime.ProviderCapabilities) zeroruntime.TurnSessionProvider {
+	return &codexTurnSessionProvider{provider: provider, caps: caps}
+}
+
+type codexTurnSessionProvider struct {
+	provider *CodexProvider
+	caps     zeroruntime.ProviderCapabilities
+}
+
+func (provider *codexTurnSessionProvider) OpenTurnSession(ctx context.Context) (zeroruntime.TurnSession, error) {
+	if provider == nil || provider.provider == nil || provider.provider.inner == nil {
+		return nil, errors.New("codex turn session requires a provider")
+	}
+	sessionCtx, cancel := context.WithCancel(ctx)
+	return &codexTurnSession{
+		ctx:         sessionCtx,
+		cancel:      cancel,
+		provider:    provider.provider,
+		prewarmDone: make(chan struct{}),
+	}, nil
+}
+
+func (provider *codexTurnSessionProvider) Capabilities() zeroruntime.ProviderCapabilities {
+	return provider.caps
+}
+
+type codexTurnSession struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	provider *CodexProvider
+
+	mu             sync.Mutex
+	connection     *websocket.Conn
+	webSocketOff   bool
+	lastRequest    *responsesRequest
+	lastResponseID string
+	lastOutput     []inputItem
+
+	prewarmOnce sync.Once
+	prewarmDone chan struct{}
+	closeOnce   sync.Once
+}
+
+// Prewarm starts the WebSocket handshake without blocking prompt assembly. The
+// first Stream waits for this bounded attempt; failure simply selects HTTP/SSE.
+func (session *codexTurnSession) Prewarm(ctx context.Context) error {
+	session.prewarmOnce.Do(func() {
+		go func() {
+			defer close(session.prewarmDone)
+			prewarmCtx, cancel := context.WithTimeout(session.ctx, prewarmTimeout)
+			defer cancel()
+			recorder := trace.FromContext(ctx)
+			span := recorder.Span(trace.SpanProviderPrewarm)
+			defer span.End()
+			recorder.Counter(trace.CounterPrewarmAttempts, 1)
+			connection, err := session.provider.dialResponsesWebSocket(prewarmCtx)
+			session.mu.Lock()
+			defer session.mu.Unlock()
+			if err != nil {
+				session.webSocketOff = true
+				return
+			}
+			session.connection = connection
+		}()
+	})
+	return nil
+}
+
+func (session *codexTurnSession) Stream(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	_ = session.Prewarm(ctx)
+	select {
+	case <-session.prewarmDone:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	fullRequest, err := session.provider.buildResponsesRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	session.mu.Lock()
+	if session.webSocketOff || session.connection == nil {
+		session.mu.Unlock()
+		return session.provider.StreamCompletion(ctx, request)
+	}
+	connection := session.connection
+	wireRequest := *fullRequest
+	wireRequest.Type = responsesWebSocketRequest
+	if delta, ok := responseInputDelta(session.lastRequest, session.lastOutput, fullRequest); ok && session.lastResponseID != "" {
+		wireRequest.PreviousResponseID = session.lastResponseID
+		wireRequest.Input = delta
+	} else if session.lastRequest != nil {
+		session.lastRequest = nil
+		session.lastResponseID = ""
+		session.lastOutput = nil
+	}
+	session.mu.Unlock()
+
+	body, err := json.Marshal(wireRequest)
+	if err != nil {
+		return nil, fmt.Errorf("encode codex websocket request: %w", err)
+	}
+	events := make(chan zeroruntime.StreamEvent, 16)
+	go func() {
+		defer close(events)
+		session.streamWebSocket(ctx, connection, body, fullRequest, request, events)
+	}()
+	return events, nil
+}
+
+func (session *codexTurnSession) Compact(context.Context, zeroruntime.CompletionRequest) ([]zeroruntime.Message, error) {
+	return nil, zeroruntime.ErrCompactionUnsupported
+}
+
+func (session *codexTurnSession) Close() error {
+	session.closeOnce.Do(func() {
+		session.cancel()
+		session.prewarmOnce.Do(func() { close(session.prewarmDone) })
+		select {
+		case <-session.prewarmDone:
+		case <-time.After(prewarmTimeout):
+		}
+		session.mu.Lock()
+		connection := session.connection
+		session.connection = nil
+		session.webSocketOff = true
+		session.mu.Unlock()
+		if connection != nil {
+			_ = connection.CloseNow()
+		}
+	})
+	return nil
+}
+
+func responseInputDelta(previous *responsesRequest, output []inputItem, current *responsesRequest) ([]inputItem, bool) {
+	if previous == nil || current == nil || !responsesRequestPropertiesEqual(previous, current) {
+		return nil, false
+	}
+	prefix := make([]inputItem, 0, len(previous.Input)+len(output))
+	prefix = append(prefix, previous.Input...)
+	prefix = append(prefix, output...)
+	if len(current.Input) <= len(prefix) || !reflect.DeepEqual(current.Input[:len(prefix)], prefix) {
+		return nil, false
+	}
+	return append([]inputItem(nil), current.Input[len(prefix):]...), true
+}
+
+func responsesRequestPropertiesEqual(left, right *responsesRequest) bool {
+	return left.Model == right.Model &&
+		left.Instructions == right.Instructions &&
+		left.Stream == right.Stream &&
+		left.Store == right.Store &&
+		left.ParallelToolCalls == right.ParallelToolCalls &&
+		left.MaxOutputTokens == right.MaxOutputTokens &&
+		reflect.DeepEqual(left.Tools, right.Tools) &&
+		reflect.DeepEqual(left.Reasoning, right.Reasoning) &&
+		left.ServiceTier == right.ServiceTier &&
+		left.PromptCacheKey == right.PromptCacheKey
+}
+
+func (session *codexTurnSession) streamWebSocket(
+	ctx context.Context,
+	connection *websocket.Conn,
+	body []byte,
+	fullRequest *responsesRequest,
+	runtimeRequest zeroruntime.CompletionRequest,
+	events chan<- zeroruntime.StreamEvent,
+) {
+	if err := connection.Write(ctx, websocket.MessageText, body); err != nil {
+		session.disableWebSocket(connection)
+		session.forwardHTTP(ctx, runtimeRequest, events)
+		return
+	}
+
+	state := newResponsesState()
+	for {
+		readCtx := ctx
+		cancel := func() {}
+		if timeout := session.provider.inner.streamIdleTimeout; timeout > 0 {
+			readCtx, cancel = context.WithTimeout(ctx, timeout)
+		}
+		messageType, data, err := connection.Read(readCtx)
+		cancel()
+		if err != nil {
+			session.disableWebSocket(connection)
+			if ctx.Err() != nil {
+				return
+			}
+			if !state.emitted {
+				session.forwardHTTP(ctx, runtimeRequest, events)
+				return
+			}
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+				Type:  zeroruntime.StreamEventError,
+				Error: session.provider.redact("provider stream error: " + err.Error()),
+			})
+			return
+		}
+		if messageType != websocket.MessageText {
+			continue
+		}
+
+		var responseEvent responsesEvent
+		if err := json.Unmarshal(data, &responseEvent); err == nil {
+			if (responseEvent.Code == previousResponseNotFoundCode || responseEvent.Code == webSocketConnectionLimitCode) &&
+				!state.emitted {
+				session.disableWebSocket(connection)
+				session.forwardHTTP(ctx, runtimeRequest, events)
+				return
+			}
+			if responseEvent.Type == responsesEventIncomplete {
+				session.disableWebSocket(connection)
+				providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+					Type:         zeroruntime.StreamEventDone,
+					FinishReason: zeroruntime.FinishReasonLength,
+				})
+				return
+			}
+		}
+
+		keepReading := session.provider.emitResponsesEvent(ctx, string(data), state, events)
+		if keepReading {
+			continue
+		}
+		if responseEvent.Type == responsesEventCompleted && responseEvent.Response != nil &&
+			responseEvent.Response.Error == nil && responseEvent.Response.Status != "failed" && state.responseID != "" {
+			session.mu.Lock()
+			if session.connection == connection && !session.webSocketOff {
+				requestCopy := *fullRequest
+				requestCopy.Input = append([]inputItem(nil), fullRequest.Input...)
+				session.lastRequest = &requestCopy
+				session.lastResponseID = state.responseID
+				session.lastOutput = state.outputInputItems()
+			}
+			session.mu.Unlock()
+		}
+		return
+	}
+}
+
+func (session *codexTurnSession) forwardHTTP(ctx context.Context, request zeroruntime.CompletionRequest, events chan<- zeroruntime.StreamEvent) {
+	stream, err := session.provider.StreamCompletion(ctx, request)
+	if err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: err.Error()})
+		return
+	}
+	for event := range stream {
+		providerio.SendEvent(ctx, events, event)
+	}
+}
+
+func (session *codexTurnSession) disableWebSocket(connection *websocket.Conn) {
+	session.mu.Lock()
+	if session.connection == connection {
+		session.connection = nil
+		session.webSocketOff = true
+		session.lastRequest = nil
+		session.lastResponseID = ""
+		session.lastOutput = nil
+	}
+	session.mu.Unlock()
+	_ = connection.CloseNow()
+}
+
+func (provider *CodexProvider) dialResponsesWebSocket(ctx context.Context) (*websocket.Conn, error) {
+	endpoint, err := responsesWebSocketURL(provider.inner.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	for authTry := 0; authTry < 2; authTry++ {
+		headers, err := provider.responsesWebSocketHeaders(ctx, authTry == 1)
+		if err != nil {
+			return nil, err
+		}
+		connection, response, err := websocket.Dial(ctx, endpoint, &websocket.DialOptions{
+			HTTPClient:      provider.inner.httpClient,
+			HTTPHeader:      headers,
+			CompressionMode: websocket.CompressionNoContextTakeover,
+		})
+		if err == nil {
+			connection.SetReadLimit(responsesWebSocketReadLimit)
+			return connection, nil
+		}
+		if response == nil || response.StatusCode != http.StatusUnauthorized || provider.inner.oauthResolver == nil || authTry == 1 {
+			return nil, err
+		}
+	}
+	return nil, errors.New("codex websocket authentication failed")
+}
+
+func (provider *CodexProvider) responsesWebSocketHeaders(ctx context.Context, forceRefresh bool) (http.Header, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, provider.inner.endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	base := providerio.AuthHeaders{
+		APIKey:            provider.inner.apiKey,
+		DefaultAuthHeader: "Authorization",
+		DefaultAuthScheme: "Bearer",
+		AuthHeader:        provider.inner.authHeader,
+		AuthScheme:        provider.inner.authScheme,
+		AuthHeaderValue:   provider.inner.authHeaderValue,
+		CustomHeaders:     provider.inner.customHeaders,
+	}
+	if resolver := provider.inner.oauthResolver; resolver != nil {
+		header, value, ok, err := resolver(ctx, forceRefresh)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{CustomHeaders: provider.inner.customHeaders})
+			if strings.TrimSpace(header) == "" {
+				header = "Authorization"
+			}
+			request.Header.Set(header, value)
+		} else {
+			providerio.ApplyAuthHeaders(request, base)
+		}
+	} else {
+		providerio.ApplyAuthHeaders(request, base)
+	}
+	provider.injectCodexHeaders(request)
+	request.Header.Set(responsesWebSocketBetaHeader, responsesWebSocketBetaValue)
+	return request.Header.Clone(), nil
+}
+
+func responsesWebSocketURL(endpoint string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil {
+		return "", err
+	}
+	switch parsed.Scheme {
+	case "http":
+		parsed.Scheme = "ws"
+	case "https":
+		parsed.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("unsupported Responses websocket URL scheme %q", parsed.Scheme)
+	}
+	return parsed.String(), nil
+}

--- a/internal/providers/openai/codex_session.go
+++ b/internal/providers/openai/codex_session.go
@@ -28,6 +28,8 @@ const (
 	responsesWebSocketReadLimit  = 16 << 20
 )
 
+var errCodexTurnSessionBusy = errors.New("codex turn session already has an active stream")
+
 // NewCodexTurnSessionProvider enables one Responses WebSocket connection for
 // each agent run. The session falls back to the existing HTTP/SSE provider when
 // the endpoint cannot upgrade or loses its response chain.
@@ -68,6 +70,7 @@ type codexTurnSession struct {
 	lastRequest    *responsesRequest
 	lastResponseID string
 	lastOutput     []inputItem
+	streamActive   bool
 
 	prewarmOnce sync.Once
 	prewarmDone chan struct{}
@@ -113,11 +116,16 @@ func (session *codexTurnSession) Stream(ctx context.Context, request zeroruntime
 	}
 
 	session.mu.Lock()
+	if session.streamActive {
+		session.mu.Unlock()
+		return nil, errCodexTurnSessionBusy
+	}
 	if session.webSocketOff || session.connection == nil {
 		session.mu.Unlock()
 		trace.FromContext(ctx).Counter(trace.CounterResponsesHTTPFallback, 1)
 		return session.provider.StreamCompletion(ctx, request)
 	}
+	session.streamActive = true
 	connection := session.connection
 	wireRequest := *fullRequest
 	wireRequest.Type = responsesWebSocketRequest
@@ -135,14 +143,22 @@ func (session *codexTurnSession) Stream(ctx context.Context, request zeroruntime
 
 	body, err := json.Marshal(wireRequest)
 	if err != nil {
+		session.releaseStream()
 		return nil, fmt.Errorf("encode codex websocket request: %w", err)
 	}
 	events := make(chan zeroruntime.StreamEvent, 16)
 	go func() {
 		defer close(events)
+		defer session.releaseStream()
 		session.streamWebSocket(ctx, connection, body, fullRequest, request, events)
 	}()
 	return events, nil
+}
+
+func (session *codexTurnSession) releaseStream() {
+	session.mu.Lock()
+	session.streamActive = false
+	session.mu.Unlock()
 }
 
 func (session *codexTurnSession) Compact(context.Context, zeroruntime.CompletionRequest) ([]zeroruntime.Message, error) {

--- a/internal/providers/openai/codex_session.go
+++ b/internal/providers/openai/codex_session.go
@@ -115,6 +115,7 @@ func (session *codexTurnSession) Stream(ctx context.Context, request zeroruntime
 	session.mu.Lock()
 	if session.webSocketOff || session.connection == nil {
 		session.mu.Unlock()
+		trace.FromContext(ctx).Counter(trace.CounterResponsesHTTPFallback, 1)
 		return session.provider.StreamCompletion(ctx, request)
 	}
 	connection := session.connection
@@ -123,7 +124,9 @@ func (session *codexTurnSession) Stream(ctx context.Context, request zeroruntime
 	if delta, ok := responseInputDelta(session.lastRequest, session.lastOutput, fullRequest); ok && session.lastResponseID != "" {
 		wireRequest.PreviousResponseID = session.lastResponseID
 		wireRequest.Input = delta
+		trace.FromContext(ctx).Counter(trace.CounterResponseChainReused, 1)
 	} else if session.lastRequest != nil {
+		trace.FromContext(ctx).Counter(trace.CounterResponseChainReset, 1)
 		session.lastRequest = nil
 		session.lastResponseID = ""
 		session.lastOutput = nil
@@ -279,6 +282,7 @@ func (session *codexTurnSession) streamWebSocket(
 }
 
 func (session *codexTurnSession) forwardHTTP(ctx context.Context, request zeroruntime.CompletionRequest, events chan<- zeroruntime.StreamEvent) {
+	trace.FromContext(ctx).Counter(trace.CounterResponsesHTTPFallback, 1)
 	stream, err := session.provider.StreamCompletion(ctx, request)
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{

--- a/internal/providers/openai/codex_session.go
+++ b/internal/providers/openai/codex_session.go
@@ -244,7 +244,8 @@ func (session *codexTurnSession) streamWebSocket(
 		}
 
 		var responseEvent responsesEvent
-		if err := json.Unmarshal(data, &responseEvent); err == nil {
+		decodeErr := json.Unmarshal(data, &responseEvent)
+		if decodeErr == nil {
 			if (responseEvent.Code == previousResponseNotFoundCode || responseEvent.Code == webSocketConnectionLimitCode) &&
 				!state.emitted {
 				session.disableWebSocket(connection)
@@ -252,7 +253,7 @@ func (session *codexTurnSession) streamWebSocket(
 				return
 			}
 			if responseEvent.Type == responsesEventIncomplete {
-				session.disableWebSocket(connection)
+				session.resetResponseChain(connection)
 				providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
 					Type:         zeroruntime.StreamEventDone,
 					FinishReason: zeroruntime.FinishReasonLength,
@@ -261,7 +262,12 @@ func (session *codexTurnSession) streamWebSocket(
 			}
 		}
 
-		keepReading := session.provider.emitResponsesEvent(ctx, string(data), state, events)
+		keepReading := false
+		if decodeErr == nil {
+			keepReading = session.provider.emitParsedResponsesEvent(ctx, &responseEvent, state, events)
+		} else {
+			keepReading = session.provider.emitResponsesEvent(ctx, string(data), state, events)
+		}
 		if keepReading {
 			continue
 		}
@@ -279,6 +285,17 @@ func (session *codexTurnSession) streamWebSocket(
 		}
 		return
 	}
+}
+
+func (session *codexTurnSession) resetResponseChain(connection *websocket.Conn) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if session.connection != connection {
+		return
+	}
+	session.lastRequest = nil
+	session.lastResponseID = ""
+	session.lastOutput = nil
 }
 
 func (session *codexTurnSession) forwardHTTP(ctx context.Context, request zeroruntime.CompletionRequest, events chan<- zeroruntime.StreamEvent) {

--- a/internal/providers/openai/codex_session_test.go
+++ b/internal/providers/openai/codex_session_test.go
@@ -293,6 +293,75 @@ func TestCodexTurnSessionDoesNotReplayAfterVisibleOutput(t *testing.T) {
 	}
 }
 
+func TestCodexTurnSessionReportsWebSocketIdleTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		defer connection.CloseNow()
+		if _, _, err := connection.Read(request.Context()); err != nil {
+			return
+		}
+		writeWebSocketEvents(request.Context(), connection,
+			`{"type":"response.output_text.delta","delta":"visible"}`,
+		)
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	provider := newCodexSessionTestProvider(t, server)
+	provider.inner.streamIdleTimeout = 20 * time.Millisecond
+	session := openCodexSession(t, provider)
+	defer session.Close()
+	stream, err := session.Stream(t.Context(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var streamError string
+	for event := range stream {
+		if event.Type == zeroruntime.StreamEventError {
+			streamError = event.Error
+			break
+		}
+	}
+	if !strings.Contains(streamError, "idle timeout after 20ms") {
+		t.Fatalf("stream error = %q, want idle-timeout detail", streamError)
+	}
+}
+
+func TestCodexTurnSessionHTTPFallbackRedactsSetupError(t *testing.T) {
+	const secret = "sk-secret-fallback"
+	provider, err := NewCodexProvider(CodexOptions{Options: Options{
+		APIKey:  secret,
+		BaseURL: "https://chatgpt.example/backend-api/codex",
+		Model:   "gpt-test",
+	}})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	session := &codexTurnSession{provider: provider}
+	events := make(chan zeroruntime.StreamEvent, 1)
+	session.forwardHTTP(t.Context(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRole(secret), Content: "invalid"}},
+	}, events)
+
+	select {
+	case event := <-events:
+		if event.Type != zeroruntime.StreamEventError {
+			t.Fatalf("fallback event type = %s, want error", event.Type)
+		}
+		if strings.Contains(event.Error, secret) {
+			t.Fatalf("fallback error leaked credential: %q", event.Error)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fallback did not emit setup error")
+	}
+}
+
 func TestCodexTurnSessionCloseDoesNotStartPrewarm(t *testing.T) {
 	provider, err := NewCodexProvider(CodexOptions{Options: Options{
 		APIKey:  "test-token",

--- a/internal/providers/openai/codex_session_test.go
+++ b/internal/providers/openai/codex_session_test.go
@@ -1,0 +1,391 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestCodexTurnSessionChainsOnlyAppendOnlyRequests(t *testing.T) {
+	var mu sync.Mutex
+	requests := []map[string]any{}
+	betaHeader := ""
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if !strings.EqualFold(request.Header.Get("Upgrade"), "websocket") {
+			http.Error(writer, "websocket required", http.StatusUpgradeRequired)
+			return
+		}
+		mu.Lock()
+		betaHeader = request.Header.Get(responsesWebSocketBetaHeader)
+		mu.Unlock()
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		defer connection.CloseNow()
+		for index := 0; index < 3; index++ {
+			_, body, err := connection.Read(request.Context())
+			if err != nil {
+				return
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return
+			}
+			mu.Lock()
+			requests = append(requests, payload)
+			mu.Unlock()
+			switch index {
+			case 0:
+				writeWebSocketEvents(request.Context(), connection,
+					`{"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`,
+					`{"type":"response.output_item.added","item_id":"call-1","item":{"type":"function_call","id":"call-1","call_id":"call-1","name":"read_file"}}`,
+					`{"type":"response.function_call_arguments.delta","item_id":"call-1","delta":"{}"}`,
+					`{"type":"response.output_item.done","item_id":"call-1","item":{"type":"function_call","id":"call-1","call_id":"call-1","name":"read_file","arguments":"{}"}}`,
+					`{"type":"response.completed","response":{"id":"resp-1","status":"completed"}}`,
+				)
+			case 1:
+				writeWebSocketEvents(request.Context(), connection,
+					`{"type":"response.output_text.delta","delta":"done"}`,
+					`{"type":"response.completed","response":{"id":"resp-2","status":"completed"}}`,
+				)
+			case 2:
+				writeWebSocketEvents(request.Context(), connection,
+					`{"type":"response.completed","response":{"id":"resp-3","status":"completed"}}`,
+				)
+			}
+		}
+	}))
+	defer server.Close()
+
+	provider := newCodexSessionTestProvider(t, server)
+	// A disabled stream watchdog must use the parent context rather than creating
+	// an immediately-expired read deadline.
+	provider.inner.streamIdleTimeout = 0
+	session := openCodexSession(t, provider)
+	defer session.Close()
+
+	base := zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: "Use tools carefully."},
+			{Role: zeroruntime.MessageRoleUser, Content: "Read the file."},
+		},
+		Tools:          []zeroruntime.ToolDefinition{{Name: "read_file", Parameters: map[string]any{"type": "object"}}},
+		PromptCacheKey: "session-1",
+	}
+	first := collectCodexSessionEvents(t, session, base)
+	if !hasToolCallEnd(first, "call-1") {
+		t.Fatalf("first stream did not produce the tool call: %#v", first)
+	}
+
+	second := base
+	second.Messages = append(append([]zeroruntime.Message(nil), base.Messages...),
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{ID: "call-1", Name: "read_file", Arguments: "{}"}}},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleTool, ToolCallID: "call-1", Content: "contents"},
+	)
+	secondEvents := collectCodexSessionEvents(t, session, second)
+	if got := joinedText(secondEvents); got != "done" {
+		t.Fatalf("second stream text = %q, want done", got)
+	}
+
+	third := second
+	third.ReasoningEffort = "high"
+	third.Messages = append(append([]zeroruntime.Message(nil), second.Messages...),
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "done"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "Continue."},
+	)
+	collectCodexSessionEvents(t, session, third)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requests) != 3 {
+		t.Fatalf("websocket requests = %d, want 3", len(requests))
+	}
+	if betaHeader != responsesWebSocketBetaValue {
+		t.Fatalf("OpenAI-Beta = %q, want %q", betaHeader, responsesWebSocketBetaValue)
+	}
+	if requests[0]["type"] != responsesWebSocketRequest || requests[0]["previous_response_id"] != nil {
+		t.Fatalf("first request chaining fields = %#v", requests[0])
+	}
+	if requests[0]["parallel_tool_calls"] != true || requests[0]["prompt_cache_key"] != "session-1" {
+		t.Fatalf("first request stable fields = %#v", requests[0])
+	}
+	if requests[1]["previous_response_id"] != "resp-1" {
+		t.Fatalf("second previous_response_id = %#v", requests[1]["previous_response_id"])
+	}
+	secondInput, _ := requests[1]["input"].([]any)
+	if len(secondInput) != 1 || secondInput[0].(map[string]any)["type"] != "function_call_output" {
+		t.Fatalf("second incremental input = %#v", requests[1]["input"])
+	}
+	if requests[2]["previous_response_id"] != nil {
+		t.Fatalf("incompatible request reused response chain: %#v", requests[2])
+	}
+	thirdInput, _ := requests[2]["input"].([]any)
+	if len(thirdInput) <= 1 {
+		t.Fatalf("incompatible request did not send full input: %#v", thirdInput)
+	}
+}
+
+func TestCodexTurnSessionFallsBackWhenPreviousResponseIsMissing(t *testing.T) {
+	var mu sync.Mutex
+	webSocketRequests := 0
+	httpRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.EqualFold(request.Header.Get("Upgrade"), "websocket") {
+			connection, err := websocket.Accept(writer, request, nil)
+			if err != nil {
+				return
+			}
+			defer connection.CloseNow()
+			for index := 0; index < 2; index++ {
+				if _, _, err := connection.Read(request.Context()); err != nil {
+					return
+				}
+				mu.Lock()
+				webSocketRequests++
+				mu.Unlock()
+				if index == 0 {
+					writeWebSocketEvents(request.Context(), connection,
+						`{"type":"response.output_item.added","item_id":"call-1","item":{"type":"function_call","id":"call-1","call_id":"call-1","name":"read_file"}}`,
+						`{"type":"response.output_item.done","item_id":"call-1","item":{"type":"function_call","id":"call-1","call_id":"call-1","name":"read_file","arguments":"{}"}}`,
+						`{"type":"response.completed","response":{"id":"resp-1","status":"completed"}}`,
+					)
+					continue
+				}
+				writeWebSocketEvents(request.Context(), connection,
+					`{"type":"response.error","code":"previous_response_not_found","message":"missing"}`,
+				)
+			}
+			return
+		}
+
+		mu.Lock()
+		httpRequests++
+		mu.Unlock()
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(writer, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"fallback\"}\n\n")
+		_, _ = fmt.Fprint(writer, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-http\",\"status\":\"completed\"}}\n\n")
+	}))
+	defer server.Close()
+
+	provider := newCodexSessionTestProvider(t, server)
+	session := openCodexSession(t, provider)
+	defer session.Close()
+	base := zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "Read it."}},
+		Tools:    []zeroruntime.ToolDefinition{{Name: "read_file", Parameters: map[string]any{"type": "object"}}},
+	}
+	collectCodexSessionEvents(t, session, base)
+	second := base
+	second.Messages = append(append([]zeroruntime.Message(nil), base.Messages...),
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{ID: "call-1", Name: "read_file", Arguments: "{}"}}},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleTool, ToolCallID: "call-1", Content: "contents"},
+	)
+	events := collectCodexSessionEvents(t, session, second)
+	if got := joinedText(events); got != "fallback" {
+		t.Fatalf("fallback stream text = %q, want fallback; events=%#v", got, events)
+	}
+	for _, event := range events {
+		if event.Type == zeroruntime.StreamEventError {
+			t.Fatalf("response-chain recovery leaked an error: %#v", event)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if webSocketRequests != 2 || httpRequests != 1 {
+		t.Fatalf("requests = websocket:%d http:%d, want 2/1", webSocketRequests, httpRequests)
+	}
+}
+
+func TestCodexTurnSessionFallsBackWhenSocketClosesBeforeOutput(t *testing.T) {
+	var mu sync.Mutex
+	httpRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.EqualFold(request.Header.Get("Upgrade"), "websocket") {
+			connection, err := websocket.Accept(writer, request, nil)
+			if err != nil {
+				return
+			}
+			if _, _, err := connection.Read(request.Context()); err == nil {
+				_ = connection.CloseNow()
+			}
+			return
+		}
+		mu.Lock()
+		httpRequests++
+		mu.Unlock()
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(writer, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"recovered\"}\n\n")
+		_, _ = fmt.Fprint(writer, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-http\",\"status\":\"completed\"}}\n\n")
+	}))
+	defer server.Close()
+
+	provider := newCodexSessionTestProvider(t, server)
+	session := openCodexSession(t, provider)
+	defer session.Close()
+	events := collectCodexSessionEvents(t, session, zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "Hello"}},
+	})
+	if got := joinedText(events); got != "recovered" {
+		t.Fatalf("fallback text = %q, want recovered", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if httpRequests != 1 {
+		t.Fatalf("HTTP fallback requests = %d, want 1", httpRequests)
+	}
+}
+
+func TestCodexTurnSessionDoesNotReplayAfterVisibleOutput(t *testing.T) {
+	var mu sync.Mutex
+	httpRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.EqualFold(request.Header.Get("Upgrade"), "websocket") {
+			connection, err := websocket.Accept(writer, request, nil)
+			if err != nil {
+				return
+			}
+			if _, _, err := connection.Read(request.Context()); err == nil {
+				writeWebSocketEvents(request.Context(), connection,
+					`{"type":"response.output_text.delta","delta":"visible"}`,
+				)
+			}
+			_ = connection.Close(websocket.StatusInternalError, "interrupted")
+			return
+		}
+		mu.Lock()
+		httpRequests++
+		mu.Unlock()
+	}))
+	defer server.Close()
+
+	provider := newCodexSessionTestProvider(t, server)
+	session := openCodexSession(t, provider)
+	defer session.Close()
+	stream, err := session.Stream(t.Context(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	sawText, sawError := false, false
+	for event := range stream {
+		sawText = sawText || event.Type == zeroruntime.StreamEventText
+		sawError = sawError || event.Type == zeroruntime.StreamEventError
+	}
+	if !sawText || !sawError {
+		t.Fatalf("visible interrupted stream = text:%v error:%v", sawText, sawError)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if httpRequests != 0 {
+		t.Fatalf("visible interrupted stream was replayed over HTTP %d time(s)", httpRequests)
+	}
+}
+
+func TestCodexTurnSessionCloseDoesNotStartPrewarm(t *testing.T) {
+	provider, err := NewCodexProvider(CodexOptions{Options: Options{
+		APIKey:  "test-token",
+		BaseURL: "https://chatgpt.example/backend-api/codex",
+		Model:   "gpt-test",
+	}})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	session, err := NewCodexTurnSessionProvider(provider, zeroruntime.ProviderCapabilities{}).OpenTurnSession(t.Context())
+	if err != nil {
+		t.Fatalf("OpenTurnSession: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- session.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Close blocked without a prewarm attempt")
+	}
+}
+
+func newCodexSessionTestProvider(t *testing.T, server *httptest.Server) *CodexProvider {
+	t.Helper()
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:     "test-token",
+			BaseURL:    server.URL,
+			Model:      "gpt-test",
+			HTTPClient: server.Client(),
+		},
+		AccountID: "account-test",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	return provider
+}
+
+func openCodexSession(t *testing.T, provider *CodexProvider) zeroruntime.TurnSession {
+	t.Helper()
+	session, err := NewCodexTurnSessionProvider(provider, zeroruntime.ProviderCapabilities{}).OpenTurnSession(t.Context())
+	if err != nil {
+		t.Fatalf("OpenTurnSession: %v", err)
+	}
+	if err := session.Prewarm(t.Context()); err != nil {
+		t.Fatalf("Prewarm: %v", err)
+	}
+	return session
+}
+
+func collectCodexSessionEvents(t *testing.T, session zeroruntime.TurnSession, request zeroruntime.CompletionRequest) []zeroruntime.StreamEvent {
+	t.Helper()
+	stream, err := session.Stream(t.Context(), request)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := []zeroruntime.StreamEvent{}
+	for event := range stream {
+		events = append(events, event)
+		if event.Type == zeroruntime.StreamEventError {
+			t.Fatalf("stream error: %s", event.Error)
+		}
+	}
+	return events
+}
+
+func writeWebSocketEvents(ctx context.Context, connection *websocket.Conn, events ...string) {
+	for _, event := range events {
+		if err := connection.Write(ctx, websocket.MessageText, []byte(event)); err != nil {
+			return
+		}
+	}
+}
+
+func hasToolCallEnd(events []zeroruntime.StreamEvent, id string) bool {
+	for _, event := range events {
+		if event.Type == zeroruntime.StreamEventToolCallEnd && event.ToolCallID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func joinedText(events []zeroruntime.StreamEvent) string {
+	var builder strings.Builder
+	for _, event := range events {
+		if event.Type == zeroruntime.StreamEventText {
+			builder.WriteString(event.Content)
+		}
+	}
+	return builder.String()
+}

--- a/internal/providers/openai/codex_session_test.go
+++ b/internal/providers/openai/codex_session_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -389,7 +390,7 @@ func TestCodexTurnSessionReportsWebSocketIdleTimeout(t *testing.T) {
 	defer server.Close()
 
 	provider := newCodexSessionTestProvider(t, server)
-	provider.inner.streamIdleTimeout = 20 * time.Millisecond
+	provider.inner.streamIdleTimeout = 200 * time.Millisecond
 	session := openCodexSession(t, provider)
 	defer session.Close()
 	stream, err := session.Stream(t.Context(), zeroruntime.CompletionRequest{
@@ -406,8 +407,54 @@ func TestCodexTurnSessionReportsWebSocketIdleTimeout(t *testing.T) {
 			break
 		}
 	}
-	if !strings.Contains(streamError, "idle timeout after 20ms") {
+	if !strings.Contains(streamError, "idle timeout after 200ms") {
 		t.Fatalf("stream error = %q, want idle-timeout detail", streamError)
+	}
+}
+
+func TestCodexTurnSessionRejectsOverlappingStreams(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseStream := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseStream)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		defer connection.CloseNow()
+		if _, _, err := connection.Read(request.Context()); err != nil {
+			return
+		}
+		close(started)
+		<-release
+		writeWebSocketEvents(request.Context(), connection,
+			`{"type":"response.completed","response":{"id":"resp-1","status":"completed"}}`,
+		)
+	}))
+	defer server.Close()
+
+	provider := newCodexSessionTestProvider(t, server)
+	session := openCodexSession(t, provider)
+	defer session.Close()
+	request := zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "Hello"}},
+	}
+	first, err := session.Stream(t.Context(), request)
+	if err != nil {
+		t.Fatalf("first Stream: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first WebSocket stream did not start")
+	}
+	if _, err := session.Stream(t.Context(), request); !errors.Is(err, errCodexTurnSessionBusy) {
+		t.Fatalf("overlapping Stream error = %v, want %v", err, errCodexTurnSessionBusy)
+	}
+	releaseStream()
+	for range first {
 	}
 }
 

--- a/internal/providers/openai/codex_session_test.go
+++ b/internal/providers/openai/codex_session_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/coder/websocket"
 
+	"github.com/Gitlawb/zero/internal/trace"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -74,6 +75,9 @@ func TestCodexTurnSessionChainsOnlyAppendOnlyRequests(t *testing.T) {
 	provider.inner.streamIdleTimeout = 0
 	session := openCodexSession(t, provider)
 	defer session.Close()
+	recorder := trace.NewRecorder("session-1", "run-1", "test")
+	recorder.Start()
+	streamContext := trace.WithContext(t.Context(), recorder)
 
 	base := zeroruntime.CompletionRequest{
 		Messages: []zeroruntime.Message{
@@ -93,7 +97,7 @@ func TestCodexTurnSessionChainsOnlyAppendOnlyRequests(t *testing.T) {
 		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{ID: "call-1", Name: "read_file", Arguments: "{}"}}},
 		zeroruntime.Message{Role: zeroruntime.MessageRoleTool, ToolCallID: "call-1", Content: "contents"},
 	)
-	secondEvents := collectCodexSessionEvents(t, session, second)
+	secondEvents := collectCodexSessionEventsContext(t, streamContext, session, second)
 	if got := joinedText(secondEvents); got != "done" {
 		t.Fatalf("second stream text = %q, want done", got)
 	}
@@ -104,7 +108,14 @@ func TestCodexTurnSessionChainsOnlyAppendOnlyRequests(t *testing.T) {
 		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "done"},
 		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "Continue."},
 	)
-	collectCodexSessionEvents(t, session, third)
+	collectCodexSessionEventsContext(t, streamContext, session, third)
+	finishedTrace := recorder.Finish()
+	if got := finishedTrace.Counter(trace.CounterResponseChainReused); got != 1 {
+		t.Fatalf("response-chain reuse count = %d, want 1", got)
+	}
+	if got := finishedTrace.Counter(trace.CounterResponseChainReset); got != 1 {
+		t.Fatalf("response-chain reset count = %d, want 1", got)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -233,7 +244,9 @@ func TestCodexTurnSessionFallsBackWhenSocketClosesBeforeOutput(t *testing.T) {
 	provider := newCodexSessionTestProvider(t, server)
 	session := openCodexSession(t, provider)
 	defer session.Close()
-	events := collectCodexSessionEvents(t, session, zeroruntime.CompletionRequest{
+	recorder := trace.NewRecorder("session-fallback", "run-fallback", "test")
+	recorder.Start()
+	events := collectCodexSessionEventsContext(t, trace.WithContext(t.Context(), recorder), session, zeroruntime.CompletionRequest{
 		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "Hello"}},
 	})
 	if got := joinedText(events); got != "recovered" {
@@ -243,6 +256,9 @@ func TestCodexTurnSessionFallsBackWhenSocketClosesBeforeOutput(t *testing.T) {
 	defer mu.Unlock()
 	if httpRequests != 1 {
 		t.Fatalf("HTTP fallback requests = %d, want 1", httpRequests)
+	}
+	if got := recorder.Finish().Counter(trace.CounterResponsesHTTPFallback); got != 1 {
+		t.Fatalf("responses HTTP fallback counter = %d, want 1", got)
 	}
 }
 
@@ -418,7 +434,12 @@ func openCodexSession(t *testing.T, provider *CodexProvider) zeroruntime.TurnSes
 
 func collectCodexSessionEvents(t *testing.T, session zeroruntime.TurnSession, request zeroruntime.CompletionRequest) []zeroruntime.StreamEvent {
 	t.Helper()
-	stream, err := session.Stream(t.Context(), request)
+	return collectCodexSessionEventsContext(t, t.Context(), session, request)
+}
+
+func collectCodexSessionEventsContext(t *testing.T, ctx context.Context, session zeroruntime.TurnSession, request zeroruntime.CompletionRequest) []zeroruntime.StreamEvent {
+	t.Helper()
+	stream, err := session.Stream(ctx, request)
 	if err != nil {
 		t.Fatalf("Stream: %v", err)
 	}

--- a/internal/providers/openai/codex_session_test.go
+++ b/internal/providers/openai/codex_session_test.go
@@ -262,6 +262,68 @@ func TestCodexTurnSessionFallsBackWhenSocketClosesBeforeOutput(t *testing.T) {
 	}
 }
 
+func TestCodexTurnSessionKeepsWebSocketAfterIncompleteResponse(t *testing.T) {
+	var mu sync.Mutex
+	webSocketRequests := 0
+	httpRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.EqualFold(request.Header.Get("Upgrade"), "websocket") {
+			connection, err := websocket.Accept(writer, request, nil)
+			if err != nil {
+				return
+			}
+			defer connection.CloseNow()
+			for index := 0; index < 2; index++ {
+				if _, _, err := connection.Read(request.Context()); err != nil {
+					return
+				}
+				mu.Lock()
+				webSocketRequests++
+				mu.Unlock()
+				if index == 0 {
+					writeWebSocketEvents(request.Context(), connection,
+						`{"type":"response.incomplete","response":{"id":"resp-1","status":"incomplete"}}`,
+					)
+					continue
+				}
+				writeWebSocketEvents(request.Context(), connection,
+					`{"type":"response.output_text.delta","delta":"websocket"}`,
+					`{"type":"response.completed","response":{"id":"resp-2","status":"completed"}}`,
+				)
+			}
+			return
+		}
+
+		mu.Lock()
+		httpRequests++
+		mu.Unlock()
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(writer, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"fallback\"}\n\n")
+		_, _ = fmt.Fprint(writer, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-http\",\"status\":\"completed\"}}\n\n")
+	}))
+	defer server.Close()
+
+	provider := newCodexSessionTestProvider(t, server)
+	session := openCodexSession(t, provider)
+	defer session.Close()
+	request := zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "Continue."}},
+	}
+	first := collectCodexSessionEvents(t, session, request)
+	if len(first) != 1 || first[0].Type != zeroruntime.StreamEventDone || first[0].FinishReason != zeroruntime.FinishReasonLength {
+		t.Fatalf("incomplete response events = %#v, want length completion", first)
+	}
+	second := collectCodexSessionEvents(t, session, request)
+	if got := joinedText(second); got != "websocket" {
+		t.Fatalf("second turn text = %q, want websocket; events=%#v", got, second)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if webSocketRequests != 2 || httpRequests != 0 {
+		t.Fatalf("requests = websocket:%d http:%d, want 2/0", webSocketRequests, httpRequests)
+	}
+}
+
 func TestCodexTurnSessionDoesNotReplayAfterVisibleOutput(t *testing.T) {
 	var mu sync.Mutex
 	httpRequests := 0

--- a/internal/providers/openai/codex_terminal_test.go
+++ b/internal/providers/openai/codex_terminal_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -91,7 +92,7 @@ func TestCodexApplyPatchUsesFreeformWireContract(t *testing.T) {
 			{Role: zeroruntime.MessageRoleTool, ToolCallID: "item-1", ToolCallProviderID: "call-1", Content: "Done!"},
 		},
 		Tools: []zeroruntime.ToolDefinition{{
-			Name: "apply_patch", Description: "Apply a patch.", Parameters: map[string]any{"type": "object"},
+			Name: "apply_patch", Description: "Apply a patch.", Type: zeroruntime.ToolDefinitionFreeform,
 		}},
 	})
 	if err != nil {
@@ -108,6 +109,38 @@ func TestCodexApplyPatchUsesFreeformWireContract(t *testing.T) {
 		request.Input[1].CallID != "call-1" || request.Input[1].Input != patch ||
 		request.Input[2].Type != "custom_tool_call_output" || request.Input[2].CallID != "call-1" {
 		t.Fatalf("custom apply_patch replay input = %#v", request.Input)
+	}
+}
+
+func TestCodexPreservesCustomApplyPatchFunction(t *testing.T) {
+	provider, err := NewCodexProvider(CodexOptions{Options: Options{
+		APIKey:  "test-token",
+		BaseURL: "https://chatgpt.example/backend-api/codex",
+		Model:   "gpt-test",
+	}})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	parameters := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"value": map[string]any{"type": "string"}},
+	}
+	request, err := provider.buildResponsesRequest(zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "Call the custom tool."}},
+		Tools: []zeroruntime.ToolDefinition{{
+			Name: "apply_patch", Description: "Custom integration tool.", Parameters: parameters,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildResponsesRequest: %v", err)
+	}
+	if len(request.Tools) != 1 {
+		t.Fatalf("tools = %#v, want one", request.Tools)
+	}
+	tool := request.Tools[0]
+	if tool.Type != string(zeroruntime.ToolDefinitionFunction) || tool.Format != nil ||
+		tool.Description != "Custom integration tool." || !reflect.DeepEqual(tool.Parameters, parameters) {
+		t.Fatalf("custom apply_patch function was rewritten: %#v", tool)
 	}
 }
 

--- a/internal/providers/openai/codex_terminal_test.go
+++ b/internal/providers/openai/codex_terminal_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -41,6 +42,72 @@ func TestResponsesStatePreservesDistinctCallID(t *testing.T) {
 	items := state.outputInputItems()
 	if len(items) != 1 || items[0].ID != "item-1" || items[0].CallID != "call-1" {
 		t.Fatalf("captured function call = %#v, want item id item-1 and call id call-1", items)
+	}
+}
+
+func TestCodexCustomApplyPatchStreamProducesFreeformCall(t *testing.T) {
+	provider := &CodexProvider{}
+	state := newResponsesState()
+	events := make(chan zeroruntime.StreamEvent, 16)
+	patch := "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n"
+	for _, payload := range []string{
+		`{"type":"response.output_item.added","item_id":"item-1","item":{"type":"custom_tool_call","call_id":"call-1","name":"apply_patch"}}`,
+		`{"type":"response.custom_tool_call_input.delta","item_id":"item-1","call_id":"call-1","delta":"*** Begin Patch\n*** Add File: hello.txt\n"}`,
+		`{"type":"response.custom_tool_call_input.delta","item_id":"item-1","call_id":"call-1","delta":"+hello\n*** End Patch\n"}`,
+		`{"type":"response.output_item.done","item_id":"item-1","item":{"type":"custom_tool_call","call_id":"call-1","name":"apply_patch","input":"*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n"}}`,
+		`{"type":"response.completed","response":{"id":"resp-1","status":"completed"}}`,
+	} {
+		if keepReading := provider.emitResponsesEvent(context.Background(), payload, state, events); !keepReading && !state.done {
+			t.Fatalf("stream stopped before terminal event for %s", payload)
+		}
+	}
+	close(events)
+	collected := zeroruntime.CollectStream(context.Background(), events)
+	if len(collected.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one", collected.ToolCalls)
+	}
+	call := collected.ToolCalls[0]
+	if call.ID != "item-1" || call.ProviderCallID != "call-1" || call.Name != "apply_patch" || !call.Freeform || call.Arguments != patch {
+		t.Fatalf("custom apply_patch call = %#v", call)
+	}
+}
+
+func TestCodexApplyPatchUsesFreeformWireContract(t *testing.T) {
+	provider, err := NewCodexProvider(CodexOptions{Options: Options{
+		APIKey:  "test-token",
+		BaseURL: "https://chatgpt.example/backend-api/codex",
+		Model:   "gpt-test",
+	}})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	patch := "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n"
+	request, err := provider.buildResponsesRequest(zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleUser, Content: "Add the file."},
+			{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{{
+				ID: "item-1", ProviderCallID: "call-1", Name: "apply_patch", Arguments: patch, Freeform: true,
+			}}},
+			{Role: zeroruntime.MessageRoleTool, ToolCallID: "item-1", ToolCallProviderID: "call-1", Content: "Done!"},
+		},
+		Tools: []zeroruntime.ToolDefinition{{
+			Name: "apply_patch", Description: "Apply a patch.", Parameters: map[string]any{"type": "object"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildResponsesRequest: %v", err)
+	}
+	if len(request.Tools) != 1 || request.Tools[0].Type != string(zeroruntime.ToolDefinitionFreeform) ||
+		request.Tools[0].Format == nil || request.Tools[0].Format.Syntax != "lark" || request.Tools[0].Parameters != nil {
+		t.Fatalf("apply_patch tool wire shape = %#v", request.Tools)
+	}
+	if !strings.Contains(request.Tools[0].Format.Definition, "*** Begin Patch") {
+		t.Fatalf("apply_patch grammar = %q", request.Tools[0].Format.Definition)
+	}
+	if len(request.Input) != 3 || request.Input[1].Type != "custom_tool_call" || request.Input[1].ID != "item-1" ||
+		request.Input[1].CallID != "call-1" || request.Input[1].Input != patch ||
+		request.Input[2].Type != "custom_tool_call_output" || request.Input[2].CallID != "call-1" {
+		t.Fatalf("custom apply_patch replay input = %#v", request.Input)
 	}
 }
 

--- a/internal/providers/openai/codex_terminal_test.go
+++ b/internal/providers/openai/codex_terminal_test.go
@@ -25,6 +25,25 @@ func TestToolCallKeyOutputIndexZero(t *testing.T) {
 	}
 }
 
+func TestResponsesStatePreservesDistinctCallID(t *testing.T) {
+	provider := &CodexProvider{}
+	state := newResponsesState()
+	events := make(chan zeroruntime.StreamEvent, 4)
+	provider.handleOutputItemAdded(context.Background(), &responsesEvent{
+		ItemID: "item-1",
+		Item: &itemPayload{
+			Type:   "function_call",
+			ID:     "item-1",
+			CallID: "call-1",
+			Name:   "read_file",
+		},
+	}, state, events)
+	items := state.outputInputItems()
+	if len(items) != 1 || items[0].ID != "item-1" || items[0].CallID != "call-1" {
+		t.Fatalf("captured function call = %#v, want item id item-1 and call id call-1", items)
+	}
+}
+
 func TestHandleTerminalResponseNilPayload(t *testing.T) {
 	p := &CodexProvider{}
 
@@ -90,11 +109,14 @@ func TestHandleTerminalResponseFailedPayloadWithoutError(t *testing.T) {
 	// A response.completed with a payload and no error remains a clean done.
 	ok := make(chan zeroruntime.StreamEvent, 8)
 	p.handleTerminalResponse(context.Background(),
-		&responsesEvent{Type: responsesEventCompleted, Response: &responsePayload{Status: "completed"}}, &responsesState{}, ok)
+		&responsesEvent{Type: responsesEventCompleted, Response: &responsePayload{ID: "resp-1", Status: "completed"}}, &responsesState{}, ok)
 	close(ok)
 	for ev := range ok {
 		if ev.Type == zeroruntime.StreamEventError {
 			t.Error("response.completed with a non-error payload must NOT emit an error")
+		}
+		if ev.Type == zeroruntime.StreamEventDone && ev.ResponseID != "resp-1" {
+			t.Errorf("done response id = %q, want resp-1", ev.ResponseID)
 		}
 	}
 }

--- a/internal/providers/openai/codex_terminal_test.go
+++ b/internal/providers/openai/codex_terminal_test.go
@@ -105,6 +105,9 @@ func TestCodexApplyPatchUsesFreeformWireContract(t *testing.T) {
 	if !strings.Contains(request.Tools[0].Format.Definition, "*** Begin Patch") {
 		t.Fatalf("apply_patch grammar = %q", request.Tools[0].Format.Definition)
 	}
+	if !strings.Contains(request.Tools[0].Description, "absolute file paths") || !strings.Contains(request.Tools[0].Description, "granted extra write root") {
+		t.Fatalf("apply_patch description does not explain extra-root paths: %q", request.Tools[0].Description)
+	}
 	if len(request.Input) != 3 || request.Input[1].Type != "custom_tool_call" || request.Input[1].ID != "item-1" ||
 		request.Input[1].CallID != "call-1" || request.Input[1].Input != patch ||
 		request.Input[2].Type != "custom_tool_call_output" || request.Input[2].CallID != "call-1" {

--- a/internal/providers/openai/codex_test.go
+++ b/internal/providers/openai/codex_test.go
@@ -771,7 +771,7 @@ func TestCodexProviderParsesResponsesTextDeltas(t *testing.T) {
 		`{"type":"response.output_text.delta","delta":"hello "}`,
 		`{"type":"response.output_text.delta","delta":"world"}`,
 		`{"type":"response.output_text.delta","delta":"!"}`,
-		`{"type":"response.completed","response":{"id":"resp-1","status":"completed","usage":{"input_tokens":7,"output_tokens":3,"output_tokens_details":{"reasoning_tokens":1},"input_tokens_details":{"cached_tokens":2}}}}`,
+		`{"type":"response.completed","response":{"id":"resp-1","status":"completed","usage":{"input_tokens":7,"output_tokens":3,"output_tokens_details":{"reasoning_tokens":1},"input_tokens_details":{"cached_tokens":2,"cache_write_tokens":1}}}}`,
 	)
 	defer srv.Close()
 
@@ -809,8 +809,8 @@ func TestCodexProviderParsesResponsesTextDeltas(t *testing.T) {
 	if usage == nil {
 		t.Fatal("expected a usage event, got none")
 	}
-	if usage.InputTokens != 7 || usage.OutputTokens != 3 || usage.CachedInputTokens != 2 || usage.ReasoningTokens != 1 {
-		t.Fatalf("usage = %+v, want input=7 output=3 cached=2 reasoning=1", *usage)
+	if usage.InputTokens != 7 || usage.OutputTokens != 3 || usage.CachedInputTokens != 2 || usage.CacheWriteTokens != 1 || usage.ReasoningTokens != 1 {
+		t.Fatalf("usage = %+v, want input=7 output=3 cached=2 cache-write=1 reasoning=1", *usage)
 	}
 	if !gotDone {
 		t.Fatal("expected a done event, got none")

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -357,6 +357,7 @@ func (provider *Provider) emitChunk(
 				PromptTokens:      chunk.Usage.PromptTokens,
 				CompletionTokens:  chunk.Usage.CompletionTokens,
 				CachedInputTokens: chunk.Usage.PromptTokensDetails.CachedTokens,
+				CacheWriteTokens:  chunk.Usage.PromptTokensDetails.CacheWriteTokens,
 				ReasoningTokens:   chunk.Usage.CompletionTokensDetails.ReasoningTokens,
 			},
 		})

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -260,14 +260,14 @@ func TestStreamCompletionAppliesCustomAuthAndHeaders(t *testing.T) {
 func TestStreamCompletionEmitsTextUsageAndDone(t *testing.T) {
 	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"choices":[{"delta":{"content":"hello "}}]}`)
-		writeSSE(w, `{"choices":[{"delta":{"content":"zero"}}],"usage":{"prompt_tokens":12,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":3}}}`)
+		writeSSE(w, `{"choices":[{"delta":{"content":"zero"}}],"usage":{"prompt_tokens":12,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":3,"cache_write_tokens":2}}}`)
 		writeSSE(w, `[DONE]`)
 	})
 
 	events := collectProviderEvents(t, provider)
 	assertEvent(t, events[0], zeroruntime.StreamEventText, "hello ")
 	assertEvent(t, events[1], zeroruntime.StreamEventText, "zero")
-	if events[2].Type != zeroruntime.StreamEventUsage || events[2].Usage.PromptTokens != 12 || events[2].Usage.CompletionTokens != 5 || events[2].Usage.CachedInputTokens != 3 {
+	if events[2].Type != zeroruntime.StreamEventUsage || events[2].Usage.PromptTokens != 12 || events[2].Usage.CompletionTokens != 5 || events[2].Usage.CachedInputTokens != 3 || events[2].Usage.CacheWriteTokens != 2 {
 		t.Fatalf("unexpected usage event: %#v", events[2])
 	}
 	if events[3].Type != zeroruntime.StreamEventDone {

--- a/internal/providers/openai/session.go
+++ b/internal/providers/openai/session.go
@@ -195,7 +195,12 @@ func (s *turnSession) computeFingerprint(request zeroruntime.CompletionRequest) 
 func wireToolsDigest(tools []zeroruntime.ToolDefinition) string {
 	rendered := make([]string, 0, len(tools))
 	for _, tool := range tools {
-		schema, err := json.Marshal(tool.Parameters)
+		wireShape := struct {
+			Type       zeroruntime.ToolDefinitionType    `json:"type,omitempty"`
+			Parameters map[string]any                    `json:"parameters,omitempty"`
+			Format     *zeroruntime.ToolDefinitionFormat `json:"format,omitempty"`
+		}{Type: tool.Type, Parameters: tool.Parameters, Format: tool.Format}
+		schema, err := json.Marshal(wireShape)
 		if err != nil {
 			rendered = append(rendered, tool.Name+"\n"+tool.Description+"\n__non_json:"+tool.Name)
 			continue

--- a/internal/providers/openai/types.go
+++ b/internal/providers/openai/types.go
@@ -109,7 +109,8 @@ type usage struct {
 }
 
 type promptTokenDetails struct {
-	CachedTokens int `json:"cached_tokens"`
+	CachedTokens     int `json:"cached_tokens"`
+	CacheWriteTokens int `json:"cache_write_tokens"`
 }
 
 type completionTokenDetails struct {

--- a/internal/providers/turn_session.go
+++ b/internal/providers/turn_session.go
@@ -40,7 +40,7 @@ func chatGPTTurnSessionEnabled() bool {
 // gateways and foreign provider values always retain the default adapter.
 func OptimizedTurnSessions(profile config.ProviderProfile, provider zeroruntime.Provider, options Options) (zeroruntime.TurnSessionProvider, bool) {
 	resolved, err := resolveProfile(profile, options)
-	if err != nil || resolved.providerKind != config.ProviderKindOpenAI {
+	if err != nil {
 		return nil, false
 	}
 	if isCodexCatalog(profile, resolved) {
@@ -56,6 +56,9 @@ func OptimizedTurnSessions(profile config.ProviderProfile, provider zeroruntime.
 			return nil, false
 		}
 		return openai.NewCodexTurnSessionProvider(concrete, caps), true
+	}
+	if resolved.providerKind != config.ProviderKindOpenAI {
+		return nil, false
 	}
 	if !openaiTurnSessionEnabled() {
 		return nil, false

--- a/internal/providers/turn_session.go
+++ b/internal/providers/turn_session.go
@@ -21,12 +21,21 @@ const chatGPTTurnSessionEnv = "ZERO_CHATGPT_TURN_SESSION"
 
 func openaiTurnSessionEnabled() bool {
 	value := strings.TrimSpace(os.Getenv(openaiTurnSessionEnv))
-	return value != "" && value != "0" && !strings.EqualFold(value, "false")
+	return value != "" && !explicitEnvFalse(value)
 }
 
 func chatGPTTurnSessionEnabled() bool {
 	value := strings.TrimSpace(os.Getenv(chatGPTTurnSessionEnv))
-	return value == "" || (value != "0" && !strings.EqualFold(value, "false") && !strings.EqualFold(value, "off"))
+	return value == "" || !explicitEnvFalse(value)
+}
+
+func explicitEnvFalse(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "0", "false", "off":
+		return true
+	default:
+		return false
+	}
 }
 
 // OptimizedTurnSessions returns the gated optimized TurnSessionProvider for an

--- a/internal/providers/turn_session.go
+++ b/internal/providers/turn_session.go
@@ -15,9 +15,18 @@ import (
 // value (e.g. "1") to enable — the same boolean idiom as ZERO_FORMAT_ON_WRITE.
 const openaiTurnSessionEnv = "ZERO_OPENAI_TURN_SESSION"
 
+// ChatGPT Responses sessions are enabled by default for their native provider.
+// Setting this to 0/false/off restores the stateless HTTP/SSE transport.
+const chatGPTTurnSessionEnv = "ZERO_CHATGPT_TURN_SESSION"
+
 func openaiTurnSessionEnabled() bool {
 	value := strings.TrimSpace(os.Getenv(openaiTurnSessionEnv))
 	return value != "" && value != "0" && !strings.EqualFold(value, "false")
+}
+
+func chatGPTTurnSessionEnabled() bool {
+	value := strings.TrimSpace(os.Getenv(chatGPTTurnSessionEnv))
+	return value == "" || (value != "0" && !strings.EqualFold(value, "false") && !strings.EqualFold(value, "off"))
 }
 
 // OptimizedTurnSessions returns the gated optimized TurnSessionProvider for an
@@ -25,20 +34,30 @@ func openaiTurnSessionEnabled() bool {
 // is ineligible. Callers leave agent Options.TurnSessionProvider nil on false,
 // so the loop's default wrap keeps today's behavior byte-identical.
 //
-// Eligibility is deliberately narrow: the resolved provider kind must be
-// official OpenAI (NOT openai-compatible gateways — the constructor merges the
-// two, so this branches on the resolved kind explicitly), not the ChatGPT
-// Codex catalog, and the provider value must be the concrete *openai.Provider
-// (a fake, a Codex provider, or nil falls back to the default path safely).
-// No base-URL check on top of the kind: prewarm and fingerprint telemetry are
-// harmless against any host, and kind==openai mirrors the existing
-// official-OpenAI precedent used for prompt_cache_key.
+// Eligibility is deliberately narrow: native ChatGPT Responses uses its
+// concrete Codex provider and defaults on with a kill switch; official OpenAI
+// chat-completions keeps its existing opt-in prewarm session. Compatible
+// gateways and foreign provider values always retain the default adapter.
 func OptimizedTurnSessions(profile config.ProviderProfile, provider zeroruntime.Provider, options Options) (zeroruntime.TurnSessionProvider, bool) {
-	if !openaiTurnSessionEnabled() {
+	resolved, err := resolveProfile(profile, options)
+	if err != nil || resolved.providerKind != config.ProviderKindOpenAI {
 		return nil, false
 	}
-	resolved, err := resolveProfile(profile, options)
-	if err != nil || resolved.providerKind != config.ProviderKindOpenAI || isCodexCatalog(profile, resolved) {
+	if isCodexCatalog(profile, resolved) {
+		if !chatGPTTurnSessionEnabled() {
+			return nil, false
+		}
+		concrete, ok := provider.(*openai.CodexProvider)
+		if !ok {
+			return nil, false
+		}
+		caps, err := resolveCapabilities(profile, options)
+		if err != nil {
+			return nil, false
+		}
+		return openai.NewCodexTurnSessionProvider(concrete, caps), true
+	}
+	if !openaiTurnSessionEnabled() {
 		return nil, false
 	}
 	concrete, ok := provider.(*openai.Provider)

--- a/internal/providers/turn_session_gate_test.go
+++ b/internal/providers/turn_session_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providers/openai"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -88,13 +89,53 @@ func TestOptimizedTurnSessionsRejectsCompatible(t *testing.T) {
 }
 
 func TestOptimizedTurnSessionsRejectsCodexCatalog(t *testing.T) {
-	t.Setenv(openaiTurnSessionEnv, "1")
+	t.Setenv(chatGPTTurnSessionEnv, "0")
+	profile := openaiEligibleProfile()
+	profile.Name = "chatgpt"
+	profile.CatalogID = "chatgpt"
+	if _, ok := OptimizedTurnSessions(profile, buildChatGPTGateProvider(t, profile), Options{}); ok {
+		t.Fatal("the ChatGPT Codex catalog must honor the turn-session kill switch")
+	}
+}
+
+func TestOptimizedTurnSessionsEnablesChatGPTResponsesByDefault(t *testing.T) {
+	t.Setenv(chatGPTTurnSessionEnv, "")
+	profile := openaiEligibleProfile()
+	profile.Name = "chatgpt"
+	profile.CatalogID = "chatgpt"
+	provider := buildChatGPTGateProvider(t, profile)
+
+	turnSessions, ok := OptimizedTurnSessions(profile, provider, Options{})
+	if !ok || turnSessions == nil {
+		t.Fatal("ChatGPT Responses provider did not receive its default turn session")
+	}
+	if got := turnSessions.Capabilities().Model; got != profile.Model {
+		t.Fatalf("Capabilities().Model = %q, want %q", got, profile.Model)
+	}
+}
+
+func buildChatGPTGateProvider(t *testing.T, profile config.ProviderProfile) *openai.CodexProvider {
+	t.Helper()
+	provider, err := openai.NewCodexProvider(openai.CodexOptions{
+		Options: openai.Options{
+			APIKey:  "test-token",
+			BaseURL: "https://chatgpt.example/backend-api/codex",
+			Model:   profile.Model,
+		},
+		AccountID: "account-test",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	return provider
+}
+
+func TestOptimizedTurnSessionsRejectsNonCodexProviderForChatGPT(t *testing.T) {
+	t.Setenv(chatGPTTurnSessionEnv, "1")
 	profile := openaiEligibleProfile()
 	profile.CatalogID = "chatgpt"
-	// Build the provider from the base profile: the point under test is the
-	// catalog check, not Codex construction (which needs OAuth wiring).
 	if _, ok := OptimizedTurnSessions(profile, buildGateProvider(t, openaiEligibleProfile()), Options{}); ok {
-		t.Fatal("the ChatGPT Codex catalog must not get the optimized session")
+		t.Fatal("a ChatGPT catalog profile with a non-Codex provider must use the default session")
 	}
 }
 

--- a/internal/providers/turn_session_gate_test.go
+++ b/internal/providers/turn_session_gate_test.go
@@ -46,7 +46,7 @@ func TestOptimizedTurnSessionsDefaultOff(t *testing.T) {
 func TestOptimizedTurnSessionsFalseyValues(t *testing.T) {
 	profile := openaiEligibleProfile()
 	provider := buildGateProvider(t, profile)
-	for _, value := range []string{"0", "false", "FALSE", "False", " ", ""} {
+	for _, value := range []string{"0", "false", "FALSE", "False", "off", "OFF", " ", ""} {
 		t.Setenv(openaiTurnSessionEnv, value)
 		if _, ok := OptimizedTurnSessions(profile, provider, Options{}); ok {
 			t.Fatalf("gate enabled for falsey value %q", value)
@@ -56,6 +56,21 @@ func TestOptimizedTurnSessionsFalseyValues(t *testing.T) {
 		t.Setenv(openaiTurnSessionEnv, value)
 		if _, ok := OptimizedTurnSessions(profile, provider, Options{}); !ok {
 			t.Fatalf("gate disabled for truthy value %q", value)
+		}
+	}
+}
+
+func TestChatGPTTurnSessionGateValues(t *testing.T) {
+	for _, value := range []string{"0", "false", "FALSE", "off", "OFF"} {
+		t.Setenv(chatGPTTurnSessionEnv, value)
+		if chatGPTTurnSessionEnabled() {
+			t.Fatalf("ChatGPT gate enabled for falsey value %q", value)
+		}
+	}
+	for _, value := range []string{"", " ", "1", "true", "on"} {
+		t.Setenv(chatGPTTurnSessionEnv, value)
+		if !chatGPTTurnSessionEnabled() {
+			t.Fatalf("ChatGPT gate disabled for default/truthy value %q", value)
 		}
 	}
 }

--- a/internal/providers/turn_session_gate_test.go
+++ b/internal/providers/turn_session_gate_test.go
@@ -114,6 +114,17 @@ func TestOptimizedTurnSessionsEnablesChatGPTResponsesByDefault(t *testing.T) {
 	}
 }
 
+func TestOptimizedTurnSessionsRecognizesCompatibleLabeledChatGPTProfile(t *testing.T) {
+	t.Setenv(chatGPTTurnSessionEnv, "")
+	profile := openaiEligibleProfile()
+	profile.Name = "chatgpt"
+	profile.CatalogID = "chatgpt"
+	profile.ProviderKind = config.ProviderKindOpenAICompatible
+	if turnSessions, ok := OptimizedTurnSessions(profile, buildChatGPTGateProvider(t, profile), Options{}); !ok || turnSessions == nil {
+		t.Fatal("ChatGPT catalog profile must use its native session regardless of the stored compatibility label")
+	}
+}
+
 func buildChatGPTGateProvider(t *testing.T, profile config.ProviderProfile) *openai.CodexProvider {
 	t.Helper()
 	provider, err := openai.NewCodexProvider(openai.CodexOptions{

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -94,6 +94,8 @@ type Event struct {
 	Meta              map[string]string `json:"meta,omitempty"`
 	PromptTokens      *int              `json:"promptTokens,omitempty"`
 	CompletionTokens  *int              `json:"completionTokens,omitempty"`
+	CachedInputTokens *int              `json:"cachedInputTokens,omitempty"`
+	CacheWriteTokens  *int              `json:"cacheWriteTokens,omitempty"`
 	TotalTokens       *int              `json:"totalTokens,omitempty"`
 	CostUSD           *float64          `json:"costUsd,omitempty"`
 	Text              string            `json:"text,omitempty"`

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -16,6 +16,8 @@ type applyPatchTool struct {
 	scope         PathScope
 }
 
+func (applyPatchTool) isBuiltInApplyPatch() {}
+
 func NewScopedApplyPatchTool(workspaceRoot string, scope PathScope) Tool {
 	return applyPatchTool{
 		baseTool: baseTool{

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
 type applyPatchTool struct {
@@ -17,6 +19,83 @@ type applyPatchTool struct {
 }
 
 func (applyPatchTool) isBuiltInApplyPatch() {}
+
+// PrepareFreeformApplyPatchArguments converts native structured-patch input
+// into the ordinary apply_patch argument map used by permission checks and tool
+// execution. Absolute patch-header paths select a granted write root and are
+// rewritten relative to that root; relative-only patches keep workspace-root
+// behavior.
+func PrepareFreeformApplyPatchArguments(tool Tool, patch string) (map[string]any, error) {
+	preparer, ok := tool.(interface {
+		prepareFreeformArguments(string) (map[string]any, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("tool is not Zero's built-in apply_patch")
+	}
+	return preparer.prepareFreeformArguments(patch)
+}
+
+func (tool applyPatchTool) prepareFreeformArguments(patch string) (map[string]any, error) {
+	args := map[string]any{"patch": patch}
+	if !isStructuredPatch(patch) {
+		return args, nil
+	}
+
+	lines := strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n")
+	selectedRoot := ""
+	for index, line := range lines {
+		prefix := ""
+		switch {
+		case strings.HasPrefix(line, structuredAddFile):
+			prefix = structuredAddFile
+		case strings.HasPrefix(line, structuredDeleteFile):
+			prefix = structuredDeleteFile
+		case strings.HasPrefix(line, structuredUpdateFile):
+			prefix = structuredUpdateFile
+		case strings.HasPrefix(line, structuredMoveTo):
+			prefix = structuredMoveTo
+		default:
+			continue
+		}
+		path := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		if !filepath.IsAbs(path) {
+			continue
+		}
+		root, relative, err := tool.freeformPatchRoot(path)
+		if err != nil {
+			return nil, err
+		}
+		if selectedRoot != "" && selectedRoot != root {
+			return nil, fmt.Errorf("freeform patch spans multiple write roots")
+		}
+		selectedRoot = root
+		lines[index] = prefix + filepath.ToSlash(relative)
+	}
+	if selectedRoot != "" {
+		args["cwd"] = selectedRoot
+		args["patch"] = strings.Join(lines, "\n")
+	}
+	return args, nil
+}
+
+func (tool applyPatchTool) freeformPatchRoot(path string) (string, string, error) {
+	roots, err := scopedRoots(tool.workspaceRoot, tool.scope)
+	if err != nil {
+		return "", "", err
+	}
+	var firstErr error
+	for _, root := range roots {
+		candidate := sandbox.NormalizePrefixForRoot(path, root)
+		_, relative, err := resolveWorkspaceTargetPath(root, candidate)
+		if err == nil {
+			return root, relative, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return "", "", firstErr
+}
 
 func NewScopedApplyPatchTool(workspaceRoot string, scope PathScope) Tool {
 	return applyPatchTool{

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -86,12 +86,19 @@ func (tool applyPatchTool) freeformPatchRoot(path string) (string, string, error
 	var firstErr error
 	for _, root := range roots {
 		candidate := sandbox.NormalizePrefixForRoot(path, root)
-		_, relative, err := resolveWorkspaceTargetPath(root, candidate)
-		if err == nil {
-			return root, relative, nil
+		candidate, err = filepath.Abs(candidate)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		relative, err := filepath.Rel(root, candidate)
+		if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative) {
+			return root, filepath.ToSlash(relative), nil
 		}
 		if firstErr == nil {
-			firstErr = err
+			firstErr = outsideWorkspaceError(path)
 		}
 	}
 	return "", "", firstErr

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -41,6 +41,7 @@ func (tool applyPatchTool) prepareFreeformArguments(patch string) (map[string]an
 
 	lines := strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n")
 	selectedRoot := ""
+	hasRelativeHeader := false
 	for index, line := range lines {
 		prefix := ""
 		switch {
@@ -57,6 +58,7 @@ func (tool applyPatchTool) prepareFreeformArguments(patch string) (map[string]an
 		}
 		path := strings.TrimSpace(strings.TrimPrefix(line, prefix))
 		if !filepath.IsAbs(path) {
+			hasRelativeHeader = true
 			continue
 		}
 		root, relative, err := tool.freeformPatchRoot(path)
@@ -70,6 +72,13 @@ func (tool applyPatchTool) prepareFreeformArguments(patch string) (map[string]an
 		lines[index] = prefix + filepath.ToSlash(relative)
 	}
 	if selectedRoot != "" {
+		roots, err := scopedRoots(tool.workspaceRoot, tool.scope)
+		if err != nil {
+			return nil, err
+		}
+		if hasRelativeHeader && selectedRoot != roots[0] {
+			return nil, fmt.Errorf("freeform patch mixes workspace-relative paths with an extra write root")
+		}
 		args["cwd"] = selectedRoot
 		args["patch"] = strings.Join(lines, "\n")
 	}

--- a/internal/tools/plan_tool_test.go
+++ b/internal/tools/plan_tool_test.go
@@ -9,6 +9,9 @@ import (
 
 func TestUpdatePlanToolStoresAndFormatsPlan(t *testing.T) {
 	tool := NewUpdatePlanTool()
+	if description := strings.ToLower(tool.Description()); !strings.Contains(description, "skip it for bounded changes in one component") {
+		t.Fatalf("update_plan description must preserve the bounded-task fast path: %q", description)
+	}
 
 	result := tool.Run(context.Background(), map[string]any{
 		"plan": []any{

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -31,7 +31,7 @@ func NewScopedReadFileTool(workspaceRoot string, scope PathScope) Tool {
 	return readFileTool{
 		baseTool: baseTool{
 			name:        "read_file",
-			description: "Read exact file text with line numbers. Use for comments, formatting, or edits; prefer read_minified_file for initial code understanding. Use offset and limit for a line range.",
+			description: "Read exact file text with line numbers. Use directly for small files likely to be edited, or when comments, formatting, or line numbers matter. Prefer read_minified_file only for exploratory understanding of large or unfamiliar code. Use offset and limit for a line range.",
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{

--- a/internal/tools/read_minified_file.go
+++ b/internal/tools/read_minified_file.go
@@ -28,7 +28,7 @@ func NewScopedReadMinifiedFileTool(workspaceRoot string, scope PathScope) Tool {
 	return readMinifiedFileTool{
 		baseTool: baseTool{
 			name:        "read_minified_file",
-			description: "Read source code in a token-efficient, language-aware form. Prefer this for initial understanding; use read_file for exact text or line numbers.",
+			description: "Read source code in a token-efficient, language-aware form. Use for exploratory understanding of large or unfamiliar source when no exact edit is planned; use read_file directly for likely edit targets. Do not immediately reread the same file exactly unless a new need for exact text or line numbers appears.",
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{

--- a/internal/tools/read_minified_file_test.go
+++ b/internal/tools/read_minified_file_test.go
@@ -8,6 +8,29 @@ import (
 	"testing"
 )
 
+func TestReadToolsDescribeExploratoryAndExactUseWithoutRedundantRereads(t *testing.T) {
+	root := t.TempDir()
+	minified := strings.ToLower(NewScopedReadMinifiedFileTool(root, nil).Description())
+	for _, want := range []string{
+		"exploratory understanding",
+		"use read_file directly for likely edit targets",
+		"unless a new need for exact text or line numbers appears",
+	} {
+		if !strings.Contains(minified, want) {
+			t.Fatalf("read_minified_file description missing %q: %s", want, minified)
+		}
+	}
+	exact := strings.ToLower(NewScopedReadFileTool(root, nil).Description())
+	for _, want := range []string{
+		"use directly for small files likely to be edited",
+		"prefer read_minified_file only for exploratory understanding",
+	} {
+		if !strings.Contains(exact, want) {
+			t.Fatalf("read_file description missing %q: %s", want, exact)
+		}
+	}
+}
+
 func TestReadMinifiedFileStripsCommentsAndLineNumbers(t *testing.T) {
 	dir := t.TempDir()
 	src := "package demo\n\nimport \"fmt\"\n\n// secret doc comment\nfunc F() { fmt.Println(\"x\") }\n"

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/sandbox"
@@ -12,7 +13,17 @@ import (
 )
 
 type Registry struct {
-	tools map[string]Tool
+	mu         sync.RWMutex
+	tools      map[string]Tool
+	generation uint64
+}
+
+// RegistrySnapshot is one immutable registry generation. Tools is a detached,
+// name-sorted slice: later registrations cannot change the snapshot observed by
+// an in-flight agent turn.
+type RegistrySnapshot struct {
+	Tools      []Tool
+	Generation uint64
 }
 
 type RunOptions struct {
@@ -107,23 +118,62 @@ func IsDeferralEligible(t Tool) bool {
 }
 
 func (registry *Registry) Register(tool Tool) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
 	registry.tools[tool.Name()] = tool
+	registry.generation++
+}
+
+// RegisterBatch publishes a group of tools as one registry generation. Readers
+// observe either the complete prior generation or the complete new one.
+func (registry *Registry) RegisterBatch(batch []Tool) {
+	if len(batch) == 0 {
+		return
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	for _, tool := range batch {
+		registry.tools[tool.Name()] = tool
+	}
+	registry.generation++
 }
 
 func (registry *Registry) Get(name string) (Tool, bool) {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
 	tool, ok := registry.tools[name]
 	return tool, ok
 }
 
 func (registry *Registry) All() []Tool {
+	return registry.Snapshot().Tools
+}
+
+// Snapshot returns a stable, sorted view of the registry at one generation.
+func (registry *Registry) Snapshot() RegistrySnapshot {
+	registry.mu.RLock()
 	tools := make([]Tool, 0, len(registry.tools))
 	for _, tool := range registry.tools {
 		tools = append(tools, tool)
 	}
+	generation := registry.generation
+	registry.mu.RUnlock()
 	sort.Slice(tools, func(left, right int) bool {
 		return tools[left].Name() < tools[right].Name()
 	})
-	return tools
+	return RegistrySnapshot{Tools: tools, Generation: generation}
+}
+
+// Clone returns an independent registry containing exactly one source snapshot.
+func (registry *Registry) Clone() *Registry {
+	clone := NewRegistry()
+	if registry == nil {
+		return clone
+	}
+	snapshot := registry.Snapshot()
+	clone.RegisterBatch(snapshot.Tools)
+	clone.generation = snapshot.Generation
+	return clone
 }
 
 func (registry *Registry) Run(ctx context.Context, name string, args map[string]any) Result {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -171,7 +171,14 @@ func (registry *Registry) Clone() *Registry {
 		return clone
 	}
 	snapshot := registry.Snapshot()
-	clone.RegisterBatch(snapshot.Tools)
+	clonedTools := make([]Tool, 0, len(snapshot.Tools))
+	for _, tool := range snapshot.Tools {
+		if cloner, ok := tool.(interface{ cloneForRegistry(*Registry) Tool }); ok {
+			tool = cloner.cloneForRegistry(clone)
+		}
+		clonedTools = append(clonedTools, tool)
+	}
+	clone.RegisterBatch(clonedTools)
 	clone.generation = snapshot.Generation
 	return clone
 }

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -122,6 +122,9 @@ func TestRegistrySnapshotAndCloneStayOnOneGeneration(t *testing.T) {
 	if got := toolNames(clone.All()); !slices.Equal(got, toolNames(second.Tools)) {
 		t.Fatalf("clone changed with source registry: %v", got)
 	}
+	if clone.Snapshot().Generation != second.Generation {
+		t.Fatalf("clone generation = %d, want %d", clone.Snapshot().Generation, second.Generation)
+	}
 }
 
 func TestRegistryBatchIsAtomicForConcurrentReaders(t *testing.T) {

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/sandbox"
@@ -93,6 +95,78 @@ func TestRegistryAllReturnsToolsSortedByName(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Fatalf("Registry.All() order = %v, want %v", got, want)
 	}
+}
+
+func TestRegistrySnapshotAndCloneStayOnOneGeneration(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(fakePlainTool{baseTool: baseTool{name: "alpha", description: "alpha"}})
+	first := registry.Snapshot()
+
+	registry.RegisterBatch([]Tool{
+		fakePlainTool{baseTool: baseTool{name: "charlie", description: "charlie"}},
+		fakePlainTool{baseTool: baseTool{name: "bravo", description: "bravo"}},
+	})
+	second := registry.Snapshot()
+	clone := registry.Clone()
+	registry.Register(fakePlainTool{baseTool: baseTool{name: "delta", description: "delta"}})
+
+	if got := toolNames(first.Tools); !slices.Equal(got, []string{"alpha"}) {
+		t.Fatalf("first snapshot changed after registration: %v", got)
+	}
+	if second.Generation != first.Generation+1 {
+		t.Fatalf("batch generation = %d, want %d", second.Generation, first.Generation+1)
+	}
+	if got := toolNames(second.Tools); !slices.Equal(got, []string{"alpha", "bravo", "charlie"}) {
+		t.Fatalf("second snapshot tools = %v", got)
+	}
+	if got := toolNames(clone.All()); !slices.Equal(got, toolNames(second.Tools)) {
+		t.Fatalf("clone changed with source registry: %v", got)
+	}
+}
+
+func TestRegistryBatchIsAtomicForConcurrentReaders(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(fakePlainTool{baseTool: baseTool{name: "base", description: "base"}})
+	batch := make([]Tool, 128)
+	for index := range batch {
+		name := fmt.Sprintf("tool_%03d", index)
+		batch[index] = fakePlainTool{baseTool: baseTool{name: name, description: name}}
+	}
+
+	start := make(chan struct{})
+	done := make(chan struct{})
+	var readers sync.WaitGroup
+	for range 4 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			<-start
+			for {
+				count := len(registry.Snapshot().Tools)
+				if count != 1 && count != len(batch)+1 {
+					t.Errorf("reader observed partial batch with %d tools", count)
+					return
+				}
+				select {
+				case <-done:
+					return
+				default:
+				}
+			}
+		}()
+	}
+	close(start)
+	registry.RegisterBatch(batch)
+	close(done)
+	readers.Wait()
+}
+
+func toolNames(toolset []Tool) []string {
+	names := make([]string, 0, len(toolset))
+	for _, tool := range toolset {
+		names = append(names, tool.Name())
+	}
+	return names
 }
 
 func TestCoreNetworkToolsExposeSafetyMetadata(t *testing.T) {

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -58,6 +58,11 @@ func NewToolSearchTool(registry *Registry) Tool {
 	}
 }
 
+func (tool toolSearchTool) cloneForRegistry(registry *Registry) Tool {
+	tool.registry = registry
+	return tool
+}
+
 // Run satisfies the Tool interface; actual dispatch goes through RunWithOptions.
 func (tool toolSearchTool) Run(ctx context.Context, args map[string]any) Result {
 	return tool.RunWithOptions(ctx, args, RunOptions{})

--- a/internal/tools/tool_search_test.go
+++ b/internal/tools/tool_search_test.go
@@ -73,6 +73,37 @@ func newDeferredFixtureRegistry() *Registry {
 	return reg
 }
 
+func TestRegistryCloneKeepsToolSearchOnFrozenSnapshot(t *testing.T) {
+	live := newDeferredFixtureRegistry()
+	live.Register(NewToolSearchTool(live))
+	runRegistry := live.Clone()
+	live.Register(searchFakeTool{
+		name:        "late_lookup",
+		description: "Registered after the run snapshot.",
+		parameters:  Schema{Type: "object", AdditionalProperties: false},
+	})
+
+	result := runRegistry.Run(context.Background(), ToolSearchToolName, map[string]any{
+		"query": "select:late_lookup",
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("tool_search status = %s: %s", result.Status, result.Output)
+	}
+	if loaded := result.Meta["load_tools"]; loaded != "" {
+		t.Fatalf("snapshot tool_search loaded late tool %q", loaded)
+	}
+	if direct := runRegistry.Run(context.Background(), "late_lookup", map[string]any{}); direct.Status != StatusError {
+		t.Fatalf("late tool unexpectedly executable in run snapshot: %#v", direct)
+	}
+
+	known := runRegistry.Run(context.Background(), ToolSearchToolName, map[string]any{
+		"query": "select:weather_lookup",
+	})
+	if loaded := known.Meta["load_tools"]; loaded != "weather_lookup" {
+		t.Fatalf("snapshot tool_search lost existing tool: load_tools=%q output=%q", loaded, known.Output)
+	}
+}
+
 func TestToolSearchExposesExpectedSafetyAndSchema(t *testing.T) {
 	tool := NewToolSearchTool(NewRegistry())
 

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -211,6 +211,14 @@ type Tool interface {
 	Run(ctx context.Context, args map[string]any) Result
 }
 
+// IsBuiltInApplyPatch reports whether tool is Zero's scoped patch tool. The
+// marker method is package-private so external and MCP tools cannot claim this
+// identity merely by sharing the public name "apply_patch".
+func IsBuiltInApplyPatch(tool Tool) bool {
+	_, ok := tool.(interface{ isBuiltInApplyPatch() })
+	return ok
+}
+
 // ArgsPermissioner is an optional interface a Tool can implement to refine its
 // permission for a SPECIFIC call based on its arguments. When a tool implements
 // it, the agent loop consults PermissionForArgs(args) instead of the static

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -26,7 +26,7 @@ func NewUpdatePlanTool() *updatePlanTool {
 	return &updatePlanTool{
 		baseTool: baseTool{
 			name: "update_plan",
-			description: "Create or update the in-memory plan for implementation or investigation with at least three meaningful dependent steps. Do not use it for simple lookups, explanations, or code navigation. " +
+			description: "Create or update the in-memory plan for work spanning multiple components or workstreams, sequencing uncertainty, or sustained tracking across many tool calls. Skip it for bounded changes in one component, simple lookups, explanations, and code navigation. " +
 				"Pass the full ordered list of steps each call; it replaces the previous plan. " +
 				"Each item needs a `content` string; `status` defaults to \"pending\" and `id` is " +
 				"auto-numbered, so you only need to supply `content` (and `status` as the task progresses). " +

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -53,6 +53,7 @@ const (
 	CounterModelSwitches     = "model_switches"
 	CounterInputTokens       = "input_tokens"
 	CounterCachedInputTokens = "cached_input_tokens"
+	CounterCacheWriteTokens  = "cache_write_tokens"
 	CounterOutputTokens      = "output_tokens"
 	CounterPrewarmAttempts   = "prewarm_attempts"
 	CounterPrefixStable      = "prefix_stable"
@@ -62,6 +63,12 @@ const (
 	// model_switches: a posture escalation changes loop policy knobs, never the
 	// model or session.
 	CounterPostureEscalations = "posture_escalations"
+)
+
+const (
+	CounterResponseChainReused   = "response_chain_reused"
+	CounterResponseChainReset    = "response_chain_reset"
+	CounterResponsesHTTPFallback = "responses_http_fallback"
 )
 
 // Span is one named wall interval attributed to part of a run. Each stamp is
@@ -290,6 +297,7 @@ func OptionalEventKeys() []string {
 		"span:" + SpanVerification,
 		"counter:" + CounterToolCalls,
 		"counter:" + CounterCachedInputTokens,
+		"counter:" + CounterCacheWriteTokens,
 		"counter:" + CounterRetryCount,
 		"counter:" + CounterReconnectCount,
 		"counter:" + CounterCompactionCount,
@@ -301,6 +309,9 @@ func OptionalEventKeys() []string {
 		"counter:" + CounterPrewarmAttempts,
 		"counter:" + CounterPrefixStable,
 		"counter:" + CounterPrefixDrift,
+		"counter:" + CounterResponseChainReused,
+		"counter:" + CounterResponseChainReset,
+		"counter:" + CounterResponsesHTTPFallback,
 		"counter:" + CounterPostureEscalations,
 		"event:prefix_hash",
 		"task_state",

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -614,11 +614,21 @@ func TestCounterPrecisionRoundTrip(t *testing.T) {
 	}
 }
 
-func TestOptionalEventKeysIncludePostureEscalations(t *testing.T) {
+func TestOptionalEventKeysIncludeRuntimeCounters(t *testing.T) {
+	keys := make(map[string]bool)
 	for _, key := range OptionalEventKeys() {
-		if key == "counter:"+CounterPostureEscalations {
-			return
+		keys[key] = true
+	}
+	for _, counter := range []string{
+		CounterCacheWriteTokens,
+		CounterResponseChainReused,
+		CounterResponseChainReset,
+		CounterResponsesHTTPFallback,
+		CounterPostureEscalations,
+	} {
+		key := "counter:" + counter
+		if !keys[key] {
+			t.Errorf("%s missing from OptionalEventKeys: %v", key, OptionalEventKeys())
 		}
 	}
-	t.Fatalf("posture_escalations missing from OptionalEventKeys: %v", OptionalEventKeys())
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -927,6 +927,13 @@ func newModel(ctx context.Context, options Options) model {
 	// terminal bracketed paste (Paste: true) is the single paste path.
 	input.KeyMap.Paste.SetEnabled(false)
 	input.Focus()
+	// The main composer paints its own cursor through composerCursorVisible.
+	// Keep the embedded textinput cursor static so the shared textinput.Blink
+	// message cannot start a second, invisible 530ms tick chain. Setup inputs
+	// still use the normal Bubbles cursor and continue blinking independently.
+	inputStyles := input.Styles()
+	inputStyles.Cursor.Blink = false
+	input.SetStyles(inputStyles)
 
 	runSpinner := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	runSpinner.Spinner.FPS = activeAnimationFrameInterval

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -85,6 +85,7 @@ type model struct {
 	savedProviders              []config.ProviderProfile
 	provider                    zeroruntime.Provider
 	newProvider                 func(config.ProviderProfile) (zeroruntime.Provider, error)
+	newTurnSessionProvider      func(config.ProviderProfile, zeroruntime.Provider) zeroruntime.TurnSessionProvider
 	probeProviderHealth         func(context.Context, providerhealth.Options) providerhealth.Result
 	discoverProviderModels      func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	discoverOllamaContextWindow func(ctx context.Context, baseURL string, model string) (int, error)
@@ -980,6 +981,7 @@ func newModel(ctx context.Context, options Options) model {
 		recapsEnabled:               options.RecapsEnabled,
 		provider:                    options.Provider,
 		newProvider:                 options.NewProvider,
+		newTurnSessionProvider:      options.NewTurnSessionProvider,
 		probeProviderHealth:         options.ProbeProviderHealth,
 		discoverProviderModels:      options.DiscoverProviderModels,
 		discoverOllamaContextWindow: options.DiscoverOllamaContextWindow,
@@ -5469,6 +5471,9 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 		options.ResponseStyle = m.responseStyle
 		options.Cwd = m.cwd
 		options.Images = images
+		if m.newTurnSessionProvider != nil && m.provider != nil {
+			options.TurnSessionProvider = m.newTurnSessionProvider(m.providerProfile, m.provider)
+		}
 		if m.captureRunImages != nil {
 			m.captureRunImages(images)
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -89,6 +89,7 @@ type model struct {
 	discoverProviderModels      func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	discoverOllamaContextWindow func(ctx context.Context, baseURL string, model string) (int, error)
 	registry                    *tools.Registry
+	awaitToolReadiness          func(context.Context)
 	// lspManager is created once per session and reused across prompts so gopls (and
 	// other language servers) stay warm — a fresh manager per run would cold-start
 	// the server on the first edit of every turn. Nil when cwd is unknown; runs then
@@ -983,6 +984,7 @@ func newModel(ctx context.Context, options Options) model {
 		discoverProviderModels:      options.DiscoverProviderModels,
 		discoverOllamaContextWindow: options.DiscoverOllamaContextWindow,
 		registry:                    registry,
+		awaitToolReadiness:          options.AwaitToolReadiness,
 		sessionStore:                sessionStore,
 		peerService:                 options.PeerService,
 		sandboxStore:                sandboxStore,
@@ -5422,6 +5424,9 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 		sessionEvents := []pendingSessionEvent{}
 		usageModelID := m.modelName
 		var specReview *pendingSpecReviewPrompt
+		if m.awaitToolReadiness != nil {
+			m.awaitToolReadiness(runCtx)
+		}
 		options := m.agentOptions
 		options.Registry = cloneToolRegistry(m.registry)
 		goalAwareRun := !runOptions.specDraft && m.activeLoopID == "" &&

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -233,17 +233,20 @@ type model struct {
 	leaderHelpOverlay bool
 	// leaderPending is true after Ctrl+X until a second key, Esc, or timeout
 	// resolves the chord (see leader.go). leaderSeq invalidates a stale tick.
-	leaderPending         bool
-	leaderSeq             int
-	transcriptBodyHeights *transcriptBodyHeightCache
-	input                 textinput.Model
-	composer              composerState
-	composerActive        bool
-	composerCursorVisible bool
-	composerPastePreviews []composerPastePreview
-	composerSelection     composerSelectionState
-	dictation             dictationController
-	sttKeyPrompt          *sttKeyPromptState
+	leaderPending          bool
+	leaderSeq              int
+	transcriptBodyHeights  *transcriptBodyHeightCache
+	input                  textinput.Model
+	composer               composerState
+	composerActive         bool
+	composerCursorVisible  bool
+	composerBlinkSeq       int
+	composerBlinkIdleTicks int
+	composerBlinkTicking   bool
+	composerPastePreviews  []composerPastePreview
+	composerSelection      composerSelectionState
+	dictation              dictationController
+	sttKeyPrompt           *sttKeyPromptState
 	// plan holds the sticky plan panel state (steps, expansion, timings)
 	// synced from the update_plan tool. See plan_panel.go.
 	plan            planPanelState
@@ -491,10 +494,11 @@ type model struct {
 	// transientNotice is a single, replaceable confirmation shown above the
 	// composer. Unlike copyStatus it is shared by lightweight slash commands
 	// and is never persisted into the transcript.
-	transientNotice    transientNotice
-	transientNoticeSeq int
-	exitConfirmActive  bool
-	exitConfirmSeq     int
+	transientNotice         transientNotice
+	transientNoticeSeq      int
+	transientNoticeTimerSeq int
+	exitConfirmActive       bool
+	exitConfirmSeq          int
 	// cancelConfirmActive/cancelConfirmSeq mirror exitConfirmActive/exitConfirmSeq
 	// (same seq-gated tea.Tick pattern) but guard a DIFFERENT action: Esc
 	// cancelling a running turn. The two are deliberately separate state (not a
@@ -958,6 +962,8 @@ func newModel(ctx context.Context, options Options) model {
 		userCommands:                loadedUserCommands,
 		loadSkills:                  options.LoadSkills,
 		composerCursorVisible:       true,
+		composerBlinkSeq:            1,
+		composerBlinkTicking:        true,
 		terminalFocused:             true,
 		userConfigPath:              options.UserConfigPath,
 		doctorUserConfigPath:        doctorUserConfigPath,
@@ -1097,6 +1103,11 @@ const (
 // composerCursorBlinkInterval is the on/off period of the composer text cursor.
 const composerCursorBlinkInterval = 530 * time.Millisecond
 
+// composerBlinkIdleTicksBeforeSettle bounds the software cursor animation.
+// Once the terminal is focused but otherwise idle, the cursor finishes a short
+// blink sequence and settles visible instead of waking the TUI forever.
+const composerBlinkIdleTicksBeforeSettle = 4
+
 // composerTypingIdleThreshold is how long a typing pause must last before the
 // cursor resumes blinking; comfortably above normal inter-keystroke gaps
 // (~150-300ms) so it won't flicker mid-sentence.
@@ -1105,16 +1116,27 @@ const composerTypingIdleThreshold = 500 * time.Millisecond
 // composerBlinkMsg toggles the composer cursor's visibility each tick. The custom
 // composer render draws its own cursor (not textinput's), so it drives its own
 // blink rather than relying on textinput.Blink.
-type composerBlinkMsg struct{}
+type composerBlinkMsg struct{ seq int }
 
-func composerBlinkCmd() tea.Cmd {
+func composerBlinkCmd(seq int) tea.Cmd {
 	return tea.Tick(composerCursorBlinkInterval, func(time.Time) tea.Msg {
-		return composerBlinkMsg{}
+		return composerBlinkMsg{seq: seq}
 	})
 }
 
+func (m model) armComposerBlink() (model, tea.Cmd) {
+	m.composerCursorVisible = true
+	m.composerBlinkIdleTicks = 0
+	if m.composerBlinkTicking {
+		return m, nil
+	}
+	m.composerBlinkTicking = true
+	m.composerBlinkSeq++
+	return m, composerBlinkCmd(m.composerBlinkSeq)
+}
+
 func (m model) Init() tea.Cmd {
-	cmds := []tea.Cmd{textinput.Blink, composerBlinkCmd()}
+	cmds := []tea.Cmd{textinput.Blink, composerBlinkCmd(m.composerBlinkSeq)}
 	if m.petAnimation != nil && !m.reducedMotion {
 		cmds = append(cmds, petTickCmd(m.petTickSeq, m.petFrameDelay()))
 	}
@@ -1297,7 +1319,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	nm = nm.syncChatScroll()
 	nm, mouseCmd := nm.syncMouseCapture()
 	nm, flushCmd := nm.settleTranscript()
-	return nm, batchCommands(cmd, mouseCmd, flushCmd, recapActivityCmd)
+	var composerCmd tea.Cmd
+	switch msg.(type) {
+	case tea.KeyPressMsg, tea.PasteMsg, tea.FocusMsg:
+		if nm.terminalFocused {
+			nm, composerCmd = nm.armComposerBlink()
+		}
+	}
+	nm, noticeCmd := nm.ensureTransientNoticeTimer()
+	return nm, batchCommands(cmd, mouseCmd, flushCmd, recapActivityCmd, composerCmd, noticeCmd)
 }
 
 func batchCommands(cmds ...tea.Cmd) tea.Cmd {
@@ -1360,16 +1390,27 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case composerBlinkMsg:
-		m = m.expireTransientNotice()
+		if !m.composerBlinkTicking || msg.seq != m.composerBlinkSeq {
+			return m, nil
+		}
 		switch {
 		case !m.terminalFocused:
-			m.composerCursorVisible = false // hidden while unfocused
+			m.composerCursorVisible = false
+			m.composerBlinkTicking = false
+			return m, nil
 		case m.now().Sub(m.lastCharTime) < composerTypingIdleThreshold:
-			m.composerCursorVisible = true // solid while actively typing
+			m.composerCursorVisible = true
+			m.composerBlinkIdleTicks = 0
 		default:
-			m.composerCursorVisible = !m.composerCursorVisible // idle + focused: blink as before
+			m.composerBlinkIdleTicks++
+			if m.composerBlinkIdleTicks >= composerBlinkIdleTicksBeforeSettle {
+				m.composerCursorVisible = true
+				m.composerBlinkTicking = false
+				return m, nil
+			}
+			m.composerCursorVisible = !m.composerCursorVisible
 		}
-		return m, composerBlinkCmd()
+		return m, composerBlinkCmd(m.composerBlinkSeq)
 	case tea.BackgroundColorMsg:
 		// A background reading changes only the contrast direction used for named
 		// palettes. It never repaints the terminal canvas.
@@ -2196,6 +2237,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.terminalFocused = false
 		m.composerCursorVisible = false
+		m.composerBlinkTicking = false
+		m.composerBlinkSeq++
 		if m.notifier != nil {
 			m.notifier.SetFocused(false)
 		}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3015,6 +3015,34 @@ func TestComposerBlinkResumesAfterRefocusAndIdle(t *testing.T) {
 	}
 }
 
+func TestComposerBlinkRejectsTickFromBeforeRefocus(t *testing.T) {
+	base := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	m := model{
+		now:                   func() time.Time { return base },
+		terminalFocused:       true,
+		lastCharTime:          base.Add(-time.Hour),
+		composerCursorVisible: true,
+		composerBlinkSeq:      5,
+		composerBlinkTicking:  true,
+	}
+	staleSeq := m.composerBlinkSeq
+
+	updated, _ := m.Update(tea.BlurMsg{})
+	m = updated.(model)
+	updated, refocusCmd := m.Update(tea.FocusMsg{})
+	m = updated.(model)
+	if refocusCmd == nil || m.composerBlinkSeq == staleSeq {
+		t.Fatal("refocus did not re-arm composer blinking with a new sequence")
+	}
+	visible := m.composerCursorVisible
+
+	updated, staleCmd := m.Update(composerBlinkMsg{seq: staleSeq})
+	m = updated.(model)
+	if staleCmd != nil || m.composerCursorVisible != visible {
+		t.Fatalf("stale tick changed composer state: cmd=%v visible=%v want=%v", staleCmd != nil, m.composerCursorVisible, visible)
+	}
+}
+
 func TestComposerBlinkTogglesWhenIdleAndFocused(t *testing.T) {
 	base := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
 	m := model{

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2884,6 +2884,13 @@ func TestComposerBlinkStaysSolidWhileTyping(t *testing.T) {
 	}
 }
 
+func TestMainComposerDisablesEmbeddedCursorBlink(t *testing.T) {
+	m := newModel(t.Context(), Options{})
+	if m.input.Styles().Cursor.Blink {
+		t.Fatal("embedded composer cursor blink must stay disabled")
+	}
+}
+
 func TestComposerBlinkHiddenWhileUnfocused(t *testing.T) {
 	base := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
 	m := model{

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -151,6 +151,39 @@ func TestPromptWaitsForToolReadinessBeforeSnapshot(t *testing.T) {
 	t.Fatal("provider request omitted tool published by readiness callback")
 }
 
+func TestPromptBuildsTurnSessionForCurrentProvider(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	profile := config.ProviderProfile{Name: "chatgpt", Model: "gpt-test"}
+	called := false
+	m := newModel(context.Background(), Options{
+		Cwd:             t.TempDir(),
+		ProviderName:    profile.Name,
+		ModelName:       profile.Model,
+		ProviderProfile: profile,
+		Provider:        provider,
+		Registry:        tools.NewRegistry(),
+		NewTurnSessionProvider: func(gotProfile config.ProviderProfile, gotProvider zeroruntime.Provider) zeroruntime.TurnSessionProvider {
+			called = true
+			if gotProfile.Name != profile.Name || gotProfile.Model != profile.Model || gotProvider != provider {
+				t.Fatalf("turn session factory inputs = %#v/%#v", gotProfile, gotProvider)
+			}
+			return zeroruntime.NewProviderTurnSessionProvider(gotProvider, zeroruntime.ProviderCapabilities{})
+		},
+	})
+	m.input.SetValue("inspect the workspace")
+
+	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	next.Update(execCmd(cmd))
+	if !called {
+		t.Fatal("agent run did not build a turn session for the current provider")
+	}
+}
+
 func TestPromptSubmitStoresReasoningSeparatelyFromAnswer(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	provider := &fakeProvider{events: []zeroruntime.StreamEvent{

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -109,6 +109,48 @@ func TestPromptSubmitInjectsLiveSessionModelContext(t *testing.T) {
 	}
 }
 
+func TestPromptWaitsForToolReadinessBeforeSnapshot(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	registry := tools.NewRegistry()
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	awaited := false
+	m := newModel(context.Background(), Options{
+		Cwd:          t.TempDir(),
+		ProviderName: "test",
+		ModelName:    "test-model",
+		Provider:     provider,
+		Registry:     registry,
+		AwaitToolReadiness: func(context.Context) {
+			awaited = true
+			registry.Register(tools.NewScopedReadFileTool(t.TempDir(), nil))
+		},
+	})
+	m.input.SetValue("inspect the workspace")
+
+	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+	next.Update(execCmd(cmd))
+
+	if !awaited {
+		t.Fatal("agent run did not await tool readiness")
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("provider requests = %d, want 1", len(provider.requests))
+	}
+	for _, definition := range provider.requests[0].Tools {
+		if definition.Name == "read_file" {
+			return
+		}
+	}
+	t.Fatal("provider request omitted tool published by readiness callback")
+}
+
 func TestPromptSubmitStoresReasoningSeparatelyFromAnswer(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	provider := &fakeProvider{events: []zeroruntime.StreamEvent{

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -548,10 +548,10 @@ func TestModelCommandSwitchesSessionModel(t *testing.T) {
 	})
 	m.input.SetValue("/model gpt-4.1-mini")
 
-	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	updated, _ := m.Update(testKey(tea.KeyEnter))
 	next := updated.(model)
 
-	if cmd != nil {
+	if next.pending {
 		t.Fatal("expected /model to be handled without starting an agent run")
 	}
 	if next.modelName != "gpt-4.1-mini" || next.provider != nextProvider {
@@ -591,10 +591,10 @@ func TestModelCommandAcceptsChatGPTCatalogModelID(t *testing.T) {
 	}
 	m.input.SetValue("/model openai/gpt-5.6-sol")
 
-	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	updated, _ := m.Update(testKey(tea.KeyEnter))
 	next := updated.(model)
 
-	if cmd != nil {
+	if next.pending {
 		t.Fatal("expected /model to be handled without starting an agent run")
 	}
 	if next.modelName != "gpt-5.6-sol" || next.provider != nextProvider {
@@ -663,10 +663,10 @@ func TestModelCommandPersistsSelectedModelToUserConfig(t *testing.T) {
 	})
 	m.input.SetValue("/model gpt-4.1-mini")
 
-	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	updated, _ := m.Update(testKey(tea.KeyEnter))
 	next := updated.(model)
 
-	if cmd != nil {
+	if next.pending {
 		t.Fatal("expected /model to be handled without starting an agent run")
 	}
 	if next.modelName != "gpt-4.1-mini" {
@@ -2868,6 +2868,8 @@ func TestComposerBlinkStaysSolidWhileTyping(t *testing.T) {
 		terminalFocused:       true,
 		lastCharTime:          base,
 		composerCursorVisible: true,
+		composerBlinkSeq:      1,
+		composerBlinkTicking:  true,
 	}
 
 	// Each iteration simulates a keystroke (refreshing lastCharTime) followed by
@@ -2876,7 +2878,7 @@ func TestComposerBlinkStaysSolidWhileTyping(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		now = now.Add(200 * time.Millisecond)
 		m.lastCharTime = now
-		updated, _ := m.Update(composerBlinkMsg{})
+		updated, _ := m.Update(composerBlinkMsg{seq: m.composerBlinkSeq})
 		m = updated.(model)
 		if !m.composerCursorVisible {
 			t.Fatalf("tick %d: expected cursor to stay visible while typing, got hidden", i)
@@ -2927,10 +2929,10 @@ func TestComposerBlinkResumesAfterRefocusAndIdle(t *testing.T) {
 		t.Fatal("expected terminalFocused to be true after FocusMsg")
 	}
 
-	updated, _ = m.Update(composerBlinkMsg{})
+	updated, _ = m.Update(composerBlinkMsg{seq: m.composerBlinkSeq})
 	m = updated.(model)
 	first := m.composerCursorVisible
-	updated, _ = m.Update(composerBlinkMsg{})
+	updated, _ = m.Update(composerBlinkMsg{seq: m.composerBlinkSeq})
 	m = updated.(model)
 	second := m.composerCursorVisible
 	if first == second {
@@ -2945,17 +2947,50 @@ func TestComposerBlinkTogglesWhenIdleAndFocused(t *testing.T) {
 		terminalFocused:       true,
 		lastCharTime:          base.Add(-time.Hour),
 		composerCursorVisible: true,
+		composerBlinkSeq:      1,
+		composerBlinkTicking:  true,
 	}
 
-	updated, _ := m.Update(composerBlinkMsg{})
+	updated, _ := m.Update(composerBlinkMsg{seq: m.composerBlinkSeq})
 	m = updated.(model)
 	if m.composerCursorVisible {
 		t.Fatal("expected cursor to toggle off on first idle+focused tick")
 	}
-	updated, _ = m.Update(composerBlinkMsg{})
+	updated, _ = m.Update(composerBlinkMsg{seq: m.composerBlinkSeq})
 	m = updated.(model)
 	if !m.composerCursorVisible {
 		t.Fatal("expected cursor to toggle back on on second idle+focused tick")
+	}
+}
+
+func TestComposerBlinkSettlesVisibleWithoutRescheduling(t *testing.T) {
+	m := model{
+		now:                   func() time.Time { return time.Unix(100, 0) },
+		terminalFocused:       true,
+		lastCharTime:          time.Unix(0, 0),
+		composerCursorVisible: true,
+		composerBlinkSeq:      1,
+		composerBlinkTicking:  true,
+	}
+	var cmd tea.Cmd
+	for range composerBlinkIdleTicksBeforeSettle {
+		var updated tea.Model
+		updated, cmd = m.Update(composerBlinkMsg{seq: m.composerBlinkSeq})
+		m = updated.(model)
+	}
+	if m.composerBlinkTicking || cmd != nil || !m.composerCursorVisible {
+		t.Fatalf("settled cursor = ticking:%v cmd:%v visible:%v", m.composerBlinkTicking, cmd != nil, m.composerCursorVisible)
+	}
+}
+
+func TestComposerInputRestartsSettledBlink(t *testing.T) {
+	m := newModel(t.Context(), Options{})
+	m.composerBlinkTicking = false
+	m.composerCursorVisible = true
+	updated, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'a', Text: "a"}))
+	m = updated.(model)
+	if !m.composerBlinkTicking || cmd == nil || !m.composerCursorVisible {
+		t.Fatalf("restarted cursor = ticking:%v cmd:%v visible:%v", m.composerBlinkTicking, cmd != nil, m.composerCursorVisible)
 	}
 }
 

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -43,17 +43,21 @@ type Options struct {
 	PrepareRunCompletionWarning func()
 	RunCompletionWarning        func() string
 	Registry                    *tools.Registry
-	SessionStore                *sessions.Store
-	SandboxStore                *sandbox.GrantStore
-	MCPConfig                   config.MCPConfig
-	MCPPermissionStore          *mcp.PermissionStore
-	MCPTokenStore               *mcp.TokenStore
-	MCPCommand                  func(context.Context, []string) MCPCommandResult
-	SandboxSetupCommand         func(context.Context) SandboxSetupCommandResult
-	UsageTracker                *usage.Tracker
-	SessionCompactor            SessionCompactor
-	PrService                   *PrService
-	PeerService                 *peermsg.Service
+	// AwaitToolReadiness gives prompt-critical integration startup a bounded
+	// chance to publish its tools before this turn snapshots the registry. The
+	// wait runs inside the asynchronous agent command, so the TUI stays usable.
+	AwaitToolReadiness  func(context.Context)
+	SessionStore        *sessions.Store
+	SandboxStore        *sandbox.GrantStore
+	MCPConfig           config.MCPConfig
+	MCPPermissionStore  *mcp.PermissionStore
+	MCPTokenStore       *mcp.TokenStore
+	MCPCommand          func(context.Context, []string) MCPCommandResult
+	SandboxSetupCommand func(context.Context) SandboxSetupCommandResult
+	UsageTracker        *usage.Tracker
+	SessionCompactor    SessionCompactor
+	PrService           *PrService
+	PeerService         *peermsg.Service
 
 	AgentOptions agent.Options
 	// LoadSkills returns the installed skills (default skills dir merged with any

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -36,6 +36,7 @@ type Options struct {
 	RecapsEnabled               bool
 	Provider                    zeroruntime.Provider
 	NewProvider                 func(config.ProviderProfile) (zeroruntime.Provider, error)
+	NewTurnSessionProvider      func(config.ProviderProfile, zeroruntime.Provider) zeroruntime.TurnSessionProvider
 	ProbeProviderHealth         func(context.Context, providerhealth.Options) providerhealth.Result
 	DiscoverProviderModels      func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	DiscoverOllamaContextWindow func(ctx context.Context, baseURL string, model string) (int, error)

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -521,9 +521,9 @@ func TestModelPickerAppliesActiveProviderCatalogModelID(t *testing.T) {
 	})
 	m.input.SetValue("/model openai/gpt-4.1")
 
-	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	updated, _ := m.Update(testKey(tea.KeyEnter))
 	next := updated.(model)
-	if cmd != nil {
+	if next.pending {
 		t.Fatal("expected /model to be handled without starting a run")
 	}
 	if captured.Model != "openai/gpt-4.1" {
@@ -867,9 +867,9 @@ func TestModelCommandAcceptsManualModelForCustomProvider(t *testing.T) {
 	})
 	m.input.SetValue("/model qwen-custom-latest")
 
-	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	updated, _ := m.Update(testKey(tea.KeyEnter))
 	next := updated.(model)
-	if cmd != nil {
+	if next.pending {
 		t.Fatal("expected /model to be handled without starting a run")
 	}
 	if captured.Model != "qwen-custom-latest" {

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -46,10 +46,10 @@ func TestEffortCommandListsAndSetsSupportedEffort(t *testing.T) {
 	}
 
 	next.input.SetValue("/effort high")
-	updated, cmd = next.Update(testKey(tea.KeyEnter))
+	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 
-	if cmd != nil {
+	if next.pending {
 		t.Fatal("expected /effort high to be handled without starting an agent run")
 	}
 	if next.reasoningEffort != modelregistry.ReasoningEffortHigh {
@@ -153,10 +153,10 @@ func TestStyleCommandListsAndSetsSessionPreference(t *testing.T) {
 	}
 
 	next.input.SetValue("/style explanatory")
-	updated, cmd = next.Update(testKey(tea.KeyEnter))
+	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
 
-	if cmd != nil {
+	if next.pending {
 		t.Fatal("expected /style explanatory to be handled without starting an agent run")
 	}
 	if next.responseStyle != "explanatory" {
@@ -915,10 +915,10 @@ func TestModelSwitchClearsUnsupportedEffortPreference(t *testing.T) {
 	})
 	m.input.SetValue("/model gpt-4.1")
 
-	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	updated, _ := m.Update(testKey(tea.KeyEnter))
 	next := updated.(model)
 
-	if cmd != nil {
+	if next.pending {
 		t.Fatal("expected /model to be handled without starting an agent run")
 	}
 	if next.reasoningEffort != "" {

--- a/internal/tui/spec_mode.go
+++ b/internal/tui/spec_mode.go
@@ -247,14 +247,7 @@ func (m model) cancelSpecReview() (tea.Model, tea.Cmd) {
 }
 
 func cloneToolRegistry(registry *tools.Registry) *tools.Registry {
-	clone := tools.NewRegistry()
-	if registry == nil {
-		return clone
-	}
-	for _, tool := range registry.All() {
-		clone.Register(tool)
-	}
-	return clone
+	return registry.Clone()
 }
 
 // renderFocusedSpecReviewPrompt draws the spec-review gate in the shared card

--- a/internal/tui/transient_notice.go
+++ b/internal/tui/transient_notice.go
@@ -52,9 +52,8 @@ const (
 )
 
 type transientNotice struct {
-	text      string
-	tone      transientNoticeTone
-	expiresAt time.Time
+	text string
+	tone transientNoticeTone
 }
 
 // transientNoticeExpiredMsg is sequence-gated so an older timer can never
@@ -72,17 +71,29 @@ func (m model) showTransientNotice(text string, tone transientNoticeTone) (model
 		return m, nil
 	}
 	seq := m.transientNoticeSeq
-	return m, tea.Tick(transientNoticeDuration, func(time.Time) tea.Msg {
+	m.transientNoticeTimerSeq = seq
+	return m, transientNoticeExpiryCmd(seq)
+}
+
+// showTransientNoticeInline is for handlers that cannot return a tea.Cmd. The
+// outer Update path notices the new sequence and schedules its one-shot expiry.
+func (m model) showTransientNoticeInline(text string, tone transientNoticeTone) model {
+	m, _ = m.setTransientNotice(text, tone)
+	return m
+}
+
+func transientNoticeExpiryCmd(seq int) tea.Cmd {
+	return tea.Tick(transientNoticeDuration, func(time.Time) tea.Msg {
 		return transientNoticeExpiredMsg{seq: seq}
 	})
 }
 
-// showTransientNoticeInline is for handlers that cannot return a tea.Cmd. The
-// composer blink is already a permanent, low-cost UI tick, so it clears this
-// notice within one blink after expiry without introducing a second timer chain.
-func (m model) showTransientNoticeInline(text string, tone transientNoticeTone) model {
-	m, _ = m.setTransientNotice(text, tone)
-	return m
+func (m model) ensureTransientNoticeTimer() (model, tea.Cmd) {
+	if m.transientNotice.text == "" || m.transientNoticeTimerSeq == m.transientNoticeSeq {
+		return m, nil
+	}
+	m.transientNoticeTimerSeq = m.transientNoticeSeq
+	return m, transientNoticeExpiryCmd(m.transientNoticeSeq)
 }
 
 func (m model) setTransientNotice(text string, tone transientNoticeTone) (model, bool) {
@@ -91,26 +102,11 @@ func (m model) setTransientNotice(text string, tone transientNoticeTone) (model,
 		return m, false
 	}
 	m.transientNotice = transientNotice{
-		text:      text,
-		tone:      tone,
-		expiresAt: m.noticeNow().Add(transientNoticeDuration),
+		text: text,
+		tone: tone,
 	}
 	m.transientNoticeSeq++
 	return m, true
-}
-
-func (m model) noticeNow() time.Time {
-	if m.now != nil {
-		return m.now()
-	}
-	return time.Now()
-}
-
-func (m model) expireTransientNotice() model {
-	if expiresAt := m.transientNotice.expiresAt; !expiresAt.IsZero() && !m.noticeNow().Before(expiresAt) {
-		m.transientNotice = transientNotice{}
-	}
-	return m
 }
 
 func (m model) transientNoticeLine(width int) string {

--- a/internal/tui/transient_notice_test.go
+++ b/internal/tui/transient_notice_test.go
@@ -28,15 +28,18 @@ func TestTransientNoticeReplacesAndExpiresSafely(t *testing.T) {
 	}
 }
 
-func TestInlineTransientNoticeExpiresOnComposerTick(t *testing.T) {
-	now := time.Unix(100, 0)
-	m := model{now: func() time.Time { return now }}
+func TestInlineTransientNoticeSchedulesIndependentExpiry(t *testing.T) {
+	m := model{}
 	m = m.showTransientNoticeInline("Voice mode on", transientNoticeSuccess)
 	if m.transientNotice.text != "Voice mode on" {
 		t.Fatalf("notice = %q", m.transientNotice.text)
 	}
-	now = now.Add(transientNoticeDuration)
-	next, _ := m.updateModel(composerBlinkMsg{})
+	next, cmd := m.Update(struct{}{})
+	m = next.(model)
+	if cmd == nil || m.transientNoticeTimerSeq != m.transientNoticeSeq {
+		t.Fatal("inline notice did not schedule its independent expiry")
+	}
+	next, _ = m.updateModel(transientNoticeExpiredMsg{seq: m.transientNoticeSeq})
 	if got := next.(model).transientNotice.text; got != "" {
 		t.Fatalf("expired inline notice = %q", got)
 	}

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -135,7 +135,7 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 					options.OnReasoning(event.Content)
 				}
 			case StreamEventToolCallStart:
-				collector.start(event.ToolCallID, event.ToolName, event.ToolCallSignature)
+				collector.start(event.ToolCallID, event.ToolCallProviderID, event.ToolName, event.ToolCallSignature, event.ToolCallFreeform)
 				if options.OnToolCallStart != nil {
 					options.OnToolCallStart(event.ToolCallID, event.ToolName)
 				}
@@ -225,7 +225,7 @@ func newToolCallCollector() *toolCallCollector {
 // start begins a tool call. A non-empty ID reuses any open call with that ID
 // (some backends re-emit the same start); an empty ID always begins a fresh
 // synthetic call so concurrent empty-id calls stay distinct.
-func (collector *toolCallCollector) start(id string, name string, signature string) {
+func (collector *toolCallCollector) start(id string, providerCallID string, name string, signature string, freeform bool) {
 	key := id
 	if id == "" {
 		// Adopt an empty-id call that a delta opened before this start, so its
@@ -240,6 +240,9 @@ func (collector *toolCallCollector) start(id string, name string, signature stri
 		}
 	}
 	call := collector.ensure(key, id)
+	if providerCallID != "" && call.ProviderCallID == "" {
+		call.ProviderCallID = providerCallID
+	}
 	// Only set the name when non-empty and still unset, so a duplicate or
 	// nameless follow-up start cannot clobber an already-resolved name.
 	if name != "" && call.Name == "" {
@@ -250,6 +253,7 @@ func (collector *toolCallCollector) start(id string, name string, signature stri
 	if signature != "" && call.Signature == "" {
 		call.Signature = signature
 	}
+	call.Freeform = call.Freeform || freeform
 }
 
 func (collector *toolCallCollector) delta(id string, fragment string) {

--- a/internal/zeroruntime/tool_call_collector_test.go
+++ b/internal/zeroruntime/tool_call_collector_test.go
@@ -1,0 +1,37 @@
+package zeroruntime
+
+import "testing"
+
+func TestToolCallCollectorPreservesProviderMetadataAndFreeformState(t *testing.T) {
+	collector := newToolCallCollector()
+	collector.start("public-1", "provider-1", "apply_patch", "sig-1", true)
+	collector.delta("public-1", "raw patch")
+	collected := &CollectedStream{}
+	collector.flush(collected)
+
+	if len(collected.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one", collected.ToolCalls)
+	}
+	call := collected.ToolCalls[0]
+	if call.ID != "public-1" || call.ProviderCallID != "provider-1" || call.Name != "apply_patch" ||
+		call.Signature != "sig-1" || call.Arguments != "raw patch" || !call.Freeform {
+		t.Fatalf("collected tool call lost provider metadata: %#v", call)
+	}
+}
+
+func TestToolCallCollectorPreservesEmptyPublicID(t *testing.T) {
+	collector := newToolCallCollector()
+	collector.start("", "provider-1", "read_file", "", false)
+	collector.delta("", `{"path":"README.md"}`)
+	collector.end("")
+	collected := &CollectedStream{}
+	collector.flush(collected)
+
+	if len(collected.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one", collected.ToolCalls)
+	}
+	call := collected.ToolCalls[0]
+	if call.ID != "" || call.ProviderCallID != "provider-1" || call.Name != "read_file" {
+		t.Fatalf("empty-public-id tool call = %#v", call)
+	}
+}

--- a/internal/zeroruntime/tool_call_collector_test.go
+++ b/internal/zeroruntime/tool_call_collector_test.go
@@ -1,6 +1,9 @@
 package zeroruntime
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestToolCallCollectorPreservesProviderMetadataAndFreeformState(t *testing.T) {
 	collector := newToolCallCollector()
@@ -33,5 +36,30 @@ func TestToolCallCollectorPreservesEmptyPublicID(t *testing.T) {
 	call := collected.ToolCalls[0]
 	if call.ID != "" || call.ProviderCallID != "provider-1" || call.Name != "read_file" {
 		t.Fatalf("empty-public-id tool call = %#v", call)
+	}
+}
+
+func TestCollectStreamErrorPreservesIncompleteToolCallMetadata(t *testing.T) {
+	events := make(chan StreamEvent, 2)
+	events <- StreamEvent{
+		Type:               StreamEventToolCallStart,
+		ToolCallID:         "public-1",
+		ToolCallProviderID: "provider-1",
+		ToolName:           "apply_patch",
+		ToolCallFreeform:   true,
+	}
+	events <- StreamEvent{Type: StreamEventError, Error: "stream failed"}
+	close(events)
+
+	collected := CollectStreamWithOptions(context.Background(), events, CollectOptions{})
+	if collected.Error != "stream failed" {
+		t.Fatalf("collected error = %q, want stream failed", collected.Error)
+	}
+	if len(collected.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v, want one incomplete call", collected.ToolCalls)
+	}
+	call := collected.ToolCalls[0]
+	if call.ProviderCallID != "provider-1" || !call.Freeform {
+		t.Fatalf("incomplete tool call lost provider metadata: %#v", call)
 	}
 }

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -184,6 +184,10 @@ type StreamEvent struct {
 	ArgumentsFragment string
 	Usage             Usage
 	Error             string
+	// ResponseID is the provider's completed response identifier when one is
+	// available. Stateful turn sessions use it to chain a later compatible
+	// request; ordinary providers and consumers leave it empty.
+	ResponseID string
 	// FinishReason carries the provider's normalized terminal stop reason when a
 	// response did not end normally (e.g. FinishReasonLength when the output hit
 	// the token cap, or FinishReasonContentFilter when it was filtered). It is

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -67,9 +67,14 @@ const (
 
 // ToolCall is a normalized assistant request to run a tool.
 type ToolCall struct {
-	ID        string
-	Name      string
-	Arguments string
+	ID             string
+	ProviderCallID string
+	Name           string
+	Arguments      string
+	// Freeform reports that Arguments is raw tool input rather than a JSON
+	// object. Only providers that advertise a matching freeform definition set
+	// it; ordinary function calls remain unchanged.
+	Freeform bool
 	// Signature carries a provider's opaque reasoning signature bound to this call
 	// (Gemini attaches a thoughtSignature to a functionCall part). It must be
 	// echoed back with the call on later turns or the provider may reject the
@@ -93,21 +98,38 @@ type ReasoningBlock struct {
 
 // Message is a normalized conversation turn passed to providers.
 type Message struct {
-	Role         MessageRole
-	Content      string
-	ToolCalls    []ToolCall
-	ToolCallID   string
-	IsError      bool             // tool-result status; ignored for non-tool messages
-	ChangedFiles []string         // durable tool-result mutation targets; ignored by providers
-	Images       []ImageBlock     // optional; nil for text-only messages
-	Reasoning    []ReasoningBlock // optional; preserved thinking blocks to replay
+	Role               MessageRole
+	Content            string
+	ToolCalls          []ToolCall
+	ToolCallID         string
+	ToolCallProviderID string
+	IsError            bool             // tool-result status; ignored for non-tool messages
+	ChangedFiles       []string         // durable tool-result mutation targets; ignored by providers
+	Images             []ImageBlock     // optional; nil for text-only messages
+	Reasoning          []ReasoningBlock // optional; preserved thinking blocks to replay
 }
 
-// ToolDefinition describes a model-visible tool and its JSON-schema parameters.
+type ToolDefinitionType string
+
+const (
+	ToolDefinitionFunction ToolDefinitionType = "function"
+	ToolDefinitionFreeform ToolDefinitionType = "custom"
+)
+
+type ToolDefinitionFormat struct {
+	Type       string `json:"type"`
+	Syntax     string `json:"syntax"`
+	Definition string `json:"definition"`
+}
+
+// ToolDefinition describes a model-visible function or freeform tool. Type is
+// empty for the legacy function shape; Format is used only by freeform tools.
 type ToolDefinition struct {
 	Name        string
 	Description string
 	Parameters  map[string]any
+	Type        ToolDefinitionType
+	Format      *ToolDefinitionFormat
 }
 
 // TokenUsage accepts provider-specific token aliases before normalization.
@@ -176,14 +198,16 @@ func (usage Usage) VisibleOutputTokens() int {
 
 // StreamEvent is one normalized event emitted by a streaming provider.
 type StreamEvent struct {
-	Type              StreamEventType
-	Content           string
-	ToolCallID        string
-	ToolName          string
-	ToolCallSignature string // opaque reasoning signature bound to this call (Gemini thoughtSignature)
-	ArgumentsFragment string
-	Usage             Usage
-	Error             string
+	Type               StreamEventType
+	Content            string
+	ToolCallID         string
+	ToolCallProviderID string
+	ToolName           string
+	ToolCallSignature  string // opaque reasoning signature bound to this call (Gemini thoughtSignature)
+	ToolCallFreeform   bool
+	ArgumentsFragment  string
+	Usage              Usage
+	Error              string
 	// ResponseID is the provider's completed response identifier when one is
 	// available. Stateful turn sessions use it to chain a later compatible
 	// request; ordinary providers and consumers leave it empty.


### PR DESCRIPTION
## Summary

- Reduce unnecessary TUI message churn by removing duplicate cursor blinking and stopping finite composer timers after idle.
- Move optional tool discovery off the startup path and publish immutable tool-registry snapshots for cheaper concurrent reads.
- Reuse compatible response sessions, send patch input in its native form, and recognize persisted ChatGPT session metadata when reconnecting.
- Expose cache read/write efficiency and reduce bounded-task turn churn through direct reads, native patches, and consolidated verification.

## Why

Zero was doing avoidable work before the first frame and between compatible provider turns. This change keeps the same user-facing capabilities while reducing startup latency and repeated turn overhead.

## Turn-efficiency comparison

A controlled coding workload used the same provider, model, reasoning level, prompt, and fresh fixture before and after the turn-efficiency changes. The after column is the faster of two post-change runs; both passed the same hidden correctness oracle:

| Metric | Zero before | Zero after |
| --- | ---: | ---: |
| Completion time | 3m 22.6s | 1m 42.5s |
| Model requests | 14 | 4 |
| Tool actions | 22 | 6 |
| Total input | 202.1K | 41.5K |
| Uncached input | 48.5K | 25.2K |
| Output tokens | 8.6K | 4.6K |
| Reasoning tokens | 3.8K | 1.9K |
| Local CPU | 3.57s | 1.59s |
| Peak RSS | 147.1 MB | 117.4 MB |
| Correctness | Passed | Passed |

## Dependency scope

Zero uses the official `charm.land/bubbletea/v2 v2.0.9` release. Demand-driven renderer changes are intentionally excluded and can follow separately after upstream support is released.

## Validation

- `make fmt-check`
- `go vet ./...`
- `go test ./...`
- `go test -race ./internal/tui ./internal/providers/openai ./internal/tools ./internal/mcp ./internal/cli ./internal/agent -count=1`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `make lint-static`
- `make vulncheck`
- `git diff HEAD --check`

All change-related checks passed against official Bubble Tea. A local full-suite run still reproduces the pre-existing `TestAltScreenTranscriptScrollKeepsFooterFixed` failure on the untouched comparison checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optimized ChatGPT sessions with streaming, response chaining, and automatic fallback.
  * Added freeform tool support, including safer `apply_patch` operations within permitted locations.
  * Optional MCP services now start in the background, with tools appearing when ready.
  * Added cached-input and cache-write token usage to command output and performance metrics.

* **Bug Fixes**
  * Preserved tool-call identifiers across responses and conversation history.
  * Improved tool registration consistency, error redaction, shutdown handling, cursor blinking, and notification timing.
  * Improved planning guidance for complex tasks and direct file editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->