### PR TITLE
perf(tui): bounded file read, LRU rendering cache, and size caps for full-file view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,18 +47,13 @@ request, or completing an implementation task:
 1. **Formatting check**: `make fmt-check`. If it fails, format with
    `go fmt ./...` (or `make fmt`) and run the check again.
 2. **Vet**: `go vet ./...` (or `make vet`).
-3. **Tests**: `make test` (`go test ./... -race -count=1`). Run the full
-   unfiltered package/module suite under `-race`. Never rely on narrow `-run`
-   filters for final validation when shared components or concurrency are touched.
-4. **Resilience & Full Lifecycle Invariant**: Tests exercising invalidations,
-   cache clears, concurrent mutations, or rejected messages must prove full
-   recovery and valid terminal state (re-issuing loads and rendering updated
-   content), never asserting passive broken intermediate states (e.g. `renderedContent == ""`).
-5. **Build**: `go run ./cmd/zero-release build`.
-6. **Smoke test**: `go run ./cmd/zero-release smoke`.
-7. **Advisory lint**: `make lint-static`.
-8. **Security**: `make vulncheck`.
-9. **Diff hygiene**: `git diff HEAD --check` (covers staged and unstaged
+3. **Tests**: `go test ./...`. Use `make test` for the full race-enabled suite,
+   or run focused tests with `-race`, when concurrency is affected.
+4. **Build**: `go run ./cmd/zero-release build`.
+5. **Smoke test**: `go run ./cmd/zero-release smoke`.
+6. **Advisory lint**: `make lint-static`.
+7. **Security**: `make vulncheck`.
+8. **Diff hygiene**: `git diff HEAD --check` (covers staged and unstaged
    tracked changes).
 
 `make lint` currently runs the formatting check and `go vet`; it does **not**
@@ -77,11 +72,6 @@ it.
 
 These classes drive multi-round reviews. Fix them before requesting review:
 
-- **End-to-End Recovery & Invalidation Cycles:** Any async state, cache invalidation,
-  or message rejection must reschedule or re-render automatically. A test that asserts
-  an empty intermediate state without verifying subsequent recovery will block review.
-- **Unfiltered `-race` Verification:** Running only focused tests (`-run`) on shared
-  components obscures cross-module regressions. Full package suites under `-race` are required.
 - **Fresh base:** Rebase onto the current PR base (`main` or stacked target)
   before review. A stale head that rolls back mainline commits is a hard
   blocker, not a merge-time detail. Resolve conflicts by keeping upstream

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,13 +47,18 @@ request, or completing an implementation task:
 1. **Formatting check**: `make fmt-check`. If it fails, format with
    `go fmt ./...` (or `make fmt`) and run the check again.
 2. **Vet**: `go vet ./...` (or `make vet`).
-3. **Tests**: `go test ./...`. Use `make test` for the full race-enabled suite,
-   or run focused tests with `-race`, when concurrency is affected.
-4. **Build**: `go run ./cmd/zero-release build`.
-5. **Smoke test**: `go run ./cmd/zero-release smoke`.
-6. **Advisory lint**: `make lint-static`.
-7. **Security**: `make vulncheck`.
-8. **Diff hygiene**: `git diff HEAD --check` (covers staged and unstaged
+3. **Tests**: `make test` (`go test ./... -race -count=1`). Run the full
+   unfiltered package/module suite under `-race`. Never rely on narrow `-run`
+   filters for final validation when shared components or concurrency are touched.
+4. **Resilience & Full Lifecycle Invariant**: Tests exercising invalidations,
+   cache clears, concurrent mutations, or rejected messages must prove full
+   recovery and valid terminal state (re-issuing loads and rendering updated
+   content), never asserting passive broken intermediate states (e.g. `renderedContent == ""`).
+5. **Build**: `go run ./cmd/zero-release build`.
+6. **Smoke test**: `go run ./cmd/zero-release smoke`.
+7. **Advisory lint**: `make lint-static`.
+8. **Security**: `make vulncheck`.
+9. **Diff hygiene**: `git diff HEAD --check` (covers staged and unstaged
    tracked changes).
 
 `make lint` currently runs the formatting check and `go vet`; it does **not**
@@ -72,6 +77,11 @@ it.
 
 These classes drive multi-round reviews. Fix them before requesting review:
 
+- **End-to-End Recovery & Invalidation Cycles:** Any async state, cache invalidation,
+  or message rejection must reschedule or re-render automatically. A test that asserts
+  an empty intermediate state without verifying subsequent recovery will block review.
+- **Unfiltered `-race` Verification:** Running only focused tests (`-run`) on shared
+  components obscures cross-module regressions. Full package suites under `-race` are required.
 - **Fresh base:** Rebase onto the current PR base (`main` or stacked target)
   before review. A stale head that rolls back mainline commits is a hard
   blocker, not a merge-time detail. Resolve conflicts by keeping upstream

--- a/internal/config/unknownfields.go
+++ b/internal/config/unknownfields.go
@@ -131,7 +131,7 @@ type knownField struct {
 }
 
 func derefType(t reflect.Type) reflect.Type {
-	for t != nil && t.Kind() == reflect.Pointer {
+	for t != nil && t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
 	return t

--- a/internal/config/unknownfields.go
+++ b/internal/config/unknownfields.go
@@ -131,7 +131,7 @@ type knownField struct {
 }
 
 func derefType(t reflect.Type) reflect.Type {
-	for t != nil && t.Kind() == reflect.Ptr {
+	for t != nil && t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t

--- a/internal/tui/btw.go
+++ b/internal/tui/btw.go
@@ -91,6 +91,20 @@ func (m model) handleBTWCommand(question string) (model, tea.Cmd) {
 	parent.flushQueue = nil
 
 	side := parent
+	// The side surface must own its file-view lifecycle. Because `side` is a
+	// value copy of `parent`, its liveSeq pointer would otherwise alias the
+	// hidden parent's: closing or switching the view in BTW would revoke the
+	// parent's in-flight load. Detach it and give the side a fresh lifetime so
+	// inherited markers cannot masquerade as the parent's snapshot.
+	side.fileView.liveSeq = nil
+	if side.fileView.active {
+		side.fileView.lifetimeToken = nextFileViewLifetimeToken()
+		side.fileView.loadedToken = [16]byte{}
+		side.fileView.loadedSeq = 0
+		side.fileView.loadedRev = 0
+		side.fileView.snapshotReady = false
+		side.fileView.renderedContent = ""
+	}
 	side.activeSession = fork
 	side.sessionEvents = events
 	side.transcript = initialTranscript()
@@ -156,10 +170,16 @@ func (m model) handleBTWCommand(question string) (model, tea.Cmd) {
 		sideRunIDBase: side.runID,
 	}
 
-	if question == "" {
-		return side, nil
+	var btwFileViewCmd tea.Cmd
+	if side.fileView.active && side.fileView.mode == fileViewFull {
+		side, btwFileViewCmd = side.startFileViewLoadCmd(side.chatColumnWidth())
 	}
-	return side.launchPrompt(question)
+
+	if question == "" {
+		return side, btwFileViewCmd
+	}
+	next, launchCmd := side.launchPrompt(question)
+	return next, batchCommands(btwFileViewCmd, launchCmd)
 }
 
 func (m model) leaveBTW() (model, tea.Cmd) {
@@ -229,9 +249,9 @@ func btwCommandUnavailable(command parsedCommand) bool {
 // messages have no run ID, so normal BTW routing intentionally leaves them on
 // the visible side surface; copying the layout fields prevents stale wrapping
 // after the parent is restored.
-func (m model) resizeBTWParent(msg tea.WindowSizeMsg) model {
+func (m model) resizeBTWParent(msg tea.WindowSizeMsg) (model, tea.Cmd) {
 	if !m.btw.active || m.btw.parent == nil {
-		return m
+		return m, nil
 	}
 	parent := *m.btw.parent
 	parent.width = msg.Width
@@ -240,8 +260,15 @@ func (m model) resizeBTWParent(msg tea.WindowSizeMsg) model {
 	parent.lineAges = nil
 	parent.lastStreamActivity = parent.now()
 	parent.input.SetWidth(maxInt(20, chatWidth(msg.Width)-14))
+	// The parent's full-file view wrapped at the old width; reload it at the new
+	// one. Its completion has no run ID, so routeBTWParentMessage matches it by
+	// lifetime token and delivers it to the hidden parent.
+	var cmd tea.Cmd
+	if parent.fileView.active && parent.fileView.mode == fileViewFull {
+		parent, cmd = parent.startFileViewLoadCmd(parent.chatColumnWidth())
+	}
 	m.btw.parent = &parent
-	return m
+	return m, cmd
 }
 
 func btwTitle(parent string) string {
@@ -264,6 +291,15 @@ func (m model) routeBTWParentMessage(msg tea.Msg) (model, tea.Cmd, bool) {
 			return m, nil, false
 		}
 		return m.routeBTWMessageToParent(msg)
+	}
+	if loaded, ok := msg.(fileViewLoadedMsg); ok {
+		// File-view completions carry no run ID. Deliver the hidden parent's
+		// load (matched by lifetime token) so it does not stay stuck on
+		// "Loading…" while BTW is active; side-owned loads fall through.
+		if m.btw.parent.fileView.active && m.btw.parent.fileView.lifetimeToken == loaded.lifetimeToken {
+			return m.routeBTWMessageToParent(msg)
+		}
+		return m, nil, false
 	}
 	runID, ok := btwMessageRunID(msg)
 	if !ok || runID <= 0 || runID >= m.btw.sideRunIDBase {

--- a/internal/tui/export_test.go
+++ b/internal/tui/export_test.go
@@ -128,6 +128,15 @@ func (c *staticRenderCache) stats() renderCacheStats {
 	return c.statsData
 }
 
+func fileViewCacheStatsForTest() fileViewCacheStats {
+	return defaultFileViewCache.stats()
+}
+
+func resetFileViewCacheForTest() {
+	defaultFileViewCache.clear()
+	defaultFileViewCache.resetStats()
+}
+
 func renderSelectableList(options selectableListOptions) string {
 	if len(options.Items) == 0 {
 		return ""

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -502,15 +502,17 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	c.statsData.HighlightCalls++
 	c.mu.Unlock()
 
-	display, ok := highlightCodeForPathWithTheme(readRes.lines, displayPath, 1<<20, nil, theme)
-	if !ok || len(display) != len(readRes.lines) {
-		display = make([]string, len(readRes.lines))
-		for i, l := range readRes.lines {
-			display[i] = sanitizeRawFileLine(l)
-		}
+	cleanLines := make([]string, len(readRes.lines))
+	for i, l := range readRes.lines {
+		cleanLines[i] = sanitizeRawFileLine(l)
 	}
 
-	rendered := formatFileViewLines(readRes.lines, display, changed, readRes.truncated, readRes.omittedLines, width, theme)
+	display, ok := highlightCodeForPathWithTheme(cleanLines, displayPath, 1<<20, nil, theme)
+	if !ok || len(display) != len(cleanLines) {
+		display = cleanLines
+	}
+
+	rendered := formatFileViewLines(cleanLines, display, changed, readRes.truncated, readRes.omittedLines, width, theme)
 
 	if fileViewBeforeCacheCommit != nil {
 		fileViewBeforeCacheCommit()
@@ -524,7 +526,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		displayPath:  displayPath,
 		modTime:      modTime,
 		size:         size,
-		lines:        readRes.lines,
+		lines:        cleanLines,
 		display:      display,
 		truncated:    readRes.truncated,
 		omittedLines: readRes.omittedLines,

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -461,6 +461,12 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 				// Re-format for the new width or changed markers using cached display and lines
 				rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width, theme)
+				if fileViewBeforeCacheCommit != nil {
+					fileViewBeforeCacheCommit()
+				}
+				if fileViewSuperseded(liveSeq, seq) {
+					return "", errFileViewSuperseded
+				}
 				entry.putRender(renderKey, rendered)
 				return rendered, nil
 			}
@@ -694,9 +700,18 @@ func (m model) startFileViewLoad(width int, refreshSource bool) (model, tea.Cmd)
 // Re-opening the file that is ALREADY being viewed is a no-op: a stray
 // re-click must not bounce the user from full mode back to diff or reset
 // their scroll position.
+func (m model) revokeFileViewRequest() {
+	if m.fileView.liveSeq != nil {
+		m.fileView.liveSeq.Add(1)
+	}
+}
+
 func (m model) openFileView(path string) (model, tea.Cmd) {
 	if m.fileView.active && m.fileView.path == path {
 		return m, nil
+	}
+	if m.fileView.active {
+		m.revokeFileViewRequest()
 	}
 	if !m.fileView.active {
 		m.fileView.parentScrollOffset = m.chatScrollOffset
@@ -727,6 +742,7 @@ func (m model) exitFileView() model {
 	if !m.fileView.active {
 		return m
 	}
+	m.revokeFileViewRequest()
 	m.chatScrollOffset = m.fileView.parentScrollOffset
 	m.fileView = fileViewState{}
 	m = m.clearHover()
@@ -738,6 +754,9 @@ func (m model) exitFileView() model {
 func (m model) setFileViewMode(mode int) (model, tea.Cmd) {
 	if !m.fileView.active || m.fileView.mode == mode {
 		return m, nil
+	}
+	if m.fileView.mode == fileViewFull && mode != fileViewFull {
+		m.revokeFileViewRequest()
 	}
 	m.fileView.mode = mode
 	m.chatScrollOffset = 0

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -509,7 +509,9 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	if elem, ok := c.items[targetPath]; ok {
 		entry := elem.Value.(*fileViewCachedEntry)
-		if entry.sourceRev >= reqSourceRev && entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
+		forceReload := (entry.sourceRev < reqSourceRev)
+		refreshSource := forceReload
+		if !refreshSource && entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
 			if fileViewSuperseded(liveSeq, seq) {
 				c.mu.Unlock()
 				return "", errFileViewSuperseded

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -98,6 +98,7 @@ type fileViewCachedEntry struct {
 	displayPath  string
 	modTime      time.Time
 	size         int64
+	sourceRev    uint64
 	lines        []string
 	display      []string
 	truncated    bool
@@ -151,22 +152,42 @@ func (e *fileViewCachedEntry) putRender(key string, val string) {
 }
 
 type fileViewRenderCache struct {
-	mu         sync.Mutex
-	maxEntries int
-	items      map[string]*list.Element // targetPath -> *list.Element containing *fileViewCachedEntry
-	lru        *list.List
-	gen        int
-	statsData  fileViewCacheStats
+	mu            sync.Mutex
+	maxEntries    int
+	items         map[string]*list.Element // targetPath -> *list.Element containing *fileViewCachedEntry
+	lru           *list.List
+	gen           int
+	pathRevisions map[string]uint64
+	statsData     fileViewCacheStats
 }
 
 var defaultFileViewCache = newFileViewRenderCache(defaultFileViewCacheMaxEntries)
 
 func newFileViewRenderCache(maxEntries int) *fileViewRenderCache {
 	return &fileViewRenderCache{
-		maxEntries: maxEntries,
-		items:      make(map[string]*list.Element),
-		lru:        list.New(),
+		maxEntries:    maxEntries,
+		items:         make(map[string]*list.Element),
+		lru:           list.New(),
+		pathRevisions: make(map[string]uint64),
 	}
+}
+
+func (c *fileViewRenderCache) invalidatePath(targetPath string) uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pathRevisions[targetPath]++
+	rev := c.pathRevisions[targetPath]
+	if elem, ok := c.items[targetPath]; ok {
+		c.lru.Remove(elem)
+		delete(c.items, targetPath)
+	}
+	return rev
+}
+
+func (c *fileViewRenderCache) requiredRevision(targetPath string) uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pathRevisions[targetPath]
 }
 
 func (c *fileViewRenderCache) clear() {
@@ -175,6 +196,9 @@ func (c *fileViewRenderCache) clear() {
 	c.gen++
 	c.items = make(map[string]*list.Element)
 	c.lru.Init()
+	for k := range c.pathRevisions {
+		c.pathRevisions[k]++
+	}
 	c.statsData.ThemeClears++
 }
 
@@ -335,6 +359,28 @@ func readFileViewBounded(path string, maxLines int, maxLineBytes int, maxTotalBy
 	}
 }
 
+// canonicalChangedLineKey normalizes a line for changed-line matching:
+// - Replaces tabs with 4 spaces (matching sanitizeRawFileLine)
+// - Strips ANSI escape sequences and non-printable control characters
+// - Trims leading and trailing whitespace
+func canonicalChangedLineKey(s string) string {
+	var out strings.Builder
+	for _, r := range s {
+		if r == '\t' {
+			out.WriteString("    ")
+		} else if r == '\r' || r == '\n' {
+			continue
+		} else if r < 32 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			if r == '\x1b' {
+				out.WriteString("^[")
+			}
+		} else {
+			out.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
 func changedLinesFingerprint(changed map[string]bool) string {
 	if len(changed) == 0 {
 		return ""
@@ -360,7 +406,7 @@ func formatFileViewLines(lines []string, display []string, changed map[string]bo
 			b.WriteString("\n")
 		}
 		marker := " "
-		if changed != nil && len(lines) > i && changed[strings.TrimSpace(lines[i])] {
+		if changed != nil && len(lines) > i && changed[canonicalChangedLineKey(lines[i])] {
 			marker = theme.accent.Render("▎")
 		}
 		b.WriteString(theme.faintest.Render(fmt.Sprintf("%*d ", gutterW, i+1)))
@@ -383,8 +429,8 @@ func formatFileViewLines(lines []string, display []string, changed map[string]bo
 // peekRenderOnly looks up an already-formatted variant in memory. It performs
 // strictly 0 I/O and 0 string formatting/allocations, guaranteeing O(1) instantaneous
 // access on the View() drawing path.
-func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, changedFingerprint string, loadedSeq, desiredSeq uint64) (string, bool) {
-	if loadedSeq != desiredSeq {
+func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, changedFingerprint string, loadedSeq, desiredSeq uint64, loadedRev, reqRev uint64) (string, bool) {
+	if loadedSeq != desiredSeq || loadedRev < reqRev {
 		return "", false
 	}
 	c.mu.Lock()
@@ -394,6 +440,10 @@ func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, chang
 		return "", false
 	}
 	entry := elem.Value.(*fileViewCachedEntry)
+	if entry.sourceRev < reqRev {
+		c.mu.Unlock()
+		return "", false
+	}
 	c.lru.MoveToFront(elem)
 	c.statsData.CacheHits++
 	c.mu.Unlock()
@@ -407,15 +457,20 @@ func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, chang
 // intended to be executed from a tea.Cmd / background worker, off the View path.
 var errFileViewSuperseded = errors.New("file view request superseded")
 
-var fileViewInsideLoad func()
-
-var fileViewBeforeCacheCommit func()
+var (
+	fileViewInsideLoad           func()
+	fileViewBeforeCacheHitFormat func()
+	fileViewBeforeDiskRead       func()
+	fileViewBeforeHighlight      func()
+	fileViewBeforeFormat         func()
+	fileViewBeforeCacheCommit    func()
+)
 
 func fileViewSuperseded(liveSeq *atomic.Uint64, seq uint64) bool {
 	return liveSeq != nil && liveSeq.Load() != seq
 }
 
-func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, changedFingerprint string, reqGen int, theme tuiTheme, refreshSource bool, liveSeq *atomic.Uint64, seq uint64) (string, error) {
+func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, changedFingerprint string, reqGen int, theme tuiTheme, reqSourceRev uint64, liveSeq *atomic.Uint64, seq uint64) (string, error) {
 	if fileViewSuperseded(liveSeq, seq) {
 		return "", errFileViewSuperseded
 	}
@@ -447,29 +502,43 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		return "", errors.New("request superseded by cache invalidation")
 	}
 
-	if !refreshSource {
-		if elem, ok := c.items[targetPath]; ok {
-			entry := elem.Value.(*fileViewCachedEntry)
-			if entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
-				c.statsData.CacheHits++
-				c.lru.MoveToFront(elem)
+	curRequiredRev := c.pathRevisions[targetPath]
+	if reqSourceRev < curRequiredRev {
+		reqSourceRev = curRequiredRev
+	}
+
+	if elem, ok := c.items[targetPath]; ok {
+		entry := elem.Value.(*fileViewCachedEntry)
+		if entry.sourceRev >= reqSourceRev && entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
+			if fileViewSuperseded(liveSeq, seq) {
 				c.mu.Unlock()
+				return "", errFileViewSuperseded
+			}
+			c.statsData.CacheHits++
+			c.lru.MoveToFront(elem)
+			c.mu.Unlock()
 
-				if rendered, ok := entry.getRender(renderKey); ok {
-					return rendered, nil
-				}
-
-				// Re-format for the new width or changed markers using cached display and lines
-				rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width, theme)
-				if fileViewBeforeCacheCommit != nil {
-					fileViewBeforeCacheCommit()
-				}
-				if fileViewSuperseded(liveSeq, seq) {
-					return "", errFileViewSuperseded
-				}
-				entry.putRender(renderKey, rendered)
+			if rendered, ok := entry.getRender(renderKey); ok {
 				return rendered, nil
 			}
+
+			if fileViewBeforeCacheHitFormat != nil {
+				fileViewBeforeCacheHitFormat()
+			}
+			if fileViewSuperseded(liveSeq, seq) {
+				return "", errFileViewSuperseded
+			}
+
+			// Re-format for the new width or changed markers using cached display and lines
+			rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width, theme)
+			if fileViewBeforeCacheCommit != nil {
+				fileViewBeforeCacheCommit()
+			}
+			if fileViewSuperseded(liveSeq, seq) {
+				return "", errFileViewSuperseded
+			}
+			entry.putRender(renderKey, rendered)
+			return rendered, nil
 		}
 	}
 
@@ -481,6 +550,13 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	c.statsData.CacheMisses++
 	c.statsData.DiskReads++
 	c.mu.Unlock()
+
+	if fileViewBeforeDiskRead != nil {
+		fileViewBeforeDiskRead()
+	}
+	if fileViewSuperseded(liveSeq, seq) {
+		return "", errFileViewSuperseded
+	}
 
 	readRes := readFileViewBounded(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes)
 	if readRes.err != nil && len(readRes.lines) == 0 {
@@ -494,6 +570,9 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		return rendered, readRes.err
 	}
 
+	if fileViewBeforeHighlight != nil {
+		fileViewBeforeHighlight()
+	}
 	if fileViewSuperseded(liveSeq, seq) {
 		return "", errFileViewSuperseded
 	}
@@ -512,6 +591,13 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		display = cleanLines
 	}
 
+	if fileViewBeforeFormat != nil {
+		fileViewBeforeFormat()
+	}
+	if fileViewSuperseded(liveSeq, seq) {
+		return "", errFileViewSuperseded
+	}
+
 	rendered := formatFileViewLines(cleanLines, display, changed, readRes.truncated, readRes.omittedLines, width, theme)
 
 	if fileViewBeforeCacheCommit != nil {
@@ -526,6 +612,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		displayPath:  displayPath,
 		modTime:      modTime,
 		size:         size,
+		sourceRev:    reqSourceRev,
 		lines:        cleanLines,
 		display:      display,
 		truncated:    readRes.truncated,
@@ -546,7 +633,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	if elem, ok := c.items[targetPath]; ok {
 		existing := elem.Value.(*fileViewCachedEntry)
-		if existing.modTime.After(modTime) {
+		if existing.modTime.After(modTime) && existing.sourceRev > reqSourceRev {
 			c.mu.Unlock()
 			return rendered, nil
 		}
@@ -593,39 +680,41 @@ func sanitizeRawFileLine(s string) string {
 
 func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string, width int, changed map[string]bool) string {
 	fingerprint := changedLinesFingerprint(changed)
-	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, fingerprint, c.generation(), zeroTheme, false, nil, 0)
+	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, fingerprint, c.generation(), zeroTheme, 0, nil, 0)
 	return rendered
 }
 
 // fileViewLoadedMsg delivers the result of an asynchronous file read & render.
 type fileViewLoadedMsg struct {
-	lifetimeToken [16]byte
-	seq           uint64
-	generation    int
-	targetPath    string
-	displayPath   string
-	width         int
-	fingerprint   string
-	rendered      string
-	err           error
+	lifetimeToken     [16]byte
+	seq               uint64
+	requiredSourceRev uint64
+	generation        int
+	targetPath        string
+	displayPath       string
+	width             int
+	fingerprint       string
+	rendered          string
+	err               error
 }
 
-func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, seq uint64, gen int, theme tuiTheme, refreshSource bool, liveSeq *atomic.Uint64) tea.Cmd {
+func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, seq uint64, gen int, reqRev uint64, theme tuiTheme, liveSeq *atomic.Uint64) tea.Cmd {
 	return func() tea.Msg {
 		if fileViewSuperseded(liveSeq, seq) {
-			return fileViewLoadedMsg{lifetimeToken: token, seq: seq, generation: gen, displayPath: displayPath, width: width, fingerprint: fingerprint, err: errFileViewSuperseded}
+			return fileViewLoadedMsg{lifetimeToken: token, seq: seq, requiredSourceRev: reqRev, generation: gen, targetPath: targetPath, displayPath: displayPath, width: width, fingerprint: fingerprint, err: errFileViewSuperseded}
 		}
-		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, fingerprint, gen, theme, refreshSource, liveSeq, seq)
+		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, fingerprint, gen, theme, reqRev, liveSeq, seq)
 		return fileViewLoadedMsg{
-			lifetimeToken: token,
-			seq:           seq,
-			generation:    gen,
-			targetPath:    targetPath,
-			displayPath:   displayPath,
-			width:         width,
-			fingerprint:   fingerprint,
-			rendered:      rendered,
-			err:           err,
+			lifetimeToken:     token,
+			seq:               seq,
+			requiredSourceRev: reqRev,
+			generation:        gen,
+			targetPath:        targetPath,
+			displayPath:       displayPath,
+			width:             width,
+			fingerprint:       fingerprint,
+			rendered:          rendered,
+			err:               err,
 		}
 	}
 }
@@ -643,6 +732,7 @@ type fileViewState struct {
 
 	// Monotonically advancing desired snapshot sequence & requested parameters
 	desiredSeq         uint64
+	requiredSourceRev  uint64
 	desiredWidth       int
 	desiredFingerprint string
 	desiredGen         int
@@ -655,6 +745,7 @@ type fileViewState struct {
 	loadedFingerprint string
 	loadedToken       [16]byte
 	loadedSeq         uint64
+	loadedRev         uint64
 	loading           bool
 	hasError          bool
 	snapshotReady     bool
@@ -677,6 +768,19 @@ func (m model) startFileViewLoad(width int, refreshSource bool) (model, tea.Cmd)
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
+	if refreshSource {
+		rev := defaultFileViewCache.invalidatePath(target)
+		if rev > m.fileView.requiredSourceRev {
+			m.fileView.requiredSourceRev = rev
+		} else {
+			m.fileView.requiredSourceRev++
+		}
+	}
+	curReq := defaultFileViewCache.requiredRevision(target)
+	if curReq > m.fileView.requiredSourceRev {
+		m.fileView.requiredSourceRev = curReq
+	}
+
 	m.fileView.desiredSeq++
 	m.fileView.desiredWidth = width
 	m.fileView.loading = true
@@ -692,8 +796,9 @@ func (m model) startFileViewLoad(width int, refreshSource bool) (model, tea.Cmd)
 	fingerprint := changedLinesFingerprint(changed)
 	m.fileView.desiredFingerprint = fingerprint
 	m.fileView.desiredGen = gen
+	reqRev := m.fileView.requiredSourceRev
 	theme := zeroTheme
-	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, seq, gen, theme, refreshSource, m.fileView.liveSeq)
+	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, seq, gen, reqRev, theme, m.fileView.liveSeq)
 }
 
 // openFileView activates the drill-in for path in diff mode. Opening from an
@@ -718,6 +823,10 @@ func (m model) openFileView(path string) (model, tea.Cmd) {
 	if !m.fileView.active {
 		m.fileView.parentScrollOffset = m.chatScrollOffset
 	}
+	target := path
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(m.cwd, target)
+	}
 	m.fileView.active = true
 	m.fileView.path = path
 	m.fileView.mode = fileViewDiff
@@ -725,6 +834,8 @@ func (m model) openFileView(path string) (model, tea.Cmd) {
 	m.fileView.renderedContent = ""
 	m.fileView.loadedToken = [16]byte{}
 	m.fileView.loadedSeq = 0
+	m.fileView.loadedRev = 0
+	m.fileView.requiredSourceRev = defaultFileViewCache.requiredRevision(target)
 	m.fileView.hasError = false
 	// A file only the git sweep knows about (bash/subagent mutation) has no edit
 	// cards to stack — open straight on the full file instead of a placeholder.
@@ -772,22 +883,31 @@ func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 	if !m.fileView.active || m.fileView.mode != fileViewFull {
 		return m, nil
 	}
+	if errors.Is(msg.err, errFileViewSuperseded) {
+		return m, nil
+	}
 	// 1. Session lifetime identity match
 	if m.fileView.lifetimeToken != msg.lifetimeToken || m.fileView.path != msg.displayPath {
 		return m, nil
 	}
-	// 2. Exact desired snapshot match: reject superseded / out-of-order completions
+	// 2. Exact desired snapshot match: reject superseded / out-of-order completions without any side effects
 	if msg.seq != m.fileView.desiredSeq ||
 		msg.width != m.fileView.desiredWidth ||
-		msg.fingerprint != m.fileView.desiredFingerprint ||
-		msg.generation != defaultFileViewCache.generation() {
-		if msg.generation != defaultFileViewCache.generation() {
-			// Cache was invalidated (e.g. theme switch) while this request was in flight.
-			return m.startFileViewLoadCmd(m.chatColumnWidth())
-		}
-		// Out-of-order or obsolete completion: drop without modifying state
+		msg.fingerprint != m.fileView.desiredFingerprint {
+		// Out-of-order or obsolete sequence: drop without modifying state or triggering retries
 		return m, nil
 	}
+
+	// 3. Current sequence with invalid theme generation: request a retry inheriting current source revision requirement
+	if msg.generation != defaultFileViewCache.generation() {
+		return m.startFileViewLoadCmd(m.chatColumnWidth())
+	}
+
+	// 4. Source revision monotonic check: if required revision was advanced while in flight, request a refresh
+	if msg.requiredSourceRev < m.fileView.requiredSourceRev {
+		return m.startFileViewRefreshCmd(m.chatColumnWidth())
+	}
+
 	m.fileView.loading = false
 	m.fileView.snapshotReady = true
 	m.fileView.renderedContent = msg.rendered
@@ -797,6 +917,7 @@ func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 	m.fileView.loadedFingerprint = msg.fingerprint
 	m.fileView.loadedToken = msg.lifetimeToken
 	m.fileView.loadedSeq = msg.seq
+	m.fileView.loadedRev = msg.requiredSourceRev
 	m.fileView.hasError = (msg.err != nil)
 	return m, nil
 }
@@ -886,12 +1007,13 @@ func (m model) renderFileViewFull(width int) string {
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.desiredFingerprint, m.fileView.loadedSeq, m.fileView.desiredSeq); ok {
+	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.desiredFingerprint, m.fileView.loadedSeq, m.fileView.desiredSeq, m.fileView.loadedRev, m.fileView.requiredSourceRev); ok {
 		return cached
 	}
 	if m.fileView.snapshotReady &&
 		m.fileView.loadedPath == m.fileView.path &&
 		m.fileView.loadedSeq == m.fileView.desiredSeq &&
+		m.fileView.loadedRev >= m.fileView.requiredSourceRev &&
 		m.fileView.loadedGen == defaultFileViewCache.generation() &&
 		m.fileView.loadedToken == m.fileView.lifetimeToken {
 		return m.fileView.renderedContent
@@ -911,8 +1033,9 @@ func (m model) fileViewChangedLines() map[string]bool {
 			if !strings.HasPrefix(line, "+") || strings.HasPrefix(line, "+++") {
 				continue
 			}
-			if text := strings.TrimSpace(strings.TrimPrefix(line, "+")); len(text) >= 4 {
-				changed[text] = true
+			raw := strings.TrimPrefix(line, "+")
+			if key := canonicalChangedLineKey(raw); len(key) >= 4 {
+				changed[key] = true
 			}
 		}
 	}

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -518,6 +518,7 @@ func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string,
 // fileViewLoadedMsg delivers the result of an asynchronous file read & render.
 type fileViewLoadedMsg struct {
 	lifetimeToken [16]byte
+	seq           uint64
 	generation    int
 	targetPath    string
 	displayPath   string
@@ -527,11 +528,12 @@ type fileViewLoadedMsg struct {
 	err           error
 }
 
-func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, gen int, theme tuiTheme) tea.Cmd {
+func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, seq uint64, gen int, theme tuiTheme) tea.Cmd {
 	return func() tea.Msg {
 		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, fingerprint, gen, theme)
 		return fileViewLoadedMsg{
 			lifetimeToken: token,
+			seq:           seq,
 			generation:    gen,
 			targetPath:    targetPath,
 			displayPath:   displayPath,
@@ -550,15 +552,26 @@ type fileViewState struct {
 	path               string // workspace-relative, as carried by changedFiles
 	mode               int    // fileViewDiff | fileViewFull
 	parentScrollOffset int
-	lifetimeToken      [16]byte // monotonic, time-ordered UUIDv7 token for this active session
-	renderedContent    string   // rendered full text when loaded
-	loadedPath         string   // path of loaded content
-	loadedWidth        int      // width of loaded content
-	loadedGen          int      // cache/theme generation of loaded content
-	loadedFingerprint  string   // changed lines fingerprint of loaded content
-	loadedToken        [16]byte // token matching the loaded content
-	loading            bool     // true while async load is in flight
-	hasError           bool     // true if the load failed
+
+	// View session lifetime identity (UUIDv7 RFC 9562 0-alloc)
+	lifetimeToken      [16]byte
+
+	// Monotonically advancing desired snapshot sequence & requested parameters
+	desiredSeq         uint64
+	desiredWidth       int
+	desiredFingerprint string
+	desiredGen         int
+
+	// Authoritative completed snapshot (only valid when loadedSeq == desiredSeq)
+	renderedContent    string
+	loadedPath         string
+	loadedWidth        int
+	loadedGen          int
+	loadedFingerprint  string
+	loadedToken        [16]byte
+	loadedSeq          uint64
+	loading            bool
+	hasError           bool
 }
 
 func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
@@ -569,13 +582,18 @@ func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
+	m.fileView.desiredSeq++
+	m.fileView.desiredWidth = width
 	m.fileView.loading = true
+	seq := m.fileView.desiredSeq
 	token := m.fileView.lifetimeToken
 	gen := defaultFileViewCache.generation()
 	changed := m.fileViewChangedLines()
 	fingerprint := changedLinesFingerprint(changed)
+	m.fileView.desiredFingerprint = fingerprint
+	m.fileView.desiredGen = gen
 	theme := zeroTheme
-	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, gen, theme)
+	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, seq, gen, theme)
 }
 
 // openFileView activates the drill-in for path in diff mode. Opening from an
@@ -597,6 +615,7 @@ func (m model) openFileView(path string) (model, tea.Cmd) {
 	m.fileView.lifetimeToken = nextFileViewLifetimeToken()
 	m.fileView.renderedContent = ""
 	m.fileView.loadedToken = [16]byte{}
+	m.fileView.loadedSeq = 0
 	m.fileView.hasError = false
 	// A file only the git sweep knows about (bash/subagent mutation) has no edit
 	// cards to stack — open straight on the full file instead of a placeholder.
@@ -640,13 +659,21 @@ func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 	if !m.fileView.active || m.fileView.mode != fileViewFull {
 		return m, nil
 	}
+	// 1. Session lifetime identity match
 	if m.fileView.lifetimeToken != msg.lifetimeToken || m.fileView.path != msg.displayPath {
 		return m, nil
 	}
-	if msg.generation != defaultFileViewCache.generation() {
-		// Cache was invalidated (e.g. theme switch) while this request was in flight.
-		// Start a fresh request for the current generation.
-		return m.startFileViewLoadCmd(m.chatColumnWidth())
+	// 2. Exact desired snapshot match: reject superseded / out-of-order completions
+	if msg.seq != m.fileView.desiredSeq ||
+		msg.width != m.fileView.desiredWidth ||
+		msg.fingerprint != m.fileView.desiredFingerprint ||
+		msg.generation != defaultFileViewCache.generation() {
+		if msg.generation != defaultFileViewCache.generation() {
+			// Cache was invalidated (e.g. theme switch) while this request was in flight.
+			return m.startFileViewLoadCmd(m.chatColumnWidth())
+		}
+		// Out-of-order or obsolete completion: drop without modifying state
+		return m, nil
 	}
 	m.fileView.loading = false
 	m.fileView.renderedContent = msg.rendered
@@ -655,6 +682,7 @@ func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 	m.fileView.loadedGen = msg.generation
 	m.fileView.loadedFingerprint = msg.fingerprint
 	m.fileView.loadedToken = msg.lifetimeToken
+	m.fileView.loadedSeq = msg.seq
 	m.fileView.hasError = (msg.err != nil)
 	return m, nil
 }
@@ -740,25 +768,19 @@ func (m model) renderFileViewFull(width int) string {
 	if m.fileView.hasError {
 		return m.fileView.renderedContent
 	}
-	if m.fileView.renderedContent != "" &&
-		m.fileView.loadedPath == m.fileView.path &&
-		m.fileView.loadedGen == defaultFileViewCache.generation() &&
-		m.fileView.loadedToken == m.fileView.lifetimeToken {
-		target := m.fileView.path
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(m.cwd, target)
-		}
-		if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.loadedFingerprint); ok {
-			return cached
-		}
-		return m.fileView.renderedContent
-	}
 	target := m.fileView.path
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.loadedFingerprint); ok {
+	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.desiredFingerprint); ok {
 		return cached
+	}
+	if m.fileView.renderedContent != "" &&
+		m.fileView.loadedPath == m.fileView.path &&
+		m.fileView.loadedSeq == m.fileView.desiredSeq &&
+		m.fileView.loadedGen == defaultFileViewCache.generation() &&
+		m.fileView.loadedToken == m.fileView.lifetimeToken {
+		return m.fileView.renderedContent
 	}
 	return zeroTheme.faint.Render(fileViewLoadingPlaceholder)
 }

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -561,8 +561,11 @@ type fileViewLoadedMsg struct {
 	err           error
 }
 
-func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, seq uint64, gen int, theme tuiTheme) tea.Cmd {
+func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, seq uint64, gen int, theme tuiTheme, live *atomic.Uint64) tea.Cmd {
 	return func() tea.Msg {
+		if live != nil && live.Load() != seq {
+			return fileViewLoadedMsg{lifetimeToken: token, seq: seq, generation: gen, displayPath: displayPath, width: width, fingerprint: fingerprint}
+		}
 		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, fingerprint, gen, theme)
 		return fileViewLoadedMsg{
 			lifetimeToken: token,
@@ -605,6 +608,8 @@ type fileViewState struct {
 	loadedSeq         uint64
 	loading           bool
 	hasError          bool
+	snapshotReady     bool
+	liveSeq           *atomic.Uint64
 }
 
 func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
@@ -618,7 +623,12 @@ func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
 	m.fileView.desiredSeq++
 	m.fileView.desiredWidth = width
 	m.fileView.loading = true
+	m.fileView.snapshotReady = false
+	if m.fileView.liveSeq == nil {
+		m.fileView.liveSeq = new(atomic.Uint64)
+	}
 	seq := m.fileView.desiredSeq
+	m.fileView.liveSeq.Store(seq)
 	token := m.fileView.lifetimeToken
 	gen := defaultFileViewCache.generation()
 	changed := m.fileViewChangedLines()
@@ -626,7 +636,7 @@ func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
 	m.fileView.desiredFingerprint = fingerprint
 	m.fileView.desiredGen = gen
 	theme := zeroTheme
-	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, seq, gen, theme)
+	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, seq, gen, theme, m.fileView.liveSeq)
 }
 
 // openFileView activates the drill-in for path in diff mode. Opening from an
@@ -709,6 +719,7 @@ func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 		return m, nil
 	}
 	m.fileView.loading = false
+	m.fileView.snapshotReady = true
 	m.fileView.renderedContent = msg.rendered
 	m.fileView.loadedPath = msg.displayPath
 	m.fileView.loadedWidth = msg.width
@@ -808,7 +819,7 @@ func (m model) renderFileViewFull(width int) string {
 	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.desiredFingerprint, m.fileView.loadedSeq, m.fileView.desiredSeq); ok {
 		return cached
 	}
-	if m.fileView.renderedContent != "" &&
+	if m.fileView.snapshotReady &&
 		m.fileView.loadedPath == m.fileView.path &&
 		m.fileView.loadedSeq == m.fileView.desiredSeq &&
 		m.fileView.loadedGen == defaultFileViewCache.generation() &&

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -554,7 +554,7 @@ type fileViewState struct {
 	parentScrollOffset int
 
 	// View session lifetime identity (UUIDv7 RFC 9562 0-alloc)
-	lifetimeToken      [16]byte
+	lifetimeToken [16]byte
 
 	// Monotonically advancing desired snapshot sequence & requested parameters
 	desiredSeq         uint64
@@ -563,15 +563,15 @@ type fileViewState struct {
 	desiredGen         int
 
 	// Authoritative completed snapshot (only valid when loadedSeq == desiredSeq)
-	renderedContent    string
-	loadedPath         string
-	loadedWidth        int
-	loadedGen          int
-	loadedFingerprint  string
-	loadedToken        [16]byte
-	loadedSeq          uint64
-	loading            bool
-	hasError           bool
+	renderedContent   string
+	loadedPath        string
+	loadedWidth       int
+	loadedGen         int
+	loadedFingerprint string
+	loadedToken       [16]byte
+	loadedSeq         uint64
+	loading           bool
+	hasError          bool
 }
 
 func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -409,6 +409,8 @@ var errFileViewSuperseded = errors.New("file view request superseded")
 
 var fileViewInsideLoad func()
 
+var fileViewBeforeCacheCommit func()
+
 func fileViewSuperseded(liveSeq *atomic.Uint64, seq uint64) bool {
 	return liveSeq != nil && liveSeq.Load() != seq
 }
@@ -504,6 +506,13 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	rendered := formatFileViewLines(readRes.lines, display, changed, readRes.truncated, readRes.omittedLines, width, theme)
 
+	if fileViewBeforeCacheCommit != nil {
+		fileViewBeforeCacheCommit()
+	}
+	if fileViewSuperseded(liveSeq, seq) {
+		return "", errFileViewSuperseded
+	}
+
 	entry := &fileViewCachedEntry{
 		targetPath:   targetPath,
 		displayPath:  displayPath,
@@ -521,6 +530,10 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	if c.gen != reqGen {
 		c.mu.Unlock()
 		return "", errors.New("request superseded by cache invalidation")
+	}
+	if fileViewSuperseded(liveSeq, seq) {
+		c.mu.Unlock()
+		return "", errFileViewSuperseded
 	}
 
 	if elem, ok := c.items[targetPath]; ok {

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -459,7 +459,10 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	display, ok := highlightCodeForPathWithTheme(readRes.lines, displayPath, 1<<20, nil, theme)
 	if !ok || len(display) != len(readRes.lines) {
-		display = readRes.lines
+		display = make([]string, len(readRes.lines))
+		for i, l := range readRes.lines {
+			display[i] = sanitizeRawFileLine(l)
+		}
 	}
 
 	rendered := formatFileViewLines(readRes.lines, display, changed, readRes.truncated, readRes.omittedLines, width, theme)
@@ -503,10 +506,31 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		backEntry := back.Value.(*fileViewCachedEntry)
 		delete(c.items, backEntry.targetPath)
 		c.lru.Remove(back)
+		c.statsData.Evictions++
 	}
 	c.mu.Unlock()
 
 	return rendered, nil
+}
+
+// sanitizeRawFileLine strips or transforms raw control characters and terminal escape sequences
+// when syntax highlighting is bypassed or unavailable, preventing terminal screen corruption.
+func sanitizeRawFileLine(s string) string {
+	var out strings.Builder
+	for _, r := range s {
+		if r == '\t' {
+			out.WriteString("    ")
+		} else if r == '\r' || r == '\n' {
+			continue
+		} else if r < 32 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			if r == '\x1b' {
+				out.WriteString("^[")
+			}
+		} else {
+			out.WriteRune(r)
+		}
+	}
+	return out.String()
 }
 
 func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string, width int, changed map[string]bool) string {

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -44,6 +45,42 @@ const (
 	fileViewDiff = iota
 	fileViewFull
 )
+
+var (
+	fileViewLifetimeTS  atomic.Uint64
+	fileViewLifetimeSeq atomic.Uint32
+)
+
+// nextFileViewLifetimeToken produces a monotonic, time-ordered 128-bit UUIDv7 (RFC 9562)
+// to uniquely identify the lifecycle of a file view session without heap allocations.
+func nextFileViewLifetimeToken() [16]byte {
+	nowMs := uint64(time.Now().UnixMilli())
+	for {
+		last := fileViewLifetimeTS.Load()
+		if nowMs > last {
+			if fileViewLifetimeTS.CompareAndSwap(last, nowMs) {
+				fileViewLifetimeSeq.Store(0)
+				break
+			}
+		} else {
+			nowMs = last
+			break
+		}
+	}
+	seq := fileViewLifetimeSeq.Add(1)
+	var u [16]byte
+	u[0] = byte(nowMs >> 40)
+	u[1] = byte(nowMs >> 32)
+	u[2] = byte(nowMs >> 24)
+	u[3] = byte(nowMs >> 16)
+	u[4] = byte(nowMs >> 8)
+	u[5] = byte(nowMs)
+	u[6] = 0x70 | byte((seq>>8)&0x0F) // Version 7
+	u[7] = byte(seq & 0xFF)
+	u[8] = 0x80 | byte((seq>>16)&0x3F) // RFC 9562 variant
+	u[9] = byte(seq >> 24)
+	return u
+}
 
 // fileViewCacheStats tracks disk I/O, Chroma highlighting, and cache hits/misses.
 type fileViewCacheStats struct {
@@ -92,6 +129,9 @@ func (e *fileViewCachedEntry) getRender(key string) (string, bool) {
 func (e *fileViewCachedEntry) putRender(key string, val string) {
 	e.rendersMu.Lock()
 	defer e.rendersMu.Unlock()
+	if e.renders == nil {
+		e.renders = make(map[string]string)
+	}
 	if _, ok := e.renders[key]; !ok {
 		for len(e.renders) >= fileViewMaxRenderVariants {
 			if len(e.renderKeys) > 0 {
@@ -334,10 +374,10 @@ func formatFileViewLines(lines []string, display []string, changed map[string]bo
 	return b.String()
 }
 
-// getRenderOnly looks up an already-rendered variant in memory (or formats from
-// already-cached in-memory syntax tokens) without performing any disk I/O, stat,
-// or Chroma syntax highlighting. Safe for direct View calls.
-func (c *fileViewRenderCache) getRenderOnly(targetPath string, width int, changed map[string]bool, theme tuiTheme) (string, bool) {
+// peekRenderOnly looks up an already-formatted variant in memory. It performs
+// strictly 0 I/O and 0 string formatting/allocations, guaranteeing O(1) instantaneous
+// access on the View() drawing path.
+func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, changedFingerprint string) (string, bool) {
 	c.mu.Lock()
 	elem, ok := c.items[targetPath]
 	if !ok {
@@ -349,29 +389,28 @@ func (c *fileViewRenderCache) getRenderOnly(targetPath string, width int, change
 	c.statsData.CacheHits++
 	c.mu.Unlock()
 
-	renderKey := fmt.Sprintf("%d:%s", width, changedLinesFingerprint(changed))
-	if val, ok := entry.getRender(renderKey); ok {
-		return val, true
-	}
-
-	rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width, theme)
-	entry.putRender(renderKey, rendered)
-	return rendered, true
+	renderKey := fmt.Sprintf("%d:%s", width, changedFingerprint)
+	return entry.getRender(renderKey)
 }
 
 // loadAndRender performs the bounded read, Chroma highlighting, and formatting
 // on a cache miss (or re-formats for a new width variant on a cache hit). It is
 // intended to be executed from a tea.Cmd / background worker, off the View path.
-func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, reqGen int, theme tuiTheme) (string, error) {
+func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, changedFingerprint string, reqGen int, theme tuiTheme) (string, error) {
 	stat, err := os.Stat(targetPath)
 	if err != nil {
+		c.mu.Lock()
+		if elem, ok := c.items[targetPath]; ok {
+			c.lru.Remove(elem)
+			delete(c.items, targetPath)
+		}
+		c.mu.Unlock()
 		rendered := theme.faint.Render("Could not read file: " + err.Error())
 		return rendered, err
 	}
 
 	modTime := stat.ModTime()
 	size := stat.Size()
-	changedFingerprint := changedLinesFingerprint(changed)
 	renderKey := fmt.Sprintf("%d:%s", width, changedFingerprint)
 
 	c.mu.Lock()
@@ -404,6 +443,12 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	readRes := readFileViewBounded(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes)
 	if readRes.err != nil && len(readRes.lines) == 0 {
+		c.mu.Lock()
+		if elem, ok := c.items[targetPath]; ok {
+			c.lru.Remove(elem)
+			delete(c.items, targetPath)
+		}
+		c.mu.Unlock()
 		rendered := theme.faint.Render("Could not read file: " + readRes.err.Error())
 		return rendered, readRes.err
 	}
@@ -465,32 +510,35 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 }
 
 func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string, width int, changed map[string]bool) string {
-	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, c.generation(), zeroTheme)
+	fingerprint := changedLinesFingerprint(changed)
+	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, fingerprint, c.generation(), zeroTheme)
 	return rendered
 }
 
 // fileViewLoadedMsg delivers the result of an asynchronous file read & render.
 type fileViewLoadedMsg struct {
-	requestID   int
-	generation  int
-	targetPath  string
-	displayPath string
-	width       int
-	rendered    string
-	err         error
+	lifetimeToken [16]byte
+	generation    int
+	targetPath    string
+	displayPath   string
+	width         int
+	fingerprint   string
+	rendered      string
+	err           error
 }
 
-func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, requestID int, gen int, theme tuiTheme) tea.Cmd {
+func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, gen int, theme tuiTheme) tea.Cmd {
 	return func() tea.Msg {
-		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, gen, theme)
+		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, fingerprint, gen, theme)
 		return fileViewLoadedMsg{
-			requestID:   requestID,
-			generation:  gen,
-			targetPath:  targetPath,
-			displayPath: displayPath,
-			width:       width,
-			rendered:    rendered,
-			err:         err,
+			lifetimeToken: token,
+			generation:    gen,
+			targetPath:    targetPath,
+			displayPath:   displayPath,
+			width:         width,
+			fingerprint:   fingerprint,
+			rendered:      rendered,
+			err:           err,
 		}
 	}
 }
@@ -498,18 +546,19 @@ func loadFileViewCmd(targetPath string, displayPath string, width int, changed m
 // fileViewState manages the drill-in view for a touched file. When active, the
 // transcript body swaps to the file's diff/content instead of the chat rows.
 type fileViewState struct {
-	active bool
-	path   string // workspace-relative, as carried by changedFiles
-	mode   int    // fileViewDiff | fileViewFull
-	// parentScrollOffset preserves the chat scroll position so closing the view
-	// returns to the same spot (mirrors subchatState).
+	active             bool
+	path               string // workspace-relative, as carried by changedFiles
+	mode               int    // fileViewDiff | fileViewFull
 	parentScrollOffset int
-	requestID          int    // monotonic ID for async load requests
-	renderedContent    string // rendered full text when loaded
-	loadedPath         string // path of loaded content
-	loadedWidth        int    // width of loaded content
-	loadedGen          int    // cache/theme generation of loaded content
-	loading            bool   // true while async load is in flight
+	lifetimeToken      [16]byte // monotonic, time-ordered UUIDv7 token for this active session
+	renderedContent    string   // rendered full text when loaded
+	loadedPath         string   // path of loaded content
+	loadedWidth        int      // width of loaded content
+	loadedGen          int      // cache/theme generation of loaded content
+	loadedFingerprint  string   // changed lines fingerprint of loaded content
+	loadedToken        [16]byte // token matching the loaded content
+	loading            bool     // true while async load is in flight
+	hasError           bool     // true if the load failed
 }
 
 func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
@@ -520,13 +569,13 @@ func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	m.fileView.requestID++
 	m.fileView.loading = true
-	reqID := m.fileView.requestID
+	token := m.fileView.lifetimeToken
 	gen := defaultFileViewCache.generation()
 	changed := m.fileViewChangedLines()
+	fingerprint := changedLinesFingerprint(changed)
 	theme := zeroTheme
-	return m, loadFileViewCmd(target, m.fileView.path, width, changed, reqID, gen, theme)
+	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, gen, theme)
 }
 
 // openFileView activates the drill-in for path in diff mode. Opening from an
@@ -545,6 +594,10 @@ func (m model) openFileView(path string) (model, tea.Cmd) {
 	m.fileView.active = true
 	m.fileView.path = path
 	m.fileView.mode = fileViewDiff
+	m.fileView.lifetimeToken = nextFileViewLifetimeToken()
+	m.fileView.renderedContent = ""
+	m.fileView.loadedToken = [16]byte{}
+	m.fileView.hasError = false
 	// A file only the git sweep knows about (bash/subagent mutation) has no edit
 	// cards to stack — open straight on the full file instead of a placeholder.
 	if len(m.fileViewResultRows()) == 0 {
@@ -587,7 +640,7 @@ func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 	if !m.fileView.active || m.fileView.mode != fileViewFull {
 		return m, nil
 	}
-	if m.fileView.path != msg.displayPath || m.fileView.requestID != msg.requestID {
+	if m.fileView.lifetimeToken != msg.lifetimeToken || m.fileView.path != msg.displayPath {
 		return m, nil
 	}
 	if msg.generation != defaultFileViewCache.generation() {
@@ -600,6 +653,9 @@ func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 	m.fileView.loadedPath = msg.displayPath
 	m.fileView.loadedWidth = msg.width
 	m.fileView.loadedGen = msg.generation
+	m.fileView.loadedFingerprint = msg.fingerprint
+	m.fileView.loadedToken = msg.lifetimeToken
+	m.fileView.hasError = (msg.err != nil)
 	return m, nil
 }
 
@@ -679,18 +735,30 @@ func (m model) renderFileViewDiff(width int) string {
 // highlighted, with a line-number gutter and an accent ▎ marker on the lines
 // this session's diffs added (matched by exact text — an approximation that
 // tolerates later drift; a stale marker just doesn't highlight).
-// It is read-only and non-blocking: if content is ready or cached in memory,
-// it is returned immediately; otherwise a loading placeholder is shown.
+// It is strictly non-blocking and performs O(1) lookup without invoking formatters.
 func (m model) renderFileViewFull(width int) string {
+	if m.fileView.hasError {
+		return m.fileView.renderedContent
+	}
+	if m.fileView.renderedContent != "" &&
+		m.fileView.loadedPath == m.fileView.path &&
+		m.fileView.loadedGen == defaultFileViewCache.generation() &&
+		m.fileView.loadedToken == m.fileView.lifetimeToken {
+		target := m.fileView.path
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(m.cwd, target)
+		}
+		if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.loadedFingerprint); ok {
+			return cached
+		}
+		return m.fileView.renderedContent
+	}
 	target := m.fileView.path
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	if cached, ok := defaultFileViewCache.getRenderOnly(target, width, m.fileViewChangedLines(), zeroTheme); ok {
+	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.loadedFingerprint); ok {
 		return cached
-	}
-	if m.fileView.renderedContent != "" && m.fileView.loadedPath == m.fileView.path && m.fileView.loadedGen == defaultFileViewCache.generation() {
-		return m.fileView.renderedContent
 	}
 	return zeroTheme.faint.Render(fileViewLoadingPlaceholder)
 }

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -15,20 +15,397 @@ package tui
 
 import (
 	"bufio"
+	"container/list"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
+	"time"
 )
 
 // fileViewMaxLines caps the full-file mode so a giant generated file can't
-// freeze a render; the tail collapses into a "… N more lines" trailer.
-const fileViewMaxLines = 4000
+// freeze a render; the tail collapses into a "… more lines (file truncated at N for display)" trailer.
+const (
+	fileViewMaxLines               = 4000
+	fileViewMaxBytes               = 1 << 20 // 1 MiB total read budget per file
+	fileViewMaxLineBytes           = 4096    // 4 KiB max line length budget
+	defaultFileViewCacheMaxEntries = 64
+	fileViewMaxRenderVariants      = 4 // max rendered variants (width/fingerprint) per cached file entry
+)
 
 const (
 	fileViewDiff = iota
 	fileViewFull
 )
+
+// fileViewCacheStats tracks disk I/O, Chroma highlighting, and cache hits/misses.
+type fileViewCacheStats struct {
+	DiskReads       int
+	HighlightCalls  int
+	CacheHits       int
+	CacheMisses     int
+	Evictions       int
+	ThemeClears     int
+	RenderEvictions int
+}
+
+type fileViewCachedEntry struct {
+	targetPath   string
+	displayPath  string
+	modTime      time.Time
+	size         int64
+	lines        []string
+	display      []string
+	truncated    bool
+	omittedLines bool
+
+	rendersMu  sync.RWMutex
+	renderKeys []string          // LRU order: oldest at index 0, most recent at end
+	renders    map[string]string // key: "width:changedLinesFingerprint" -> formatted ANSI string
+}
+
+func (e *fileViewCachedEntry) getRender(key string) (string, bool) {
+	e.rendersMu.RLock()
+	val, ok := e.renders[key]
+	e.rendersMu.RUnlock()
+	if !ok {
+		return "", false
+	}
+	e.rendersMu.Lock()
+	for i, k := range e.renderKeys {
+		if k == key {
+			e.renderKeys = append(append(e.renderKeys[:i], e.renderKeys[i+1:]...), key)
+			break
+		}
+	}
+	e.rendersMu.Unlock()
+	return val, true
+}
+
+func (e *fileViewCachedEntry) putRender(key string, val string) {
+	e.rendersMu.Lock()
+	defer e.rendersMu.Unlock()
+	if _, ok := e.renders[key]; !ok {
+		for len(e.renders) >= fileViewMaxRenderVariants {
+			if len(e.renderKeys) > 0 {
+				oldKey := e.renderKeys[0]
+				e.renderKeys = e.renderKeys[1:]
+				delete(e.renders, oldKey)
+			} else {
+				for k := range e.renders {
+					delete(e.renders, k)
+					break
+				}
+			}
+		}
+		e.renderKeys = append(e.renderKeys, key)
+	}
+	e.renders[key] = val
+}
+
+type fileViewRenderCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	items      map[string]*list.Element // targetPath -> *list.Element containing *fileViewCachedEntry
+	lru        *list.List
+	statsData  fileViewCacheStats
+}
+
+var defaultFileViewCache = newFileViewRenderCache(defaultFileViewCacheMaxEntries)
+
+func newFileViewRenderCache(maxEntries int) *fileViewRenderCache {
+	return &fileViewRenderCache{
+		maxEntries: maxEntries,
+		items:      make(map[string]*list.Element),
+		lru:        list.New(),
+	}
+}
+
+func (c *fileViewRenderCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string]*list.Element)
+	c.lru.Init()
+}
+
+func (c *fileViewRenderCache) resetStats() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.statsData = fileViewCacheStats{}
+}
+
+func (c *fileViewRenderCache) stats() fileViewCacheStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.statsData
+}
+
+type fileViewReadResult struct {
+	lines        []string
+	truncated    bool
+	omittedLines bool
+	err          error
+}
+
+func readFileViewBounded(path string, maxLines int, maxLineBytes int, maxTotalBytes int) fileViewReadResult {
+	file, err := os.Open(path)
+	if err != nil {
+		return fileViewReadResult{err: err}
+	}
+	defer file.Close()
+
+	var lines []string
+	var totalSourceBytes int
+	truncated := false
+	omittedLines := false
+
+	// Enforce hard source-byte read limit to avoid reading unbounded data from disk.
+	// We allow up to maxTotalBytes + 1 so we can detect truncation without reading to EOF.
+	limitReader := io.LimitReader(file, int64(maxTotalBytes)+1)
+	reader := bufio.NewReader(limitReader)
+
+	for len(lines) < maxLines && totalSourceBytes < maxTotalBytes {
+		var lineBuf []byte
+		var lineTruncated bool
+
+		for {
+			chunk, isPrefix, err := reader.ReadLine()
+			chunkLen := len(chunk)
+			if chunkLen > 0 {
+				remainTotal := maxTotalBytes - totalSourceBytes
+				if remainTotal <= 0 {
+					truncated = true
+					omittedLines = true
+					if len(lineBuf) > 0 {
+						lines = append(lines, string(lineBuf))
+					}
+					goto finished
+				}
+
+				if chunkLen > remainTotal {
+					chunk = chunk[:remainTotal]
+					totalSourceBytes += remainTotal
+					truncated = true
+					omittedLines = true
+					lineTruncated = true
+				} else {
+					totalSourceBytes += chunkLen
+				}
+
+				remainLine := maxLineBytes - len(lineBuf)
+				if remainLine > 0 {
+					if len(chunk) > remainLine {
+						lineBuf = append(lineBuf, chunk[:remainLine]...)
+						lineTruncated = true
+					} else {
+						lineBuf = append(lineBuf, chunk...)
+					}
+				} else {
+					lineTruncated = true
+				}
+			}
+
+			if err != nil {
+				if len(lineBuf) > 0 {
+					lines = append(lines, string(lineBuf))
+					if lineTruncated {
+						truncated = true
+					}
+				}
+				if !errors.Is(err, io.EOF) {
+					if len(lines) == 0 {
+						return fileViewReadResult{err: err}
+					}
+					truncated = true
+					omittedLines = true
+				}
+				goto finished
+			}
+
+			if totalSourceBytes >= maxTotalBytes {
+				if isPrefix {
+					truncated = true
+					omittedLines = true
+				} else if lineTruncated {
+					truncated = true
+				}
+				if len(lineBuf) > 0 {
+					lines = append(lines, string(lineBuf))
+				}
+				goto finished
+			}
+
+			if !isPrefix {
+				break
+			}
+		}
+
+		if lineTruncated {
+			truncated = true
+		}
+		lines = append(lines, string(lineBuf))
+		if totalSourceBytes >= maxTotalBytes {
+			break
+		}
+	}
+
+finished:
+	if !omittedLines {
+		if reader.Buffered() > 0 {
+			truncated = true
+			omittedLines = true
+		} else if _, err := reader.Peek(1); err == nil {
+			truncated = true
+			omittedLines = true
+		} else {
+			var probe [1]byte
+			if n, _ := file.Read(probe[:]); n > 0 {
+				truncated = true
+				omittedLines = true
+			}
+		}
+	}
+
+	return fileViewReadResult{
+		lines:        lines,
+		truncated:    truncated,
+		omittedLines: omittedLines,
+	}
+}
+
+func changedLinesFingerprint(changed map[string]bool) string {
+	if len(changed) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(changed))
+	for k, v := range changed {
+		if v {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, "\x00")
+}
+
+func formatFileViewLines(lines []string, display []string, changed map[string]bool, truncated bool, omittedLines bool, width int) string {
+	gutterW := len(fmt.Sprintf("%d", len(lines)))
+	textBudget := maxInt(8, width-gutterW-3) // gutter + space + marker column
+
+	var b strings.Builder
+	for i, line := range display {
+		line = fitStyledLine(line, textBudget)
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		marker := " "
+		if changed != nil && len(lines) > i && changed[strings.TrimSpace(lines[i])] {
+			marker = zeroTheme.accent.Render("▎")
+		}
+		b.WriteString(zeroTheme.faintest.Render(fmt.Sprintf("%*d ", gutterW, i+1)))
+		b.WriteString(marker)
+		b.WriteString(line)
+	}
+	if truncated {
+		// No exact remaining-line count: computing one would require reading the
+		// rest of the file, defeating the bounded read above.
+		b.WriteString("\n")
+		if omittedLines {
+			b.WriteString(zeroTheme.faint.Render(fmt.Sprintf("… more lines (file truncated at %d for display)", len(lines))))
+		} else {
+			b.WriteString(zeroTheme.faint.Render("… (line content truncated at display limit)"))
+		}
+	}
+	return b.String()
+}
+
+func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string, width int, changed map[string]bool) string {
+	stat, err := os.Stat(targetPath)
+	if err != nil {
+		return zeroTheme.faint.Render("Could not read file: " + err.Error())
+	}
+
+	modTime := stat.ModTime()
+	size := stat.Size()
+	changedFingerprint := changedLinesFingerprint(changed)
+	renderKey := fmt.Sprintf("%d:%s", width, changedFingerprint)
+
+	c.mu.Lock()
+	if elem, ok := c.items[targetPath]; ok {
+		entry := elem.Value.(*fileViewCachedEntry)
+		if entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
+			c.statsData.CacheHits++
+			c.lru.MoveToFront(elem)
+			c.mu.Unlock()
+
+			if rendered, ok := entry.getRender(renderKey); ok {
+				return rendered
+			}
+
+			// Re-format for the new width or changed markers using cached display and lines
+			rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width)
+			entry.putRender(renderKey, rendered)
+			return rendered
+		}
+	}
+
+	c.statsData.CacheMisses++
+	c.statsData.DiskReads++
+	c.mu.Unlock()
+
+	readRes := readFileViewBounded(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes)
+	if readRes.err != nil && len(readRes.lines) == 0 {
+		return zeroTheme.faint.Render("Could not read file: " + readRes.err.Error())
+	}
+
+	c.mu.Lock()
+	c.statsData.HighlightCalls++
+	c.mu.Unlock()
+
+	display, ok := highlightCodeForPath(readRes.lines, displayPath, 1<<20, nil)
+	if !ok || len(display) != len(readRes.lines) {
+		display = readRes.lines
+	}
+
+	rendered := formatFileViewLines(readRes.lines, display, changed, readRes.truncated, readRes.omittedLines, width)
+
+	entry := &fileViewCachedEntry{
+		targetPath:   targetPath,
+		displayPath:  displayPath,
+		modTime:      modTime,
+		size:         size,
+		lines:        readRes.lines,
+		display:      display,
+		truncated:    readRes.truncated,
+		omittedLines: readRes.omittedLines,
+		renderKeys:   []string{renderKey},
+		renders:      map[string]string{renderKey: rendered},
+	}
+
+	c.mu.Lock()
+	if elem, ok := c.items[targetPath]; ok {
+		c.lru.Remove(elem)
+		delete(c.items, targetPath)
+	}
+	elem := c.lru.PushFront(entry)
+	c.items[targetPath] = elem
+
+	for len(c.items) > c.maxEntries {
+		back := c.lru.Back()
+		if back == nil {
+			break
+		}
+		backEntry := back.Value.(*fileViewCachedEntry)
+		delete(c.items, backEntry.targetPath)
+		c.lru.Remove(back)
+	}
+	c.mu.Unlock()
+
+	return rendered
+}
 
 // fileViewState manages the drill-in view for a touched file. When active, the
 // transcript body swaps to the file's diff/content instead of the chat rows.
@@ -170,64 +547,7 @@ func (m model) renderFileViewFull(width int) string {
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	// Stream the read and stop at the cap: os.ReadFile would load a multi-GB
-	// file wholesale before any truncation, which is the exact render freeze
-	// fileViewMaxLines exists to prevent.
-	file, err := os.Open(target)
-	if err != nil {
-		return zeroTheme.faint.Render("Could not read file: " + err.Error())
-	}
-	defer file.Close()
-	var lines []string
-	truncated := false
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
-	for scanner.Scan() {
-		if len(lines) == fileViewMaxLines {
-			truncated = true
-			break
-		}
-		lines = append(lines, scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		if len(lines) == 0 {
-			return zeroTheme.faint.Render("Could not read file: " + err.Error())
-		}
-		truncated = true // e.g. a single over-long line mid-file: show what we have
-	}
-
-	changed := m.fileViewChangedLines()
-	gutterW := len(fmt.Sprintf("%d", len(lines)))
-	textBudget := maxInt(8, width-gutterW-3) // gutter + space + marker column
-	// Highlight with an effectively-infinite measure so the highlighter never
-	// wraps — output lines stay 1:1 with file lines and the gutter numbering
-	// can't desync. Each line is then truncated to the column budget below.
-	display, ok := highlightCodeForPath(lines, m.fileView.path, 1<<20, nil)
-	if !ok || len(display) != len(lines) {
-		display = lines // no lexer for this path: render plain
-	}
-
-	var b strings.Builder
-	for i, line := range display {
-		line = fitStyledLine(line, textBudget)
-		if i > 0 {
-			b.WriteString("\n")
-		}
-		marker := " "
-		if changed[strings.TrimSpace(lines[i])] {
-			marker = zeroTheme.accent.Render("▎")
-		}
-		b.WriteString(zeroTheme.faintest.Render(fmt.Sprintf("%*d ", gutterW, i+1)))
-		b.WriteString(marker)
-		b.WriteString(line)
-	}
-	if truncated {
-		// No exact remaining-line count: computing one would require reading the
-		// rest of the file, defeating the bounded read above.
-		b.WriteString("\n")
-		b.WriteString(zeroTheme.faint.Render(fmt.Sprintf("… more lines (file truncated at %d for display)", len(lines))))
-	}
-	return b.String()
+	return defaultFileViewCache.getOrRender(target, m.fileView.path, width, m.fileViewChangedLines())
 }
 
 // fileViewChangedLines collects the trimmed text of every line the session's

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -405,7 +405,24 @@ func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, chang
 // loadAndRender performs the bounded read, Chroma highlighting, and formatting
 // on a cache miss (or re-formats for a new width variant on a cache hit). It is
 // intended to be executed from a tea.Cmd / background worker, off the View path.
-func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, changedFingerprint string, reqGen int, theme tuiTheme) (string, error) {
+var errFileViewSuperseded = errors.New("file view request superseded")
+
+var fileViewInsideLoad func()
+
+func fileViewSuperseded(liveSeq *atomic.Uint64, seq uint64) bool {
+	return liveSeq != nil && liveSeq.Load() != seq
+}
+
+func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, changedFingerprint string, reqGen int, theme tuiTheme, refreshSource bool, liveSeq *atomic.Uint64, seq uint64) (string, error) {
+	if fileViewSuperseded(liveSeq, seq) {
+		return "", errFileViewSuperseded
+	}
+	if fileViewInsideLoad != nil {
+		fileViewInsideLoad()
+	}
+	if fileViewSuperseded(liveSeq, seq) {
+		return "", errFileViewSuperseded
+	}
 	stat, err := os.Stat(targetPath)
 	if err != nil {
 		c.mu.Lock()
@@ -428,22 +445,29 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		return "", errors.New("request superseded by cache invalidation")
 	}
 
-	if elem, ok := c.items[targetPath]; ok {
-		entry := elem.Value.(*fileViewCachedEntry)
-		if entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
-			c.statsData.CacheHits++
-			c.lru.MoveToFront(elem)
-			c.mu.Unlock()
+	if !refreshSource {
+		if elem, ok := c.items[targetPath]; ok {
+			entry := elem.Value.(*fileViewCachedEntry)
+			if entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
+				c.statsData.CacheHits++
+				c.lru.MoveToFront(elem)
+				c.mu.Unlock()
 
-			if rendered, ok := entry.getRender(renderKey); ok {
+				if rendered, ok := entry.getRender(renderKey); ok {
+					return rendered, nil
+				}
+
+				// Re-format for the new width or changed markers using cached display and lines
+				rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width, theme)
+				entry.putRender(renderKey, rendered)
 				return rendered, nil
 			}
-
-			// Re-format for the new width or changed markers using cached display and lines
-			rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width, theme)
-			entry.putRender(renderKey, rendered)
-			return rendered, nil
 		}
+	}
+
+	if fileViewSuperseded(liveSeq, seq) {
+		c.mu.Unlock()
+		return "", errFileViewSuperseded
 	}
 
 	c.statsData.CacheMisses++
@@ -460,6 +484,10 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		c.mu.Unlock()
 		rendered := theme.faint.Render("Could not read file: " + readRes.err.Error())
 		return rendered, readRes.err
+	}
+
+	if fileViewSuperseded(liveSeq, seq) {
+		return "", errFileViewSuperseded
 	}
 
 	c.mu.Lock()
@@ -544,7 +572,7 @@ func sanitizeRawFileLine(s string) string {
 
 func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string, width int, changed map[string]bool) string {
 	fingerprint := changedLinesFingerprint(changed)
-	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, fingerprint, c.generation(), zeroTheme)
+	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, fingerprint, c.generation(), zeroTheme, false, nil, 0)
 	return rendered
 }
 
@@ -561,12 +589,12 @@ type fileViewLoadedMsg struct {
 	err           error
 }
 
-func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, seq uint64, gen int, theme tuiTheme, live *atomic.Uint64) tea.Cmd {
+func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, fingerprint string, token [16]byte, seq uint64, gen int, theme tuiTheme, refreshSource bool, liveSeq *atomic.Uint64) tea.Cmd {
 	return func() tea.Msg {
-		if live != nil && live.Load() != seq {
-			return fileViewLoadedMsg{lifetimeToken: token, seq: seq, generation: gen, displayPath: displayPath, width: width, fingerprint: fingerprint}
+		if fileViewSuperseded(liveSeq, seq) {
+			return fileViewLoadedMsg{lifetimeToken: token, seq: seq, generation: gen, displayPath: displayPath, width: width, fingerprint: fingerprint, err: errFileViewSuperseded}
 		}
-		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, fingerprint, gen, theme)
+		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, fingerprint, gen, theme, refreshSource, liveSeq, seq)
 		return fileViewLoadedMsg{
 			lifetimeToken: token,
 			seq:           seq,
@@ -613,6 +641,14 @@ type fileViewState struct {
 }
 
 func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
+	return m.startFileViewLoad(width, false)
+}
+
+func (m model) startFileViewRefreshCmd(width int) (model, tea.Cmd) {
+	return m.startFileViewLoad(width, true)
+}
+
+func (m model) startFileViewLoad(width int, refreshSource bool) (model, tea.Cmd) {
 	if !m.fileView.active || m.fileView.mode != fileViewFull || m.fileView.path == "" {
 		return m, nil
 	}
@@ -636,7 +672,7 @@ func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
 	m.fileView.desiredFingerprint = fingerprint
 	m.fileView.desiredGen = gen
 	theme := zeroTheme
-	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, seq, gen, theme, m.fileView.liveSeq)
+	return m, loadFileViewCmd(target, m.fileView.path, width, changed, fingerprint, token, seq, gen, theme, refreshSource, m.fileView.liveSeq)
 }
 
 // openFileView activates the drill-in for path in diff mode. Opening from an

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -383,7 +383,10 @@ func formatFileViewLines(lines []string, display []string, changed map[string]bo
 // peekRenderOnly looks up an already-formatted variant in memory. It performs
 // strictly 0 I/O and 0 string formatting/allocations, guaranteeing O(1) instantaneous
 // access on the View() drawing path.
-func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, changedFingerprint string) (string, bool) {
+func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, changedFingerprint string, loadedSeq, desiredSeq uint64) (string, bool) {
+	if loadedSeq != desiredSeq {
+		return "", false
+	}
 	c.mu.Lock()
 	elem, ok := c.items[targetPath]
 	if !ok {
@@ -802,7 +805,7 @@ func (m model) renderFileViewFull(width int) string {
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.desiredFingerprint); ok {
+	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.desiredFingerprint, m.fileView.loadedSeq, m.fileView.desiredSeq); ok {
 		return cached
 	}
 	if m.fileView.renderedContent != "" &&

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -203,6 +203,35 @@ type fileViewReadResult struct {
 	err          error
 }
 
+type fileViewByteCounter struct {
+	r io.Reader
+	n int
+}
+
+func (c *fileViewByteCounter) Read(p []byte) (int, error) {
+	got, err := c.r.Read(p)
+	c.n += got
+	return got, err
+}
+
+func (c *fileViewByteCounter) delivered(buf *bufio.Reader) int {
+	n := c.n - buf.Buffered()
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func stripFileViewLineEnding(b []byte) []byte {
+	if n := len(b); n > 0 && b[n-1] == '\n' {
+		b = b[:n-1]
+	}
+	if n := len(b); n > 0 && b[n-1] == '\r' {
+		b = b[:n-1]
+	}
+	return b
+}
+
 func readFileViewBounded(path string, maxLines int, maxLineBytes int, maxTotalBytes int) fileViewReadResult {
 	file, err := os.Open(path)
 	if err != nil {
@@ -211,115 +240,92 @@ func readFileViewBounded(path string, maxLines int, maxLineBytes int, maxTotalBy
 	defer file.Close()
 
 	var lines []string
-	var totalSourceBytes int
 	truncated := false
 	omittedLines := false
+	counter := &fileViewByteCounter{r: io.LimitReader(file, int64(maxTotalBytes)+1)}
+	reader := bufio.NewReader(counter)
 
-	// Enforce hard source-byte read limit to avoid reading unbounded data from disk.
-	// We allow up to maxTotalBytes + 1 so we can detect truncation without reading to EOF.
-	limitReader := io.LimitReader(file, int64(maxTotalBytes)+1)
-	reader := bufio.NewReader(limitReader)
+	moreSource := func() bool {
+		if reader.Buffered() > 0 {
+			return true
+		}
+		_, err := reader.Peek(1)
+		return err == nil
+	}
 
-	for len(lines) < maxLines && totalSourceBytes < maxTotalBytes {
-		var lineBuf []byte
-		var lineTruncated bool
-
-		for {
-			chunk, isPrefix, err := reader.ReadLine()
-			chunkLen := len(chunk)
-			if chunkLen > 0 {
-				remainTotal := maxTotalBytes - totalSourceBytes
-				if remainTotal <= 0 {
-					truncated = true
-					omittedLines = true
-					if len(lineBuf) > 0 {
-						lines = append(lines, string(lineBuf))
-					}
-					goto finished
-				}
-
-				if chunkLen > remainTotal {
-					chunk = chunk[:remainTotal]
-					totalSourceBytes += remainTotal
-					truncated = true
-					omittedLines = true
-					lineTruncated = true
-				} else {
-					totalSourceBytes += chunkLen
-				}
-
-				remainLine := maxLineBytes - len(lineBuf)
-				if remainLine > 0 {
-					if len(chunk) > remainLine {
-						lineBuf = append(lineBuf, chunk[:remainLine]...)
-						lineTruncated = true
-					} else {
-						lineBuf = append(lineBuf, chunk...)
-					}
-				} else {
-					lineTruncated = true
-				}
+	for len(lines) < maxLines {
+		start := counter.delivered(reader)
+		if start >= maxTotalBytes {
+			if moreSource() {
+				truncated = true
+				omittedLines = true
 			}
-
-			if err != nil {
-				if len(lineBuf) > 0 {
-					lines = append(lines, string(lineBuf))
-					if lineTruncated {
-						truncated = true
-					}
-				}
-				if !errors.Is(err, io.EOF) {
-					if len(lines) == 0 {
-						return fileViewReadResult{err: err}
-					}
-					truncated = true
-					omittedLines = true
-				}
-				goto finished
-			}
-
-			if totalSourceBytes >= maxTotalBytes {
-				if isPrefix {
-					truncated = true
-					omittedLines = true
-				} else if lineTruncated {
-					truncated = true
-				}
-				if len(lineBuf) > 0 {
-					lines = append(lines, string(lineBuf))
-				}
-				goto finished
-			}
-
-			if !isPrefix {
-				break
-			}
+			break
 		}
 
+		var raw []byte
+		for {
+			frag, err := reader.ReadSlice('\n')
+			raw = append(raw, frag...)
+			if errors.Is(err, bufio.ErrBufferFull) {
+				continue
+			}
+			if err != nil && !errors.Is(err, io.EOF) {
+				if len(lines) == 0 && len(raw) == 0 {
+					return fileViewReadResult{err: err}
+				}
+				truncated = true
+				omittedLines = true
+				break
+			}
+			break
+		}
+
+		if len(raw) == 0 {
+			break
+		}
+
+		consumed := counter.delivered(reader)
+		budget := maxTotalBytes - start
+		if budget < 0 {
+			budget = 0
+		}
+		kept := raw
+		if len(kept) > budget {
+			kept = kept[:budget]
+			truncated = true
+			omittedLines = true
+		}
+		display := stripFileViewLineEnding(kept)
+		lineTruncated := false
+		if len(display) > maxLineBytes {
+			display = display[:maxLineBytes]
+			lineTruncated = true
+			truncated = true
+		}
+		if consumed > maxTotalBytes {
+			truncated = true
+			omittedLines = true
+		}
 		if lineTruncated {
 			truncated = true
 		}
-		lines = append(lines, string(lineBuf))
-		if totalSourceBytes >= maxTotalBytes {
+		lines = append(lines, string(display))
+		if consumed >= maxTotalBytes {
+			if moreSource() {
+				truncated = true
+				omittedLines = true
+			}
+			break
+		}
+		if len(raw) > 0 && raw[len(raw)-1] != '\n' && !moreSource() {
 			break
 		}
 	}
 
-finished:
-	if !omittedLines {
-		if reader.Buffered() > 0 {
-			truncated = true
-			omittedLines = true
-		} else if _, err := reader.Peek(1); err == nil {
-			truncated = true
-			omittedLines = true
-		} else {
-			var probe [1]byte
-			if n, _ := file.Read(probe[:]); n > 0 {
-				truncated = true
-				omittedLines = true
-			}
-		}
+	if !omittedLines && len(lines) >= maxLines && moreSource() {
+		truncated = true
+		omittedLines = true
 	}
 
 	return fileViewReadResult{

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -190,16 +191,26 @@ func (c *fileViewRenderCache) requiredRevision(targetPath string) uint64 {
 	return c.pathRevisions[targetPath]
 }
 
-func (c *fileViewRenderCache) clear() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+func (c *fileViewRenderCache) purgeLocked() {
 	c.gen++
 	c.items = make(map[string]*list.Element)
 	c.lru.Init()
 	for k := range c.pathRevisions {
 		c.pathRevisions[k]++
 	}
+}
+
+func (c *fileViewRenderCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.purgeLocked()
 	c.statsData.ThemeClears++
+}
+
+func (c *fileViewRenderCache) invalidateUnknownScope() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.purgeLocked()
 }
 
 func (c *fileViewRenderCache) generation() int {
@@ -222,6 +233,8 @@ func (c *fileViewRenderCache) stats() fileViewCacheStats {
 
 type fileViewReadResult struct {
 	lines        []string
+	modTime      time.Time
+	size         int64
 	truncated    bool
 	omittedLines bool
 	err          error
@@ -257,11 +270,30 @@ func stripFileViewLineEnding(b []byte) []byte {
 }
 
 func readFileViewBounded(path string, maxLines int, maxLineBytes int, maxTotalBytes int) fileViewReadResult {
-	file, err := os.Open(path)
+	return readFileViewBoundedCancellable(path, maxLines, maxLineBytes, maxTotalBytes, nil, 0)
+}
+
+func readFileViewBoundedCancellable(path string, maxLines int, maxLineBytes int, maxTotalBytes int, liveSeq *atomic.Uint64, seq uint64) fileViewReadResult {
+	if fileViewSuperseded(liveSeq, seq) {
+		return fileViewReadResult{err: errFileViewSuperseded}
+	}
+
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		return fileViewReadResult{err: err}
 	}
 	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return fileViewReadResult{err: err}
+	}
+	if !stat.Mode().IsRegular() {
+		return fileViewReadResult{err: fmt.Errorf("cannot read non-regular file (mode %s)", stat.Mode().String())}
+	}
+	if fileViewSuperseded(liveSeq, seq) {
+		return fileViewReadResult{err: errFileViewSuperseded}
+	}
 
 	var lines []string
 	truncated := false
@@ -278,6 +310,15 @@ func readFileViewBounded(path string, maxLines int, maxLineBytes int, maxTotalBy
 	}
 
 	for len(lines) < maxLines {
+		if fileViewSuperseded(liveSeq, seq) {
+			return fileViewReadResult{err: errFileViewSuperseded}
+		}
+		if fileViewInsideDiskRead != nil {
+			fileViewInsideDiskRead()
+			if fileViewSuperseded(liveSeq, seq) {
+				return fileViewReadResult{err: errFileViewSuperseded}
+			}
+		}
 		start := counter.delivered(reader)
 		if start >= maxTotalBytes {
 			if moreSource() {
@@ -289,6 +330,9 @@ func readFileViewBounded(path string, maxLines int, maxLineBytes int, maxTotalBy
 
 		var raw []byte
 		for {
+			if fileViewSuperseded(liveSeq, seq) {
+				return fileViewReadResult{err: errFileViewSuperseded}
+			}
 			frag, err := reader.ReadSlice('\n')
 			raw = append(raw, frag...)
 			if errors.Is(err, bufio.ErrBufferFull) {
@@ -354,6 +398,8 @@ func readFileViewBounded(path string, maxLines int, maxLineBytes int, maxTotalBy
 
 	return fileViewReadResult{
 		lines:        lines,
+		modTime:      stat.ModTime(),
+		size:         stat.Size(),
 		truncated:    truncated,
 		omittedLines: omittedLines,
 	}
@@ -461,9 +507,12 @@ var (
 	fileViewInsideLoad           func()
 	fileViewBeforeCacheHitFormat func()
 	fileViewBeforeDiskRead       func()
+	fileViewInsideDiskRead       func()
 	fileViewBeforeHighlight      func()
+	fileViewInsideHighlight      func()
 	fileViewBeforeFormat         func()
 	fileViewBeforeCacheCommit    func()
+	fileViewHighlightMu          sync.Mutex
 )
 
 func fileViewSuperseded(liveSeq *atomic.Uint64, seq uint64) bool {
@@ -480,6 +529,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	if fileViewSuperseded(liveSeq, seq) {
 		return "", errFileViewSuperseded
 	}
+
 	stat, err := os.Stat(targetPath)
 	if err != nil {
 		c.mu.Lock()
@@ -490,6 +540,17 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		c.mu.Unlock()
 		rendered := theme.faint.Render("Could not read file: " + err.Error())
 		return rendered, err
+	}
+	if !stat.Mode().IsRegular() {
+		c.mu.Lock()
+		if elem, ok := c.items[targetPath]; ok {
+			c.lru.Remove(elem)
+			delete(c.items, targetPath)
+		}
+		c.mu.Unlock()
+		readErr := fmt.Errorf("cannot display non-regular file %s (mode %s)", displayPath, stat.Mode().String())
+		rendered := theme.faint.Render("Could not read file: " + readErr.Error())
+		return rendered, readErr
 	}
 
 	modTime := stat.ModTime()
@@ -510,8 +571,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	if elem, ok := c.items[targetPath]; ok {
 		entry := elem.Value.(*fileViewCachedEntry)
 		forceReload := (entry.sourceRev < reqSourceRev)
-		refreshSource := forceReload
-		if !refreshSource && entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
+		if !forceReload && entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
 			if fileViewSuperseded(liveSeq, seq) {
 				c.mu.Unlock()
 				return "", errFileViewSuperseded
@@ -560,7 +620,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		return "", errFileViewSuperseded
 	}
 
-	readRes := readFileViewBounded(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes)
+	readRes := readFileViewBoundedCancellable(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes, liveSeq, seq)
 	if readRes.err != nil && len(readRes.lines) == 0 {
 		c.mu.Lock()
 		if elem, ok := c.items[targetPath]; ok {
@@ -572,6 +632,11 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		return rendered, readRes.err
 	}
 
+	cleanLines := make([]string, len(readRes.lines))
+	for i, l := range readRes.lines {
+		cleanLines[i] = sanitizeRawFileLine(l)
+	}
+
 	if fileViewBeforeHighlight != nil {
 		fileViewBeforeHighlight()
 	}
@@ -579,16 +644,26 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		return "", errFileViewSuperseded
 	}
 
-	c.mu.Lock()
-	c.statsData.HighlightCalls++
-	c.mu.Unlock()
-
-	cleanLines := make([]string, len(readRes.lines))
-	for i, l := range readRes.lines {
-		cleanLines[i] = sanitizeRawFileLine(l)
+	display, ok := func() ([]string, bool) {
+		fileViewHighlightMu.Lock()
+		defer fileViewHighlightMu.Unlock()
+		if fileViewSuperseded(liveSeq, seq) {
+			return nil, false
+		}
+		if fileViewInsideHighlight != nil {
+			fileViewInsideHighlight()
+			if fileViewSuperseded(liveSeq, seq) {
+				return nil, false
+			}
+		}
+		c.mu.Lock()
+		c.statsData.HighlightCalls++
+		c.mu.Unlock()
+		return highlightCodeForPathWithTheme(cleanLines, displayPath, 1<<20, nil, theme)
+	}()
+	if fileViewSuperseded(liveSeq, seq) {
+		return "", errFileViewSuperseded
 	}
-
-	display, ok := highlightCodeForPathWithTheme(cleanLines, displayPath, 1<<20, nil, theme)
 	if !ok || len(display) != len(cleanLines) {
 		display = cleanLines
 	}
@@ -612,8 +687,8 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	entry := &fileViewCachedEntry{
 		targetPath:   targetPath,
 		displayPath:  displayPath,
-		modTime:      modTime,
-		size:         size,
+		modTime:      readRes.modTime,
+		size:         readRes.size,
 		sourceRev:    reqSourceRev,
 		lines:        cleanLines,
 		display:      display,
@@ -635,7 +710,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	if elem, ok := c.items[targetPath]; ok {
 		existing := elem.Value.(*fileViewCachedEntry)
-		if existing.modTime.After(modTime) && existing.sourceRev > reqSourceRev {
+		if existing.modTime.After(readRes.modTime) && existing.sourceRev > reqSourceRev {
 			c.mu.Unlock()
 			return rendered, nil
 		}

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	tea "charm.land/bubbletea/v2"
 )
 
 // fileViewMaxLines caps the full-file mode so a giant generated file can't
@@ -35,6 +37,7 @@ const (
 	fileViewMaxLineBytes           = 4096    // 4 KiB max line length budget
 	defaultFileViewCacheMaxEntries = 64
 	fileViewMaxRenderVariants      = 4 // max rendered variants (width/fingerprint) per cached file entry
+	fileViewLoadingPlaceholder     = "Loading…"
 )
 
 const (
@@ -112,6 +115,7 @@ type fileViewRenderCache struct {
 	maxEntries int
 	items      map[string]*list.Element // targetPath -> *list.Element containing *fileViewCachedEntry
 	lru        *list.List
+	gen        int
 	statsData  fileViewCacheStats
 }
 
@@ -128,8 +132,16 @@ func newFileViewRenderCache(maxEntries int) *fileViewRenderCache {
 func (c *fileViewRenderCache) clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.gen++
 	c.items = make(map[string]*list.Element)
 	c.lru.Init()
+	c.statsData.ThemeClears++
+}
+
+func (c *fileViewRenderCache) generation() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gen
 }
 
 func (c *fileViewRenderCache) resetStats() {
@@ -322,10 +334,39 @@ func formatFileViewLines(lines []string, display []string, changed map[string]bo
 	return b.String()
 }
 
-func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string, width int, changed map[string]bool) string {
+// getRenderOnly looks up an already-rendered variant in memory (or formats from
+// already-cached in-memory syntax tokens) without performing any disk I/O, stat,
+// or Chroma syntax highlighting. Safe for direct View calls.
+func (c *fileViewRenderCache) getRenderOnly(targetPath string, width int, changed map[string]bool) (string, bool) {
+	c.mu.Lock()
+	elem, ok := c.items[targetPath]
+	if !ok {
+		c.mu.Unlock()
+		return "", false
+	}
+	entry := elem.Value.(*fileViewCachedEntry)
+	c.lru.MoveToFront(elem)
+	c.statsData.CacheHits++
+	c.mu.Unlock()
+
+	renderKey := fmt.Sprintf("%d:%s", width, changedLinesFingerprint(changed))
+	if val, ok := entry.getRender(renderKey); ok {
+		return val, true
+	}
+
+	rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width)
+	entry.putRender(renderKey, rendered)
+	return rendered, true
+}
+
+// loadAndRender performs the bounded read, Chroma highlighting, and formatting
+// on a cache miss (or re-formats for a new width variant on a cache hit). It is
+// intended to be executed from a tea.Cmd / background worker, off the View path.
+func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, reqGen int) (string, error) {
 	stat, err := os.Stat(targetPath)
 	if err != nil {
-		return zeroTheme.faint.Render("Could not read file: " + err.Error())
+		rendered := zeroTheme.faint.Render("Could not read file: " + err.Error())
+		return rendered, err
 	}
 
 	modTime := stat.ModTime()
@@ -334,6 +375,11 @@ func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string,
 	renderKey := fmt.Sprintf("%d:%s", width, changedFingerprint)
 
 	c.mu.Lock()
+	if c.gen != reqGen {
+		c.mu.Unlock()
+		return "", errors.New("request superseded by cache invalidation")
+	}
+
 	if elem, ok := c.items[targetPath]; ok {
 		entry := elem.Value.(*fileViewCachedEntry)
 		if entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
@@ -342,13 +388,13 @@ func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string,
 			c.mu.Unlock()
 
 			if rendered, ok := entry.getRender(renderKey); ok {
-				return rendered
+				return rendered, nil
 			}
 
 			// Re-format for the new width or changed markers using cached display and lines
 			rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width)
 			entry.putRender(renderKey, rendered)
-			return rendered
+			return rendered, nil
 		}
 	}
 
@@ -358,7 +404,8 @@ func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string,
 
 	readRes := readFileViewBounded(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes)
 	if readRes.err != nil && len(readRes.lines) == 0 {
-		return zeroTheme.faint.Render("Could not read file: " + readRes.err.Error())
+		rendered := zeroTheme.faint.Render("Could not read file: " + readRes.err.Error())
+		return rendered, readRes.err
 	}
 
 	c.mu.Lock()
@@ -386,6 +433,11 @@ func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string,
 	}
 
 	c.mu.Lock()
+	if c.gen != reqGen {
+		c.mu.Unlock()
+		return "", errors.New("request superseded by cache invalidation")
+	}
+
 	if elem, ok := c.items[targetPath]; ok {
 		c.lru.Remove(elem)
 		delete(c.items, targetPath)
@@ -404,7 +456,38 @@ func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string,
 	}
 	c.mu.Unlock()
 
+	return rendered, nil
+}
+
+func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string, width int, changed map[string]bool) string {
+	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, c.generation())
 	return rendered
+}
+
+// fileViewLoadedMsg delivers the result of an asynchronous file read & render.
+type fileViewLoadedMsg struct {
+	requestID   int
+	generation  int
+	targetPath  string
+	displayPath string
+	width       int
+	rendered    string
+	err         error
+}
+
+func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, requestID int, gen int) tea.Cmd {
+	return func() tea.Msg {
+		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, gen)
+		return fileViewLoadedMsg{
+			requestID:   requestID,
+			generation:  gen,
+			targetPath:  targetPath,
+			displayPath: displayPath,
+			width:       width,
+			rendered:    rendered,
+			err:         err,
+		}
+	}
 }
 
 // fileViewState manages the drill-in view for a touched file. When active, the
@@ -416,6 +499,27 @@ type fileViewState struct {
 	// parentScrollOffset preserves the chat scroll position so closing the view
 	// returns to the same spot (mirrors subchatState).
 	parentScrollOffset int
+	requestID          int    // monotonic ID for async load requests
+	renderedContent    string // rendered full text when loaded
+	loadedPath         string // path of loaded content
+	loadedWidth        int    // width of loaded content
+	loading            bool   // true while async load is in flight
+}
+
+func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
+	if !m.fileView.active || m.fileView.mode != fileViewFull || m.fileView.path == "" {
+		return m, nil
+	}
+	target := m.fileView.path
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(m.cwd, target)
+	}
+	m.fileView.requestID++
+	m.fileView.loading = true
+	reqID := m.fileView.requestID
+	gen := defaultFileViewCache.generation()
+	changed := m.fileViewChangedLines()
+	return m, loadFileViewCmd(target, m.fileView.path, width, changed, reqID, gen)
 }
 
 // openFileView activates the drill-in for path in diff mode. Opening from an
@@ -424,9 +528,9 @@ type fileViewState struct {
 // Re-opening the file that is ALREADY being viewed is a no-op: a stray
 // re-click must not bounce the user from full mode back to diff or reset
 // their scroll position.
-func (m model) openFileView(path string) model {
+func (m model) openFileView(path string) (model, tea.Cmd) {
 	if m.fileView.active && m.fileView.path == path {
-		return m
+		return m, nil
 	}
 	if !m.fileView.active {
 		m.fileView.parentScrollOffset = m.chatScrollOffset
@@ -441,7 +545,10 @@ func (m model) openFileView(path string) model {
 	}
 	m.chatScrollOffset = 0
 	m = m.clearHover() // bodyY numbering differs between the file body and the chat
-	return m
+	if m.fileView.mode == fileViewFull {
+		return m.startFileViewLoadCmd(m.chatColumnWidth())
+	}
+	return m, nil
 }
 
 // exitFileView deactivates the view and restores the chat scroll position.
@@ -457,12 +564,32 @@ func (m model) exitFileView() model {
 
 // setFileViewMode switches diff/full, resetting the scroll to the bottom-anchored
 // start since the two bodies have unrelated heights.
-func (m model) setFileViewMode(mode int) model {
+func (m model) setFileViewMode(mode int) (model, tea.Cmd) {
 	if !m.fileView.active || m.fileView.mode == mode {
-		return m
+		return m, nil
 	}
 	m.fileView.mode = mode
 	m.chatScrollOffset = 0
+	if mode == fileViewFull {
+		return m.startFileViewLoadCmd(m.chatColumnWidth())
+	}
+	return m, nil
+}
+
+func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) model {
+	if !m.fileView.active || m.fileView.mode != fileViewFull {
+		return m
+	}
+	if m.fileView.path != msg.displayPath || m.fileView.requestID != msg.requestID {
+		return m
+	}
+	if msg.generation != defaultFileViewCache.generation() {
+		return m
+	}
+	m.fileView.loading = false
+	m.fileView.renderedContent = msg.rendered
+	m.fileView.loadedPath = msg.displayPath
+	m.fileView.loadedWidth = msg.width
 	return m
 }
 
@@ -542,12 +669,20 @@ func (m model) renderFileViewDiff(width int) string {
 // highlighted, with a line-number gutter and an accent ▎ marker on the lines
 // this session's diffs added (matched by exact text — an approximation that
 // tolerates later drift; a stale marker just doesn't highlight).
+// It is read-only and non-blocking: if content is ready or cached in memory,
+// it is returned immediately; otherwise a loading placeholder is shown.
 func (m model) renderFileViewFull(width int) string {
 	target := m.fileView.path
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	return defaultFileViewCache.getOrRender(target, m.fileView.path, width, m.fileViewChangedLines())
+	if cached, ok := defaultFileViewCache.getRenderOnly(target, width, m.fileViewChangedLines()); ok {
+		return cached
+	}
+	if m.fileView.renderedContent != "" && m.fileView.loadedPath == m.fileView.path {
+		return m.fileView.renderedContent
+	}
+	return zeroTheme.faint.Render(fileViewLoadingPlaceholder)
 }
 
 // fileViewChangedLines collects the trimmed text of every line the session's

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -303,7 +303,7 @@ func changedLinesFingerprint(changed map[string]bool) string {
 	return strings.Join(keys, "\x00")
 }
 
-func formatFileViewLines(lines []string, display []string, changed map[string]bool, truncated bool, omittedLines bool, width int) string {
+func formatFileViewLines(lines []string, display []string, changed map[string]bool, truncated bool, omittedLines bool, width int, theme tuiTheme) string {
 	gutterW := len(fmt.Sprintf("%d", len(lines)))
 	textBudget := maxInt(8, width-gutterW-3) // gutter + space + marker column
 
@@ -315,9 +315,9 @@ func formatFileViewLines(lines []string, display []string, changed map[string]bo
 		}
 		marker := " "
 		if changed != nil && len(lines) > i && changed[strings.TrimSpace(lines[i])] {
-			marker = zeroTheme.accent.Render("▎")
+			marker = theme.accent.Render("▎")
 		}
-		b.WriteString(zeroTheme.faintest.Render(fmt.Sprintf("%*d ", gutterW, i+1)))
+		b.WriteString(theme.faintest.Render(fmt.Sprintf("%*d ", gutterW, i+1)))
 		b.WriteString(marker)
 		b.WriteString(line)
 	}
@@ -326,9 +326,9 @@ func formatFileViewLines(lines []string, display []string, changed map[string]bo
 		// rest of the file, defeating the bounded read above.
 		b.WriteString("\n")
 		if omittedLines {
-			b.WriteString(zeroTheme.faint.Render(fmt.Sprintf("… more lines (file truncated at %d for display)", len(lines))))
+			b.WriteString(theme.faint.Render(fmt.Sprintf("… more lines (file truncated at %d for display)", len(lines))))
 		} else {
-			b.WriteString(zeroTheme.faint.Render("… (line content truncated at display limit)"))
+			b.WriteString(theme.faint.Render("… (line content truncated at display limit)"))
 		}
 	}
 	return b.String()
@@ -337,7 +337,7 @@ func formatFileViewLines(lines []string, display []string, changed map[string]bo
 // getRenderOnly looks up an already-rendered variant in memory (or formats from
 // already-cached in-memory syntax tokens) without performing any disk I/O, stat,
 // or Chroma syntax highlighting. Safe for direct View calls.
-func (c *fileViewRenderCache) getRenderOnly(targetPath string, width int, changed map[string]bool) (string, bool) {
+func (c *fileViewRenderCache) getRenderOnly(targetPath string, width int, changed map[string]bool, theme tuiTheme) (string, bool) {
 	c.mu.Lock()
 	elem, ok := c.items[targetPath]
 	if !ok {
@@ -354,7 +354,7 @@ func (c *fileViewRenderCache) getRenderOnly(targetPath string, width int, change
 		return val, true
 	}
 
-	rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width)
+	rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width, theme)
 	entry.putRender(renderKey, rendered)
 	return rendered, true
 }
@@ -362,10 +362,10 @@ func (c *fileViewRenderCache) getRenderOnly(targetPath string, width int, change
 // loadAndRender performs the bounded read, Chroma highlighting, and formatting
 // on a cache miss (or re-formats for a new width variant on a cache hit). It is
 // intended to be executed from a tea.Cmd / background worker, off the View path.
-func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, reqGen int) (string, error) {
+func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath string, width int, changed map[string]bool, reqGen int, theme tuiTheme) (string, error) {
 	stat, err := os.Stat(targetPath)
 	if err != nil {
-		rendered := zeroTheme.faint.Render("Could not read file: " + err.Error())
+		rendered := theme.faint.Render("Could not read file: " + err.Error())
 		return rendered, err
 	}
 
@@ -392,7 +392,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 			}
 
 			// Re-format for the new width or changed markers using cached display and lines
-			rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width)
+			rendered := formatFileViewLines(entry.lines, entry.display, changed, entry.truncated, entry.omittedLines, width, theme)
 			entry.putRender(renderKey, rendered)
 			return rendered, nil
 		}
@@ -404,7 +404,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	readRes := readFileViewBounded(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes)
 	if readRes.err != nil && len(readRes.lines) == 0 {
-		rendered := zeroTheme.faint.Render("Could not read file: " + readRes.err.Error())
+		rendered := theme.faint.Render("Could not read file: " + readRes.err.Error())
 		return rendered, readRes.err
 	}
 
@@ -412,12 +412,12 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	c.statsData.HighlightCalls++
 	c.mu.Unlock()
 
-	display, ok := highlightCodeForPath(readRes.lines, displayPath, 1<<20, nil)
+	display, ok := highlightCodeForPathWithTheme(readRes.lines, displayPath, 1<<20, nil, theme)
 	if !ok || len(display) != len(readRes.lines) {
 		display = readRes.lines
 	}
 
-	rendered := formatFileViewLines(readRes.lines, display, changed, readRes.truncated, readRes.omittedLines, width)
+	rendered := formatFileViewLines(readRes.lines, display, changed, readRes.truncated, readRes.omittedLines, width, theme)
 
 	entry := &fileViewCachedEntry{
 		targetPath:   targetPath,
@@ -439,6 +439,11 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	}
 
 	if elem, ok := c.items[targetPath]; ok {
+		existing := elem.Value.(*fileViewCachedEntry)
+		if existing.modTime.After(modTime) {
+			c.mu.Unlock()
+			return rendered, nil
+		}
 		c.lru.Remove(elem)
 		delete(c.items, targetPath)
 	}
@@ -460,7 +465,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 }
 
 func (c *fileViewRenderCache) getOrRender(targetPath string, displayPath string, width int, changed map[string]bool) string {
-	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, c.generation())
+	rendered, _ := c.loadAndRender(targetPath, displayPath, width, changed, c.generation(), zeroTheme)
 	return rendered
 }
 
@@ -475,9 +480,9 @@ type fileViewLoadedMsg struct {
 	err         error
 }
 
-func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, requestID int, gen int) tea.Cmd {
+func loadFileViewCmd(targetPath string, displayPath string, width int, changed map[string]bool, requestID int, gen int, theme tuiTheme) tea.Cmd {
 	return func() tea.Msg {
-		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, gen)
+		rendered, err := defaultFileViewCache.loadAndRender(targetPath, displayPath, width, changed, gen, theme)
 		return fileViewLoadedMsg{
 			requestID:   requestID,
 			generation:  gen,
@@ -503,6 +508,7 @@ type fileViewState struct {
 	renderedContent    string // rendered full text when loaded
 	loadedPath         string // path of loaded content
 	loadedWidth        int    // width of loaded content
+	loadedGen          int    // cache/theme generation of loaded content
 	loading            bool   // true while async load is in flight
 }
 
@@ -519,7 +525,8 @@ func (m model) startFileViewLoadCmd(width int) (model, tea.Cmd) {
 	reqID := m.fileView.requestID
 	gen := defaultFileViewCache.generation()
 	changed := m.fileViewChangedLines()
-	return m, loadFileViewCmd(target, m.fileView.path, width, changed, reqID, gen)
+	theme := zeroTheme
+	return m, loadFileViewCmd(target, m.fileView.path, width, changed, reqID, gen, theme)
 }
 
 // openFileView activates the drill-in for path in diff mode. Opening from an
@@ -576,21 +583,24 @@ func (m model) setFileViewMode(mode int) (model, tea.Cmd) {
 	return m, nil
 }
 
-func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) model {
+func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 	if !m.fileView.active || m.fileView.mode != fileViewFull {
-		return m
+		return m, nil
 	}
 	if m.fileView.path != msg.displayPath || m.fileView.requestID != msg.requestID {
-		return m
+		return m, nil
 	}
 	if msg.generation != defaultFileViewCache.generation() {
-		return m
+		// Cache was invalidated (e.g. theme switch) while this request was in flight.
+		// Start a fresh request for the current generation.
+		return m.startFileViewLoadCmd(m.chatColumnWidth())
 	}
 	m.fileView.loading = false
 	m.fileView.renderedContent = msg.rendered
 	m.fileView.loadedPath = msg.displayPath
 	m.fileView.loadedWidth = msg.width
-	return m
+	m.fileView.loadedGen = msg.generation
+	return m, nil
 }
 
 // fileViewNavBar renders the single-line header shown in place of the pinned
@@ -676,10 +686,10 @@ func (m model) renderFileViewFull(width int) string {
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	if cached, ok := defaultFileViewCache.getRenderOnly(target, width, m.fileViewChangedLines()); ok {
+	if cached, ok := defaultFileViewCache.getRenderOnly(target, width, m.fileViewChangedLines(), zeroTheme); ok {
 		return cached
 	}
-	if m.fileView.renderedContent != "" && m.fileView.loadedPath == m.fileView.path {
+	if m.fileView.renderedContent != "" && m.fileView.loadedPath == m.fileView.path && m.fileView.loadedGen == defaultFileViewCache.generation() {
 		return m.fileView.renderedContent
 	}
 	return zeroTheme.faint.Render(fileViewLoadingPlaceholder)

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -16,6 +16,7 @@ package tui
 import (
 	"bufio"
 	"container/list"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -38,8 +39,13 @@ const (
 	fileViewMaxBytes               = 1 << 20 // 1 MiB total read budget per file
 	fileViewMaxLineBytes           = 4096    // 4 KiB max line length budget
 	defaultFileViewCacheMaxEntries = 64
-	fileViewMaxRenderVariants      = 4 // max rendered variants (width/fingerprint) per cached file entry
-	fileViewLoadingPlaceholder     = "Loading…"
+	// defaultFileViewCacheMaxBytes bounds the total retained bytes of the file
+	// view cache so wide renders of large files cannot grow without limit
+	// (measured at tens to hundreds of MiB before this cap). It counts the stable
+	// source+display payload plus every rendered variant.
+	defaultFileViewCacheMaxBytes = 8 << 20 // 8 MiB
+	fileViewMaxRenderVariants    = 4       // max rendered variants (width/fingerprint) per cached file entry
+	fileViewLoadingPlaceholder   = "Loading…"
 )
 
 const (
@@ -85,13 +91,14 @@ func nextFileViewLifetimeToken() [16]byte {
 
 // fileViewCacheStats tracks disk I/O, Chroma highlighting, and cache hits/misses.
 type fileViewCacheStats struct {
-	DiskReads       int
-	HighlightCalls  int
-	CacheHits       int
-	CacheMisses     int
-	Evictions       int
-	ThemeClears     int
-	RenderEvictions int
+	DiskReads        int
+	HighlightCalls   int
+	CacheHits        int
+	CacheMisses      int
+	Evictions        int
+	ThemeClears      int
+	RenderEvictions  int
+	SkippedOversized int
 }
 
 type fileViewCachedEntry struct {
@@ -100,6 +107,8 @@ type fileViewCachedEntry struct {
 	modTime      time.Time
 	size         int64
 	sourceRev    uint64
+	sourceHash   [sha256.Size]byte
+	sourceBytes  int
 	lines        []string
 	display      []string
 	truncated    bool
@@ -108,6 +117,36 @@ type fileViewCachedEntry struct {
 	rendersMu  sync.RWMutex
 	renderKeys []string          // LRU order: oldest at index 0, most recent at end
 	renders    map[string]string // key: "width:changedLinesFingerprint" -> formatted ANSI string
+}
+
+// byteSize is the total retained payload for the entry: the stable source and
+// display lines plus every rendered variant. The reader uses it to enforce the
+// cache-wide byte budget.
+func (e *fileViewCachedEntry) byteSize() int {
+	n := e.sourceBytes
+	e.rendersMu.RLock()
+	for k, v := range e.renders {
+		n += len(k) + len(v)
+	}
+	e.rendersMu.RUnlock()
+	return n
+}
+
+// fileViewSourceHash fingerprints the bounded source lines so a metadata-only
+// change (cp -p, rsync -t, tar -xp restoring mtime and size) cannot serve a
+// stale entry. Lines are joined with a separator the reader never emits inside
+// a line, so shifted boundaries cannot collide.
+func fileViewSourceHash(lines []string) [sha256.Size]byte {
+	h := sha256.New()
+	for i, line := range lines {
+		if i > 0 {
+			h.Write([]byte{'\n'})
+		}
+		h.Write([]byte(line))
+	}
+	var out [sha256.Size]byte
+	copy(out[:], h.Sum(nil))
+	return out
 }
 
 func (e *fileViewCachedEntry) getRender(key string) (string, bool) {
@@ -128,20 +167,28 @@ func (e *fileViewCachedEntry) getRender(key string) (string, bool) {
 	return val, true
 }
 
-func (e *fileViewCachedEntry) putRender(key string, val string) {
+// putRender stores a formatted variant and returns the change in retained
+// bytes (positive on growth, negative when an old variant is dropped or
+// replaced). The caller folds the delta into the cache-wide budget.
+func (e *fileViewCachedEntry) putRender(key string, val string) int {
 	e.rendersMu.Lock()
 	defer e.rendersMu.Unlock()
 	if e.renders == nil {
 		e.renders = make(map[string]string)
 	}
-	if _, ok := e.renders[key]; !ok {
+	delta := 0
+	if prev, ok := e.renders[key]; ok {
+		delta -= len(prev)
+	} else {
 		for len(e.renders) >= fileViewMaxRenderVariants {
 			if len(e.renderKeys) > 0 {
 				oldKey := e.renderKeys[0]
 				e.renderKeys = e.renderKeys[1:]
+				delta -= len(oldKey) + len(e.renders[oldKey])
 				delete(e.renders, oldKey)
 			} else {
-				for k := range e.renders {
+				for k, v := range e.renders {
+					delta -= len(k) + len(v)
 					delete(e.renders, k)
 					break
 				}
@@ -150,11 +197,15 @@ func (e *fileViewCachedEntry) putRender(key string, val string) {
 		e.renderKeys = append(e.renderKeys, key)
 	}
 	e.renders[key] = val
+	delta += len(key) + len(val)
+	return delta
 }
 
 type fileViewRenderCache struct {
 	mu            sync.Mutex
 	maxEntries    int
+	maxBytes      int
+	retained      int
 	items         map[string]*list.Element // targetPath -> *list.Element containing *fileViewCachedEntry
 	lru           *list.List
 	gen           int
@@ -162,11 +213,12 @@ type fileViewRenderCache struct {
 	statsData     fileViewCacheStats
 }
 
-var defaultFileViewCache = newFileViewRenderCache(defaultFileViewCacheMaxEntries)
+var defaultFileViewCache = newFileViewRenderCache(defaultFileViewCacheMaxEntries, defaultFileViewCacheMaxBytes)
 
-func newFileViewRenderCache(maxEntries int) *fileViewRenderCache {
+func newFileViewRenderCache(maxEntries int, maxBytes int) *fileViewRenderCache {
 	return &fileViewRenderCache{
 		maxEntries:    maxEntries,
+		maxBytes:      maxBytes,
 		items:         make(map[string]*list.Element),
 		lru:           list.New(),
 		pathRevisions: make(map[string]uint64),
@@ -178,10 +230,7 @@ func (c *fileViewRenderCache) invalidatePath(targetPath string) uint64 {
 	defer c.mu.Unlock()
 	c.pathRevisions[targetPath]++
 	rev := c.pathRevisions[targetPath]
-	if elem, ok := c.items[targetPath]; ok {
-		c.lru.Remove(elem)
-		delete(c.items, targetPath)
-	}
+	c.removeItemLocked(targetPath)
 	return rev
 }
 
@@ -191,13 +240,59 @@ func (c *fileViewRenderCache) requiredRevision(targetPath string) uint64 {
 	return c.pathRevisions[targetPath]
 }
 
+// removeItemLocked drops targetPath from the LRU and folds its bytes back out
+// of retained. It intentionally leaves pathRevisions alone: an invalidated path
+// stays dirty until its entry is evicted by capacity or the cache is purged.
+func (c *fileViewRenderCache) removeItemLocked(targetPath string) {
+	elem, ok := c.items[targetPath]
+	if !ok {
+		return
+	}
+	c.retained -= elem.Value.(*fileViewCachedEntry).byteSize()
+	c.lru.Remove(elem)
+	delete(c.items, targetPath)
+}
+
+// evictOverflowLocked trims the LRU until both the entry count and the retained
+// byte budget fit. Evicting an entry also drops its path revision: the path is no
+// longer cached, so keeping the revision would only leak one key per file.
+func (c *fileViewRenderCache) evictOverflowLocked() {
+	for len(c.items) > c.maxEntries || (c.maxBytes > 0 && c.retained > c.maxBytes) {
+		back := c.lru.Back()
+		if back == nil {
+			c.retained = 0
+			return
+		}
+		backEntry := back.Value.(*fileViewCachedEntry)
+		c.retained -= backEntry.byteSize()
+		delete(c.items, backEntry.targetPath)
+		c.lru.Remove(back)
+		delete(c.pathRevisions, backEntry.targetPath)
+		c.statsData.Evictions++
+	}
+}
+
+// commitRenderPut applies a variant's byte delta and re-trims the cache.
+func (c *fileViewRenderCache) commitRenderPut(entry *fileViewCachedEntry, key string, val string) {
+	delta := entry.putRender(key, val)
+	c.mu.Lock()
+	c.retained += delta
+	c.evictOverflowLocked()
+	c.mu.Unlock()
+}
+
+func (c *fileViewRenderCache) evictPath(targetPath string) {
+	c.mu.Lock()
+	c.removeItemLocked(targetPath)
+	c.mu.Unlock()
+}
+
 func (c *fileViewRenderCache) purgeLocked() {
 	c.gen++
 	c.items = make(map[string]*list.Element)
 	c.lru.Init()
-	for k := range c.pathRevisions {
-		c.pathRevisions[k]++
-	}
+	c.retained = 0
+	c.pathRevisions = make(map[string]uint64)
 }
 
 func (c *fileViewRenderCache) clear() {
@@ -498,9 +593,13 @@ func (c *fileViewRenderCache) peekRenderOnly(targetPath string, width int, chang
 	return entry.getRender(renderKey)
 }
 
-// loadAndRender performs the bounded read, Chroma highlighting, and formatting
-// on a cache miss (or re-formats for a new width variant on a cache hit). It is
-// intended to be executed from a tea.Cmd / background worker, off the View path.
+// loadAndRender performs the bounded read, Chroma highlighting, and formatting.
+// The bounded source is always read: mtime/size are kept only as a hint because
+// `cp -p`, `rsync -t` and `tar -xp` can restore matching metadata over different
+// bytes, so the content hash decides freshness. On a matching metadata+hash pair
+// the highlight/format work is reused (re-formatting only for a new width
+// variant). It is intended to run from a tea.Cmd / background worker, off the
+// View path.
 var errFileViewSuperseded = errors.New("file view request superseded")
 
 var (
@@ -532,22 +631,12 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	stat, err := os.Stat(targetPath)
 	if err != nil {
-		c.mu.Lock()
-		if elem, ok := c.items[targetPath]; ok {
-			c.lru.Remove(elem)
-			delete(c.items, targetPath)
-		}
-		c.mu.Unlock()
+		c.evictPath(targetPath)
 		rendered := theme.faint.Render("Could not read file: " + err.Error())
 		return rendered, err
 	}
 	if !stat.Mode().IsRegular() {
-		c.mu.Lock()
-		if elem, ok := c.items[targetPath]; ok {
-			c.lru.Remove(elem)
-			delete(c.items, targetPath)
-		}
-		c.mu.Unlock()
+		c.evictPath(targetPath)
 		readErr := fmt.Errorf("cannot display non-regular file %s (mode %s)", displayPath, stat.Mode().String())
 		rendered := theme.faint.Render("Could not read file: " + readErr.Error())
 		return rendered, readErr
@@ -562,6 +651,29 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		c.mu.Unlock()
 		return "", errors.New("request superseded by cache invalidation")
 	}
+	c.statsData.DiskReads++
+	c.mu.Unlock()
+
+	if fileViewBeforeDiskRead != nil {
+		fileViewBeforeDiskRead()
+	}
+	if fileViewSuperseded(liveSeq, seq) {
+		return "", errFileViewSuperseded
+	}
+
+	readRes := readFileViewBoundedCancellable(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes, liveSeq, seq)
+	if readRes.err != nil && len(readRes.lines) == 0 {
+		c.evictPath(targetPath)
+		rendered := theme.faint.Render("Could not read file: " + readRes.err.Error())
+		return rendered, readRes.err
+	}
+	sourceHash := fileViewSourceHash(readRes.lines)
+
+	c.mu.Lock()
+	if c.gen != reqGen {
+		c.mu.Unlock()
+		return "", errors.New("request superseded by cache invalidation")
+	}
 
 	curRequiredRev := c.pathRevisions[targetPath]
 	if reqSourceRev < curRequiredRev {
@@ -570,8 +682,12 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 
 	if elem, ok := c.items[targetPath]; ok {
 		entry := elem.Value.(*fileViewCachedEntry)
-		forceReload := (entry.sourceRev < reqSourceRev)
-		if !forceReload && entry.modTime.Equal(modTime) && entry.size == size && entry.displayPath == displayPath {
+		forceReload := entry.sourceRev < reqSourceRev
+		if !forceReload &&
+			entry.modTime.Equal(modTime) &&
+			entry.size == size &&
+			entry.displayPath == displayPath &&
+			entry.sourceHash == sourceHash {
 			if fileViewSuperseded(liveSeq, seq) {
 				c.mu.Unlock()
 				return "", errFileViewSuperseded
@@ -599,7 +715,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 			if fileViewSuperseded(liveSeq, seq) {
 				return "", errFileViewSuperseded
 			}
-			entry.putRender(renderKey, rendered)
+			c.commitRenderPut(entry, renderKey, rendered)
 			return rendered, nil
 		}
 	}
@@ -610,27 +726,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	}
 
 	c.statsData.CacheMisses++
-	c.statsData.DiskReads++
 	c.mu.Unlock()
-
-	if fileViewBeforeDiskRead != nil {
-		fileViewBeforeDiskRead()
-	}
-	if fileViewSuperseded(liveSeq, seq) {
-		return "", errFileViewSuperseded
-	}
-
-	readRes := readFileViewBoundedCancellable(targetPath, fileViewMaxLines, fileViewMaxLineBytes, fileViewMaxBytes, liveSeq, seq)
-	if readRes.err != nil && len(readRes.lines) == 0 {
-		c.mu.Lock()
-		if elem, ok := c.items[targetPath]; ok {
-			c.lru.Remove(elem)
-			delete(c.items, targetPath)
-		}
-		c.mu.Unlock()
-		rendered := theme.faint.Render("Could not read file: " + readRes.err.Error())
-		return rendered, readRes.err
-	}
 
 	cleanLines := make([]string, len(readRes.lines))
 	for i, l := range readRes.lines {
@@ -684,12 +780,22 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		return "", errFileViewSuperseded
 	}
 
+	sourceBytes := 0
+	for _, l := range cleanLines {
+		sourceBytes += len(l)
+	}
+	for _, d := range display {
+		sourceBytes += len(d)
+	}
+
 	entry := &fileViewCachedEntry{
 		targetPath:   targetPath,
 		displayPath:  displayPath,
 		modTime:      readRes.modTime,
 		size:         readRes.size,
 		sourceRev:    reqSourceRev,
+		sourceHash:   sourceHash,
+		sourceBytes:  sourceBytes,
 		lines:        cleanLines,
 		display:      display,
 		truncated:    readRes.truncated,
@@ -707,6 +813,11 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		c.mu.Unlock()
 		return "", errFileViewSuperseded
 	}
+	if c.maxEntries <= 0 || c.maxBytes <= 0 || entry.byteSize() > c.maxBytes {
+		c.statsData.SkippedOversized++
+		c.mu.Unlock()
+		return rendered, nil
+	}
 
 	if elem, ok := c.items[targetPath]; ok {
 		existing := elem.Value.(*fileViewCachedEntry)
@@ -714,22 +825,11 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 			c.mu.Unlock()
 			return rendered, nil
 		}
-		c.lru.Remove(elem)
-		delete(c.items, targetPath)
+		c.removeItemLocked(targetPath)
 	}
-	elem := c.lru.PushFront(entry)
-	c.items[targetPath] = elem
-
-	for len(c.items) > c.maxEntries {
-		back := c.lru.Back()
-		if back == nil {
-			break
-		}
-		backEntry := back.Value.(*fileViewCachedEntry)
-		delete(c.items, backEntry.targetPath)
-		c.lru.Remove(back)
-		c.statsData.Evictions++
-	}
+	c.items[targetPath] = c.lru.PushFront(entry)
+	c.retained += entry.byteSize()
+	c.evictOverflowLocked()
 	c.mu.Unlock()
 
 	return rendered, nil

--- a/internal/tui/file_view.go
+++ b/internal/tui/file_view.go
@@ -45,6 +45,8 @@ const (
 	// source+display payload plus every rendered variant.
 	defaultFileViewCacheMaxBytes = 8 << 20 // 8 MiB
 	fileViewMaxRenderVariants    = 4       // max rendered variants (width/fingerprint) per cached file entry
+	fileViewMaxPathRevisions     = 1024    // hard cap on retained per-path revision counters
+	fileViewMinPathRevisions     = 256     // floor for the revision bound on small caches
 	fileViewLoadingPlaceholder   = "Loading…"
 )
 
@@ -178,7 +180,7 @@ func (e *fileViewCachedEntry) putRender(key string, val string) int {
 	}
 	delta := 0
 	if prev, ok := e.renders[key]; ok {
-		delta -= len(prev)
+		delta = len(val) - len(prev)
 	} else {
 		for len(e.renders) >= fileViewMaxRenderVariants {
 			if len(e.renderKeys) > 0 {
@@ -195,9 +197,9 @@ func (e *fileViewCachedEntry) putRender(key string, val string) int {
 			}
 		}
 		e.renderKeys = append(e.renderKeys, key)
+		delta += len(key) + len(val)
 	}
 	e.renders[key] = val
-	delta += len(key) + len(val)
 	return delta
 }
 
@@ -210,6 +212,9 @@ type fileViewRenderCache struct {
 	lru           *list.List
 	gen           int
 	pathRevisions map[string]uint64
+	revOrder      *list.List               // LRU of revision keys: front = most recently invalidated path
+	revElems      map[string]*list.Element // targetPath -> *list.Element containing the path string
+	revEpochFloor uint64                   // minimum required revision for any path absent from pathRevisions
 	statsData     fileViewCacheStats
 }
 
@@ -222,14 +227,22 @@ func newFileViewRenderCache(maxEntries int, maxBytes int) *fileViewRenderCache {
 		items:         make(map[string]*list.Element),
 		lru:           list.New(),
 		pathRevisions: make(map[string]uint64),
+		revOrder:      list.New(),
+		revElems:      make(map[string]*list.Element),
 	}
 }
 
 func (c *fileViewRenderCache) invalidatePath(targetPath string) uint64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.pathRevisions[targetPath]++
 	rev := c.pathRevisions[targetPath]
+	if rev < c.revEpochFloor {
+		rev = c.revEpochFloor
+	}
+	rev++
+	c.pathRevisions[targetPath] = rev
+	c.touchRevisionLocked(targetPath)
+	c.trimRevisionsLocked()
 	c.removeItemLocked(targetPath)
 	return rev
 }
@@ -237,7 +250,79 @@ func (c *fileViewRenderCache) invalidatePath(targetPath string) uint64 {
 func (c *fileViewRenderCache) requiredRevision(targetPath string) uint64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.pathRevisions[targetPath]
+	return c.requiredRevisionLocked(targetPath)
+}
+
+// requiredRevisionLocked returns targetPath's revision, or the epoch floor when
+// its metadata has been evicted. Any request older than an evicted revision is
+// therefore rejected without needing the dead key to stay resident.
+func (c *fileViewRenderCache) requiredRevisionLocked(targetPath string) uint64 {
+	if rev, ok := c.pathRevisions[targetPath]; ok {
+		return rev
+	}
+	return c.revEpochFloor
+}
+
+// maxPathRevisions bounds how many per-path revision counters are retained. It
+// scales with the entry budget but never drops below a small floor and never
+// grows past a hard cap.
+func (c *fileViewRenderCache) maxPathRevisions() int {
+	limit := c.maxEntries * 4
+	if limit < fileViewMinPathRevisions {
+		limit = fileViewMinPathRevisions
+	}
+	if limit > fileViewMaxPathRevisions {
+		limit = fileViewMaxPathRevisions
+	}
+	return limit
+}
+
+// touchRevisionLocked moves targetPath to the front of the revision LRU,
+// inserting it when new.
+func (c *fileViewRenderCache) touchRevisionLocked(targetPath string) {
+	if c.revOrder == nil {
+		c.revOrder = list.New()
+	}
+	if c.revElems == nil {
+		c.revElems = make(map[string]*list.Element)
+	}
+	if elem, ok := c.revElems[targetPath]; ok {
+		c.revOrder.MoveToFront(elem)
+		return
+	}
+	c.revElems[targetPath] = c.revOrder.PushFront(targetPath)
+}
+
+// dropRevisionLocked removes a path's revision metadata and advances the epoch
+// floor so requests captured before the removal cannot commit.
+func (c *fileViewRenderCache) dropRevisionLocked(targetPath string) {
+	rev, ok := c.pathRevisions[targetPath]
+	if !ok {
+		return
+	}
+	delete(c.pathRevisions, targetPath)
+	if c.revElems != nil {
+		if elem, ok := c.revElems[targetPath]; ok {
+			c.revOrder.Remove(elem)
+			delete(c.revElems, targetPath)
+		}
+	}
+	if rev > c.revEpochFloor {
+		c.revEpochFloor = rev
+	}
+}
+
+// trimRevisionsLocked evicts the oldest revision keys once the map exceeds the
+// bound, advancing the epoch floor as it goes.
+func (c *fileViewRenderCache) trimRevisionsLocked() {
+	limit := c.maxPathRevisions()
+	for len(c.pathRevisions) > limit {
+		back := c.revOrder.Back()
+		if back == nil {
+			return
+		}
+		c.dropRevisionLocked(back.Value.(string))
+	}
 }
 
 // removeItemLocked drops targetPath from the LRU and folds its bytes back out
@@ -267,18 +352,25 @@ func (c *fileViewRenderCache) evictOverflowLocked() {
 		c.retained -= backEntry.byteSize()
 		delete(c.items, backEntry.targetPath)
 		c.lru.Remove(back)
-		delete(c.pathRevisions, backEntry.targetPath)
+		c.dropRevisionLocked(backEntry.targetPath)
 		c.statsData.Evictions++
 	}
 }
 
-// commitRenderPut applies a variant's byte delta and re-trims the cache.
+// commitRenderPut applies a variant's byte delta and re-trims the cache. The
+// entry is only accounted for while it is still the resident cache value for
+// its path: a concurrent purge, eviction, or replacement must not leak bytes
+// into c.retained from a detached entry.
 func (c *fileViewRenderCache) commitRenderPut(entry *fileViewCachedEntry, key string, val string) {
-	delta := entry.putRender(key, val)
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	elem, ok := c.items[entry.targetPath]
+	if !ok || elem.Value.(*fileViewCachedEntry) != entry {
+		return
+	}
+	delta := entry.putRender(key, val)
 	c.retained += delta
 	c.evictOverflowLocked()
-	c.mu.Unlock()
 }
 
 func (c *fileViewRenderCache) evictPath(targetPath string) {
@@ -293,6 +385,9 @@ func (c *fileViewRenderCache) purgeLocked() {
 	c.lru.Init()
 	c.retained = 0
 	c.pathRevisions = make(map[string]uint64)
+	c.revOrder = list.New()
+	c.revElems = make(map[string]*list.Element)
+	c.revEpochFloor = 0
 }
 
 func (c *fileViewRenderCache) clear() {
@@ -318,6 +413,15 @@ func (c *fileViewRenderCache) resetStats() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.statsData = fileViewCacheStats{}
+}
+
+// recordHit notes a snapshot served entirely from resident state. The accepted
+// snapshot bypasses the LRU lookup, so it accounts for its own hit to keep the
+// no-I/O contract observable in the cache statistics.
+func (c *fileViewRenderCache) recordHit() {
+	c.mu.Lock()
+	c.statsData.CacheHits++
+	c.mu.Unlock()
 }
 
 func (c *fileViewRenderCache) stats() fileViewCacheStats {
@@ -675,7 +779,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 		return "", errors.New("request superseded by cache invalidation")
 	}
 
-	curRequiredRev := c.pathRevisions[targetPath]
+	curRequiredRev := c.requiredRevisionLocked(targetPath)
 	if reqSourceRev < curRequiredRev {
 		reqSourceRev = curRequiredRev
 	}
@@ -687,7 +791,9 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 			entry.modTime.Equal(modTime) &&
 			entry.size == size &&
 			entry.displayPath == displayPath &&
-			entry.sourceHash == sourceHash {
+			entry.sourceHash == sourceHash &&
+			entry.truncated == readRes.truncated &&
+			entry.omittedLines == readRes.omittedLines {
 			if fileViewSuperseded(liveSeq, seq) {
 				c.mu.Unlock()
 				return "", errFileViewSuperseded
@@ -815,6 +921,7 @@ func (c *fileViewRenderCache) loadAndRender(targetPath string, displayPath strin
 	}
 	if c.maxEntries <= 0 || c.maxBytes <= 0 || entry.byteSize() > c.maxBytes {
 		c.statsData.SkippedOversized++
+		c.removeItemLocked(targetPath)
 		c.mu.Unlock()
 		return rendered, nil
 	}
@@ -903,6 +1010,9 @@ type fileViewState struct {
 	path               string // workspace-relative, as carried by changedFiles
 	mode               int    // fileViewDiff | fileViewFull
 	parentScrollOffset int
+	// preservedScrollOffset holds the reader's offset while an async reload
+	// swaps the body for the one-line loading placeholder.
+	preservedScrollOffset int
 
 	// View session lifetime identity (UUIDv7 RFC 9562 0-alloc)
 	lifetimeToken [16]byte
@@ -937,6 +1047,16 @@ func (m model) startFileViewRefreshCmd(width int) (model, tea.Cmd) {
 	return m.startFileViewLoad(width, true)
 }
 
+// refreshFileViewMarkers reloads an open full-file view so its gutter markers
+// and fingerprint are recomputed against the current transcript after a session
+// or transcript transition. No-op unless a full view is open.
+func (m model) refreshFileViewMarkers() (model, tea.Cmd) {
+	if m.fileView.active && m.fileView.mode == fileViewFull {
+		return m.startFileViewLoadCmd(m.chatColumnWidth())
+	}
+	return m, nil
+}
+
 func (m model) startFileViewLoad(width int, refreshSource bool) (model, tea.Cmd) {
 	if !m.fileView.active || m.fileView.mode != fileViewFull || m.fileView.path == "" {
 		return m, nil
@@ -958,6 +1078,11 @@ func (m model) startFileViewLoad(width int, refreshSource bool) (model, tea.Cmd)
 		m.fileView.requiredSourceRev = curReq
 	}
 
+	// Remember where the reader is before the body temporarily becomes the
+	// loading placeholder; syncChatScroll holds it and handleFileViewLoaded
+	// reconciles it against the real body. Intentional resets (new file,
+	// diff/full switch) zero chatScrollOffset before reaching here.
+	m.fileView.preservedScrollOffset = m.chatScrollOffset
 	m.fileView.desiredSeq++
 	m.fileView.desiredWidth = width
 	m.fileView.loading = true
@@ -1096,6 +1221,17 @@ func (m model) handleFileViewLoaded(msg fileViewLoadedMsg) (model, tea.Cmd) {
 	m.fileView.loadedSeq = msg.seq
 	m.fileView.loadedRev = msg.requiredSourceRev
 	m.fileView.hasError = (msg.err != nil)
+	// Reconcile the held reading offset against the real body now that the
+	// loading placeholder is gone; clamp in case the file shrank.
+	if m.fileView.preservedScrollOffset > 0 {
+		current, maxOffset := m.chatScrollMetrics()
+		m.chatScrollOffset = clampInt(m.fileView.preservedScrollOffset, 0, maxOffset)
+		if m.chatScrollOffset > 0 {
+			m.chatBodyLines = current
+		} else {
+			m.chatBodyLines = 0
+		}
+	}
 	return m, nil
 }
 
@@ -1184,16 +1320,17 @@ func (m model) renderFileViewFull(width int) string {
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(m.cwd, target)
 	}
-	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.desiredFingerprint, m.fileView.loadedSeq, m.fileView.desiredSeq, m.fileView.loadedRev, m.fileView.requiredSourceRev); ok {
-		return cached
-	}
 	if m.fileView.snapshotReady &&
 		m.fileView.loadedPath == m.fileView.path &&
 		m.fileView.loadedSeq == m.fileView.desiredSeq &&
 		m.fileView.loadedRev >= m.fileView.requiredSourceRev &&
 		m.fileView.loadedGen == defaultFileViewCache.generation() &&
 		m.fileView.loadedToken == m.fileView.lifetimeToken {
+		defaultFileViewCache.recordHit()
 		return m.fileView.renderedContent
+	}
+	if cached, ok := defaultFileViewCache.peekRenderOnly(target, width, m.fileView.desiredFingerprint, m.fileView.loadedSeq, m.fileView.desiredSeq, m.fileView.loadedRev, m.fileView.requiredSourceRev); ok {
+		return cached
 	}
 	return zeroTheme.faint.Render(fileViewLoadingPlaceholder)
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1773,3 +1773,53 @@ func TestFileViewLifecycle_SupersededResizeSkipsWork(t *testing.T) {
 		t.Fatal("latest width must still load")
 	}
 }
+
+func TestFilesPanelSecondActivationOpensFullViewThroughUpdate(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "web"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "web", "app.js"), []byte("let a = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.runDetailsOpen = true
+	m, cmd := m.selectFile("web/app.js")
+	if cmd != nil {
+		t.Fatal("first FILES activation must only select")
+	}
+	if m.fileView.active {
+		t.Fatal("first FILES activation must not open the file view")
+	}
+	if m.selectedFile != "web/app.js" {
+		t.Fatalf("selectedFile = %q", m.selectedFile)
+	}
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(model)
+	if !m.fileView.active || m.fileView.path != "web/app.js" {
+		t.Fatal("Enter on the selected FILES row must call openFileView")
+	}
+	if m.runDetailsOpen {
+		t.Fatal("drilling in must close run details")
+	}
+
+	updated, cmd = m.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	m = updated.(model)
+	if m.fileView.mode != fileViewFull {
+		t.Fatal("f must switch to full mode")
+	}
+	if cmd == nil {
+		t.Fatal("full mode must schedule an async load")
+	}
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), fileViewLoadingPlaceholder) {
+		t.Fatal("expected loading before async result")
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "let a = 1") {
+		t.Fatalf("expected loaded file content, got %s", plainRender(t, m.renderFileViewFull(80)))
+	}
+}

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1615,7 +1615,10 @@ func TestFileViewLifecycle_ReverseOrderToolMutationCompletions(t *testing.T) {
 		t.Fatal("expected cmdA for mutation A")
 	}
 
-	// Mutation B immediately modifies file to v2 before A completes
+	// Capture A while v1 is still on disk so msgA contains the genuine v1 snapshot
+	msgA := cmdA()
+
+	// Mutation B immediately modifies file to v2 before A is applied
 	if err := os.WriteFile(filePath, []byte("version 2 state\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -1640,8 +1643,7 @@ func TestFileViewLifecycle_ReverseOrderToolMutationCompletions(t *testing.T) {
 		t.Fatalf("expected version 2 state after B completes, got: %s", plainRender(t, m.renderFileViewFull(80)))
 	}
 
-	// A arrives late (reverse-order)
-	msgA := cmdA()
+	// A arrives late (reverse-order delivery of stale snapshot)
 	updated, _ = m.Update(msgA)
 	m = updated.(model)
 
@@ -1652,6 +1654,55 @@ func TestFileViewLifecycle_ReverseOrderToolMutationCompletions(t *testing.T) {
 	}
 	if !strings.Contains(rendered, "version 2 state") {
 		t.Fatalf("expected version 2 state still visible, got: %s", rendered)
+	}
+}
+
+func TestFileViewSanitizesControlSequencesInHighlightedSource(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	// Recognized Go source with OSC 52 clipboard hijacking sequence in a comment
+	// and ANSI CSI styling codes inside a string literal.
+	goContent := `package main
+
+// \x1b]52;c;cGFzc3dvcmQ=\x07 malicious comment
+func main() {
+	const escape = "\x1b[31;1mred\x1b[0m"
+}
+`
+	// Replace raw escape escapes with actual byte values 0x1b and 0x07
+	goContent = strings.ReplaceAll(goContent, `\x1b`, "\x1b")
+	goContent = strings.ReplaceAll(goContent, `\x07`, "\x07")
+
+	filePath := filepath.Join(dir, "malicious.go")
+	if err := os.WriteFile(filePath, []byte(goContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "malicious.go")
+
+	rendered := m.renderFileViewFull(80)
+
+	// Verify that raw hostile control sequences never reach the rendered output
+	if strings.Contains(rendered, "\x1b]52;") {
+		t.Fatalf("rendered output must not contain raw OSC 52 sequence, got: %q", rendered)
+	}
+	if strings.Contains(rendered, "\x07") {
+		t.Fatalf("rendered output must not contain BEL character, got: %q", rendered)
+	}
+	if strings.Contains(rendered, "\x1b[31;1m") {
+		t.Fatalf("rendered output must not contain raw source-supplied CSI sequence, got: %q", rendered)
+	}
+
+	// Verify that the sanitized printable representation is present and styled
+	plain := plainRender(t, rendered)
+	if !strings.Contains(plain, "^[") {
+		t.Fatalf("expected sanitized escape prefix '^[' in plain view, got: %q", plain)
+	}
+	if !strings.Contains(plain, "malicious comment") {
+		t.Fatalf("expected safe comment text in plain view, got: %q", plain)
 	}
 }
 

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1728,7 +1729,15 @@ func TestFileViewLifecycle_ShellEscapeReloadsFullView(t *testing.T) {
 	m := filesPanelTestModel()
 	m.cwd = dir
 	m = testOpenFile(m, "shell.go")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldTime := info.ModTime()
 	if err := os.WriteFile(path, []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
 		t.Fatal(err)
 	}
 	updated, cmd := m.Update(bashResultMsg{output: "ok"})
@@ -1797,7 +1806,7 @@ func TestFilesPanelSecondActivationOpensFullViewThroughUpdate(t *testing.T) {
 		t.Fatalf("selectedFile = %q", m.selectedFile)
 	}
 
-	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	m = updated.(model)
 	if !m.fileView.active || m.fileView.path != "web/app.js" {
 		t.Fatal("Enter on the selected FILES row must call openFileView")
@@ -1821,5 +1830,57 @@ func TestFilesPanelSecondActivationOpensFullViewThroughUpdate(t *testing.T) {
 	m = updated.(model)
 	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "let a = 1") {
 		t.Fatalf("expected loaded file content, got %s", plainRender(t, m.renderFileViewFull(80)))
+	}
+}
+
+func TestFileViewLifecycle_SupersedeStopsInFlightWork(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "stall.go"), []byte("package stall\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	fileViewInsideLoad = func() {
+		select {
+		case <-entered:
+		default:
+			close(entered)
+		}
+		<-release
+	}
+	defer func() { fileViewInsideLoad = nil }()
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m, cmdA := m.openFileView("stall.go")
+	if cmdA == nil {
+		t.Fatal("expected initial load")
+	}
+	doneA := make(chan tea.Msg, 1)
+	go func() { doneA <- cmdA() }()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("load A did not enter worker")
+	}
+	m, cmdB := m.startFileViewLoadCmd(100)
+	if cmdB == nil {
+		t.Fatal("expected superseding load")
+	}
+	close(release)
+	msgA := <-doneA
+	loaded, ok := msgA.(fileViewLoadedMsg)
+	if !ok {
+		t.Fatalf("msgA type %T", msgA)
+	}
+	if !errors.Is(loaded.err, errFileViewSuperseded) {
+		t.Fatalf("in-flight A must stop, err=%v", loaded.err)
+	}
+	msgB := cmdB()
+	updated, _ := m.Update(msgB)
+	m = updated.(model)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(100)), "package stall") {
+		t.Fatal("latest request must complete")
 	}
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1882,5 +1883,76 @@ func TestFileViewLifecycle_SupersedeStopsInFlightWork(t *testing.T) {
 	m = updated.(model)
 	if !strings.Contains(plainRender(t, m.renderFileViewFull(100)), "package stall") {
 		t.Fatal("latest request must complete")
+	}
+}
+
+func TestFileViewLifecycle_SupersededHighlightMustNotClobberCache(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clobber.go")
+	if err := os.WriteFile(path, []byte("package old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "clobber.go")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldTime := info.ModTime()
+	if err := os.WriteFile(path, []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var n int32
+	fileViewBeforeCacheCommit = func() {
+		if atomic.AddInt32(&n, 1) == 1 {
+			close(entered)
+			<-release
+		}
+	}
+	defer func() { fileViewBeforeCacheCommit = nil }()
+
+	m, cmdA := m.startFileViewRefreshCmd(80)
+	if cmdA == nil {
+		t.Fatal("expected refresh A")
+	}
+	doneA := make(chan tea.Msg, 1)
+	go func() { doneA <- cmdA() }()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("A did not reach cache commit")
+	}
+	m, cmdB := m.startFileViewRefreshCmd(80)
+	if cmdB == nil {
+		t.Fatal("expected refresh B")
+	}
+	updated, _ := m.Update(cmdB())
+	m = updated.(model)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package new") {
+		t.Fatal("B must be accepted before releasing A")
+	}
+	close(release)
+	msgA := <-doneA
+	loaded, ok := msgA.(fileViewLoadedMsg)
+	if !ok {
+		t.Fatalf("msgA type %T", msgA)
+	}
+	if !errors.Is(loaded.err, errFileViewSuperseded) {
+		t.Fatalf("A must not commit, err=%v", loaded.err)
+	}
+	got := plainRender(t, m.renderFileViewFull(80))
+	if strings.Contains(got, "package old") {
+		t.Fatalf("stale highlight must not clobber cache, got %s", got)
+	}
+	if !strings.Contains(got, "package new") {
+		t.Fatalf("expected package new, got %s", got)
 	}
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1328,3 +1328,129 @@ func TestFileViewLifecycle_LateCompletionAcrossReopenDiscarded(t *testing.T) {
 		t.Fatalf("expected new session content, got: %s", rendered)
 	}
 }
+
+// TestFileViewLifecycle_ReverseOrderResizeCompletions verifies that when two resize events
+// schedule requests A (earlier) and B (later), and B completes before A, the subsequent
+// late arrival of A is discarded and does not overwrite B's width or rendered snapshot.
+func TestFileViewLifecycle_ReverseOrderResizeCompletions(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "resize_order.go")
+	if err := os.WriteFile(filePath, []byte("package resize_order\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "resize_order.go")
+
+	// Schedule Request A for width 60
+	m, cmdA := m.startFileViewLoadCmd(60)
+	if cmdA == nil {
+		t.Fatal("expected cmdA")
+	}
+
+	// Schedule Request B for width 100
+	m, cmdB := m.startFileViewLoadCmd(100)
+	if cmdB == nil {
+		t.Fatal("expected cmdB")
+	}
+
+	// Message B completes first
+	msgB := cmdB()
+	updated, _ := m.Update(msgB)
+	m = updated.(model)
+
+	if m.fileView.loadedWidth != 100 {
+		t.Fatalf("expected loadedWidth 100 after B completes, got %d", m.fileView.loadedWidth)
+	}
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(100)), "package resize_order") {
+		t.Fatalf("expected width 100 content rendered, got: %s", plainRender(t, m.renderFileViewFull(100)))
+	}
+
+	// Message A arrives late (reverse-order)
+	msgA := cmdA()
+	updated, _ = m.Update(msgA)
+	m = updated.(model)
+
+	// State MUST remain B (width 100), not overwritten by A (width 60)
+	if m.fileView.loadedWidth != 100 {
+		t.Fatalf("late completion A must NOT overwrite loadedWidth, got %d (want 100)", m.fileView.loadedWidth)
+	}
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(100)), "package resize_order") {
+		t.Fatalf("expected width 100 content still visible, got: %s", plainRender(t, m.renderFileViewFull(100)))
+	}
+}
+
+// TestFileViewLifecycle_ReverseOrderToolMutationCompletions verifies that when two tool
+// mutations trigger requests A (version 1) and B (version 2), and B completes before A,
+// the subsequent arrival of A cannot revert the visible snapshot back to version 1.
+func TestFileViewLifecycle_ReverseOrderToolMutationCompletions(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "tool_order.go")
+	if err := os.WriteFile(filePath, []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "tool_order.go")
+
+	// Mutation A modifies file to v1
+	if err := os.WriteFile(filePath, []byte("version 1 state\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rowA := transcriptRow{
+		kind:         rowToolResult,
+		tool:         "write_file",
+		changedFiles: []string{"tool_order.go"},
+		detail:       "+version 1 state",
+	}
+	updated, cmdA := m.Update(agentRowMsg{runID: m.activeRunID, row: rowA})
+	m = updated.(model)
+	if cmdA == nil {
+		t.Fatal("expected cmdA for mutation A")
+	}
+
+	// Mutation B immediately modifies file to v2 before A completes
+	if err := os.WriteFile(filePath, []byte("version 2 state\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rowB := transcriptRow{
+		kind:         rowToolResult,
+		tool:         "edit_file",
+		changedFiles: []string{"tool_order.go"},
+		detail:       "+version 2 state",
+	}
+	updated, cmdB := m.Update(agentRowMsg{runID: m.activeRunID, row: rowB})
+	m = updated.(model)
+	if cmdB == nil {
+		t.Fatal("expected cmdB for mutation B")
+	}
+
+	// B completes first
+	msgB := cmdB()
+	updated, _ = m.Update(msgB)
+	m = updated.(model)
+
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "version 2 state") {
+		t.Fatalf("expected version 2 state after B completes, got: %s", plainRender(t, m.renderFileViewFull(80)))
+	}
+
+	// A arrives late (reverse-order)
+	msgA := cmdA()
+	updated, _ = m.Update(msgA)
+	m = updated.(model)
+
+	// View MUST remain version 2, never reverted by A
+	rendered := plainRender(t, m.renderFileViewFull(80))
+	if strings.Contains(rendered, "version 1 state") {
+		t.Fatalf("stale version 1 completion must NOT overwrite version 2, got: %s", rendered)
+	}
+	if !strings.Contains(rendered, "version 2 state") {
+		t.Fatalf("expected version 2 state still visible, got: %s", rendered)
+	}
+}

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -18,6 +18,26 @@ import (
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
+func testOpenFile(m model, path string) model {
+	next, cmd := m.openFileView(path)
+	if cmd != nil {
+		msg := cmd()
+		updated, _ := next.Update(msg)
+		return updated.(model)
+	}
+	return next
+}
+
+func testSetMode(m model, mode int) model {
+	next, cmd := m.setFileViewMode(mode)
+	if cmd != nil {
+		msg := cmd()
+		updated, _ := next.Update(msg)
+		return updated.(model)
+	}
+	return next
+}
+
 // TestFileViewOpenExitRestoresScroll: opening saves the chat scroll position,
 // resets it for the file body, and Esc restores it; switching files while open
 // keeps the ORIGINAL saved position (not the file view's own).
@@ -25,7 +45,7 @@ func TestFileViewOpenExitRestoresScroll(t *testing.T) {
 	m := filesPanelTestModel()
 	m.chatScrollOffset = 12
 
-	m = m.openFileView("web/app.js")
+	m, _ = m.openFileView("web/app.js")
 	if !m.fileView.active || m.fileView.mode != fileViewDiff {
 		t.Fatalf("open should activate in diff mode: %+v", m.fileView)
 	}
@@ -34,7 +54,7 @@ func TestFileViewOpenExitRestoresScroll(t *testing.T) {
 	}
 
 	m.chatScrollOffset = 5 // scrolled within the file body
-	m = m.openFileView("internal/tui/sidebar.go")
+	m, _ = m.openFileView("internal/tui/sidebar.go")
 	if m.fileView.parentScrollOffset != 12 {
 		t.Fatalf("switching files must keep the original parent offset, got %d", m.fileView.parentScrollOffset)
 	}
@@ -49,15 +69,23 @@ func TestFileViewOpenExitRestoresScroll(t *testing.T) {
 // d/f switch modes while the composer is empty and never while typing.
 func TestFileViewEscAndModeKeys(t *testing.T) {
 	m := filesPanelTestModel()
-	m = m.openFileView("web/app.js")
+	m, _ = m.openFileView("web/app.js")
 
-	updated, _ := m.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
 	m = updated.(model)
+	if cmd != nil {
+		updated, _ = m.Update(cmd())
+		m = updated.(model)
+	}
 	if m.fileView.mode != fileViewFull {
 		t.Fatal("f should switch to full mode")
 	}
-	updated, _ = m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	updated, cmd = m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
 	m = updated.(model)
+	if cmd != nil {
+		updated, _ = m.Update(cmd())
+		m = updated.(model)
+	}
 	if m.fileView.mode != fileViewDiff {
 		t.Fatal("d should switch back to diff mode")
 	}
@@ -83,7 +111,7 @@ func TestFileViewEscAndModeKeys(t *testing.T) {
 // placeholder.
 func TestFileViewDiffBody(t *testing.T) {
 	m := filesPanelTestModel()
-	m = m.openFileView("internal/tui/sidebar.go")
+	m, _ = m.openFileView("internal/tui/sidebar.go")
 	body := plainRender(t, m.renderFileViewDiff(78))
 	if !strings.Contains(body, "edit 1 of 2") || !strings.Contains(body, "edit 2 of 2") {
 		t.Fatalf("expected chronological edit labels:\n%s", body)
@@ -113,8 +141,8 @@ func TestFileViewFullBody(t *testing.T) {
 		detail:       "+let a = 1",
 		changedFiles: []string{"app.js"},
 	})
-	m = m.openFileView("app.js")
-	m = m.setFileViewMode(fileViewFull)
+	m = testOpenFile(m, "app.js")
+	m = testSetMode(m, fileViewFull)
 
 	body := m.renderFileViewFull(78)
 	plain := plainRender(t, body)
@@ -133,6 +161,11 @@ func TestFileViewFullBody(t *testing.T) {
 	}
 
 	m.fileView.path = "gone.js"
+	m, cmd := m.startFileViewLoadCmd(78)
+	if cmd != nil {
+		updated, _ := m.Update(cmd())
+		m = updated.(model)
+	}
 	if got := plainRender(t, m.renderFileViewFull(78)); !strings.Contains(got, "Could not read file") {
 		t.Errorf("missing file should degrade to an error line, got:\n%s", got)
 	}
@@ -144,7 +177,7 @@ func TestFileViewFullBody(t *testing.T) {
 // relies on.
 func TestFileViewSwapsTranscriptBody(t *testing.T) {
 	m := filesPanelTestModel()
-	m = m.openFileView("internal/tui/sidebar.go")
+	m, _ = m.openFileView("internal/tui/sidebar.go")
 
 	items := m.transcriptBodyItems(m.chatColumnWidth(), "", false)
 	if len(items) != 1 {
@@ -179,7 +212,7 @@ func TestSidebarAgentClickIsIgnoredWithoutRail(t *testing.T) {
 		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-1 on team default.", runID: 1},
 	)
 	m.activeRunID = 1
-	m = m.openFileView("web/app.js")
+	m, _ = m.openFileView("web/app.js")
 
 	width := sidebarWidth(m.width)
 	agents := m.sidebarAgentSelectables(width)
@@ -248,11 +281,11 @@ func TestResumedFileEditUsesPersistedDisplayPreview(t *testing.T) {
 // unconditional openFileView bounced full mode back to diff and reset scroll.
 func TestOpenFileViewSamePathIsNoOp(t *testing.T) {
 	m := filesPanelTestModel()
-	m = m.openFileView("web/app.js")
-	m = m.setFileViewMode(fileViewFull)
+	m = testOpenFile(m, "web/app.js")
+	m = testSetMode(m, fileViewFull)
 	m.chatScrollOffset = 7 // scrolled within the file body
 
-	m = m.openFileView("web/app.js")
+	m, _ = m.openFileView("web/app.js")
 	if m.fileView.mode != fileViewFull {
 		t.Fatal("re-opening the same file must keep full mode")
 	}
@@ -260,7 +293,7 @@ func TestOpenFileViewSamePathIsNoOp(t *testing.T) {
 		t.Fatalf("re-opening the same file must keep the scroll, got %d", m.chatScrollOffset)
 	}
 	// A DIFFERENT file still switches (and resets to diff mode as documented).
-	m = m.openFileView("internal/tui/sidebar.go")
+	m, _ = m.openFileView("internal/tui/sidebar.go")
 	if m.fileView.path != "internal/tui/sidebar.go" || m.fileView.mode != fileViewDiff {
 		t.Fatalf("opening another file should switch views: %+v", m.fileView)
 	}
@@ -281,7 +314,7 @@ func TestFileViewFullBodyTruncatesLongFile(t *testing.T) {
 	m := filesPanelTestModel()
 	m.cwd = dir
 	m.gitTouched = []gitSweepFile{{path: "big.txt"}}
-	m = m.openFileView("big.txt")
+	m = testOpenFile(m, "big.txt")
 
 	plain := plainRender(t, m.renderFileViewFull(80))
 	lines := strings.Split(plain, "\n")
@@ -299,7 +332,7 @@ func TestFileViewFullBodyTruncatesLongFile(t *testing.T) {
 func TestDetailedTranscriptClosesFileView(t *testing.T) {
 	m := filesPanelTestModel()
 	m.altScreen = true
-	m = m.openFileView("web/app.js")
+	m, _ = m.openFileView("web/app.js")
 
 	if !m.fileView.active {
 		t.Fatal("sanity check: openFileView should activate the file view")
@@ -326,7 +359,7 @@ func TestDetailedTranscriptClosesFileView(t *testing.T) {
 func TestDetailedTranscriptStaysClosedOnSecondToggle(t *testing.T) {
 	m := filesPanelTestModel()
 	m.altScreen = true
-	m = m.openFileView("web/app.js")
+	m, _ = m.openFileView("web/app.js")
 
 	updated, _ := m.Update(testKeyCtrl('o'))
 	m = updated.(model)
@@ -347,7 +380,7 @@ func TestDetailedTranscriptStaysClosedOnSecondToggle(t *testing.T) {
 // (Esc exiting the view instead of reaching the prompt's deny handling).
 func TestFileViewKeysDeferToBlockingModal(t *testing.T) {
 	m := filesPanelTestModel()
-	m = m.openFileView("web/app.js")
+	m, _ = m.openFileView("web/app.js")
 	m.pendingPermission = &pendingPermissionPrompt{
 		request: agent.PermissionRequest{ToolName: "write_file"},
 		decide:  func(agent.PermissionDecision) {},
@@ -381,10 +414,10 @@ func TestFileViewRepeatedViewNoDiskIOOrHighlighting(t *testing.T) {
 
 	m := filesPanelTestModel()
 	m.cwd = dir
-	m = m.openFileView("sample.go")
-	m = m.setFileViewMode(fileViewFull)
+	m = testOpenFile(m, "sample.go")
+	m = testSetMode(m, fileViewFull)
 
-	// First render: Misses cache, performs 1 disk read and 1 highlight call
+	// First render: Misses cache during testSetMode cmd execution, performed 1 disk read and 1 highlight call
 	firstRender := m.renderFileViewFull(80)
 	if !strings.Contains(firstRender, "hello world") {
 		t.Fatalf("first render missing content: %s", firstRender)
@@ -413,8 +446,8 @@ func TestFileViewRepeatedViewNoDiskIOOrHighlighting(t *testing.T) {
 	if statsAfterRepeated.HighlightCalls != 1 {
 		t.Fatalf("repeated View calls must not trigger Chroma highlighting, got %d", statsAfterRepeated.HighlightCalls)
 	}
-	if statsAfterRepeated.CacheHits != 10 {
-		t.Fatalf("expected 10 cache hits, got %d", statsAfterRepeated.CacheHits)
+	if statsAfterRepeated.CacheHits != statsAfterFirst.CacheHits+10 {
+		t.Fatalf("expected 10 additional cache hits, got %d (before: %d)", statsAfterRepeated.CacheHits, statsAfterFirst.CacheHits)
 	}
 
 	// Same byte length as `content`, so only mtime can invalidate the entry.
@@ -428,6 +461,13 @@ func TestFileViewRepeatedViewNoDiskIOOrHighlighting(t *testing.T) {
 	future := time.Now().Add(time.Hour)
 	if err := os.Chtimes(filePath, future, future); err != nil {
 		t.Fatal(err)
+	}
+
+	// Re-trigger load command after file update
+	m, cmd := m.startFileViewLoadCmd(80)
+	if cmd != nil {
+		updated, _ := m.Update(cmd())
+		m = updated.(model)
 	}
 
 	updatedRender := m.renderFileViewFull(80)
@@ -465,8 +505,8 @@ func TestFileViewMaxBytesBudgetTruncation(t *testing.T) {
 
 	m := filesPanelTestModel()
 	m.cwd = dir
-	m = m.openFileView("giant_bytes.txt")
-	m = m.setFileViewMode(fileViewFull)
+	m = testOpenFile(m, "giant_bytes.txt")
+	m = testSetMode(m, fileViewFull)
 
 	body := m.renderFileViewFull(80)
 	plain := plainRender(t, body)
@@ -497,8 +537,8 @@ func TestFileViewMaxLineBytesBudgetTruncation(t *testing.T) {
 
 	m := filesPanelTestModel()
 	m.cwd = dir
-	m = m.openFileView("giant_line.js")
-	m = m.setFileViewMode(fileViewFull)
+	m = testOpenFile(m, "giant_line.js")
+	m = testSetMode(m, fileViewFull)
 
 	body := m.renderFileViewFull(80)
 	plain := plainRender(t, body)
@@ -529,8 +569,8 @@ func TestFileViewCacheEviction(t *testing.T) {
 	m.cwd = dir
 	for i := 0; i < numFiles; i++ {
 		fname := fmt.Sprintf("file_%d.txt", i)
-		m = m.openFileView(fname)
-		m = m.setFileViewMode(fileViewFull)
+		m = testOpenFile(m, fname)
+		m = testSetMode(m, fileViewFull)
 		_ = m.renderFileViewFull(80)
 	}
 
@@ -557,8 +597,8 @@ func TestFileViewClearOnThemeChange(t *testing.T) {
 
 	m := filesPanelTestModel()
 	m.cwd = dir
-	m = m.openFileView("code.go")
-	m = m.setFileViewMode(fileViewFull)
+	m = testOpenFile(m, "code.go")
+	m = testSetMode(m, fileViewFull)
 	_ = m.renderFileViewFull(80)
 
 	defaultFileViewCache.mu.Lock()
@@ -715,8 +755,8 @@ func TestFileViewCache_RenderVariantsBoundedUnderResize(t *testing.T) {
 
 	m := filesPanelTestModel()
 	m.cwd = dir
-	m = m.openFileView("resize_test.go")
-	m = m.setFileViewMode(fileViewFull)
+	m = testOpenFile(m, "resize_test.go")
+	m = testSetMode(m, fileViewFull)
 
 	// Execute mixed-width getOrRender calls concurrently from multiple goroutines
 	var wg sync.WaitGroup
@@ -758,5 +798,210 @@ func TestFileViewCache_RenderVariantsBoundedUnderResize(t *testing.T) {
 	}
 	if keyCount > fileViewMaxRenderVariants {
 		t.Fatalf("renderKeys count %d exceeded maximum limit %d", keyCount, fileViewMaxRenderVariants)
+	}
+}
+
+// TestFileViewAsyncCacheMissLifecycle exercises the cache-miss lifecycle through
+// the actual View/Update boundary:
+//  1. Initial full-mode activation returns a command while View() renders the
+//     loading placeholder without performing disk I/O or Chroma work.
+//  2. The command executes asynchronously and returns fileViewLoadedMsg.
+//  3. Update() applies the message to the model.
+//  4. View() renders the loaded, formatted content.
+func TestFileViewAsyncCacheMissLifecycle(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "async_sample.go")
+	content := "package main\n\nfunc AsyncWork() string {\n\treturn \"done\"\n}\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+
+	// Step 1: Open file with no edit rows (opens in full mode directly with async cmd)
+	m, cmd := m.openFileView("async_sample.go")
+	if cmd == nil {
+		t.Fatal("expected async load command on cache miss")
+	}
+
+	// View before cmd completes must render loading placeholder with 0 disk I/O or highlighting
+	initialView := m.renderFileViewFull(80)
+	if !strings.Contains(initialView, "Loading…") {
+		t.Fatalf("expected loading placeholder before command completes, got:\n%s", initialView)
+	}
+	statsBefore := fileViewCacheStatsForTest()
+	if statsBefore.DiskReads != 0 || statsBefore.HighlightCalls != 0 {
+		t.Fatalf("View() must not stat/read/highlight directly: %+v", statsBefore)
+	}
+
+	// Step 2: Execute command asynchronously
+	msg := cmd()
+	loadedMsg, ok := msg.(fileViewLoadedMsg)
+	if !ok {
+		t.Fatalf("expected fileViewLoadedMsg, got %T", msg)
+	}
+	if loadedMsg.err != nil {
+		t.Fatalf("unexpected load error: %v", loadedMsg.err)
+	}
+
+	// Step 3: Update model with loaded message
+	updated, _ := m.Update(loadedMsg)
+	m = updated.(model)
+
+	// Step 4: View now renders the loaded content
+	loadedView := m.renderFileViewFull(80)
+	if !strings.Contains(loadedView, "AsyncWork") {
+		t.Fatalf("expected loaded content in view, got:\n%s", loadedView)
+	}
+	statsAfter := fileViewCacheStatsForTest()
+	if statsAfter.DiskReads != 1 || statsAfter.HighlightCalls != 1 {
+		t.Fatalf("expected exactly 1 disk read and 1 highlight call, got: %+v", statsAfter)
+	}
+
+	// Also verify switching from diff mode to full mode triggers the cmd
+	appFile := filepath.Join(dir, "web", "app.js")
+	if err := os.MkdirAll(filepath.Join(dir, "web"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(appFile, []byte("let webApp = true;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mDiff, cmdDiff := m.openFileView("web/app.js")
+	if cmdDiff != nil || mDiff.fileView.mode != fileViewDiff {
+		t.Fatalf("file with edit cards must open in diff mode with nil cmd: mode=%d, cmd=%v", mDiff.fileView.mode, cmdDiff)
+	}
+	mFull, cmdFull := mDiff.setFileViewMode(fileViewFull)
+	if cmdFull == nil || mFull.fileView.mode != fileViewFull {
+		t.Fatal("switching to full mode must return load command")
+	}
+	updated, _ = mFull.Update(cmdFull())
+	mFull = updated.(model)
+	if !strings.Contains(mFull.renderFileViewFull(80), "webApp") {
+		t.Fatalf("expected loaded webApp content, got: %s", mFull.renderFileViewFull(80))
+	}
+}
+
+// TestFileViewAsyncDiscardSupersededResult verifies that if a user switches files
+// or exits the view while an async load is in flight, the completed message from
+// the old file is safely discarded and does not overwrite the active view.
+func TestFileViewAsyncDiscardSupersededResult(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "fileA.txt")
+	fileB := filepath.Join(dir, "fileB.txt")
+	if err := os.WriteFile(fileA, []byte("Content of File A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fileB, []byte("Content of File B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+
+	// Start loading File A
+	m, cmdA := m.openFileView("fileA.txt")
+	if cmdA == nil {
+		t.Fatal("expected cmd for fileA")
+	}
+
+	// User switches to File B before cmdA returns
+	m, cmdB := m.openFileView("fileB.txt")
+	if cmdB == nil {
+		t.Fatal("expected cmd for fileB")
+	}
+
+	// Now cmdA completes and its message is dispatched
+	msgA := cmdA()
+	updated, _ := m.Update(msgA)
+	m = updated.(model)
+
+	// File A's result must be discarded because active file is File B
+	viewWhileB := m.renderFileViewFull(80)
+	if strings.Contains(viewWhileB, "Content of File A") {
+		t.Fatalf("stale File A result must not paint over File B: %s", viewWhileB)
+	}
+
+	// Now cmdB completes and is dispatched
+	msgB := cmdB()
+	updated, _ = m.Update(msgB)
+	m = updated.(model)
+
+	viewFinal := m.renderFileViewFull(80)
+	if !strings.Contains(viewFinal, "Content of File B") {
+		t.Fatalf("expected File B content, got: %s", viewFinal)
+	}
+}
+
+// TestFileViewAsyncDiscardOnModeSwitchOrExit verifies that if a view exits or
+// switches back to diff mode, completed async loads are safely ignored.
+func TestFileViewAsyncDiscardOnModeSwitchOrExit(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "discard_mode.txt")
+	if err := os.WriteFile(fileA, []byte("Some content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+
+	m, cmdA := m.openFileView("discard_mode.txt")
+	if cmdA == nil {
+		t.Fatal("expected cmd")
+	}
+
+	// Exit file view before command returns
+	m = m.exitFileView()
+	if m.fileView.active {
+		t.Fatal("view should be inactive")
+	}
+
+	// Now deliver the message
+	msgA := cmdA()
+	updated, _ := m.Update(msgA)
+	m = updated.(model)
+
+	if m.fileView.active {
+		t.Fatal("discarded message must not re-activate file view")
+	}
+}
+
+// TestFileViewAsyncDiscardOnThemeInvalidation verifies that if a theme switch occurs
+// while an async load is in flight, the old theme's completion message is discarded.
+func TestFileViewAsyncDiscardOnThemeInvalidation(t *testing.T) {
+	defer applyTheme(themeDark, true)
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "theme_test.go")
+	if err := os.WriteFile(fileA, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+
+	m, cmd := m.openFileView("theme_test.go")
+	if cmd == nil {
+		t.Fatal("expected cmd")
+	}
+
+	// Invalidate cache by switching theme before cmd completes
+	applyTheme(themeLight, false)
+
+	// Now old cmd completes
+	msg := cmd()
+	updated, _ := m.Update(msg)
+	m = updated.(model)
+
+	// The message must have been rejected due to generation mismatch
+	if m.fileView.renderedContent != "" {
+		t.Fatalf("expected empty renderedContent after invalidation, got %q", m.fileView.renderedContent)
 	}
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -973,7 +973,8 @@ func TestFileViewAsyncDiscardOnModeSwitchOrExit(t *testing.T) {
 }
 
 // TestFileViewAsyncDiscardOnThemeInvalidation verifies that if a theme switch occurs
-// while an async load is in flight, the old theme's completion message is discarded.
+// while an async load is in flight, the old theme's completion message is discarded
+// and a fresh load command for the new theme generation is triggered.
 func TestFileViewAsyncDiscardOnThemeInvalidation(t *testing.T) {
 	defer applyTheme(themeDark, true)
 	resetFileViewCacheForTest()
@@ -995,13 +996,70 @@ func TestFileViewAsyncDiscardOnThemeInvalidation(t *testing.T) {
 	// Invalidate cache by switching theme before cmd completes
 	applyTheme(themeLight, false)
 
-	// Now old cmd completes
+	// Now old cmd completes with stale generation
 	msg := cmd()
-	updated, _ := m.Update(msg)
+	updated, retryCmd := m.Update(msg)
 	m = updated.(model)
 
 	// The message must have been rejected due to generation mismatch
 	if m.fileView.renderedContent != "" {
 		t.Fatalf("expected empty renderedContent after invalidation, got %q", m.fileView.renderedContent)
+	}
+	if retryCmd == nil {
+		t.Fatal("expected retry command for new generation after invalidation")
+	}
+
+	// Executing the retry command loads the file under the new generation
+	retryMsg := retryCmd()
+	updated, _ = m.Update(retryMsg)
+	m = updated.(model)
+
+	if !strings.Contains(m.renderFileViewFull(80), "package") {
+		t.Fatalf("expected file content loaded after retry, got: %s", m.renderFileViewFull(80))
+	}
+	if m.fileView.loadedGen != defaultFileViewCache.generation() {
+		t.Fatalf("loadedGen %d != cache generation %d", m.fileView.loadedGen, defaultFileViewCache.generation())
+	}
+}
+
+// TestFileViewThemeSwitchWhileLoaded verifies that switching themes invalidates
+// the loaded generation and allows immediate reloading for the new palette.
+func TestFileViewThemeSwitchWhileLoaded(t *testing.T) {
+	defer applyTheme(themeDark, true)
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "switch_test.go")
+	if err := os.WriteFile(fileA, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+
+	m = testOpenFile(m, "switch_test.go")
+	if !strings.Contains(m.renderFileViewFull(80), "package") {
+		t.Fatal("file should be loaded initially")
+	}
+
+	// Switch theme: generation advances, cache is cleared
+	applyTheme(themeLight, false)
+
+	// renderFileViewFull must not return the stale dark-theme content
+	staleCheck := m.renderFileViewFull(80)
+	if strings.Contains(staleCheck, "package") {
+		t.Fatalf("stale renderedContent must not be rendered after generation increment: %s", staleCheck)
+	}
+
+	// Starting a new load command re-populates for the new theme
+	m, reloadCmd := m.startFileViewLoadCmd(80)
+	if reloadCmd == nil {
+		t.Fatal("expected reload command")
+	}
+	updated, _ := m.Update(reloadCmd())
+	m = updated.(model)
+
+	if !strings.Contains(m.renderFileViewFull(80), "package") {
+		t.Fatalf("expected reloaded content for new theme, got: %s", m.renderFileViewFull(80))
 	}
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1699,3 +1699,77 @@ func TestFileViewLifecycle_ResizeRoundTripDoesNotReuseStaleCache(t *testing.T) {
 		t.Fatalf("expected content after matching seq completes, got: %s", plainRender(t, m.renderFileViewFull(80)))
 	}
 }
+
+func TestFileViewLifecycle_EmptyFileIsCompletedSnapshot(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "empty.go"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "empty.go")
+	got := plainRender(t, m.renderFileViewFull(80))
+	if strings.Contains(got, fileViewLoadingPlaceholder) {
+		t.Fatalf("empty completed snapshot must not stay on loading, got %q", got)
+	}
+	if !m.fileView.snapshotReady {
+		t.Fatal("snapshotReady must be set for an empty file")
+	}
+}
+
+func TestFileViewLifecycle_ShellEscapeReloadsFullView(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shell.go")
+	if err := os.WriteFile(path, []byte("package old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "shell.go")
+	if err := os.WriteFile(path, []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	updated, cmd := m.Update(bashResultMsg{output: "ok"})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("bashResultMsg must schedule a file-view reload")
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package new") {
+		t.Fatalf("expected reloaded content after shell escape, got %s", got)
+	}
+}
+
+func TestFileViewLifecycle_SupersededResizeSkipsWork(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "coalesce.go"), []byte("package coalesce\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	var cmd0 tea.Cmd
+	m, cmd0 = m.openFileView("coalesce.go")
+	if cmd0 == nil {
+		t.Fatal("expected initial load")
+	}
+	var cmd1, cmd2 tea.Cmd
+	m, cmd1 = m.startFileViewLoadCmd(60)
+	m, cmd2 = m.startFileViewLoadCmd(100)
+	_ = cmd0()
+	_ = cmd1()
+	msg := cmd2()
+	updated, _ := m.Update(msg)
+	m = updated.(model)
+	stats := fileViewCacheStatsForTest()
+	if stats.DiskReads != 1 {
+		t.Fatalf("superseded loads must not re-read, DiskReads=%d", stats.DiskReads)
+	}
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(100)), "package coalesce") {
+		t.Fatal("latest width must still load")
+	}
+}

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1063,3 +1063,268 @@ func TestFileViewThemeSwitchWhileLoaded(t *testing.T) {
 		t.Fatalf("expected reloaded content for new theme, got: %s", m.renderFileViewFull(80))
 	}
 }
+
+// TestFileViewLifecycle_OpenToLoad tests the full model update flow from open to async load completion.
+func TestFileViewLifecycle_OpenToLoad(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "app.go")
+	if err := os.WriteFile(filePath, []byte("package app\nfunc Run() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+
+	// Open file via model action
+	m, cmd := m.openFileView("app.go")
+	if !m.fileView.active || m.fileView.mode != fileViewFull {
+		t.Fatal("file view should be active in full mode for new file")
+	}
+	if cmd == nil {
+		t.Fatal("expected async load command on open")
+	}
+
+	// View displays loading placeholder before completion
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), fileViewLoadingPlaceholder) {
+		t.Fatalf("expected loading placeholder, got: %s", plainRender(t, m.renderFileViewFull(80)))
+	}
+
+	// Process load completion
+	updated, _ := m.Update(cmd())
+	m = updated.(model)
+
+	rendered := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(rendered, "package app") || !strings.Contains(rendered, "func Run()") {
+		t.Fatalf("expected loaded content, got: %s", rendered)
+	}
+	if m.fileView.hasError {
+		t.Fatal("expected no error")
+	}
+}
+
+// TestFileViewLifecycle_RapidResizeCoalesced verifies that repeated resize events
+// do not cause race conditions or synchronous render spikes, and the latest resize wins.
+func TestFileViewLifecycle_RapidResizeCoalesced(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "resize.go")
+	if err := os.WriteFile(filePath, []byte("package resize\nconst BigWidth = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "resize.go")
+
+	var cmds []tea.Cmd
+	for w := 40; w <= 120; w += 10 {
+		var cmd tea.Cmd
+		m, cmd = m.startFileViewLoadCmd(w)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+
+	// Deliver the latest resize command completion
+	lastCmd := cmds[len(cmds)-1]
+	updated, _ := m.Update(lastCmd())
+	m = updated.(model)
+
+	if m.fileView.loadedWidth != 120 {
+		t.Fatalf("expected loadedWidth 120, got %d", m.fileView.loadedWidth)
+	}
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(120)), "package resize") {
+		t.Fatalf("expected content for width 120, got: %s", plainRender(t, m.renderFileViewFull(120)))
+	}
+}
+
+// TestFileViewLifecycle_ThemeSwitchReloadsActiveView tests that selecting a theme
+// in production immediately triggers a reload command for the active file view.
+func TestFileViewLifecycle_ThemeSwitchReloadsActiveView(t *testing.T) {
+	defer applyTheme(themeDark, true)
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "theme_active.go")
+	if err := os.WriteFile(filePath, []byte("package theme\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "theme_active.go")
+
+	// Trigger /theme light via command handling
+	cmdAction := parsedCommand{kind: commandTheme, text: "light"}
+	updated, reloadCmd := m.dispatchCommand(cmdAction)
+	m = updated.(model)
+
+	if reloadCmd == nil {
+		t.Fatal("expected reload command on active file view after theme change")
+	}
+
+	// Complete the reload
+	updated, _ = m.Update(reloadCmd())
+	m = updated.(model)
+
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package theme") {
+		t.Fatalf("expected reloaded theme content, got: %s", plainRender(t, m.renderFileViewFull(80)))
+	}
+	if m.fileView.loadedGen != defaultFileViewCache.generation() {
+		t.Fatalf("expected loadedGen %d, got %d", defaultFileViewCache.generation(), m.fileView.loadedGen)
+	}
+}
+
+// TestFileViewLifecycle_DirectToolMutationTriggersRefresh tests that tool result
+// rows from write_file or edit_file directly refresh an active file view snapshot.
+func TestFileViewLifecycle_DirectToolMutationTriggersRefresh(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "live_edit.go")
+	if err := os.WriteFile(filePath, []byte("version 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "live_edit.go")
+
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "version 1") {
+		t.Fatal("initial load should have version 1")
+	}
+
+	// Directly modify file on disk
+	if err := os.WriteFile(filePath, []byte("version 2 modified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dispatch tool result for write_file affecting live_edit.go
+	toolRow := transcriptRow{
+		kind:         rowToolResult,
+		tool:         "write_file",
+		changedFiles: []string{"live_edit.go"},
+		detail:       "+version 2 modified",
+	}
+	updated, reloadCmd := m.Update(agentRowMsg{runID: m.activeRunID, row: toolRow})
+	m = updated.(model)
+
+	if reloadCmd == nil {
+		t.Fatal("expected reload command on direct tool mutation for active file")
+	}
+
+	// Execute reload
+	updated, _ = m.Update(reloadCmd())
+	m = updated.(model)
+
+	rendered := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(rendered, "version 2 modified") {
+		t.Fatalf("expected version 2 after tool mutation reload, got: %s", rendered)
+	}
+}
+
+// TestFileViewLifecycle_DeletionOverrulesStaleCache tests that when a file is deleted,
+// the reload failure evicts the former cache entry and immediately displays the error.
+func TestFileViewLifecycle_DeletionOverrulesStaleCache(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "deleted.go")
+	if err := os.WriteFile(filePath, []byte("package deleted\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "deleted.go")
+
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package deleted") {
+		t.Fatal("initial load failed")
+	}
+
+	// Delete the file
+	if err := os.Remove(filePath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force reload
+	m, reloadCmd := m.startFileViewLoadCmd(80)
+	if reloadCmd == nil {
+		t.Fatal("expected reload command")
+	}
+
+	updated, _ := m.Update(reloadCmd())
+	m = updated.(model)
+
+	if !m.fileView.hasError {
+		t.Fatal("expected hasError to be true after deletion")
+	}
+
+	rendered := plainRender(t, m.renderFileViewFull(80))
+	if strings.Contains(rendered, "package deleted") {
+		t.Fatalf("stale cache must not be shown after deletion, got: %s", rendered)
+	}
+	if !strings.Contains(rendered, "Could not read file") {
+		t.Fatalf("expected error message in view, got: %s", rendered)
+	}
+}
+
+// TestFileViewLifecycle_LateCompletionAcrossReopenDiscarded tests that if a file view
+// is exited and the same path is reopened, any late-arriving completion from the first
+// session is discarded and cannot populate the new session.
+func TestFileViewLifecycle_LateCompletionAcrossReopenDiscarded(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "reopen.go")
+	if err := os.WriteFile(filePath, []byte("original content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+
+	// Session 1: open and get command
+	m, cmd1 := m.openFileView("reopen.go")
+	if cmd1 == nil {
+		t.Fatal("expected cmd1")
+	}
+
+	// Exit session 1
+	m = m.exitFileView()
+	if m.fileView.active {
+		t.Fatal("view should be inactive")
+	}
+
+	// Modify file on disk before session 2
+	if err := os.WriteFile(filePath, []byte("new session content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Session 2: reopen same path
+	m, cmd2 := m.openFileView("reopen.go")
+	if cmd2 == nil {
+		t.Fatal("expected cmd2")
+	}
+
+	// Late completion from session 1 arrives
+	msg1 := cmd1()
+	updated, _ := m.Update(msg1)
+	m = updated.(model)
+
+	// Session 1 message must have been discarded: view is still waiting on session 2
+	if m.fileView.renderedContent != "" {
+		t.Fatalf("late completion from session 1 must be discarded, got: %s", m.fileView.renderedContent)
+	}
+
+	// Session 2 completion arrives
+	msg2 := cmd2()
+	updated, _ = m.Update(msg2)
+	m = updated.(model)
+
+	rendered := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(rendered, "new session content") {
+		t.Fatalf("expected new session content, got: %s", rendered)
+	}
+}

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1652,3 +1652,50 @@ func TestFileViewLifecycle_ReverseOrderToolMutationCompletions(t *testing.T) {
 		t.Fatalf("expected version 2 state still visible, got: %s", rendered)
 	}
 }
+
+func TestFileViewLifecycle_ResizeRoundTripDoesNotReuseStaleCache(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "roundtrip.go")
+	if err := os.WriteFile(filePath, []byte("package roundtrip\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, "roundtrip.go")
+
+	m, cmd80 := m.startFileViewLoadCmd(80)
+	if cmd80 == nil {
+		t.Fatal("expected first width-80 load")
+	}
+	updated, _ := m.Update(cmd80())
+	m = updated.(model)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package roundtrip") {
+		t.Fatal("expected committed width-80 content")
+	}
+
+	m, cmd100 := m.startFileViewLoadCmd(100)
+	if cmd100 == nil {
+		t.Fatal("expected width-100 load")
+	}
+	m, cmd80b := m.startFileViewLoadCmd(80)
+	if cmd80b == nil {
+		t.Fatal("expected second width-80 load")
+	}
+
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, fileViewLoadingPlaceholder) {
+		t.Fatalf("80→100→80 must stay on loading until desiredSeq completes, got: %s", got)
+	}
+	if strings.Contains(got, "package roundtrip") {
+		t.Fatalf("must not reuse cached width 80 from an earlier seq, got: %s", got)
+	}
+
+	updated, _ = m.Update(cmd80b())
+	m = updated.(model)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package roundtrip") {
+		t.Fatalf("expected content after matching seq completes, got: %s", plainRender(t, m.renderFileViewFull(80)))
+	}
+}

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1956,3 +1956,105 @@ func TestFileViewLifecycle_SupersededHighlightMustNotClobberCache(t *testing.T) 
 		t.Fatalf("expected package new, got %s", got)
 	}
 }
+
+func TestFileViewExitRevokesWorkerToken(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "leave.go"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("package p\nfunc B() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m, cmd := m.openFileView(name)
+	if cmd == nil {
+		t.Fatal("load cmd")
+	}
+	token := m.fileView.liveSeq
+	if token == nil {
+		t.Fatal("liveSeq")
+	}
+	seq := token.Load()
+	m = m.exitFileView()
+	if token.Load() == seq {
+		t.Fatal("exitFileView must revoke the token the worker still holds")
+	}
+}
+
+func TestFileViewCacheHitRespectsLiveSeq(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "hit.go"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("package p\nfunc A() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m, cmd := m.openFileView(name)
+	if cmd == nil {
+		t.Fatal("cache miss must yield load cmd")
+	}
+	updated, _ := m.Update(cmd())
+	m = updated.(model)
+	if m.fileView.liveSeq == nil {
+		t.Fatal("liveSeq")
+	}
+	seq := m.fileView.liveSeq.Load()
+	live := m.fileView.liveSeq
+	fileViewBeforeCacheCommit = func() { live.Store(seq + 1) }
+	defer func() { fileViewBeforeCacheCommit = nil }()
+	target := filepath.Join(dir, name)
+	gen := defaultFileViewCache.generation()
+	_, err := defaultFileViewCache.loadAndRender(target, name, m.fileView.loadedWidth+17, nil, m.fileView.loadedFingerprint, gen, zeroTheme, false, live, seq)
+	if !errors.Is(err, errFileViewSuperseded) {
+		t.Fatalf("cache-hit put after supersede: err=%v", err)
+	}
+}
+
+func TestFileViewPlanToolRefreshesWhenGitSweepNil(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "mut.go"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("package old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.activeRunID = 7
+	m.gitFileBaseline = nil
+	m.gitSweepUnavailable = true
+	m = testOpenFile(m, name)
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	updated, cmd := m.Update(agentRowMsg{
+		runID: 7,
+		row: transcriptRow{
+			kind:         rowToolResult,
+			tool:         "bash",
+			status:       tools.StatusOK,
+			changedFiles: []string{name},
+		},
+	})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("bash/plan mutation must refresh the file view even when maybeGitSweep is nil")
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			updated, _ = m.Update(c())
+			m = updated.(model)
+		}
+	} else {
+		updated, _ = m.Update(msg)
+		m = updated.(model)
+	}
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package new") {
+		t.Fatalf("stale view after git-nil mutation: %s", got)
+	}
+}

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -741,6 +741,204 @@ func TestReadFileViewBounded_ExactMaxBytesUnterminatedLineTruncated(t *testing.T
 	}
 }
 
+func TestReadFileViewBounded_SourceByteBudgetCountsDelimiters(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		maxLines      int
+		maxLineBytes  int
+		maxTotalBytes int
+		wantLines     []string
+		wantTrunc     bool
+		wantOmitted   bool
+		wantTrailer   string
+	}{
+		{
+			name:          "empty file",
+			content:       "",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 1,
+			wantLines:     nil,
+		},
+		{
+			name:          "budget 1 two LF empty lines",
+			content:       "\n\n",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 1,
+			wantLines:     []string{""},
+			wantTrunc:     true,
+			wantOmitted:   true,
+			wantTrailer:   "more lines",
+		},
+		{
+			name:          "single LF exact budget",
+			content:       "\n",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 1,
+			wantLines:     []string{""},
+		},
+		{
+			name:          "LF content line exact budget",
+			content:       "ab\n",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 3,
+			wantLines:     []string{"ab"},
+		},
+		{
+			name:          "LF second line one byte over",
+			content:       "ab\ncd\n",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 3,
+			wantLines:     []string{"ab"},
+			wantTrunc:     true,
+			wantOmitted:   true,
+			wantTrailer:   "more lines",
+		},
+		{
+			name:          "CRLF two empty lines budget 2",
+			content:       "\r\n\r\n",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 2,
+			wantLines:     []string{""},
+			wantTrunc:     true,
+			wantOmitted:   true,
+			wantTrailer:   "more lines",
+		},
+		{
+			name:          "CRLF exact budget",
+			content:       "ab\r\n",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 4,
+			wantLines:     []string{"ab"},
+		},
+		{
+			name:          "CRLF one byte over",
+			content:       "ab\r\ncd",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 3,
+			wantLines:     []string{"ab"},
+			wantTrunc:     true,
+			wantOmitted:   true,
+			wantTrailer:   "more lines",
+		},
+		{
+			name:          "exact budget unterminated last line",
+			content:       "abc",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 3,
+			wantLines:     []string{"abc"},
+		},
+		{
+			name:          "unterminated last line one byte over",
+			content:       "abcd",
+			maxLines:      4000,
+			maxLineBytes:  4096,
+			maxTotalBytes: 3,
+			wantLines:     []string{"abc"},
+			wantTrunc:     true,
+			wantOmitted:   true,
+			wantTrailer:   "more lines",
+		},
+		{
+			name:          "overlong physical line clipped then next line shown",
+			content:       strings.Repeat("x", 20) + "\nnext\n",
+			maxLines:      4000,
+			maxLineBytes:  8,
+			maxTotalBytes: 100,
+			wantLines:     []string{strings.Repeat("x", 8), "next"},
+			wantTrunc:     true,
+			wantTrailer:   "line content truncated",
+		},
+		{
+			name:          "overlong physical line newline counts against byte budget",
+			content:       strings.Repeat("x", 10) + "\ny\n",
+			maxLines:      4000,
+			maxLineBytes:  4,
+			maxTotalBytes: 11,
+			wantLines:     []string{strings.Repeat("x", 4)},
+			wantTrunc:     true,
+			wantOmitted:   true,
+			wantTrailer:   "more lines",
+		},
+		{
+			name:          "line count cap with leftover",
+			content:       "a\nb\nc\nd\n",
+			maxLines:      2,
+			maxLineBytes:  4096,
+			maxTotalBytes: 100,
+			wantLines:     []string{"a", "b"},
+			wantTrunc:     true,
+			wantOmitted:   true,
+			wantTrailer:   "more lines",
+		},
+		{
+			name:          "line count cap exact file",
+			content:       "a\nb\n",
+			maxLines:      2,
+			maxLineBytes:  4096,
+			maxTotalBytes: 100,
+			wantLines:     []string{"a", "b"},
+		},
+		{
+			name:          "byte budget binds before line count cap on empty LF lines",
+			content:       "\n\n\n\n",
+			maxLines:      10,
+			maxLineBytes:  4096,
+			maxTotalBytes: 2,
+			wantLines:     []string{"", ""},
+			wantTrunc:     true,
+			wantOmitted:   true,
+			wantTrailer:   "more lines",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "input.txt")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			res := readFileViewBounded(path, tc.maxLines, tc.maxLineBytes, tc.maxTotalBytes)
+			if res.err != nil {
+				t.Fatalf("unexpected read error: %v", res.err)
+			}
+			if res.truncated != tc.wantTrunc {
+				t.Fatalf("truncated=%v, want %v (lines=%q)", res.truncated, tc.wantTrunc, res.lines)
+			}
+			if res.omittedLines != tc.wantOmitted {
+				t.Fatalf("omittedLines=%v, want %v (lines=%q)", res.omittedLines, tc.wantOmitted, res.lines)
+			}
+			if len(res.lines) != len(tc.wantLines) {
+				t.Fatalf("retained %d lines %q, want %d %q", len(res.lines), res.lines, len(tc.wantLines), tc.wantLines)
+			}
+			for i := range tc.wantLines {
+				if res.lines[i] != tc.wantLines[i] {
+					t.Fatalf("line %d = %q, want %q", i, res.lines[i], tc.wantLines[i])
+				}
+			}
+
+			plain := plainRender(t, formatFileViewLines(res.lines, res.lines, nil, res.truncated, res.omittedLines, 80, zeroTheme))
+			if tc.wantTrailer == "" {
+				if strings.Contains(plain, "truncated") {
+					t.Fatalf("expected no trailer, got %q", plain)
+				}
+			} else if !strings.Contains(plain, tc.wantTrailer) {
+				t.Fatalf("expected trailer %q in %q", tc.wantTrailer, plain)
+			}
+		})
+	}
+}
+
 // TestFileViewCache_RenderVariantsBoundedUnderResize verifies that varying width
 // and changed-line fingerprints cannot grow an entry's renders map beyond
 // fileViewMaxRenderVariants, even under concurrent access from multiple goroutines.

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -2056,7 +2056,7 @@ func TestFileViewCacheHitRespectsLiveSeq(t *testing.T) {
 	defer func() { fileViewBeforeCacheCommit = nil }()
 	target := filepath.Join(dir, name)
 	gen := defaultFileViewCache.generation()
-	_, err := defaultFileViewCache.loadAndRender(target, name, m.fileView.loadedWidth+17, nil, m.fileView.loadedFingerprint, gen, zeroTheme, false, live, seq)
+	_, err := defaultFileViewCache.loadAndRender(target, name, m.fileView.loadedWidth+17, nil, m.fileView.loadedFingerprint, gen, zeroTheme, 0, live, seq)
 	if !errors.Is(err, errFileViewSuperseded) {
 		t.Fatalf("cache-hit put after supersede: err=%v", err)
 	}
@@ -2107,5 +2107,359 @@ func TestFileViewPlanToolRefreshesWhenGitSweepNil(t *testing.T) {
 	got := plainRender(t, m.renderFileViewFull(80))
 	if !strings.Contains(got, "package new") {
 		t.Fatalf("stale view after git-nil mutation: %s", got)
+	}
+}
+
+func TestFileViewTransitionMatrix_MutationClosedDiffFull(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "sample.go"
+	filePath := filepath.Join(dir, name)
+
+	// Phase 1: Closed mutation with equal size & equal mtime
+	if err := os.WriteFile(filePath, []byte("package old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.activeRunID = 1
+
+	// Seed cache
+	m = testOpenFile(m, name)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package old") {
+		t.Fatal("initial seed must show package old")
+	}
+	m = m.exitFileView()
+
+	// Mutate on disk with same length ("package new\n" has 12 bytes == "package old\n")
+	fi, _ := os.Stat(filePath)
+	oldTime := fi.ModTime()
+	if err := os.WriteFile(filePath, []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chtimes(filePath, oldTime, oldTime)
+
+	// Deliver mutation row while closed
+	updated, _ := m.Update(agentRowMsg{
+		runID: 1,
+		row: transcriptRow{
+			kind:         rowToolResult,
+			tool:         "edit_file",
+			status:       tools.StatusOK,
+			changedFiles: []string{name},
+		},
+	})
+	m = updated.(model)
+
+	// Re-open and switch to full mode: must not reuse stale cache entry
+	m = testOpenFile(m, name)
+	m = testSetMode(m, fileViewFull)
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package new") {
+		t.Fatalf("reopening after closed mutation must render package new, got: %s", got)
+	}
+
+	// Phase 2: Diff mode mutation with equal metadata
+	if err := os.WriteFile(filePath, []byte("package old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chtimes(filePath, oldTime, oldTime)
+	m = testSetMode(m, fileViewFull) // refreshed to old
+	m = testSetMode(m, fileViewDiff)
+
+	// Mutate while in diff mode
+	if err := os.WriteFile(filePath, []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chtimes(filePath, oldTime, oldTime)
+	updated, _ = m.Update(agentRowMsg{
+		runID: 1,
+		row: transcriptRow{
+			kind:         rowToolResult,
+			tool:         "edit_file",
+			status:       tools.StatusOK,
+			changedFiles: []string{name},
+		},
+	})
+	m = updated.(model)
+
+	// Switch back to full mode: must not reuse stale cache entry
+	m = testSetMode(m, fileViewFull)
+	got = plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package new") {
+		t.Fatalf("switching to full after diff mutation must render package new, got: %s", got)
+	}
+
+	// Phase 3: Full mode live mutation
+	if err := os.WriteFile(filePath, []byte("package live\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	updated, cmd := m.Update(agentRowMsg{
+		runID: 1,
+		row: transcriptRow{
+			kind:         rowToolResult,
+			tool:         "edit_file",
+			status:       tools.StatusOK,
+			changedFiles: []string{name},
+		},
+	})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("full mode mutation must yield refresh cmd")
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+	got = plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package live") {
+		t.Fatalf("full mode live mutation must render package live, got: %s", got)
+	}
+}
+
+func TestFileViewTransitionMatrix_RefreshResizeThemeOrdering(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "order.go"
+	filePath := filepath.Join(dir, name)
+
+	if err := os.WriteFile(filePath, []byte("package v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.activeRunID = 1
+	m = testOpenFile(m, name)
+
+	// Mutate to v2 with equal size & mtime
+	fi, _ := os.Stat(filePath)
+	oldTime := fi.ModTime()
+	if err := os.WriteFile(filePath, []byte("package v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chtimes(filePath, oldTime, oldTime)
+
+	// 1. Tool mutation schedules refresh
+	updated, refreshCmd := m.Update(agentRowMsg{
+		runID: 1,
+		row: transcriptRow{
+			kind:         rowToolResult,
+			tool:         "edit_file",
+			status:       tools.StatusOK,
+			changedFiles: []string{name},
+		},
+	})
+	m = updated.(model)
+	if refreshCmd == nil {
+		t.Fatal("mutation must schedule refresh")
+	}
+
+	// 2. Before refreshCmd completes, a resize event arrives (advances desiredSeq with refreshSource=false)
+	updated, resizeCmd := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(model)
+	if resizeCmd == nil {
+		t.Fatal("resize must yield load cmd")
+	}
+
+	// 3. Obsolete refreshCmd returns: must be rejected
+	oldRefreshMsg := refreshCmd()
+	updated, _ = m.Update(oldRefreshMsg)
+	m = updated.(model)
+
+	// 4. Winning resizeCmd completes: MUST inherit requiredSourceRev and render v2
+	resizeMsg := resizeCmd()
+	updated, _ = m.Update(resizeMsg)
+	m = updated.(model)
+
+	got := plainRender(t, m.renderFileViewFull(120))
+	if !strings.Contains(got, "package v2") {
+		t.Fatalf("resize following mutation must render package v2, got: %s", got)
+	}
+}
+
+func TestFileViewTransitionMatrix_DeterministicStageHooksSupersession(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "hooks.go"
+	filePath := filepath.Join(dir, name)
+	if err := os.WriteFile(filePath, []byte("package hooks\nfunc Work() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks := []struct {
+		name       string
+		isCacheHit bool
+		set        func(fn func())
+	}{
+		{"InsideLoad", false, func(fn func()) { fileViewInsideLoad = fn }},
+		{"BeforeCacheHitFormat", true, func(fn func()) { fileViewBeforeCacheHitFormat = fn }},
+		{"BeforeDiskRead", false, func(fn func()) { fileViewBeforeDiskRead = fn }},
+		{"BeforeHighlight", false, func(fn func()) { fileViewBeforeHighlight = fn }},
+		{"BeforeFormat", false, func(fn func()) { fileViewBeforeFormat = fn }},
+		{"BeforeCacheCommit", false, func(fn func()) { fileViewBeforeCacheCommit = fn }},
+	}
+
+	for _, tc := range hooks {
+		t.Run(tc.name, func(t *testing.T) {
+			resetFileViewCacheForTest()
+			m := filesPanelTestModel()
+			m.cwd = dir
+
+			if tc.isCacheHit {
+				// Seed cache first
+				m = testOpenFile(m, name)
+				m = testSetMode(m, fileViewFull)
+			}
+
+			m, cmd := m.openFileView(name)
+			if tc.isCacheHit {
+				var loadCmd tea.Cmd
+				m, loadCmd = m.startFileViewLoadCmd(m.chatColumnWidth() + 15) // width variant
+				cmd = loadCmd
+			}
+			if cmd == nil {
+				t.Fatal("load cmd")
+			}
+			live := m.fileView.liveSeq
+			seq := m.fileView.desiredSeq
+
+			executedHook := false
+			tc.set(func() {
+				executedHook = true
+				live.Store(seq + 1) // supersede A with B
+			})
+			defer tc.set(nil)
+
+			msg := cmd()
+			if !executedHook {
+				t.Fatalf("hook %s was never executed", tc.name)
+			}
+			loaded := msg.(fileViewLoadedMsg)
+			if !errors.Is(loaded.err, errFileViewSuperseded) {
+				t.Fatalf("hook %s: expected errFileViewSuperseded, got %v", tc.name, loaded.err)
+			}
+
+			// Delivery of superseded message must be a complete no-op
+			updated, nextCmd := m.handleFileViewLoaded(loaded)
+			if nextCmd != nil {
+				t.Fatalf("hook %s: superseded message must not schedule retry", tc.name)
+			}
+			if updated.fileView.snapshotReady {
+				t.Fatalf("hook %s: superseded message must not mark snapshotReady", tc.name)
+			}
+		})
+	}
+}
+
+func TestFileViewTransitionMatrix_CurrentCompletionFollowedByObsoleteCompletion(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "race.go"
+	filePath := filepath.Join(dir, name)
+	if err := os.WriteFile(filePath, []byte("package race\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m, cmd1 := m.openFileView(name)
+	if cmd1 == nil {
+		t.Fatal("cmd1")
+	}
+
+	// Resize to advance sequence from 1 to 2
+	updated, cmd2 := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated.(model)
+	if cmd2 == nil {
+		t.Fatal("cmd2")
+	}
+
+	// Sequence 2 completes first
+	msg2 := cmd2()
+	updated, _ = m.Update(msg2)
+	m = updated.(model)
+	if !m.fileView.snapshotReady || m.fileView.loadedSeq != 2 {
+		t.Fatalf("seq 2 must be loaded, ready=%v seq=%d", m.fileView.snapshotReady, m.fileView.loadedSeq)
+	}
+
+	// Sequence 1 arrives late: must be a complete no-op
+	msg1 := cmd1()
+	updated, lateCmd := m.Update(msg1)
+	m = updated.(model)
+	if lateCmd != nil {
+		t.Fatal("late completion must not schedule retry")
+	}
+	if !m.fileView.snapshotReady || m.fileView.loadedSeq != 2 {
+		t.Fatalf("late completion must not degrade state: ready=%v seq=%d", m.fileView.snapshotReady, m.fileView.loadedSeq)
+	}
+}
+
+func TestFileView_ChangedLineMatchingWithTabsAndControlChars(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "tabmatch.go"
+	content := "package main\n\nvar Field\t= 1\nvar Clean = 2\n"
+	filePath := filepath.Join(dir, name)
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.transcript = append(m.transcript, transcriptRow{
+		kind:         rowToolResult,
+		tool:         "edit_file",
+		status:       tools.StatusOK,
+		changedFiles: []string{name},
+		detail:       "--- a/tabmatch.go\n+++ b/tabmatch.go\n@@ -1,2 +1,3 @@\n+var Field\t= 1\n",
+	})
+
+	m = testOpenFile(m, name)
+	m = testSetMode(m, fileViewFull)
+	rendered := m.renderFileViewFull(80)
+
+	// The rendered source displays 4 spaces instead of raw tab, and retains the accent gutter marker ▎
+	if strings.Contains(rendered, "\t") {
+		t.Fatal("rendered output must not contain raw tab characters")
+	}
+	if !strings.Contains(rendered, "▎") {
+		t.Fatalf("added line with interior tab must retain accent gutter marker, got:\n%s", rendered)
+	}
+}
+
+func TestRunDetails_KeyboardActivationStrictRowTargets(t *testing.T) {
+	m := filesPanelTestModel()
+	m.altScreen = true
+	m.width = 80
+	m.height = 30
+	m.runDetailsOpen = true
+
+	// Build a transcript with 7 files touched so files 0..3 are visible, file 4 is overflow trailer ("… more in transcript"), files 5..6 hidden
+	for i := 0; i < 7; i++ {
+		name := fmt.Sprintf("file_%d.go", i)
+		m.transcript = append(m.transcript, transcriptRow{
+			kind:         rowToolResult,
+			tool:         "edit_file",
+			status:       tools.StatusOK,
+			changedFiles: []string{name},
+		})
+	}
+
+	// 1. Visible file (file_6.go) can be activated on Enter
+	m.selectedFile = "file_6.go"
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	res := updated.(model)
+	if !res.fileView.active || res.fileView.path != "file_6.go" {
+		t.Fatalf("visible file in run details must be activated on Enter: active=%v path=%s", res.fileView.active, res.fileView.path)
+	}
+
+	// Reset file view
+	m = res.exitFileView()
+	m.runDetailsOpen = true
+
+	// 2. Hidden / overflow file (file_0.go) must NOT be activated on Enter
+	m.selectedFile = "file_0.go"
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	res = updated.(model)
+	if res.fileView.active {
+		t.Fatalf("overflow hidden file (file_0.go) must not be activated on Enter from run details modal")
 	}
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1,9 +1,13 @@
 package tui
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -2461,5 +2465,464 @@ func TestRunDetails_KeyboardActivationStrictRowTargets(t *testing.T) {
 	res = updated.(model)
 	if res.fileView.active {
 		t.Fatalf("overflow hidden file (file_0.go) must not be activated on Enter from run details modal")
+	}
+}
+
+func TestFileView_RewindReturnsAsyncCommandAndDoesNotBlockUpdate(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "target.go")
+	if err := os.WriteFile(filePath, []byte("package before_rewind\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := testSessionStore(t)
+	session, err := store.Create(sessions.CreateInput{Title: "RewindTest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendTestEvent(t, store, session.SessionID, sessions.EventSessionCheckpoint, map[string]any{"tool": "write_file", "files": []any{}})
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.sessionStore = store
+	m.activeSession = session
+	m.activeRunID = 1
+
+	// Open file in full view
+	m = testOpenFile(m, "target.go")
+	m = testSetMode(m, fileViewFull)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package before_rewind") {
+		t.Fatal("expected initial view to show before_rewind")
+	}
+
+	// Overwrite on disk to simulate restored file
+	if err := os.WriteFile(filePath, []byte("package after_rewind\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, summary, rewindCmd := m.handleRewindCommand("latest")
+	if !strings.Contains(summary, "Rewound") {
+		t.Fatalf("expected summary to indicate rewound, got %q", summary)
+	}
+	if rewindCmd == nil {
+		t.Fatal("handleRewindCommand must return an async tea.Cmd when fileView is active in full mode")
+	}
+
+	// Model in Update must NOT have synchronously rendered the new file yet:
+	// it must NOT display package after_rewind until Bubble Tea delivers fileViewLoadedMsg.
+	if strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package after_rewind") {
+		t.Fatal("expected view to not synchronously show after_rewind before async tea.Cmd is executed")
+	}
+
+	// Now execute rewindCmd as Bubble Tea runtime would
+	msg := rewindCmd()
+	loadedMsg, ok := msg.(fileViewLoadedMsg)
+	if !ok {
+		t.Fatalf("expected fileViewLoadedMsg, got %T", msg)
+	}
+	updated, _ := m.Update(loadedMsg)
+	m = updated.(model)
+
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package after_rewind") {
+		t.Fatalf("rewind reload must render after_rewind, got: %s", got)
+	}
+}
+
+func TestFileView_RewindPartialFailure_ActiveAndClosedView(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "partial_fail.go")
+	if err := os.WriteFile(filePath, []byte("package before_partial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := testSessionStore(t)
+	session, err := store.Create(sessions.CreateInput{Title: "PartialFailRewind"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendTestEvent(t, store, session.SessionID, sessions.EventSessionCheckpoint, map[string]any{"tool": "write_file", "files": []any{}})
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.sessionStore = store
+	m.activeSession = session
+	m.activeRunID = 1
+
+	// 1. Active view: open and cache
+	m = testOpenFile(m, "partial_fail.go")
+	m = testSetMode(m, fileViewFull)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package before_partial") {
+		t.Fatal("expected before_partial")
+	}
+
+	// Restored file written to disk
+	if err := os.WriteFile(filePath, []byte("package after_partial_restored\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Invalidate session ID so ApplyRewind fails after disk mutation
+	m.activeSession.SessionID = "non_existent_session"
+
+	// Invoke handleRewindCommand directly: ApplyRewind will fail!
+	m, summary, refreshCmd := m.handleRewindCommand("0")
+	if !strings.Contains(summary, "Rewind\n") {
+		t.Fatalf("expected error summary, got: %s", summary)
+	}
+	if refreshCmd == nil {
+		t.Fatal("expected refreshCmd on ApplyRewind error")
+	}
+
+	msg := refreshCmd()
+	loaded, ok := msg.(fileViewLoadedMsg)
+	if !ok {
+		t.Fatalf("expected fileViewLoadedMsg, got %T", msg)
+	}
+	updated, _ := m.Update(loaded)
+	m = updated.(model)
+
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package after_partial_restored") {
+		t.Fatalf("expected after_partial_restored, got: %s", got)
+	}
+
+	// 2. Closed view: close view, write v3, trigger another failed rewind, reopen
+	m = m.exitFileView()
+	if err := os.WriteFile(filePath, []byte("package after_partial_v3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, _, _ = m.handleRewindCommand("0")
+
+	m = testOpenFile(m, "partial_fail.go")
+	m = testSetMode(m, fileViewFull)
+	got = plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package after_partial_v3") {
+		t.Fatalf("expected after_partial_v3 on reopen, got: %s", got)
+	}
+}
+
+func TestFileView_UnknownScopeCommandMutationClosedView(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "equal_len.go"
+	filePath := filepath.Join(dir, name)
+
+	// Seed file with "package old\n" (12 bytes)
+	if err := os.WriteFile(filePath, []byte("package old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.activeRunID = 1
+
+	// Open and cache
+	m = testOpenFile(m, name)
+	m = testSetMode(m, fileViewFull)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package old") {
+		t.Fatal("expected initial render of package old")
+	}
+
+	// Close view
+	m = m.exitFileView()
+
+	// Mutate on disk with identical size (12 bytes) and restored mtime
+	fi, _ := os.Stat(filePath)
+	oldModTime := fi.ModTime()
+	if err := os.WriteFile(filePath, []byte("package new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chtimes(filePath, oldModTime, oldModTime)
+
+	// Deliver an unknown-scope tool result (bash command) while view is closed
+	updated, _ := m.Update(agentRowMsg{
+		runID: 1,
+		row: transcriptRow{
+			kind:   rowToolResult,
+			tool:   "bash",
+			status: tools.StatusOK,
+			detail: "sed -i 's/old/new/g' equal_len.go",
+		},
+	})
+	m = updated.(model)
+
+	// Reopen view: must NOT serve cached package old
+	m = testOpenFile(m, name)
+	m = testSetMode(m, fileViewFull)
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package new") {
+		t.Fatalf("reopening after closed unknown-scope mutation must render package new, got: %s", got)
+	}
+}
+
+func TestFileView_NoTOCTOUFileOpenInTUI(t *testing.T) {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, "file_view.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that inside readFileViewBoundedCancellable, os.Stat is NOT called before os.OpenFile
+	ast.Inspect(node, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "readFileViewBoundedCancellable" {
+			return true
+		}
+
+		var sawOpenFile bool
+		var sawPreStat bool
+
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if ident.Name == "os" && sel.Sel.Name == "Stat" && !sawOpenFile {
+				sawPreStat = true
+			}
+			if ident.Name == "os" && sel.Sel.Name == "OpenFile" {
+				sawOpenFile = true
+			}
+			return true
+		})
+
+		if sawPreStat {
+			t.Fatal("TOCTOU vulnerability detected: os.Stat called before os.OpenFile in readFileViewBoundedCancellable")
+		}
+		if !sawOpenFile {
+			t.Fatal("expected os.OpenFile with O_NONBLOCK in readFileViewBoundedCancellable")
+		}
+		return false
+	})
+}
+
+func TestFileView_SupersededInsideDiskReadAndHighlight(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "cancel_test.go")
+	if err := os.WriteFile(filePath, []byte("package cancel\nfunc Foo() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := newFileViewRenderCache(10)
+	theme := zeroTheme
+	var liveSeq atomic.Uint64
+	liveSeq.Store(1)
+
+	// 1. Superseded during disk read loop
+	fileViewInsideDiskRead = func() {
+		liveSeq.Store(2) // supersede request 1
+	}
+	defer func() { fileViewInsideDiskRead = nil }()
+
+	_, err := cache.loadAndRender(filePath, "cancel_test.go", 80, nil, "", 0, theme, 0, &liveSeq, 1)
+	if !errors.Is(err, errFileViewSuperseded) {
+		t.Fatalf("expected errFileViewSuperseded on inside-disk-read supersession, got: %v", err)
+	}
+	fileViewInsideDiskRead = nil
+
+	// 2. Superseded before highlight
+	liveSeq.Store(10)
+	fileViewBeforeHighlight = func() {
+		liveSeq.Store(11) // supersede request 10
+	}
+	defer func() { fileViewBeforeHighlight = nil }()
+
+	_, err = cache.loadAndRender(filePath, "cancel_test.go", 80, nil, "", 0, theme, 0, &liveSeq, 10)
+	if !errors.Is(err, errFileViewSuperseded) {
+		t.Fatalf("expected errFileViewSuperseded on before-highlight supersession, got: %v", err)
+	}
+	fileViewBeforeHighlight = nil
+
+	// 3. Superseded inside highlight (under fileViewHighlightMu)
+	liveSeq.Store(20)
+	fileViewInsideHighlight = func() {
+		liveSeq.Store(21) // supersede request 20
+	}
+	defer func() { fileViewInsideHighlight = nil }()
+
+	_, err = cache.loadAndRender(filePath, "cancel_test.go", 80, nil, "", 0, theme, 0, &liveSeq, 20)
+	if !errors.Is(err, errFileViewSuperseded) {
+		t.Fatalf("expected errFileViewSuperseded on inside-highlight supersession, got: %v", err)
+	}
+	if cache.stats().HighlightCalls != 0 {
+		t.Fatalf("expected 0 HighlightCalls on superseded request, got: %d", cache.stats().HighlightCalls)
+	}
+	fileViewInsideHighlight = nil
+}
+
+func TestFileView_DispatchCommandRewindReturnsPromptlyWithCmd(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "prompt_test.go")
+	if err := os.WriteFile(filePath, []byte("package before_dispatch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := testSessionStore(t)
+	session, err := store.Create(sessions.CreateInput{Title: "DispatchRewind"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendTestEvent(t, store, session.SessionID, sessions.EventSessionCheckpoint, map[string]any{"tool": "write_file", "files": []any{}})
+
+	m := newModel(context.Background(), Options{SessionStore: store})
+	m.cwd = dir
+	m.activeSession = session
+	m.activeRunID = 1
+
+	// Open in full view
+	m = testOpenFile(m, "prompt_test.go")
+	m = testSetMode(m, fileViewFull)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package before_dispatch") {
+		t.Fatal("expected view to display before_dispatch")
+	}
+
+	// Restored file content on disk
+	if err := os.WriteFile(filePath, []byte("package after_dispatch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Type /rewind and press enter
+	m.input.SetValue("/rewind latest")
+	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	m = updated.(model)
+
+	if cmd == nil {
+		t.Fatal("expected /rewind via dispatchCommand to return a non-nil async tea.Cmd")
+	}
+
+	// Before executing cmd, full view must NOT have synchronously loaded the new content:
+	if strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package after_dispatch") {
+		t.Fatal("expected view to not show after_dispatch before async command is delivered")
+	}
+
+	// Now execute cmd and deliver
+	msg := cmd()
+	loadedMsg, ok := msg.(fileViewLoadedMsg)
+	if !ok {
+		t.Fatalf("expected fileViewLoadedMsg from rewind tea.Cmd, got %T", msg)
+	}
+	updated, _ = m.Update(loadedMsg)
+	m = updated.(model)
+
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package after_dispatch") {
+		t.Fatalf("expected view to update to after_dispatch after delivery, got: %s", got)
+	}
+}
+
+func TestFileView_CommandAndSweepCompletionOrders(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	name := "order_test.go"
+	filePath := filepath.Join(dir, name)
+
+	// Order 1: Command tool result arrives -> Git sweep arrives later
+	if err := os.WriteFile(filePath, []byte("package v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.activeRunID = 1
+
+	m = testOpenFile(m, name)
+	m = testSetMode(m, fileViewFull)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package v1") {
+		t.Fatal("expected v1")
+	}
+
+	// Mutate on disk to v2
+	if err := os.WriteFile(filePath, []byte("package v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 1: command tool result
+	updated, cmd1 := m.Update(agentRowMsg{
+		runID: 1,
+		row: transcriptRow{
+			kind:   rowToolResult,
+			tool:   "bash",
+			status: tools.StatusOK,
+			detail: "echo 'package v2' > order_test.go",
+		},
+	})
+	m = updated.(model)
+	if cmd1 != nil {
+		msg := cmd1()
+		if loaded, ok := msg.(fileViewLoadedMsg); ok {
+			updated, _ = m.Update(loaded)
+			m = updated.(model)
+		}
+	}
+
+	// Step 2: git sweep arrives later
+	updated, cmd2 := m.Update(gitSweepMsg{
+		ok:    true,
+		files: []gitSweepFile{{path: name, adds: 1}},
+	})
+	m = updated.(model)
+	if cmd2 != nil {
+		msg := cmd2()
+		if loaded, ok := msg.(fileViewLoadedMsg); ok {
+			updated, _ = m.Update(loaded)
+			m = updated.(model)
+		}
+	}
+
+	got := plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package v2") {
+		t.Fatalf("expected package v2 after command->sweep order, got: %s", got)
+	}
+
+	// Order 2: Git sweep arrives first -> Command tool result arrives second
+	if err := os.WriteFile(filePath, []byte("package v3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, cmdA := m.Update(gitSweepMsg{
+		ok:    true,
+		files: []gitSweepFile{{path: name, adds: 1}},
+	})
+	m = updated.(model)
+	if cmdA != nil {
+		msg := cmdA()
+		if loaded, ok := msg.(fileViewLoadedMsg); ok {
+			updated, _ = m.Update(loaded)
+			m = updated.(model)
+		}
+	}
+
+	updated, cmdB := m.Update(agentRowMsg{
+		runID: 1,
+		row: transcriptRow{
+			kind:   rowToolResult,
+			tool:   "bash",
+			status: tools.StatusOK,
+			detail: "echo 'package v3' > order_test.go",
+		},
+	})
+	m = updated.(model)
+	if cmdB != nil {
+		msg := cmdB()
+		if loaded, ok := msg.(fileViewLoadedMsg); ok {
+			updated, _ = m.Update(loaded)
+			m = updated.(model)
+		}
+	}
+
+	got = plainRender(t, m.renderFileViewFull(80))
+	if !strings.Contains(got, "package v3") {
+		t.Fatalf("expected package v3 after sweep->command order, got: %s", got)
 	}
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -360,5 +362,401 @@ func TestFileViewKeysDeferToBlockingModal(t *testing.T) {
 	m = updated.(model)
 	if !m.fileView.active {
 		t.Fatal("Esc with a permission prompt up must not exit the file view")
+	}
+}
+
+// TestFileViewRepeatedViewNoDiskIOOrHighlighting proves that repeated calls
+// to render the full file view do not perform disk I/O or Chroma syntax
+// highlighting after the initial load, and that modifying the file on disk
+// properly invalidates and triggers a reload.
+func TestFileViewRepeatedViewNoDiskIOOrHighlighting(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "sample.go")
+	content := "package main\n\nfunc main() {\n\tprintln(\"hello world\")\n}\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = m.openFileView("sample.go")
+	m = m.setFileViewMode(fileViewFull)
+
+	// First render: Misses cache, performs 1 disk read and 1 highlight call
+	firstRender := m.renderFileViewFull(80)
+	if !strings.Contains(firstRender, "hello world") {
+		t.Fatalf("first render missing content: %s", firstRender)
+	}
+
+	statsAfterFirst := fileViewCacheStatsForTest()
+	if statsAfterFirst.DiskReads != 1 {
+		t.Fatalf("expected 1 disk read on initial view, got %d", statsAfterFirst.DiskReads)
+	}
+	if statsAfterFirst.HighlightCalls != 1 {
+		t.Fatalf("expected 1 highlight call on initial view, got %d", statsAfterFirst.HighlightCalls)
+	}
+
+	// Repeated renders (e.g. 10 frames during typing/scrolling/resize)
+	for i := 0; i < 10; i++ {
+		rendered := m.renderFileViewFull(80)
+		if rendered != firstRender {
+			t.Fatalf("subsequent render %d mismatch", i)
+		}
+	}
+
+	statsAfterRepeated := fileViewCacheStatsForTest()
+	if statsAfterRepeated.DiskReads != 1 {
+		t.Fatalf("repeated View calls must not trigger disk reads, got %d", statsAfterRepeated.DiskReads)
+	}
+	if statsAfterRepeated.HighlightCalls != 1 {
+		t.Fatalf("repeated View calls must not trigger Chroma highlighting, got %d", statsAfterRepeated.HighlightCalls)
+	}
+	if statsAfterRepeated.CacheHits != 10 {
+		t.Fatalf("expected 10 cache hits, got %d", statsAfterRepeated.CacheHits)
+	}
+
+	// Same byte length as `content`, so only mtime can invalidate the entry.
+	newContent := "package main\n\nfunc main() {\n\tprintln(\"HELLO WORLD\")\n}\n"
+	if len(newContent) != len(content) {
+		t.Fatalf("test setup: newContent length %d must match original length %d", len(newContent), len(content))
+	}
+	if err := os.WriteFile(filePath, []byte(newContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(filePath, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	updatedRender := m.renderFileViewFull(80)
+	if !strings.Contains(updatedRender, "HELLO WORLD") {
+		t.Fatalf("expected updated content after disk mutation, got: %s", updatedRender)
+	}
+
+	statsAfterUpdate := fileViewCacheStatsForTest()
+	if statsAfterUpdate.DiskReads != 2 {
+		t.Fatalf("expected 2 disk reads after file change, got %d", statsAfterUpdate.DiskReads)
+	}
+	if statsAfterUpdate.HighlightCalls != 2 {
+		t.Fatalf("expected 2 highlight calls after file change, got %d", statsAfterUpdate.HighlightCalls)
+	}
+}
+
+// TestFileViewMaxBytesBudgetTruncation verifies that files exceeding the
+// total byte budget (fileViewMaxBytes) are truncated and display the trailer.
+func TestFileViewMaxBytesBudgetTruncation(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "giant_bytes.txt")
+
+	// Generate a file with total size ~1.5 MB (> fileViewMaxBytes of 1 MiB)
+	line := strings.Repeat("a", 500) + "\n"
+	numLines := (fileViewMaxBytes / 500) + 100
+	var sb strings.Builder
+	for i := 0; i < numLines; i++ {
+		sb.WriteString(line)
+	}
+	if err := os.WriteFile(filePath, []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = m.openFileView("giant_bytes.txt")
+	m = m.setFileViewMode(fileViewFull)
+
+	body := m.renderFileViewFull(80)
+	plain := plainRender(t, body)
+
+	if !strings.Contains(plain, "truncated") {
+		t.Fatalf("expected truncation trailer for file exceeding byte budget, got:\n%s", plain)
+	}
+
+	renderedLines := strings.Split(plain, "\n")
+	if len(renderedLines) >= numLines {
+		t.Fatalf("rendered line count %d should be strictly less than total file lines %d", len(renderedLines), numLines)
+	}
+}
+
+// TestFileViewMaxLineBytesBudgetTruncation verifies that single overlong lines
+// exceeding fileViewMaxLineBytes are clamped without crashing or unbounded memory.
+func TestFileViewMaxLineBytesBudgetTruncation(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "giant_line.js")
+
+	// Generate a single overlong line of 50,000 bytes (> fileViewMaxLineBytes of 4096)
+	giantLine := "let data = \"" + strings.Repeat("x", 50000) + "\";\nlet next = 1;\n"
+	if err := os.WriteFile(filePath, []byte(giantLine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = m.openFileView("giant_line.js")
+	m = m.setFileViewMode(fileViewFull)
+
+	body := m.renderFileViewFull(80)
+	plain := plainRender(t, body)
+
+	if !strings.Contains(plain, "let next = 1") {
+		t.Fatalf("expected next line to be readable after overlong line truncation, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "truncated") {
+		t.Fatalf("expected truncation trailer for overlong line, got:\n%s", plain)
+	}
+}
+
+// TestFileViewCacheEviction verifies that the LRU cache caps entry count to
+// defaultFileViewCacheMaxEntries.
+func TestFileViewCacheEviction(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	numFiles := defaultFileViewCacheMaxEntries + 10
+	for i := 0; i < numFiles; i++ {
+		fname := fmt.Sprintf("file_%d.txt", i)
+		if err := os.WriteFile(filepath.Join(dir, fname), []byte(fmt.Sprintf("content %d\n", i)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	for i := 0; i < numFiles; i++ {
+		fname := fmt.Sprintf("file_%d.txt", i)
+		m = m.openFileView(fname)
+		m = m.setFileViewMode(fileViewFull)
+		_ = m.renderFileViewFull(80)
+	}
+
+	defaultFileViewCache.mu.Lock()
+	cachedCount := len(defaultFileViewCache.items)
+	defaultFileViewCache.mu.Unlock()
+
+	if cachedCount > defaultFileViewCacheMaxEntries {
+		t.Fatalf("cache size %d exceeded maxEntries %d", cachedCount, defaultFileViewCacheMaxEntries)
+	}
+}
+
+// TestFileViewClearOnThemeChange verifies that switching themes clears the
+// file view cache so updated palette styles are applied.
+func TestFileViewClearOnThemeChange(t *testing.T) {
+	defer applyTheme(themeDark, true)
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(filePath, []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = m.openFileView("code.go")
+	m = m.setFileViewMode(fileViewFull)
+	_ = m.renderFileViewFull(80)
+
+	defaultFileViewCache.mu.Lock()
+	entriesBefore := len(defaultFileViewCache.items)
+	defaultFileViewCache.mu.Unlock()
+
+	if entriesBefore == 0 {
+		t.Fatal("expected cached entries before theme switch")
+	}
+
+	applyTheme(themeLight, false)
+
+	defaultFileViewCache.mu.Lock()
+	entriesAfter := len(defaultFileViewCache.items)
+	defaultFileViewCache.mu.Unlock()
+
+	if entriesAfter != 0 {
+		t.Fatalf("expected cache to be cleared after theme change, got %d entries", entriesAfter)
+	}
+}
+
+// TestReadFileViewBounded_GiantSingleLineStopsAtBudget verifies that reading a
+// multi-megabyte physical line without newlines stops immediately at maxTotalBytes
+// rather than reading through to EOF or loading the entire line into memory.
+func TestReadFileViewBounded_GiantSingleLineStopsAtBudget(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "giant_single_line.txt")
+
+	// 5 MiB single line without any newlines
+	totalSize := 5 * 1024 * 1024
+	giantContent := strings.Repeat("A", totalSize)
+	if err := os.WriteFile(filePath, []byte(giantContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	maxTotalBytes := 1 << 20 // 1 MiB budget
+	maxLineBytes := 4096     // 4 KiB line cap
+	maxLines := 4000
+
+	res := readFileViewBounded(filePath, maxLines, maxLineBytes, maxTotalBytes)
+	if res.err != nil {
+		t.Fatalf("unexpected read error: %v", res.err)
+	}
+
+	if !res.truncated {
+		t.Fatal("expected truncated=true when reading 5 MiB single line with 1 MiB budget")
+	}
+
+	if len(res.lines) != 1 {
+		t.Fatalf("expected exactly 1 truncated line, got %d", len(res.lines))
+	}
+
+	if len(res.lines[0]) > maxLineBytes {
+		t.Fatalf("retained line length %d exceeded per-line cap %d", len(res.lines[0]), maxLineBytes)
+	}
+}
+
+// TestReadFileViewBounded_ExactMaxBytesNotTruncated verifies that a file exactly
+// equal in size to maxTotalBytes without extra unread bytes is read completely
+// without an erroneous truncation flag or trailer.
+func TestReadFileViewBounded_ExactMaxBytesNotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "exact_budget.txt")
+
+	maxTotalBytes := 1024 * 1024 // 1 MiB
+	maxLineBytes := 4096
+	maxLines := 4000
+
+	// Construct exactly 1024 * 1024 bytes with 512 lines of 2048 bytes (2047 chars + '\n')
+	lineLen := 2048
+	numLines := maxTotalBytes / lineLen
+	remainder := maxTotalBytes % lineLen
+
+	var sb strings.Builder
+	for i := 0; i < numLines; i++ {
+		sb.WriteString(strings.Repeat("B", lineLen-1) + "\n")
+	}
+	if remainder > 0 {
+		sb.WriteString(strings.Repeat("C", remainder))
+	}
+
+	content := []byte(sb.String())
+	if len(content) != maxTotalBytes {
+		t.Fatalf("generated content size %d != %d", len(content), maxTotalBytes)
+	}
+
+	if err := os.WriteFile(filePath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := readFileViewBounded(filePath, maxLines, maxLineBytes, maxTotalBytes)
+	if res.err != nil {
+		t.Fatalf("unexpected read error: %v", res.err)
+	}
+
+	if res.truncated {
+		t.Fatal("expected truncated=false for file exactly matching maxTotalBytes with no trailing data")
+	}
+
+	totalReadLen := 0
+	for _, l := range res.lines {
+		totalReadLen += len(l)
+	}
+	if totalReadLen == 0 {
+		t.Fatal("expected lines to be populated")
+	}
+}
+
+// TestReadFileViewBounded_ExactMaxBytesUnterminatedLineTruncated verifies that a single
+// unterminated physical line of exactly maxTotalBytes is correctly marked truncated=true
+// when the line length exceeds maxLineBytes.
+func TestReadFileViewBounded_ExactMaxBytesUnterminatedLineTruncated(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "exact_single_line_unterminated.txt")
+
+	maxTotalBytes := 1024 * 1024 // 1 MiB
+	maxLineBytes := 4096
+	maxLines := 4000
+
+	// 1 MiB continuous single line without any newlines
+	content := []byte(strings.Repeat("X", maxTotalBytes))
+	if err := os.WriteFile(filePath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := readFileViewBounded(filePath, maxLines, maxLineBytes, maxTotalBytes)
+	if res.err != nil {
+		t.Fatalf("unexpected read error: %v", res.err)
+	}
+
+	if !res.truncated {
+		t.Fatal("expected truncated=true for 1 MiB single unterminated line clipped at maxLineBytes")
+	}
+
+	if len(res.lines) != 1 {
+		t.Fatalf("expected exactly 1 line, got %d", len(res.lines))
+	}
+	if len(res.lines[0]) > maxLineBytes {
+		t.Fatalf("retained line length %d exceeded maxLineBytes %d", len(res.lines[0]), maxLineBytes)
+	}
+}
+
+// TestFileViewCache_RenderVariantsBoundedUnderResize verifies that varying width
+// and changed-line fingerprints cannot grow an entry's renders map beyond
+// fileViewMaxRenderVariants, even under concurrent access from multiple goroutines.
+func TestFileViewCache_RenderVariantsBoundedUnderResize(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "resize_test.go")
+	if err := os.WriteFile(filePath, []byte("package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = m.openFileView("resize_test.go")
+	m = m.setFileViewMode(fileViewFull)
+
+	// Execute mixed-width getOrRender calls concurrently from multiple goroutines
+	var wg sync.WaitGroup
+	workers := 8
+	callsPerWorker := 20
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < callsPerWorker; i++ {
+				width := 40 + ((workerID*callsPerWorker + i) % 50)
+				changed := map[string]bool{}
+				if width%2 == 0 {
+					changed[fmt.Sprintf("marker_%d_%d", workerID, width)] = true
+				}
+				_ = defaultFileViewCache.getOrRender(filePath, "resize_test.go", width, changed)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	defaultFileViewCache.mu.Lock()
+	elem, ok := defaultFileViewCache.items[filePath]
+	defaultFileViewCache.mu.Unlock()
+
+	if !ok || elem == nil {
+		t.Fatal("expected cached entry for file")
+	}
+
+	entry := elem.Value.(*fileViewCachedEntry)
+	entry.rendersMu.RLock()
+	variantCount := len(entry.renders)
+	keyCount := len(entry.renderKeys)
+	entry.rendersMu.RUnlock()
+
+	if variantCount > fileViewMaxRenderVariants {
+		t.Fatalf("variant count %d exceeded maximum limit %d", variantCount, fileViewMaxRenderVariants)
+	}
+	if keyCount > fileViewMaxRenderVariants {
+		t.Fatalf("renderKeys count %d exceeded maximum limit %d", keyCount, fileViewMaxRenderVariants)
 	}
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -2714,7 +2714,7 @@ func TestFileView_SupersededInsideDiskReadAndHighlight(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cache := newFileViewRenderCache(10)
+	cache := newFileViewRenderCache(10, defaultFileViewCacheMaxBytes)
 	theme := zeroTheme
 	var liveSeq atomic.Uint64
 	liveSeq.Store(1)
@@ -2924,5 +2924,192 @@ func TestFileView_CommandAndSweepCompletionOrders(t *testing.T) {
 	got = plainRender(t, m.renderFileViewFull(80))
 	if !strings.Contains(got, "package v3") {
 		t.Fatalf("expected package v3 after sweep->command order, got: %s", got)
+	}
+}
+
+// TestFileViewCacheByteBudget verifies the cache-wide byte cap: retained stays
+// within maxBytes, eviction fires before the budget is exceeded, and the named
+// default bound is pinned so a silent regression is caught.
+func TestFileViewCacheByteBudget(t *testing.T) {
+	if defaultFileViewCacheMaxBytes != 8<<20 {
+		t.Fatalf("defaultFileViewCacheMaxBytes = %d, want %d", defaultFileViewCacheMaxBytes, 8<<20)
+	}
+	defaultFileViewCache.mu.Lock()
+	pinned := defaultFileViewCache.maxBytes
+	defaultFileViewCache.mu.Unlock()
+	if pinned != defaultFileViewCacheMaxBytes {
+		t.Fatalf("default cache maxBytes = %d, want %d", pinned, defaultFileViewCacheMaxBytes)
+	}
+
+	dir := t.TempDir()
+	const maxBytes = 48 * 1024
+	cache := newFileViewRenderCache(64, maxBytes)
+
+	payload := strings.Repeat("abcdefghij\n", 400) // ~4 KiB per file
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("byte_cap_%d.txt", i)
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cache.loadAndRender(path, name, 80, nil, "", cache.generation(), zeroTheme, 0, nil, 0); err != nil {
+			t.Fatalf("load %d: %v", i, err)
+		}
+	}
+
+	cache.mu.Lock()
+	retained := cache.retained
+	entries := len(cache.items)
+	cache.mu.Unlock()
+	if retained > maxBytes {
+		t.Fatalf("retained %d exceeded maxBytes %d", retained, maxBytes)
+	}
+	if entries == 0 {
+		t.Fatal("expected at least one cached entry")
+	}
+	if evictions := cache.stats().Evictions; evictions == 0 {
+		t.Fatal("expected byte-budget eviction to fire")
+	}
+}
+
+// TestFileViewCacheRefusesOversizedEntry verifies a single entry larger than the
+// byte budget is returned to the caller but never retained.
+func TestFileViewCacheRefusesOversizedEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oversized.txt")
+	if err := os.WriteFile(path, []byte(strings.Repeat("z", 4096)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cache := newFileViewRenderCache(64, 512)
+	rendered, err := cache.loadAndRender(path, "oversized.txt", 80, nil, "", cache.generation(), zeroTheme, 0, nil, 0)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !strings.Contains(rendered, "zzz") {
+		t.Fatal("oversized entry must still be returned to the caller")
+	}
+	cache.mu.Lock()
+	entries := len(cache.items)
+	retained := cache.retained
+	cache.mu.Unlock()
+	if entries != 0 || retained != 0 {
+		t.Fatalf("oversized entry must not be cached: entries=%d retained=%d", entries, retained)
+	}
+	if stats := cache.stats(); stats.SkippedOversized != 1 {
+		t.Fatalf("SkippedOversized = %d, want 1", stats.SkippedOversized)
+	}
+}
+
+// TestFileViewCacheEvictionDropsPathRevision verifies that LRU eviction removes
+// the evicted path's revision key, so revisions cannot leak one key per file.
+func TestFileViewCacheEvictionDropsPathRevision(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "rev_a.txt")
+	b := filepath.Join(dir, "rev_b.txt")
+	for _, p := range []string{a, b} {
+		if err := os.WriteFile(p, []byte("alpha\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cache := newFileViewRenderCache(1, defaultFileViewCacheMaxBytes)
+
+	// Give a a revision, then load it so the entry and its revision coexist.
+	cache.invalidatePath(a)
+	if _, err := cache.loadAndRender(a, "rev_a.txt", 80, nil, "", cache.generation(), zeroTheme, cache.requiredRevision(a), nil, 0); err != nil {
+		t.Fatalf("load a: %v", err)
+	}
+	cache.mu.Lock()
+	_, hasA := cache.pathRevisions[a]
+	cache.mu.Unlock()
+	if !hasA {
+		t.Fatal("expected revision key for a before eviction")
+	}
+
+	// Loading b with maxEntries=1 evicts a and must drop a's revision.
+	if _, err := cache.loadAndRender(b, "rev_b.txt", 80, nil, "", cache.generation(), zeroTheme, 0, nil, 0); err != nil {
+		t.Fatalf("load b: %v", err)
+	}
+	cache.mu.Lock()
+	_, hasA = cache.pathRevisions[a]
+	orphans := len(cache.pathRevisions)
+	cache.mu.Unlock()
+	if hasA {
+		t.Fatal("evicted path a must not keep a revision key")
+	}
+	if orphans != 0 {
+		t.Fatalf("expected no orphan revision keys, got %d", orphans)
+	}
+}
+
+// TestFileViewCachePurgeResetsPathRevisions verifies clear() resets the revision
+// map instead of bumping dead keys forever, so /clear cannot leak one key per
+// abandoned tool result.
+func TestFileViewCachePurgeResetsPathRevisions(t *testing.T) {
+	cache := newFileViewRenderCache(8, defaultFileViewCacheMaxBytes)
+	cache.invalidatePath("one.go")
+	cache.invalidatePath("two.go")
+	cache.mu.Lock()
+	before := len(cache.pathRevisions)
+	cache.mu.Unlock()
+	if before != 2 {
+		t.Fatalf("expected 2 revision keys, got %d", before)
+	}
+
+	cache.clear()
+	cache.mu.Lock()
+	after := len(cache.pathRevisions)
+	cache.mu.Unlock()
+	if after != 0 {
+		t.Fatalf("clear() must drop revision keys, got %d", after)
+	}
+	if rev := cache.invalidatePath("one.go"); rev != 1 {
+		t.Fatalf("revision after purge = %d, want 1", rev)
+	}
+}
+
+// TestFileViewCacheFreshnessBySourceHash verifies that metadata (mtime+size) is
+// only a hint: when an overwrite restores the same metadata with different
+// bytes, the cached render must not be served.
+func TestFileViewCacheFreshnessBySourceHash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fresh.go")
+	original := "package main\n// AAAA\n"
+	updated := "package main\n// BBBB\n"
+	if len(original) != len(updated) {
+		t.Fatal("test setup: contents must have equal length")
+	}
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Unix(1700000000, 0)
+	if err := os.Chtimes(path, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := newFileViewRenderCache(64, defaultFileViewCacheMaxBytes)
+	first, err := cache.loadAndRender(path, "fresh.go", 80, nil, "", cache.generation(), zeroTheme, 0, nil, 0)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if !strings.Contains(first, "AAAA") {
+		t.Fatalf("first render missing original content: %q", first)
+	}
+
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := cache.loadAndRender(path, "fresh.go", 80, nil, "", cache.generation(), zeroTheme, 0, nil, 0)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if strings.Contains(second, "AAAA") || !strings.Contains(second, "BBBB") {
+		t.Fatalf("stale render served after same-metadata overwrite: %q", second)
+	}
+	if stats := cache.stats(); stats.HighlightCalls != 2 {
+		t.Fatalf("HighlightCalls = %d, want 2 (hash mismatch must force a miss)", stats.HighlightCalls)
 	}
 }

--- a/internal/tui/file_view_test.go
+++ b/internal/tui/file_view_test.go
@@ -1343,8 +1343,10 @@ func TestFileViewLifecycle_RapidResizeCoalesced(t *testing.T) {
 	}
 }
 
-// TestFileViewLifecycle_ThemeSwitchReloadsActiveView tests that selecting a theme
-// in production immediately triggers a reload command for the active file view.
+// TestFileViewLifecycle_ThemeSwitchReloadsActiveView tests that selecting a
+// registered theme in production immediately triggers a reload for the active
+// file view, and that the returned command structure actually delivers the
+// reloaded snapshot under the new cache generation.
 func TestFileViewLifecycle_ThemeSwitchReloadsActiveView(t *testing.T) {
 	defer applyTheme(themeDark, true)
 	resetFileViewCacheForTest()
@@ -1359,21 +1361,30 @@ func TestFileViewLifecycle_ThemeSwitchReloadsActiveView(t *testing.T) {
 	m.cwd = dir
 	m = testOpenFile(m, "theme_active.go")
 
-	// Trigger /theme light via command handling
-	cmdAction := parsedCommand{kind: commandTheme, text: "light"}
-	updated, reloadCmd := m.dispatchCommand(cmdAction)
+	generationBefore := defaultFileViewCache.generation()
+
+	// "dune" is a registered palette (unlike the retired "light" preference), so
+	// the dispatch clears the theme's palette and advances the cache generation.
+	cmdAction := parsedCommand{kind: commandTheme, text: "dune"}
+	updated, dispatchCmd := m.dispatchCommand(cmdAction)
 	m = updated.(model)
 
-	if reloadCmd == nil {
-		t.Fatal("expected reload command on active file view after theme change")
+	if dispatchCmd == nil {
+		t.Fatal("expected a command on the active file view after a valid theme change")
+	}
+	if generationAfter := defaultFileViewCache.generation(); generationAfter <= generationBefore {
+		t.Fatalf("valid theme switch must advance the cache generation: before=%d after=%d", generationBefore, generationAfter)
 	}
 
-	// Complete the reload
-	updated, _ = m.Update(reloadCmd())
-	m = updated.(model)
+	// dispatchCommand returns tea.Batch(noticeCmd, loadCmd); unwrap the batch so
+	// the load completion is delivered to Update instead of being dropped.
+	m = deliverCommandMessages(t, m, dispatchCmd)
 
-	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package theme") {
-		t.Fatalf("expected reloaded theme content, got: %s", plainRender(t, m.renderFileViewFull(80)))
+	if m.fileView.loading {
+		t.Fatal("active file view must leave the loading state after the reload completes")
+	}
+	if got := plainRender(t, m.renderFileViewFull(80)); !strings.Contains(got, "package theme") {
+		t.Fatalf("expected reloaded theme content, got: %s", got)
 	}
 	if m.fileView.loadedGen != defaultFileViewCache.generation() {
 		t.Fatalf("expected loadedGen %d, got %d", defaultFileViewCache.generation(), m.fileView.loadedGen)
@@ -3111,5 +3122,397 @@ func TestFileViewCacheFreshnessBySourceHash(t *testing.T) {
 	}
 	if stats := cache.stats(); stats.HighlightCalls != 2 {
 		t.Fatalf("HighlightCalls = %d, want 2 (hash mismatch must force a miss)", stats.HighlightCalls)
+	}
+}
+
+// deliverCommandMessages executes a tea.Cmd tree and feeds every produced
+// message back into the model through Update, unwrapping tea.BatchMsg so a
+// batched dispatch (notice + reload) reaches its load completion. Commands that
+// Update schedules in response are intentionally not followed.
+func deliverCommandMessages(t *testing.T, m model, cmd tea.Cmd) model {
+	t.Helper()
+	if cmd == nil {
+		return m
+	}
+	pending := []tea.Cmd{cmd}
+	for len(pending) > 0 {
+		current := pending[0]
+		pending = pending[1:]
+		if current == nil {
+			continue
+		}
+		msg := current()
+		if msg == nil {
+			continue
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			pending = append(pending, batch...)
+			continue
+		}
+		updated, _ := m.Update(msg)
+		m = updated.(model)
+	}
+	return m
+}
+
+// TestFileViewLifecycle_OversizedReplacementEvictsObsoleteEntry verifies that an
+// oversized replacement is still the displayed snapshot: the obsolete resident
+// entry is removed and cannot win the next cache lookup, and the oversized
+// admission is counted without being retained.
+func TestFileViewLifecycle_OversizedReplacementEvictsObsoleteEntry(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	name := "oversized_lifecycle.go"
+	filePath := filepath.Join(dir, name)
+	if err := os.WriteFile(filePath, []byte("package original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m = testOpenFile(m, name)
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(80)), "package original") {
+		t.Fatal("expected the seed file to be cached and displayed")
+	}
+	m = m.exitFileView()
+
+	// 4000 * 78 == 312000 bytes: inside the 1 MiB read budget, but the retained
+	// source plus its highlighted and rendered payload exceeds the cache budget.
+	line := "var a = 123; var b = 456; var c = 789; var d = 123; var e = 456; var f = 789;\n"
+	payload := strings.Repeat(line, 4000)
+	if len(payload) != 312000 {
+		t.Fatalf("test payload = %d bytes, want 312000", len(payload))
+	}
+	if err := os.WriteFile(filePath, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	statsBefore := fileViewCacheStatsForTest()
+	m = testOpenFile(m, name)
+
+	displayed := plainRender(t, m.renderFileViewFull(80))
+	if strings.Contains(displayed, "package original") {
+		t.Fatal("the obsolete cached entry must not override the oversized replacement")
+	}
+	if !strings.Contains(displayed, "var a = 123") {
+		t.Fatal("the oversized replacement must be the displayed snapshot")
+	}
+	statsAfter := fileViewCacheStatsForTest()
+	if statsAfter.SkippedOversized <= statsBefore.SkippedOversized {
+		t.Fatalf("SkippedOversized must increase: before=%d after=%d", statsBefore.SkippedOversized, statsAfter.SkippedOversized)
+	}
+	defaultFileViewCache.mu.Lock()
+	_, resident := defaultFileViewCache.items[filePath]
+	defaultFileViewCache.mu.Unlock()
+	if resident {
+		t.Fatal("an oversized replacement must not remain resident")
+	}
+}
+
+// TestFileViewLifecycle_PendingRefreshPreservesViewport verifies that a pending
+// full-file reload keeps the reader's scroll position, and that completion
+// reconciles that position against the real body instead of leaving it at the
+// loading placeholder's zero height.
+func TestFileViewLifecycle_PendingRefreshPreservesViewport(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	name := "viewport.go"
+	var body strings.Builder
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(&body, "line %d\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesPanelTestModel()
+	m.cwd = dir
+	m.altScreen = true
+	m.width = 100
+	m.height = 30
+	m = testOpenFile(m, name)
+	if !m.fileView.snapshotReady {
+		t.Fatal("expected the initial full-file snapshot")
+	}
+
+	m.chatScrollOffset = 50
+	updated, batchCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated.(model)
+	if batchCmd == nil {
+		t.Fatal("resize on an open full view must schedule a reload")
+	}
+	if !m.fileView.loading {
+		t.Fatal("reload should be pending after the resize")
+	}
+	if m.chatScrollOffset != 50 {
+		t.Fatalf("pending reload must preserve the reading position: got %d, want 50", m.chatScrollOffset)
+	}
+
+	m = deliverCommandMessages(t, m, batchCmd)
+	if m.fileView.loading {
+		t.Fatal("expected the reload to complete")
+	}
+	if m.chatScrollOffset != 50 {
+		t.Fatalf("completed reload must preserve the reading position: got %d, want 50", m.chatScrollOffset)
+	}
+	if !strings.Contains(plainRender(t, m.renderFileViewFull(100)), "line 199") {
+		t.Fatal("expected the completed body to render the file tail")
+	}
+}
+
+// TestFileViewLifecycle_BTWPreservesParentLoadOwnership verifies that a parent
+// file load completing while a BTW conversation is visible is routed to the
+// hidden parent, so returning restores a settled snapshot rather than a stalled
+// "Loading…" view.
+func TestFileViewLifecycle_BTWPreservesParentLoadOwnership(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	name := "parent_view.go"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("package parent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newBTWTestModel(t)
+	m.cwd = dir
+
+	// Open a full view but keep its load command pending in the parent.
+	m, parentLoadCmd := m.openFileView(name)
+	if parentLoadCmd == nil {
+		t.Fatal("expected a pending parent load command")
+	}
+	if !m.fileView.loading {
+		t.Fatal("parent view should be loading")
+	}
+
+	// Enter BTW; the hidden parent retains ownership of its pending load.
+	side, _ := m.handleBTWCommand("")
+	if !side.btw.active || side.btw.parent == nil {
+		t.Fatal("expected an active BTW conversation")
+	}
+
+	// The parent's load completes while BTW is visible. It must update the hidden
+	// parent, not the side surface.
+	updated, _ := side.Update(parentLoadCmd())
+	side = updated.(model)
+	if side.btw.parent == nil {
+		t.Fatal("BTW lost the parent snapshot")
+	}
+	if side.btw.parent.fileView.loading {
+		t.Fatal("parent load completion must settle the hidden parent's loading state")
+	}
+	if !side.btw.parent.fileView.snapshotReady {
+		t.Fatal("hidden parent must integrate its snapshot before returning")
+	}
+
+	restored, _ := side.leaveBTW()
+	if restored.fileView.loading {
+		t.Fatal("restored parent must not be stuck loading")
+	}
+	got := plainRender(t, restored.renderFileViewFull(80))
+	if !strings.Contains(got, "package parent") {
+		t.Fatalf("restored parent must render its snapshot, got: %s", got)
+	}
+	if strings.Contains(got, fileViewLoadingPlaceholder) {
+		t.Fatal("restored parent must not show the loading placeholder")
+	}
+}
+
+// TestFileViewLifecycle_RevisionMetadataBounded verifies that per-path revision
+// counters for never-cached paths stay bounded, and that retiring a revision
+// cannot make an older request appear current (ABA protection).
+func TestFileViewLifecycle_RevisionMetadataBounded(t *testing.T) {
+	dir := t.TempDir()
+	warm := filepath.Join(dir, "revision_warm.go")
+	if err := os.WriteFile(warm, []byte("package warm\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := newFileViewRenderCache(defaultFileViewCacheMaxEntries, defaultFileViewCacheMaxBytes)
+	oldRev := cache.invalidatePath(warm)
+	if _, err := cache.loadAndRender(warm, "revision_warm.go", 80, nil, "", cache.generation(), zeroTheme, oldRev, nil, 0); err != nil {
+		t.Fatalf("warm load: %v", err)
+	}
+
+	for i := 0; i < 10000; i++ {
+		cache.invalidatePath(filepath.Join(dir, fmt.Sprintf("never_cached_%d.go", i)))
+	}
+
+	cache.mu.Lock()
+	revisionCount := len(cache.pathRevisions)
+	epochFloor := cache.revEpochFloor
+	cache.mu.Unlock()
+	if revisionCount > fileViewMaxPathRevisions {
+		t.Fatalf("pathRevisions = %d, exceeds hard cap %d", revisionCount, fileViewMaxPathRevisions)
+	}
+	if revisionCount > cache.maxPathRevisions() {
+		t.Fatalf("pathRevisions = %d, exceeds policy bound %d", revisionCount, cache.maxPathRevisions())
+	}
+
+	if got := cache.requiredRevision(warm); got <= oldRev {
+		t.Fatalf("retired revision must not read as current: required=%d old=%d", got, oldRev)
+	}
+	if epochFloor <= oldRev {
+		t.Fatalf("epoch floor %d must advance past retired revision %d", epochFloor, oldRev)
+	}
+
+	// A request captured before the retirement must not reuse the still-resident
+	// entry; it has to re-render under the advanced authority.
+	highlightBefore := cache.stats().HighlightCalls
+	if _, err := cache.loadAndRender(warm, "revision_warm.go", 80, nil, "", cache.generation(), zeroTheme, oldRev, nil, 0); err != nil {
+		t.Fatalf("stale load: %v", err)
+	}
+	if highlightAfter := cache.stats().HighlightCalls; highlightAfter != highlightBefore+1 {
+		t.Fatalf("stale request must not commit a cache hit: HighlightCalls %d -> %d", highlightBefore, highlightAfter)
+	}
+}
+
+// TestFileViewLifecycle_TruncationStateEquivalence verifies that two versions
+// with identical size, timestamp, and retained source hash but a different
+// truncation status are not interchangeable: the clipped version keeps its
+// warning, and the warning disappears again when clipping stops.
+func TestFileViewLifecycle_TruncationStateEquivalence(t *testing.T) {
+	resetFileViewCacheForTest()
+
+	dir := t.TempDir()
+	name := "truncation_state.go"
+	filePath := filepath.Join(dir, name)
+	stamp := time.Unix(1700000000, 0)
+	fill := strings.Repeat("x", fileViewMaxLineBytes)
+
+	// Version A: CRLF-terminated, so the line is exactly at the limit and not clipped.
+	if err := os.WriteFile(filePath, []byte(fill+"\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filePath, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	first, err := defaultFileViewCache.loadAndRender(filePath, name, 80, nil, "", defaultFileViewCache.generation(), zeroTheme, 0, nil, 0)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if strings.Contains(plainRender(t, first), "truncated") {
+		t.Fatal("an unclipped line must not display a truncation warning")
+	}
+
+	// Version B: the same 4098 bytes and timestamp, but the physical line now
+	// exceeds the per-line display limit while the retained line and hash do not.
+	if err := os.WriteFile(filePath, []byte(fill+"Z\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filePath, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	second, err := defaultFileViewCache.loadAndRender(filePath, name, 80, nil, "", defaultFileViewCache.generation(), zeroTheme, 0, nil, 0)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if !strings.Contains(plainRender(t, second), "truncated") {
+		t.Fatal("a clipped replacement must display its truncation warning")
+	}
+
+	// Reverse: going back to the unclipped CRLF form must drop the warning.
+	if err := os.WriteFile(filePath, []byte(fill+"\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filePath, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	third, err := defaultFileViewCache.loadAndRender(filePath, name, 80, nil, "", defaultFileViewCache.generation(), zeroTheme, 0, nil, 0)
+	if err != nil {
+		t.Fatalf("third load: %v", err)
+	}
+	if strings.Contains(plainRender(t, third), "truncated") {
+		t.Fatal("a previously cached warning must disappear when clipping stops")
+	}
+}
+
+// TestFileViewLifecycle_VariantAccountingConsistency verifies that same-key
+// variant rewrites do not charge the key twice, and that a detached or purged
+// entry cannot leak bytes into the cache's retained counter.
+func TestFileViewLifecycle_VariantAccountingConsistency(t *testing.T) {
+	// Same-key replacement accounts for the difference, not the key again.
+	entry := &fileViewCachedEntry{}
+	key := "80:"
+	current := strings.Repeat("a", 100)
+	if delta := entry.putRender(key, current); delta != len(key)+len(current) {
+		t.Fatalf("initial put delta = %d, want %d", delta, len(key)+len(current))
+	}
+	for i := 0; i < 10; i++ {
+		next := strings.Repeat("b", 40+i)
+		delta := entry.putRender(key, next)
+		if want := len(next) - len(current); delta != want {
+			t.Fatalf("same-key rewrite %d delta = %d, want %d", i, delta, want)
+		}
+		current = next
+	}
+	if got, want := entry.byteSize(), len(key)+len(current); got != want {
+		t.Fatalf("entry byteSize = %d, want %d", got, want)
+	}
+
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "variant_accounting.go")
+	if err := os.WriteFile(path, []byte("package accounting\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cache := newFileViewRenderCache(64, defaultFileViewCacheMaxBytes)
+	if _, err := cache.loadAndRender(path, "variant_accounting.go", 80, nil, "", cache.generation(), zeroTheme, 0, nil, 0); err != nil {
+		t.Fatalf("seed load: %v", err)
+	}
+
+	cache.mu.Lock()
+	elem := cache.items[path]
+	retainedBefore := cache.retained
+	var residentBytes int
+	if elem != nil {
+		residentBytes = elem.Value.(*fileViewCachedEntry).byteSize()
+	}
+	cache.mu.Unlock()
+	if elem == nil {
+		t.Fatal("expected a resident entry to seed the accounting check")
+	}
+	if retainedBefore != residentBytes {
+		t.Fatalf("retained = %d, want resident payload %d", retainedBefore, residentBytes)
+	}
+
+	// Evicting the entry detaches it without destroying the value the caller holds.
+	cache.evictPath(path)
+	cache.mu.Lock()
+	afterEvict := cache.retained
+	_, resident := cache.items[path]
+	cache.mu.Unlock()
+	if afterEvict != 0 || resident {
+		t.Fatalf("eviction must release and detach the entry: retained=%d resident=%v", afterEvict, resident)
+	}
+	cache.commitRenderPut(elem.Value.(*fileViewCachedEntry), "80:detached", strings.Repeat("z", 512))
+	cache.mu.Lock()
+	polluted := cache.retained
+	_, readmitted := cache.items[path]
+	cache.mu.Unlock()
+	if polluted != afterEvict {
+		t.Fatalf("a detached entry must not charge retained: %d -> %d", afterEvict, polluted)
+	}
+	if readmitted {
+		t.Fatal("a detached entry must not be re-admitted by commitRenderPut")
+	}
+
+	// A purge detaches every entry the same way.
+	if _, err := cache.loadAndRender(path, "variant_accounting.go", 80, nil, "", cache.generation(), zeroTheme, 0, nil, 0); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	cache.mu.Lock()
+	purged := cache.items[path].Value.(*fileViewCachedEntry)
+	cache.mu.Unlock()
+	cache.clear()
+	cache.commitRenderPut(purged, "80:purged", strings.Repeat("y", 512))
+	cache.mu.Lock()
+	retainedAfterPurge := cache.retained
+	purgedItems := len(cache.items)
+	cache.mu.Unlock()
+	if retainedAfterPurge != 0 || purgedItems != 0 {
+		t.Fatalf("a purged entry must not charge retained: retained=%d items=%d", retainedAfterPurge, purgedItems)
 	}
 }

--- a/internal/tui/file_view_unix_test.go
+++ b/internal/tui/file_view_unix_test.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestFileView_SpecialTargetNonRegularFileRejected(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	pipePath := filepath.Join(dir, "test.pipe")
+
+	// Create a FIFO if supported on the platform
+	if err := syscall.Mkfifo(pipePath, 0o600); err != nil {
+		t.Skipf("mkfifo not supported on this environment: %v", err)
+	}
+
+	res := readFileViewBounded(pipePath, 100, 1000, 10000)
+	if res.err == nil {
+		t.Fatal("expected error reading FIFO non-regular file, got nil")
+	}
+	if !strings.Contains(res.err.Error(), "non-regular") {
+		t.Fatalf("expected non-regular error message, got: %v", res.err)
+	}
+}
+
+func TestFileView_FIFONeverBlocksOpen(t *testing.T) {
+	resetFileViewCacheForTest()
+	dir := t.TempDir()
+	pipePath := filepath.Join(dir, "hang_test.pipe")
+
+	if err := syscall.Mkfifo(pipePath, 0o600); err != nil {
+		t.Skipf("mkfifo not supported on this environment: %v", err)
+	}
+
+	done := make(chan fileViewReadResult, 1)
+	go func() {
+		res := readFileViewBounded(pipePath, 100, 1000, 10000)
+		done <- res
+	}()
+
+	select {
+	case res := <-done:
+		if res.err == nil || !strings.Contains(res.err.Error(), "non-regular") {
+			t.Fatalf("expected non-regular error, got: %v", res.err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("readFileViewBounded blocked on open(2) for FIFO without writer (TOCTOU / missing O_NONBLOCK)")
+	}
+}

--- a/internal/tui/files_git_sweep_test.go
+++ b/internal/tui/files_git_sweep_test.go
@@ -152,12 +152,12 @@ func TestTouchedFilesMergesGitSweep(t *testing.T) {
 func TestOpenFileViewGitOnlyFallsBackToFull(t *testing.T) {
 	m := filesPanelTestModel()
 	m.gitTouched = []gitSweepFile{{path: "kanban/board.tsx", created: true}}
-	m = m.openFileView("kanban/board.tsx")
+	m, _ = m.openFileView("kanban/board.tsx")
 	if m.fileView.mode != fileViewFull {
 		t.Fatal("git-only file should open in full mode")
 	}
 	m = m.exitFileView()
-	m = m.openFileView("web/app.js")
+	m, _ = m.openFileView("web/app.js")
 	if m.fileView.mode != fileViewDiff {
 		t.Fatal("a file with edit cards still opens in diff mode")
 	}

--- a/internal/tui/files_panel.go
+++ b/internal/tui/files_panel.go
@@ -377,6 +377,12 @@ func (m model) selectFile(path string) (model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) runDetailsInnerWidth() int {
+	overlayWidth := minInt(72, maxInt(40, m.width-8))
+	overlayWidth = minInt(overlayWidth, m.width)
+	return maxInt(12, overlayWidth-4)
+}
+
 func (m model) runDetailsFileAtMouse(msg tea.MouseMsg) (string, bool) {
 	if !m.runDetailsOpen || !m.runDetailsAllowed() {
 		return "", false
@@ -387,19 +393,46 @@ func (m model) runDetailsFileAtMouse(msg tea.MouseMsg) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	lines := viewLines(overlay)
-	_, lines, _ = normalizeOverlayBlock(lines, width)
-	if hit.y < 0 || hit.y >= len(lines) {
-		return "", false
-	}
-	row := lines[hit.y]
-	for _, f := range m.touchedFiles() {
-		shown := truncatePathLeft(f.path, 40)
-		if strings.Contains(row, f.path) || strings.Contains(row, shown) {
-			return f.path, true
+	inner := m.runDetailsInnerWidth()
+	fileLines, hits := m.sidebarFileLines(inner)
+	content := m.runDetailsLines(inner)
+	fileStart := -1
+	if len(fileLines) > 0 {
+		for i, line := range content {
+			if line == fileLines[0] {
+				fileStart = i
+				break
+			}
 		}
 	}
-	return "", false
+	overlayLines := viewLines(overlay)
+	_, overlayLines, _ = normalizeOverlayBlock(overlayLines, width)
+	contentOrigin := -1
+	if len(content) > 0 {
+		for i, line := range overlayLines {
+			if line == content[0] {
+				contentOrigin = i
+				break
+			}
+		}
+	}
+	if fileStart < 0 || contentOrigin < 0 {
+		return "", false
+	}
+	y := hit.y - contentOrigin
+	var match fileHit
+	found := false
+	for _, h := range hits {
+		if y == fileStart+h.lineOffset {
+			match = h
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", false
+	}
+	return match.path, true
 }
 
 // scrollOffsetForTranscriptRow computes the chatScrollOffset that places the

--- a/internal/tui/files_panel.go
+++ b/internal/tui/files_panel.go
@@ -394,36 +394,26 @@ func (m model) runDetailsFileAtMouse(msg tea.MouseMsg) (string, bool) {
 		return "", false
 	}
 	inner := m.runDetailsInnerWidth()
-	fileLines, hits := m.sidebarFileLines(inner)
-	content := m.runDetailsLines(inner)
-	fileStart := -1
-	if len(fileLines) > 0 {
-		for i, line := range content {
-			if line == fileLines[0] {
-				fileStart = i
-				break
-			}
-		}
-	}
+	layout := m.runDetailsLayout(inner)
 	overlayLines := viewLines(overlay)
 	_, overlayLines, _ = normalizeOverlayBlock(overlayLines, width)
 	contentOrigin := -1
-	if len(content) > 0 {
+	if len(layout.lines) > 0 {
 		for i, line := range overlayLines {
-			if line == content[0] {
+			if line == layout.lines[0] {
 				contentOrigin = i
 				break
 			}
 		}
 	}
-	if fileStart < 0 || contentOrigin < 0 {
+	if layout.fileStart < 0 || contentOrigin < 0 {
 		return "", false
 	}
 	y := hit.y - contentOrigin
 	var match fileHit
 	found := false
-	for _, h := range hits {
-		if y == fileStart+h.lineOffset {
+	for _, h := range layout.fileHits {
+		if y == layout.fileStart+h.lineOffset {
 			match = h
 			found = true
 			break

--- a/internal/tui/files_panel.go
+++ b/internal/tui/files_panel.go
@@ -15,6 +15,8 @@ import (
 	"sort"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
@@ -357,8 +359,13 @@ func (m *model) setSelectedFile(path string) {
 
 // selectFile marks path as the selected file and scrolls the transcript so its
 // most recent edit card is in view; the card tint comes from the renderers
-// reading selectedFile (rowTouchesSelectedFile).
-func (m model) selectFile(path string) model {
+// reading selectedFile (rowTouchesSelectedFile). A second activation of the
+// same path drills into the file view and returns any load command.
+func (m model) selectFile(path string) (model, tea.Cmd) {
+	if m.selectedFile == path {
+		m.runDetailsOpen = false
+		return m.openFileView(path)
+	}
 	rowIndex := m.lastRowIndexForFile(path)
 	m.setSelectedFile(path)
 	if offset, ok := m.scrollOffsetForTranscriptRow(rowIndex); ok {
@@ -367,7 +374,32 @@ func (m model) selectFile(path string) model {
 			m.chatBodyLines = 0
 		}
 	}
-	return m
+	return m, nil
+}
+
+func (m model) runDetailsFileAtMouse(msg tea.MouseMsg) (string, bool) {
+	if !m.runDetailsOpen || !m.runDetailsAllowed() {
+		return "", false
+	}
+	width := m.width
+	overlay := m.runDetailsOverlay(width)
+	hit, ok := m.overlayMouseHit(msg, overlay, width)
+	if !ok {
+		return "", false
+	}
+	lines := viewLines(overlay)
+	_, lines, _ = normalizeOverlayBlock(lines, width)
+	if hit.y < 0 || hit.y >= len(lines) {
+		return "", false
+	}
+	row := lines[hit.y]
+	for _, f := range m.touchedFiles() {
+		shown := truncatePathLeft(f.path, 40)
+		if strings.Contains(row, f.path) || strings.Contains(row, shown) {
+			return f.path, true
+		}
+	}
+	return "", false
 }
 
 // scrollOffsetForTranscriptRow computes the chatScrollOffset that places the

--- a/internal/tui/files_panel.go
+++ b/internal/tui/files_panel.go
@@ -395,21 +395,12 @@ func (m model) runDetailsFileAtMouse(msg tea.MouseMsg) (string, bool) {
 	}
 	inner := m.runDetailsInnerWidth()
 	layout := m.runDetailsLayout(inner)
-	overlayLines := viewLines(overlay)
-	_, overlayLines, _ = normalizeOverlayBlock(overlayLines, width)
-	contentOrigin := -1
-	if len(layout.lines) > 0 {
-		for i, line := range overlayLines {
-			if line == layout.lines[0] {
-				contentOrigin = i
-				break
-			}
-		}
-	}
-	if layout.fileStart < 0 || contentOrigin < 0 {
+	if layout.fileStart < 0 {
 		return "", false
 	}
-	y := hit.y - contentOrigin
+	// styledBlockFillTitle contributes a 1-line top border with title before the content rows.
+	const topBorderHeight = 1
+	y := hit.y - topBorderHeight
 	var match fileHit
 	found := false
 	for _, h := range layout.fileHits {

--- a/internal/tui/files_panel_test.go
+++ b/internal/tui/files_panel_test.go
@@ -327,3 +327,49 @@ func TestSidebarHasContentForLiveWrite(t *testing.T) {
 		t.Fatal("a live in-flight write must count as sidebar content")
 	}
 }
+
+func TestRunDetailsFileMouseSelectionEndToEnd(t *testing.T) {
+	m := filesPanelTestModel()
+	m.width = 80
+	m.height = 24
+	m.altScreen = true
+	m.runDetailsOpen = true
+
+	overlay := m.runDetailsOverlay(m.width)
+	if overlay == "" {
+		t.Fatal("expected non-empty runDetailsOverlay")
+	}
+
+	inner := m.runDetailsInnerWidth()
+	layout := m.runDetailsLayout(inner)
+	if len(layout.fileHits) == 0 || layout.fileStart < 0 {
+		t.Fatalf("expected file hits in layout, got: %+v", layout)
+	}
+
+	targetHit := layout.fileHits[0] // "internal/tui/sidebar.go"
+	overlayLines := viewLines(overlay)
+	left, trimmedLines, overlayWidth := normalizeOverlayBlock(overlayLines, m.width)
+	if overlayWidth <= 0 || len(trimmedLines) == 0 {
+		t.Fatalf("invalid overlay block normalization: left=%d, width=%d", left, overlayWidth)
+	}
+
+	rect := m.overlayMouseRect(len(trimmedLines), m.width)
+	// Click on the target file row: top border is row 0 of the overlay, content starts at row 1
+	clickY := rect.y + 1 + layout.fileStart + targetHit.lineOffset
+	clickX := left + 4 // inside the border and padding
+
+	clickMsg := testMouseClick(tea.MouseLeft, clickX, clickY)
+
+	path, ok := m.runDetailsFileAtMouse(clickMsg)
+	if !ok || path != targetHit.path {
+		t.Fatalf("runDetailsFileAtMouse failed: ok=%v, got=%q, want=%q", ok, path, targetHit.path)
+	}
+
+	// Route the click through m.Update to verify end-to-end selection
+	updated, _ := m.Update(clickMsg)
+	m = updated.(model)
+
+	if m.selectedFile != targetHit.path {
+		t.Fatalf("expected selectedFile %q after mouse click, got %q", targetHit.path, m.selectedFile)
+	}
+}

--- a/internal/tui/files_panel_test.go
+++ b/internal/tui/files_panel_test.go
@@ -296,6 +296,24 @@ func TestSidebarFileLinesOverflowExcludesLiveRow(t *testing.T) {
 
 // TestSidebarHasContentForLiveWrite: the sidebar counts an in-flight first
 // write as content, so the FILES pulse is visible before any result row lands.
+func TestSidebarFileHitsDistinguishSuffixPaths(t *testing.T) {
+	m := sidebarTestModel()
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowToolResult, tool: "edit_file", id: "a", status: tools.StatusOK, changedFiles: []string{"a.go"}},
+		transcriptRow{kind: rowToolResult, tool: "edit_file", id: "b", status: tools.StatusOK, changedFiles: []string{"dir/a.go"}},
+	)
+	_, hits := m.sidebarFileLines(80)
+	if len(hits) < 2 {
+		t.Fatalf("want two fileHit rows, got %#v", hits)
+	}
+	if hits[0].path == hits[1].path {
+		t.Fatal("fileHit paths must stay distinct")
+	}
+	if hits[0].lineOffset == hits[1].lineOffset {
+		t.Fatal("fileHit rows must not share a line offset")
+	}
+}
+
 func TestSidebarHasContentForLiveWrite(t *testing.T) {
 	m := sidebarTestModel()
 	m.plan.steps = nil // drop the helper's seeded plan: no agents/plan/files now

--- a/internal/tui/flush_test.go
+++ b/internal/tui/flush_test.go
@@ -111,7 +111,7 @@ func TestAltScreenSettledCacheInvalidatesWithFileSelection(t *testing.T) {
 		t.Fatal("precondition: settled cache should be populated")
 	}
 
-	m = m.selectFile("internal/tui/sidebar.go")
+	m, _ = m.selectFile("internal/tui/sidebar.go")
 	if m.altScreenSettledWidth != 0 {
 		t.Fatal("selecting a file touched by a settled row must invalidate the cache")
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1446,6 +1446,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.hasDarkBg = msg.IsDark()
 		if m.themeMode != themeSystem {
 			applyTheme(m.themeMode, m.hasDarkBg)
+			if m.fileView.active && m.fileView.mode == fileViewFull {
+				return m.startFileViewLoadCmd(m.chatColumnWidth())
+			}
 		}
 		return m, nil
 	case tea.MouseMsg:
@@ -2941,10 +2944,21 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// A finished command tool may have mutated files git can see but no
 		// changedFiles reports (npm create, heredoc writes, subagent edits) —
 		// re-sweep so the FILES sidebar picks them up mid-turn.
-		if msg.row.kind == rowToolResult && isPlanCommandTool(msg.row.tool) {
-			var sweep tea.Cmd
-			m, sweep = m.maybeGitSweep()
-			return m, sweep
+		if msg.row.kind == rowToolResult {
+			if isPlanCommandTool(msg.row.tool) {
+				var sweep tea.Cmd
+				m, sweep = m.maybeGitSweep()
+				return m, sweep
+			}
+			if m.fileView.active && m.fileView.mode == fileViewFull {
+				for _, p := range msg.row.changedFiles {
+					if p == m.fileView.path {
+						var loadCmd tea.Cmd
+						m, loadCmd = m.startFileViewLoadCmd(m.chatColumnWidth())
+						return m, loadCmd
+					}
+				}
+			}
 		}
 		return m, nil
 	case swarmSessionsMsg:
@@ -4555,10 +4569,21 @@ func (m model) choosePicker() (tea.Model, tea.Cmd) {
 		// local preview and never changes the active palette.
 		text := ""
 		m, text = m.handleThemeCommand(item.Value)
+		var loadCmd tea.Cmd
+		if m.fileView.active && m.fileView.mode == fileViewFull {
+			m, loadCmd = m.startFileViewLoadCmd(m.chatColumnWidth())
+		}
 		if validThemeMode(item.Value) && !strings.Contains(text, "could not save theme preference") {
-			return m.showTransientNotice(m.themeAppliedNotice(), transientNoticeSuccess)
+			next, noticeCmd := m.showTransientNotice(m.themeAppliedNotice(), transientNoticeSuccess)
+			if loadCmd != nil {
+				return next, tea.Batch(noticeCmd, loadCmd)
+			}
+			return next, noticeCmd
 		}
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		if loadCmd != nil {
+			return m, loadCmd
+		}
 	}
 	return m, cmd
 }
@@ -4966,10 +4991,21 @@ func (m model) dispatchCommand(command parsedCommand) (tea.Model, tea.Cmd) {
 		}
 		text := ""
 		m, text = m.handleThemeCommand(command.text)
+		var loadCmd tea.Cmd
+		if m.fileView.active && m.fileView.mode == fileViewFull {
+			m, loadCmd = m.startFileViewLoadCmd(m.chatColumnWidth())
+		}
 		if validThemeMode(command.text) && !strings.Contains(text, "could not save theme preference") {
-			return m.showTransientNotice(m.themeAppliedNotice(), transientNoticeSuccess)
+			next, noticeCmd := m.showTransientNotice(m.themeAppliedNotice(), transientNoticeSuccess)
+			if loadCmd != nil {
+				return next, tea.Batch(noticeCmd, loadCmd)
+			}
+			return next, noticeCmd
 		}
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		if loadCmd != nil {
+			return m, loadCmd
+		}
 		return m, nil
 	case commandImage:
 		m = m.handleImageCommand(command.text)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2977,7 +2977,13 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.prState = msg.state
 		return m, nil
 	case gitSweepMsg:
-		return m.handleGitSweepMsg(msg), nil
+		m = m.handleGitSweepMsg(msg)
+		if m.fileView.active && m.fileView.mode == fileViewFull {
+			var cmd tea.Cmd
+			m, cmd = m.startFileViewLoadCmd(m.chatColumnWidth())
+			return m, cmd
+		}
+		return m, nil
 	case prWatcherStartedMsg:
 		if msg.stop == nil {
 			return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2960,6 +2960,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if isPlanCommandTool(msg.row.tool) {
 				var sweep tea.Cmd
 				m, sweep = m.maybeGitSweep()
+				defaultFileViewCache.invalidateUnknownScope()
 				if m.fileView.active {
 					target := m.fileView.path
 					if !filepath.IsAbs(target) {
@@ -3033,6 +3034,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case gitSweepMsg:
 		m = m.handleGitSweepMsg(msg)
+		if msg.ok && !msg.baseline {
+			for _, f := range msg.files {
+				p := f.path
+				if !filepath.IsAbs(p) {
+					p = filepath.Join(m.cwd, p)
+				}
+				defaultFileViewCache.invalidatePath(p)
+			}
+		}
 		if m.fileView.active && m.fileView.mode == fileViewFull {
 			var cmd tea.Cmd
 			m, cmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
@@ -3050,8 +3060,12 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case bashResultMsg:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.output})
-		if m.fileView.active && m.fileView.mode == fileViewFull {
-			return m.startFileViewRefreshCmd(m.chatColumnWidth())
+		defaultFileViewCache.invalidateUnknownScope()
+		if m.fileView.active {
+			m.fileView.requiredSourceRev++
+			if m.fileView.mode == fileViewFull {
+				return m.startFileViewRefreshCmd(m.chatColumnWidth())
+			}
 		}
 		return m, nil
 	case providerModelsDiscoveredMsg:
@@ -4945,9 +4959,10 @@ func (m model) dispatchCommand(command parsedCommand) (tea.Model, tea.Cmd) {
 		return m.toggleDetailedTranscript(), nil
 	case commandRewind:
 		text := ""
-		m, text = m.handleRewindCommand(command.text)
+		var rewindCmd tea.Cmd
+		m, text, rewindCmd = m.handleRewindCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
-		return m, nil
+		return m, rewindCmd
 	case commandEffort:
 		if strings.TrimSpace(command.text) == "" {
 			if m.pending {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1383,7 +1383,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	switch msg := msg.(type) {
 	case fileViewLoadedMsg:
-		return m.handleFileViewLoaded(msg), nil
+		return m.handleFileViewLoaded(msg)
 	case uv.CellSizeEvent:
 		if msg.Width > 0 && msg.Height > 0 {
 			m.petCellPixelWidth = msg.Width

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1675,6 +1675,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case m.runDetailsOpen:
 			if keyIs(msg, tea.KeyEsc) || m.keyMatch(m.keyBindings.toggleSidebar, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'b') }) {
 				m.runDetailsOpen = false
+				return m, nil
+			}
+			if keyIs(msg, tea.KeyEnter) && m.selectedFile != "" {
+				return m.selectFile(m.selectedFile)
 			}
 			return m, nil
 		case m.keyMatch(m.keyBindings.toggleDetailed, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'o') }):

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2958,7 +2958,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				for _, p := range msg.row.changedFiles {
 					if p == m.fileView.path {
 						var loadCmd tea.Cmd
-						m, loadCmd = m.startFileViewLoadCmd(m.chatColumnWidth())
+						m, loadCmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
 						return m, loadCmd
 					}
 				}
@@ -2998,7 +2998,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m = m.handleGitSweepMsg(msg)
 		if m.fileView.active && m.fileView.mode == fileViewFull {
 			var cmd tea.Cmd
-			m, cmd = m.startFileViewLoadCmd(m.chatColumnWidth())
+			m, cmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
 			return m, cmd
 		}
 		return m, nil
@@ -3014,7 +3014,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case bashResultMsg:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.output})
 		if m.fileView.active && m.fileView.mode == fileViewFull {
-			return m.startFileViewLoadCmd(m.chatColumnWidth())
+			return m.startFileViewRefreshCmd(m.chatColumnWidth())
 		}
 		return m, nil
 	case providerModelsDiscoveredMsg:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1375,11 +1375,12 @@ func batchCommands(cmds ...tea.Cmd) tea.Cmd {
 }
 
 func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var resizeCmd tea.Cmd
 	if size, ok := msg.(tea.WindowSizeMsg); ok {
-		m = m.resizeBTWParent(size)
+		m, resizeCmd = m.resizeBTWParent(size)
 	}
 	if next, cmd, routed := m.routeBTWParentMessage(msg); routed {
-		return next, cmd
+		return next, batchCommands(cmd, resizeCmd)
 	}
 	switch msg := msg.(type) {
 	case fileViewLoadedMsg:
@@ -2485,9 +2486,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.fileView.active && m.fileView.mode == fileViewFull {
 			var cmd tea.Cmd
 			m, cmd = m.startFileViewLoadCmd(m.chatColumnWidth())
-			return m, tea.Batch(m.ensureSpinnerTick(), cmd)
+			return m, batchCommands(m.ensureSpinnerTick(), cmd, resizeCmd)
 		}
-		return m, m.ensureSpinnerTick()
+		return m, batchCommands(m.ensureSpinnerTick(), resizeCmd)
 	case permissionRequestMsg:
 		// The agent goroutine that raised this request is BLOCKED waiting on the
 		// decision callback, so every branch below must resolve it exactly once —
@@ -3738,6 +3739,15 @@ func (m model) chatTranscriptViewport() (transcriptViewport, bool) {
 // so the absolute view holds; at the bottom (offset 0) it follows normally. Only the
 // scrolled-up path renders the body, so the common case stays cheap.
 func (m model) syncChatScroll() model {
+	// A pending full-file reload temporarily renders a one-line loading
+	// placeholder. Measuring it would clamp the reader's offset to 0 and lose
+	// their place, so hold the preserved offset until handleFileViewLoaded
+	// reconciles it against the real body.
+	if m.altScreen && m.fileView.active && m.fileView.mode == fileViewFull &&
+		m.fileView.loading && m.fileView.preservedScrollOffset > 0 {
+		m.chatScrollOffset = m.fileView.preservedScrollOffset
+		return m
+	}
 	if !m.altScreen || m.chatScrollOffset <= 0 {
 		// At the bottom (or inline mode): follow the tail; reset the pin baseline.
 		m.chatBodyLines = 0
@@ -4597,10 +4607,14 @@ func (m model) choosePicker() (tea.Model, tea.Cmd) {
 	case pickerSession:
 		// item.Value is the chosen session id; handleResumeCommand hydrates it and
 		// rebuilds the transcript (returning "" on success, an error note on failure).
+		previousSessionID := m.activeSession.SessionID
 		text := ""
 		m, text = m.handleResumeCommand(item.Value)
 		if text != "" {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		}
+		if m.activeSession.SessionID != previousSessionID {
+			m, cmd = m.refreshFileViewMarkers()
 		}
 	case pickerSkill:
 		// Fill the composer with "/name " so the user adds their request before
@@ -4770,7 +4784,9 @@ func (m model) dispatchCommand(command parsedCommand) (tea.Model, tea.Cmd) {
 		if m.loopActive() {
 			m = m.appendLoopSystem(m.loopFooterSummary() + " still running — /loop stop all to end them.")
 		}
-		return m, nil
+		var clearCmd tea.Cmd
+		m, clearCmd = m.refreshFileViewMarkers()
+		return m, clearCmd
 	case commandNew:
 		// A fresh session mid-run would strand the in-flight turn's events; make the
 		// user cancel first. Idle, /new saves the current session (already on disk)
@@ -4779,7 +4795,10 @@ func (m model) dispatchCommand(command parsedCommand) (tea.Model, tea.Cmd) {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "A run is in progress. Press Esc to cancel it first, then /new."})
 			return m, nil
 		}
-		return m.startNewSession(), nil
+		next := m.startNewSession()
+		var newCmd tea.Cmd
+		next, newCmd = next.refreshFileViewMarkers()
+		return next, newCmd
 	case commandBTW:
 		return m.handleBTWCommand(command.text)
 	case commandLoop:
@@ -4912,6 +4931,7 @@ func (m model) dispatchCommand(command parsedCommand) (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.searchText(command.text)})
 		return m, nil
 	case commandResume:
+		previousSessionID := m.activeSession.SessionID
 		if m.pending {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{
 				kind: actionAppendError,
@@ -4939,7 +4959,11 @@ func (m model) dispatchCommand(command parsedCommand) (tea.Model, tea.Cmd) {
 		} else if text != "" {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		}
-		return m, nil
+		var resumeCmd tea.Cmd
+		if m.activeSession.SessionID != previousSessionID {
+			m, resumeCmd = m.refreshFileViewMarkers()
+		}
+		return m, resumeCmd
 	case commandRename:
 		if title := strings.TrimSpace(command.text); title != "" {
 			return m.renameActiveSession(title), nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1382,6 +1382,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return next, cmd
 	}
 	switch msg := msg.(type) {
+	case fileViewLoadedMsg:
+		return m.handleFileViewLoaded(msg), nil
 	case uv.CellSizeEvent:
 		if msg.Width > 0 && msg.Height > 0 {
 			m.petCellPixelWidth = msg.Width
@@ -1679,9 +1681,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// (so mid-sentence typing is never hijacked) and no modal is up (so a
 			// permission prompt / ask-user / wizard keeps its own key handling).
 			if keyText(msg) == "f" {
-				return m.setFileViewMode(fileViewFull), nil
+				return m.setFileViewMode(fileViewFull)
 			}
-			return m.setFileViewMode(fileViewDiff), nil
+			return m.setFileViewMode(fileViewDiff)
 		case m.keyMatch(m.keyBindings.toggleMouse, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'e') }) && canFireComposerGatedToggle(m.keyBindings.toggleMouse, defaultToggleMouseChord, m.composerValue() == ""):
 			// Release/recapture the mouse so the user can drag-select and copy text
 			// natively (mouse capture otherwise intercepts terminal selection). The
@@ -2465,6 +2467,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// A resumed/idle session may already hold agents; keep their short lifecycle
 		// fade alive. No-op when the loop is already running or nothing animates.
+		if m.fileView.active && m.fileView.mode == fileViewFull {
+			var cmd tea.Cmd
+			m, cmd = m.startFileViewLoadCmd(m.chatColumnWidth())
+			return m, tea.Batch(m.ensureSpinnerTick(), cmd)
+		}
 		return m, m.ensureSpinnerTick()
 	case permissionRequestMsg:
 		// The agent goroutine that raised this request is BLOCKED waiting on the

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2952,6 +2952,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if isPlanCommandTool(msg.row.tool) {
 				var sweep tea.Cmd
 				m, sweep = m.maybeGitSweep()
+				if m.fileView.active && m.fileView.mode == fileViewFull {
+					var loadCmd tea.Cmd
+					m, loadCmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
+					return m, tea.Batch(sweep, loadCmd)
+				}
 				return m, sweep
 			}
 			if m.fileView.active && m.fileView.mode == fileViewFull {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1678,7 +1678,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if keyIs(msg, tea.KeyEnter) && m.selectedFile != "" {
-				return m.selectFile(m.selectedFile)
+				overlayWidth := minInt(72, maxInt(40, m.width-8))
+				inner := maxInt(12, overlayWidth-4)
+				layout := m.runDetailsLayout(inner)
+				for _, h := range layout.fileHits {
+					if h.path == m.selectedFile {
+						return m.selectFile(m.selectedFile)
+					}
+				}
+				return m, nil
 			}
 			return m, nil
 		case m.keyMatch(m.keyBindings.toggleDetailed, msg, func(tea.KeyMsg) bool { return keyCtrl(msg, 'o') }):
@@ -2952,21 +2960,45 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if isPlanCommandTool(msg.row.tool) {
 				var sweep tea.Cmd
 				m, sweep = m.maybeGitSweep()
-				if m.fileView.active && m.fileView.mode == fileViewFull {
-					var loadCmd tea.Cmd
-					m, loadCmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
-					return m, tea.Batch(sweep, loadCmd)
+				if m.fileView.active {
+					target := m.fileView.path
+					if !filepath.IsAbs(target) {
+						target = filepath.Join(m.cwd, target)
+					}
+					defaultFileViewCache.invalidatePath(target)
+					m.fileView.requiredSourceRev++
+					if m.fileView.mode == fileViewFull {
+						var loadCmd tea.Cmd
+						m, loadCmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
+						return m, tea.Batch(sweep, loadCmd)
+					}
 				}
 				return m, sweep
 			}
-			if m.fileView.active && m.fileView.mode == fileViewFull {
-				for _, p := range msg.row.changedFiles {
-					if p == m.fileView.path {
-						var loadCmd tea.Cmd
-						m, loadCmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
-						return m, loadCmd
+			var loadCmds []tea.Cmd
+			for _, p := range msg.row.changedFiles {
+				target := p
+				if !filepath.IsAbs(target) {
+					target = filepath.Join(m.cwd, target)
+				}
+				rev := defaultFileViewCache.invalidatePath(target)
+				if m.fileView.active && (p == m.fileView.path || target == m.fileView.path) {
+					if rev > m.fileView.requiredSourceRev {
+						m.fileView.requiredSourceRev = rev
+					} else {
+						m.fileView.requiredSourceRev++
+					}
+					if m.fileView.mode == fileViewFull {
+						var cmd tea.Cmd
+						m, cmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
+						if cmd != nil {
+							loadCmds = append(loadCmds, cmd)
+						}
 					}
 				}
+			}
+			if len(loadCmds) > 0 {
+				return m, tea.Batch(loadCmds...)
 			}
 		}
 		return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3009,6 +3009,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case bashResultMsg:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.output})
+		if m.fileView.active && m.fileView.mode == fileViewFull {
+			return m.startFileViewLoadCmd(m.chatColumnWidth())
+		}
 		return m, nil
 	case providerModelsDiscoveredMsg:
 		return m.applyProviderModelsDiscovered(msg), nil

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -154,6 +154,11 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	if next, cmd, handled := m.handlePetMouse(msg); handled {
 		return next, cmd
 	}
+	if mouseLeftPress(msg) && m.runDetailsOpen {
+		if path, ok := m.runDetailsFileAtMouse(msg); ok {
+			return m.selectFile(path)
+		}
+	}
 	if mouseLeftPress(msg) {
 		switch {
 		case m.providerWizard != nil:

--- a/internal/tui/run_details.go
+++ b/internal/tui/run_details.go
@@ -26,11 +26,23 @@ func (m model) runDetailsOverlay(width int) string {
 	overlayWidth := minInt(72, maxInt(40, width-8))
 	overlayWidth = minInt(overlayWidth, width)
 	inner := maxInt(12, overlayWidth-4)
-	lines := m.runDetailsLines(inner)
+	lines := m.runDetailsLayout(inner).lines
 	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, "Run details", lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
 }
 
+type runDetailsLayout struct {
+	lines     []string
+	fileHits  []fileHit
+	fileStart int
+}
+
 func (m model) runDetailsLines(width int) []string {
+	return m.runDetailsLayout(width).lines
+}
+
+func (m model) runDetailsLayout(width int) runDetailsLayout {
+	var out runDetailsLayout
+	out.fileStart = -1
 	lines := make([]string, 0, 16)
 	appendSection := func(header string, rows []string) {
 		if len(rows) == 0 {
@@ -48,8 +60,27 @@ func (m model) runDetailsLines(width int) []string {
 
 	appendSection(m.sidebarAgentHeader(width), m.sidebarAgentLines(width))
 	appendSection(m.sidebarPlanHeader(width), m.sidebarPlanLines(width))
-	fileLines, _ := m.sidebarFileLines(width)
-	appendSection(m.sidebarFilesHeader(width), fileLines)
+	fileLines, hits := m.sidebarFileLines(width)
+	if len(fileLines) > 0 {
+		if len(lines) > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, m.sidebarFilesHeader(width))
+		out.fileStart = len(lines)
+		kept := fileLines
+		if len(kept) > runDetailsMaxItems {
+			kept = append(append([]string(nil), fileLines[:runDetailsMaxItems-1]...), "  "+zeroTheme.faint.Render("… more in transcript"))
+			var filtered []fileHit
+			for _, h := range hits {
+				if h.lineOffset < runDetailsMaxItems-1 {
+					filtered = append(filtered, h)
+				}
+			}
+			hits = filtered
+		}
+		lines = append(lines, kept...)
+		out.fileHits = hits
+	}
 	appendSection(sidebarHeader("ACTIVITY", width), m.sidebarActivityLines(width, runDetailsMaxItems))
 	if tokens := m.sidebarTokenText(); tokens != "" {
 		if len(lines) > 0 {
@@ -58,8 +89,10 @@ func (m model) runDetailsLines(width int) []string {
 		lines = append(lines, zeroTheme.faint.Render(tokens))
 	}
 	if len(lines) == 0 {
-		return []string{zeroTheme.faint.Render("No active run details yet.")}
+		out.lines = []string{zeroTheme.faint.Render("No active run details yet.")}
+		return out
 	}
 	lines = append(lines, "", zeroTheme.faint.Render("Esc or Ctrl+B closes"))
-	return lines
+	out.lines = lines
+	return out
 }

--- a/internal/tui/run_details.go
+++ b/internal/tui/run_details.go
@@ -36,10 +36,6 @@ type runDetailsLayout struct {
 	fileStart int
 }
 
-func (m model) runDetailsLines(width int) []string {
-	return m.runDetailsLayout(width).lines
-}
-
 func (m model) runDetailsLayout(width int) runDetailsLayout {
 	var out runDetailsLayout
 	out.fileStart = -1

--- a/internal/tui/run_details_test.go
+++ b/internal/tui/run_details_test.go
@@ -64,3 +64,31 @@ func TestRunDetailsOverlayHidesBehindPicker(t *testing.T) {
 		t.Fatalf("run details must yield to a picker that owns the keyboard, got:\n%s", got)
 	}
 }
+
+func TestRunDetailsHitsAlignWithSidebar(t *testing.T) {
+	m := filesPanelTestModel()
+	inner := 40
+	fileLines, hits := m.sidebarFileLines(inner)
+	if len(hits) == 0 || len(fileLines) == 0 {
+		t.Fatal("sidebar hits")
+	}
+	layout := m.runDetailsLayout(inner)
+	if layout.fileStart < 0 {
+		t.Fatal("run details dropped FILES block identity")
+	}
+	if len(layout.fileHits) != len(hits) && len(fileLines) <= runDetailsMaxItems {
+		t.Fatalf("hit count %d vs sidebar %d", len(layout.fileHits), len(hits))
+	}
+	for _, h := range layout.fileHits {
+		idx := layout.fileStart + h.lineOffset
+		if idx < 0 || idx >= len(layout.lines) {
+			t.Fatalf("hit %q offset %d outside details", h.path, h.lineOffset)
+		}
+		if h.lineOffset < 0 || h.lineOffset >= len(fileLines) {
+			t.Fatalf("hit %q offset %d outside sidebar lines", h.path, h.lineOffset)
+		}
+		if layout.lines[idx] != fileLines[h.lineOffset] {
+			t.Fatalf("hit map != rendered row for %q", h.path)
+		}
+	}
+}

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -740,27 +740,40 @@ func (m model) runCompact() tea.Cmd {
 // handleRewindCommand restores workspace files to a checkpoint and truncates the
 // session log. "/rewind" or "/rewind latest" undoes the most recent checkpoint;
 // "/rewind <n>" rewinds to a specific event sequence.
-func (m model) handleRewindCommand(args string) (model, string) {
+func (m model) handleRewindCommand(args string) (model, string, tea.Cmd) {
 	if m.sessionStore == nil || m.activeSession.SessionID == "" {
-		return m, "Rewind\nno active session to rewind."
+		return m, "Rewind\nno active session to rewind.", nil
 	}
 	if m.pending {
-		return m, "Rewind\ncannot rewind while a run is in progress."
+		return m, "Rewind\ncannot rewind while a run is in progress.", nil
 	}
 	// A cancelled run's late flush hasn't appended its checkpoint events yet:
 	// ApplyRewind would prune those checkpoint blobs as unreferenced, then the
 	// flush would re-append pre-rewind events after the rewind marker.
 	if len(m.flushRunIDs) > 0 {
-		return m, "Rewind\ncannot rewind while a cancelled run is still flushing — retry in a moment."
+		return m, "Rewind\ncannot rewind while a cancelled run is still flushing — retry in a moment.", nil
 	}
 	arg := strings.TrimSpace(strings.ToLower(args))
 	target, err := m.resolveRewindTarget(arg)
 	if err != nil {
-		return m, "Rewind\n" + err.Error()
+		return m, "Rewind\n" + err.Error(), nil
 	}
+
+	// Workspace files may be touched or restored starting with ApplyRewind:
+	// Invalidate file view cache immediately so any partial or full disk mutation
+	// cannot serve stale pre-rewind snapshots regardless of subsequent step failures.
+	defaultFileViewCache.invalidateUnknownScope()
+	if m.fileView.active {
+		m.fileView.requiredSourceRev++
+	}
+
 	report, err := m.sessionStore.ApplyRewind(m.activeSession.SessionID, m.cwd, target)
 	if err != nil {
-		return m, "Rewind\n" + err.Error()
+		var refreshCmd tea.Cmd
+		if m.fileView.active && m.fileView.mode == fileViewFull {
+			m, refreshCmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
+		}
+		return m, "Rewind\n" + err.Error(), refreshCmd
 	}
 
 	// ApplyRewind truncated the persisted event log, restored files, and appended a
@@ -776,7 +789,11 @@ func (m model) handleRewindCommand(args string) (model, string) {
 	events, readErr := m.sessionStore.ReadEvents(m.activeSession.SessionID)
 	if readErr != nil {
 		m.sessionEvents = nil // drop stale context so it can't reach the next prompt
-		return m, fmt.Sprintf("Rewind\nrewound to sequence %d, but reloading the session failed (in-memory context cleared): %s", target, readErr.Error())
+		var refreshCmd tea.Cmd
+		if m.fileView.active && m.fileView.mode == fileViewFull {
+			m, refreshCmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
+		}
+		return m, fmt.Sprintf("Rewind\nrewound to sequence %d, but reloading the session failed (in-memory context cleared): %s", target, readErr.Error()), refreshCmd
 	}
 	m.sessionEvents = append([]sessions.Event{}, events...)
 	rows := initialTranscript()
@@ -786,21 +803,9 @@ func (m model) handleRewindCommand(args string) (model, string) {
 	// pre-rewind scrollback above it stays, as scrollback cannot be un-printed.
 	m.resetFlushFrontier("· rewound ·")
 
-	// Workspace files have been restored to checkpoint state: invalidate the file view
-	// cache and trigger an authoritative reload if full file view is active.
-	defaultFileViewCache.clear()
-	if m.fileView.active {
-		m.fileView.requiredSourceRev++
-		if m.fileView.mode == fileViewFull {
-			var cmd tea.Cmd
-			m, cmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
-			if cmd != nil {
-				msg := cmd()
-				if loadedMsg, ok := msg.(fileViewLoadedMsg); ok {
-					m, _ = m.handleFileViewLoaded(loadedMsg)
-				}
-			}
-		}
+	var refreshCmd tea.Cmd
+	if m.fileView.active && m.fileView.mode == fileViewFull {
+		m, refreshCmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
 	}
 
 	summary := fmt.Sprintf("Rewound to sequence %d\n%d file(s) restored, %d deleted, %d skipped.",
@@ -808,7 +813,7 @@ func (m model) handleRewindCommand(args string) (model, string) {
 	if len(report.Skipped) > 0 {
 		summary += "\nskipped (not recoverable): " + strings.Join(report.Skipped, ", ")
 	}
-	return m, summary
+	return m, summary, refreshCmd
 }
 
 // resolveRewindTarget maps a /rewind argument to a keep-through event sequence.

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -786,6 +786,23 @@ func (m model) handleRewindCommand(args string) (model, string) {
 	// pre-rewind scrollback above it stays, as scrollback cannot be un-printed.
 	m.resetFlushFrontier("· rewound ·")
 
+	// Workspace files have been restored to checkpoint state: invalidate the file view
+	// cache and trigger an authoritative reload if full file view is active.
+	defaultFileViewCache.clear()
+	if m.fileView.active {
+		m.fileView.requiredSourceRev++
+		if m.fileView.mode == fileViewFull {
+			var cmd tea.Cmd
+			m, cmd = m.startFileViewRefreshCmd(m.chatColumnWidth())
+			if cmd != nil {
+				msg := cmd()
+				if loadedMsg, ok := msg.(fileViewLoadedMsg); ok {
+					m, _ = m.handleFileViewLoaded(loadedMsg)
+				}
+			}
+		}
+	}
+
 	summary := fmt.Sprintf("Rewound to sequence %d\n%d file(s) restored, %d deleted, %d skipped.",
 		target, report.FilesRestored, report.FilesDeleted, len(report.Skipped))
 	if len(report.Skipped) > 0 {

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -785,7 +785,7 @@ func TestRewindRefreshesInMemorySessionState(t *testing.T) {
 	}
 	eventsBefore := len(m.sessionEvents)
 
-	m, out := m.handleRewindCommand("latest")
+	m, out, _ := m.handleRewindCommand("latest")
 	if !strings.Contains(out, "Rewound") {
 		t.Fatalf("expected a rewind summary, got %q", out)
 	}

--- a/internal/tui/syntax_highlight.go
+++ b/internal/tui/syntax_highlight.go
@@ -207,7 +207,11 @@ func highlightCodeForPath(code []string, path string, measure int, bg color.Colo
 }
 
 func highlightCodeForPathWithTheme(code []string, path string, measure int, bg color.Color, theme tuiTheme) ([]string, bool) {
-	return highlightCodeWithLexerThemeAndLineBackgrounds(cachedLexerForPath(path), code, measure, theme, nil, nil)
+	backgrounds := make([]color.Color, len(code))
+	for index := range backgrounds {
+		backgrounds[index] = bg
+	}
+	return highlightCodeWithLexerThemeAndLineBackgrounds(cachedLexerForPath(path), code, measure, theme, backgrounds, nil)
 }
 
 // highlightShellCommand styles a one-line command for a tool-card heading.

--- a/internal/tui/syntax_highlight.go
+++ b/internal/tui/syntax_highlight.go
@@ -203,7 +203,11 @@ func highlightCodeAuto(code []string, lang string, measure int) ([]string, bool)
 }
 
 func highlightCodeForPath(code []string, path string, measure int, bg color.Color) ([]string, bool) {
-	return highlightCodeWithLexer(cachedLexerForPath(path), code, measure, bg)
+	return highlightCodeForPathWithTheme(code, path, measure, bg, zeroTheme)
+}
+
+func highlightCodeForPathWithTheme(code []string, path string, measure int, bg color.Color, theme tuiTheme) ([]string, bool) {
+	return highlightCodeWithLexerThemeAndLineBackgrounds(cachedLexerForPath(path), code, measure, theme, nil, nil)
 }
 
 // highlightShellCommand styles a one-line command for a tool-card heading.
@@ -394,6 +398,10 @@ func highlightCodeWithLexerAndSpans(lexer chroma.Lexer, code []string, measure i
 }
 
 func highlightCodeWithLexerAndLineBackgrounds(lexer chroma.Lexer, code []string, measure int, backgrounds []color.Color, spans []highlightSpan) ([]string, bool) {
+	return highlightCodeWithLexerThemeAndLineBackgrounds(lexer, code, measure, zeroTheme, backgrounds, spans)
+}
+
+func highlightCodeWithLexerThemeAndLineBackgrounds(lexer chroma.Lexer, code []string, measure int, theme tuiTheme, backgrounds []color.Color, spans []highlightSpan) ([]string, bool) {
 	if measure < 4 {
 		return nil, false
 	}
@@ -476,7 +484,7 @@ func highlightCodeWithLexerAndLineBackgrounds(lexer chroma.Lexer, code []string,
 
 	line, column := 0, 0
 	for _, token := range iterator.Tokens() {
-		style := tokenStyle(token.Type)
+		style := tokenStyleForTheme(theme, token.Type)
 		for index, part := range strings.Split(token.Value, "\n") {
 			if index > 0 {
 				flushLine()

--- a/internal/tui/theme_select.go
+++ b/internal/tui/theme_select.go
@@ -92,6 +92,9 @@ func applyTheme(mode themeMode, terminalDark bool) themeMode {
 	if defaultRenderCache != nil {
 		defaultRenderCache.clear() // old-palette entries must not be reused
 	}
+	if defaultFileViewCache != nil {
+		defaultFileViewCache.clear()
+	}
 	return resolved
 }
 


### PR DESCRIPTION
## Summary
Fixes #833

`internal/tui/file_view.go` previously read files from disk synchronously and performed Chroma syntax highlighting directly inside the `View()` render loop on every frame, causing UI stutter and unbounded allocations on large files.

### Key Changes
- Decoupled disk I/O and syntax highlighting into an asynchronous cache keyed by filepath, file size, modtime, and theme.
- Enforced hard memory limits: 4,000 maximum rendered lines, 1 MiB total byte cap, and 4 KiB max line length.
- Invalidates the cache cleanly upon theme switches (`applyTheme`).
- Added unit and concurrency tests (`internal/tui/file_view_test.go`) validating 0 additional I/O on repeated `View()` calls and clean truncation under `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File views now load asynchronously, keeping the interface responsive.
  - Added loading and error states for file content.
  - File content refreshes automatically after resizing, theme changes, edits, and related updates.
  - Improved caching and validation help ensure current content is displayed.

- **Bug Fixes**
  - Corrected syntax highlighting backgrounds for themed file views.
  - Prevented stale cached content from being reused after theme changes.
  - Improved handling of late file-load results, rapid updates, and reopened views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->