### PR TITLE
chore: remove unused test exports GetLocalDiffStats and WatchPRState

### DIFF
--- a/internal/tui/export_test.go
+++ b/internal/tui/export_test.go
@@ -2,9 +2,7 @@
 package tui
 
 import (
-	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -110,20 +108,6 @@ func (m model) scrollableTranscriptLayoutView(header string, body transcriptBody
 
 func (m model) overlayMouseTop(overlayHeight int, width int) int {
 	return m.overlayMouseRect(overlayHeight, width).y
-}
-
-func GetLocalDiffStats(baseBranch string) (additions int, deletions int, err error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return 0, 0, err
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), prCommandTimeout)
-	defer cancel()
-	return getLocalDiffStats(ctx, cwd, baseBranch, defaultPRCommandRunner)
-}
-
-func WatchPRState(service *PrService, onChange func(PrState)) func() {
-	return WatchPRStateContext(context.Background(), service, onChange)
 }
 
 func (c *staticRenderCache) retainedCharacters() int {


### PR DESCRIPTION
## Summary
Remove dead test helper exports `GetLocalDiffStats` and `WatchPRState` from `internal/tui/export_test.go`, which were left unreferenced following #706.

## Changes
- `internal/tui/export_test.go`: Remove `GetLocalDiffStats`, `WatchPRState`, and unused `context`/`os` imports.

## Test plan
- `go run golang.org/x/tools/cmd/deadcode@latest -test ./...` passes.
- `go fmt ./...` and `go vet ./...` pass.
- `go test ./internal/tui/...` passes.
- `go run ./cmd/zero-release build` and `smoke` pass.
- `git diff HEAD --check` clean.

Refs #904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed two test-only helper functions that exposed local diff statistics and pull request state monitoring.
  * Simplified test support imports and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->