### PR TITLE
security(mcp): fix stdio dispatcher type confusion (Z-052)

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -385,7 +385,34 @@ func (client *Client) readLoop() {
 			client.failAll(err)
 			return
 		}
+		// Explicit type validation: distinguish requests/notifications (have
+		// method) from responses (no method, has id). Only responses may be
+		// delivered to pending callers. Server-initiated requests must never be
+		// misdelivered as a response even when the id collides with a pending
+		// client request (Z-052).
+		if message.Method != "" {
+			if message.ID != nil {
+				// Server-initiated request: route to request handler and
+				// reply with method-not-found so the server does not hang.
+				// The client does not currently handle inbound requests, so
+				// every method is unknown. Log for diagnostics.
+				_, _ = fmt.Fprintf(os.Stderr, "[mcp] server request %q (id %v) not handled: replying method not found\n", message.Method, message.ID)
+				client.mu.Lock()
+				_ = client.writer.write(rpcMessage{
+					JSONRPC: "2.0",
+					ID:      message.ID,
+					Error:   &rpcError{Code: -32601, Message: "method not found: " + message.Method},
+				})
+				client.mu.Unlock()
+			}
+			// Notifications (no id) and handled server requests are not
+			// responses — do not dispatch.
+			continue
+		}
 		if message.ID == nil {
+			// No id and no method: invalid or stray message. Ignore but log
+			// for diagnostics to help trace protocol mismatches.
+			_, _ = fmt.Fprintf(os.Stderr, "[mcp] ignoring unexpected message without id (method %q)\n", message.Method)
 			continue
 		}
 		id, ok := rpcMessageID(message.ID)

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -539,6 +539,12 @@ func (client *remoteSSEClient) deliverEventMessage(value string) error {
 	if err := decoder.Decode(&message); err != nil {
 		return fmt.Errorf("decode MCP SSE stream message: %w", err)
 	}
+	// Explicit type validation: only messages without a method are responses.
+	// Server-initiated requests (method set) must not be misdelivered to a
+	// pending caller even when the id collides (Z-052).
+	if message.Method != "" {
+		return nil
+	}
 	key := rpcResponseKey(message.ID)
 	if key == "" {
 		return nil


### PR DESCRIPTION
Fixes MCP stdio dispatcher type confusion (Z-052) in `internal/mcp/client.go:381`.

The `readLoop` previously classified messages only by `ID == nil`. A server-initiated request `{"id":1,"method":"..."}` with an `id` colliding with a pending client request `{"id":1,"method":"tools/list"}` was dispatched to `pending[1]` as if it were a response. `request()` at `client.go:347` then saw `Method` set but `Result`/`Error` empty and returned an empty `CallToolResult`, surfacing as silent empty tool output.

Changes:
* `internal/mcp/client.go:393-418` – Explicit type validation: `if message.Method != ""` is treated as request/notification, never as response. Server requests (`Method != "" && ID != nil`) are routed to a handler that replies `{"id":<same>,"error":{"code":-32601,"message":"method not found: <method>"}}` under `client.mu` and are not dispatched. Notifications (`Method != "" && ID==nil`) are ignored. Only `Method == "" && ID != nil` proceeds to `rpcMessageID`/`pending` lookup. Added `fmt.Fprintf(os.Stderr, "[mcp] ...")` diagnostics for server requests and invalid `ID==nil && Method==""` messages.
* `internal/mcp/network_client.go:542-548` – Mirror check in `remoteSSEClient.deliverEventMessage`: `if message.Method != "" { return nil }` to prevent SSE stream misdelivery when `id` collides.

This implements the three recommended fixes from #924: explicit type validation, separate request routing, improved diagnostics.

## Linked issue

Fixes #924

## Checklist

- [x] The linked issue already has the `issue-approved` label. <!-- requires maintainer approval per CONTRIBUTING.md -->
- [x] `go vet ./...` and `go test ./internal/mcp -race` pass locally (`TestClientRequestWaitsForMatchingResponseID`, `TestStdioClientListsAndCallsTools`, SSE/HTTP clients). Full `go vet ./...` clean.
- [x] `gofmt` clean (`make fmt-check` passes, `git diff --check` clean).
- [x] Verified with `io.Pipe` reproduction: colliding `server/request id=1` before correct `{"id":1,"result":{"value":"matched"}}` previously returned `Value=""` (misdelivered), now correctly returns `Value="matched"` and server receives `-32601 method not found`. Existing tests exercise the `method` vs `id` distinction (`TestClientRequestWaitsForMatchingResponseID`, `TestDecodeSSERPCMessageSkipsNotifications`).
- [ ] UI changes include screenshots or a short recording where possible. <!-- N/A -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unexpected server messages during communication.
  - Server-initiated requests now receive an appropriate “method not found” response instead of disrupting response processing.
  - Notifications and malformed messages are safely ignored.
  - Responses are matched only when they contain valid request identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->