### PR TITLE
ci: Run the race detector on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,34 @@ jobs:
       - name: Smoke binary
         run: go run ./cmd/zero-release smoke
 
+  race:
+    name: Race Detector
+    runs-on: ubuntu-latest
+    # A race the detector newly reports can present as a deadlock rather than a
+    # failure, and the default job timeout is six hours. This job is expected to
+    # be the longest in the workflow, so the ceiling is generous but finite.
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Invoke the Makefile target rather than repeating its flags. `make test`
+      # is already `go test ./... -race -count=1`, so running it here is what
+      # stops the project's declared test command and what CI actually runs
+      # from drifting apart again. The race detector needs cgo, which the
+      # hosted ubuntu runner supplies without an extra setup step.
+      - name: Test with the race detector
+        run: make test
+
   performance:
     name: Performance Smoke
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
   race:
     name: Race Detector
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # A race the detector newly reports can present as a deadlock rather than a
     # failure, and the default job timeout is six hours. This job is expected to
     # be the longest in the workflow, so the ceiling is generous but finite.


### PR DESCRIPTION
## Summary

`make test` is `go test ./... -race -count=1`, but nothing invokes that target.
`ci.yml:79` and `pr-auto-review.yml:42` both run plain `go test ./...`, and
`-race` appears nowhere under `.github/workflows`. The race detector has never
run on a pull request, so the concurrent paths where a race is easiest to
introduce and hardest to catch in review are unchecked: the turn loop, streaming
provider I/O, the session store, cron, swarm mailboxes, and the cross-process
lock paths in the credential and OAuth stores.

Fixes #939

## Changes

One job added to `.github/workflows/ci.yml`, 28 lines, nothing else touched.

**A dedicated job, not `-race` on the existing matrix step.** A failure reads as
a race rather than as a smoke failure, and the run does not serialize ahead of
`Build binary` and `Smoke binary` in the matrix job.

I expected the duration to be the deciding factor and it is not. Measured on
this PR (run 32550027280), the job takes 4m47s against a 3m33s plain ubuntu
`Test` step on `main`, so roughly 1.3x rather than the several-fold cost I
assumed. It runs in parallel and finishes inside `Smoke (windows-latest)`, which
remains the long pole at 9m24s, so PR wall time is unchanged:

| job | duration |
| --- | --- |
| Smoke (windows-latest) | 9m24s |
| Race Detector | 4m47s |
| Smoke (ubuntu-latest) | 4m36s |
| Smoke (macos-latest) | 4m36s |
| Security & code health | 2m06s |
| Performance Smoke | 0m31s |

**Ubuntu only.** The detector instruments Go's memory model rather than anything
OS-specific, so one platform buys most of the coverage. At the measured cost,
widening to the full matrix is more affordable than I assumed when I wrote this,
and worth a follow-up, though Windows would need weighing separately since it is
already the long pole.

**`make test` rather than repeating the flags.** Invoking the target is the part
that stops this from recurring: a change to how the project tests takes effect
in CI without a second edit, instead of the Makefile and the workflow drifting
apart the way they already have.

**`timeout-minutes: 30`.** A race the detector newly reports can present as a
deadlock rather than a failure, and the default job timeout is six hours.

## Test plan

The CI run on this PR is the test. `Race Detector` appears and passes, alongside
the five pre-existing checks, all green. There is no unit test to add for a
workflow job, and no way to exercise it before it exists on a branch.

Checked locally on `ad34dc8`:

- `.github/workflows/ci.yml` parses, and the job graph is
  `smoke, race, performance, security` with the new job's final step being
  `make test`.
- `make -n test` was not run: `make` is not installed on this machine. The
  target was read from the Makefile, not executed. The hosted ubuntu runner has
  both `make` and the C toolchain `-race` needs, so no setup step is required.

## Result of the first run

The open question was whether the suite has a pre-existing data race, which
would have made this red on arrival and needed fixing before the check could
block. It does not: the first run the detector has ever had on this codebase is
green, so the job is viable as a blocking check with no cleanup in front of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated race-condition testing in the CI pipeline.
  * Race-enabled tests now run on Ubuntu with a 30-minute execution limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->