### PR TITLE
fix(daemon): wait on tracked workers in TestPoolDrainKillsStraggler (#919)

### DIFF
--- a/internal/daemon/pool_test.go
+++ b/internal/daemon/pool_test.go
@@ -224,7 +224,9 @@ func TestPoolDrainKillsStraggler(t *testing.T) {
 		_, _ = pool.Run(context.Background(), WorkerSpec{Session: "a"}, &collectSink{})
 		close(runDone)
 	}()
-	waitFor(t, func() bool { return pool.QueueDepth() == 1 })
+	// Drain reads p.active (exposed as WorkerStats), not QueueDepth/slot occupancy.
+	// QueueDepth can become 1 before track(), so Drain would take the n==0 early return.
+	waitFor(t, func() bool { return len(pool.WorkerStats()) == 1 })
 
 	pool.Drain() // KillTimeout elapses, straggler is force-killed
 	if atomic.LoadInt32(&straggler.killed) != 1 {


### PR DESCRIPTION
## Summary

Fixes #919.

`TestPoolDrainKillsStraggler` was racing on loaded CI because it waited on `pool.QueueDepth() == 1` (slot occupancy) before calling `Drain()`. `QueueDepth()` becomes 1 as soon as `Run` leases a slot; the worker is only added to `p.active` later, after `Launcher` returns (`runOnce` → `track`). `Drain()` reads `len(p.active)` and takes the `n == 0` early return if it runs in that window, so `straggler.killed` stays 0.

This is a test synchronization defect, not a production `Drain` bug.

## Change

In `internal/daemon/pool_test.go`, wait on the state `Drain` actually reads:

```go
waitFor(t, func() bool { return len(pool.WorkerStats()) == 1 })
```

`WorkerStats()` is built from `p.active`.

I grepped neighbouring pool tests for the same `QueueDepth()` wait-before-`Drain` pattern. The only other `QueueDepth()` wait is in `TestPoolQueuesWhenFull`, which is asserting slot occupancy / queueing, not drain tracking — left unchanged.

Test-only; no production code change.

## Notes

Opened by **cairn-intern**. Parent issue has `issue-approved` + `bug`.

I did not run `go test` for this change (no local checkout). Worth `go test ./internal/daemon/ -run TestPoolDrainKillsStraggler` on CI.

There is an overlapping in-flight PR (#927) that also cites #919 but takes a larger production Drain/launch-race approach. This PR is the small test-only sync the issue describes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test synchronization for worker shutdown scenarios.
  * Added clarification to ensure straggler workers are properly detected and terminated during drain operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->