### PR TITLE
fix(sandbox): Make WSL backend tests deterministic

### DIFF
--- a/internal/sandbox/adapters.go
+++ b/internal/sandbox/adapters.go
@@ -7,6 +7,7 @@ import (
 type BackendOptions struct {
 	GOOS             string
 	LookupExecutable func(string) (string, error)
+	DetectWSL        func() WSLInfo
 }
 
 type Backend struct {
@@ -53,6 +54,7 @@ func SelectBackend(options BackendOptions) Backend {
 	return NewSandboxManager(SandboxManagerOptions{
 		GOOS:             options.GOOS,
 		LookupExecutable: options.LookupExecutable,
+		DetectWSL:        options.DetectWSL,
 	}).Backend()
 }
 

--- a/internal/sandbox/adapters_test.go
+++ b/internal/sandbox/adapters_test.go
@@ -45,12 +45,27 @@ func TestSelectBackendChoosesPlatformAdapterWithFallback(t *testing.T) {
 				}
 				return "", errors.New("missing")
 			},
+			DetectWSL: func() WSLInfo { return WSLInfo{} },
 		})
 		if backend.Name != BackendUnavailable || backend.Available {
 			t.Fatalf("linux backend = %#v, want native sandbox unavailable without Linux helper", backend)
 		}
 		if !strings.Contains(backend.Message, "Linux sandbox helper is not available") {
 			t.Fatalf("linux fallback message = %q, want missing helper", backend.Message)
+		}
+	})
+
+	t.Run("linux helper missing under WSL reports WSL fallback", func(t *testing.T) {
+		backend := SelectBackend(BackendOptions{
+			GOOS:             "linux",
+			LookupExecutable: func(string) (string, error) { return "", errors.New("missing") },
+			DetectWSL:        func() WSLInfo { return WSLInfo{IsWSL: true, IsWSL2: true} },
+		})
+		if backend.Name != BackendWSL || backend.Available || !backend.Fallback {
+			t.Fatalf("linux backend = %#v, want explicit WSL fallback", backend)
+		}
+		if !strings.Contains(backend.Message, "WSL2") {
+			t.Fatalf("linux fallback message = %q, want WSL2 diagnostic", backend.Message)
 		}
 	})
 

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -51,6 +51,7 @@ const (
 type SandboxManagerOptions struct {
 	GOOS             string
 	LookupExecutable func(string) (string, error)
+	DetectWSL        func() WSLInfo
 	Backend          Backend
 }
 
@@ -96,7 +97,7 @@ func NewSandboxManager(options SandboxManagerOptions) SandboxManager {
 		goos = runtime.GOOS
 	}
 	if backend.Name == "" {
-		backend = selectPlatformBackend(goos, options.LookupExecutable)
+		backend = selectPlatformBackend(goos, options.LookupExecutable, options.DetectWSL)
 	}
 	if backend.Platform == "" {
 		backend.Platform = goos
@@ -168,9 +169,12 @@ func lookupExecutable(name string) (string, error) {
 	return "", errors.New("executable file not found")
 }
 
-func selectPlatformBackend(goos string, lookup func(string) (string, error)) Backend {
+func selectPlatformBackend(goos string, lookup func(string) (string, error), detect func() WSLInfo) Backend {
 	if lookup == nil {
 		lookup = lookupExecutable
+	}
+	if detect == nil {
+		detect = detectWSL
 	}
 	switch goos {
 	case "linux":
@@ -180,7 +184,7 @@ func selectPlatformBackend(goos string, lookup func(string) (string, error)) Bac
 			}
 			return nativeBackend(goos, BackendLinuxBwrap, helper, "Linux sandbox helper available")
 		}
-		if info := detectWSL(); info.IsWSL {
+		if info := detect(); info.IsWSL {
 			return wslBackend(goos, info)
 		}
 		return unavailableBackend(goos, "Linux sandbox helper is not available")


### PR DESCRIPTION
## Summary

Make Linux backend selection tests deterministic on WSL hosts by allowing WSL detection to be injected. Production still defaults to detecting the real host environment.

## Changes

- Add `DetectWSL` to `BackendOptions` and `SandboxManagerOptions`.
- Use the production `detectWSL()` implementation when no detector is supplied.
- Pin the non-WSL missing-helper fallback and add explicit WSL2 fallback coverage.

## Test plan

- `go test ./internal/sandbox -run TestSelectBackendChoosesPlatformAdapterWithFallback/linux_helper_missing_falls_back_explicitly -count=1`
- `go test ./...`
- `go vet ./...`

Fixes #947


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux sandbox detection when the standard helper is unavailable.
  * WSL2 environments are now clearly identified as an unavailable fallback with diagnostic information.

* **Tests**
  * Added coverage verifying WSL2 fallback behavior for Linux systems lacking the sandbox helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->