### PR TITLE
feat(sessions): automatic retention policy and cleanup

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1348,7 +1348,7 @@ Commands:
   repo-map   Build a deterministic repository map for agent context
   search     Search persisted local Zero session events
   find       Alias for search
-  sessions   Inspect local Zero session lineage
+  sessions   Inspect local Zero session lineage and prune old session directories
   spec       Review and approve saved spec-mode drafts
   specialist Manage local Zero specialist profiles
   plugins    Inspect, install, and remove local Zero plugins

--- a/internal/cli/completions.go
+++ b/internal/cli/completions.go
@@ -52,7 +52,7 @@ var completionRoot = completionNode{
 		{names: []string{"context"}},
 		{names: []string{"repo-map", "repomap"}},
 		{names: []string{"search", "find"}},
-		{names: []string{"sessions", "session"}, children: leafNodes("list", "children", "lineage", "tree", "rewind-plan", "rewind", "compact-plan")},
+		{names: []string{"sessions", "session"}, children: leafNodes("list", "children", "lineage", "tree", "rewind-plan", "rewind", "compact-plan", "prune", "clean")},
 		{names: []string{"spec"}, children: leafNodes("show", "approve", "reject")},
 		{names: []string{"init"}},
 		{names: []string{"specialists", "specialist"}, children: []completionNode{

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/zerocommands"
@@ -18,6 +21,11 @@ type sessionCommandOptions struct {
 	excludeTarget  bool
 	preserveLast   int
 	maxPromptChars int
+	dryRun         bool
+	olderThan      time.Duration
+	olderThanSet   bool
+	maxCount       int
+	maxCountSet    bool
 }
 
 func runSessions(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -72,6 +80,11 @@ func runSessions(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 			return writeExecUsageError(stderr, "sessions compact-plan requires a session id")
 		}
 		return runSessionsCompactPlan(store, remaining[0], options, stdout, stderr)
+	case "prune", "clean":
+		if len(remaining) != 0 {
+			return writeExecUsageError(stderr, "sessions prune does not accept positional arguments")
+		}
+		return runSessionsPrune(store, options, stdout, stderr, deps)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown sessions command %q", command))
 	}
@@ -89,6 +102,8 @@ func parseSessionsArgs(args []string) (string, []string, sessionCommandOptions, 
 			return command, remaining, options, true, nil
 		case "--json":
 			options.json = true
+		case "--dry-run":
+			options.dryRun = true
 		case "--exclude-target":
 			options.excludeTarget = true
 		case "--kind":
@@ -187,6 +202,48 @@ func parseSessionsArgs(args []string) (string, []string, sessionCommandOptions, 
 				}
 				options.maxPromptChars = maxPromptChars
 				continue
+			case arg == "--older-than":
+				value, next, err := nextFlagValue(args, index, arg)
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				olderThan, err := parseOlderThanDuration(value)
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				options.olderThan = olderThan
+				options.olderThanSet = true
+				index = next
+				continue
+			case strings.HasPrefix(arg, "--older-than="):
+				olderThan, err := parseOlderThanDuration(strings.TrimPrefix(arg, "--older-than="))
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				options.olderThan = olderThan
+				options.olderThanSet = true
+				continue
+			case arg == "--max-count":
+				value, next, err := nextFlagValue(args, index, arg)
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				maxCount, err := parsePositiveIntFlag(arg, value)
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				options.maxCount = maxCount
+				options.maxCountSet = true
+				index = next
+				continue
+			case strings.HasPrefix(arg, "--max-count="):
+				maxCount, err := parsePositiveIntFlag("--max-count", strings.TrimSpace(strings.TrimPrefix(arg, "--max-count=")))
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				options.maxCount = maxCount
+				options.maxCountSet = true
+				continue
 			}
 			if strings.HasPrefix(arg, "-") {
 				return command, remaining, options, false, execUsageError{fmt.Sprintf("unknown sessions flag %q", arg)}
@@ -225,7 +282,7 @@ func parseSessionKindFlag(value string) (sessions.SessionKind, error) {
 
 func isSessionsCommand(command string) bool {
 	switch command {
-	case "list", "children", "lineage", "tree", "rewind-plan", "rewind", "compact-plan":
+	case "list", "children", "lineage", "tree", "rewind-plan", "rewind", "compact-plan", "prune", "clean":
 		return true
 	default:
 		return false
@@ -243,6 +300,10 @@ func validateSessionCommandFlags(command string, options sessionCommandOptions) 
 	hasCompactionFlag := options.preserveLast > 0 || options.maxPromptChars > 0
 	if hasCompactionFlag && command != "compact-plan" {
 		return execUsageError{"--preserve-last and --max-prompt-chars are only valid for sessions compact-plan"}
+	}
+	hasPruneFlag := options.dryRun || options.olderThanSet || options.maxCountSet
+	if hasPruneFlag && command != "prune" && command != "clean" {
+		return execUsageError{"--dry-run, --older-than, and --max-count are only valid for sessions prune"}
 	}
 	return nil
 }
@@ -532,6 +593,7 @@ Commands:
   rewind-plan <id>      Preview events kept and dropped by a rewind
   rewind <id>           Restore workspace files and truncate the log to a checkpoint
   compact-plan <id>     Preview events compacted and preserved by compaction
+  prune                 Apply the configured session retention policy (alias: clean)
 
 Flags:
       --json            Print JSON output
@@ -541,7 +603,118 @@ Flags:
       --exclude-target  Drop the target event (rewind-plan, rewind)
       --preserve-last <n> Keep recent events in compact-plan
       --max-prompt-chars <n> Limit compact-plan summary prompt
+      --dry-run         Print sessions prune would delete without removing them
+      --older-than <dur> Age cutoff for prune (e.g. 7d, 24h); overrides sessions.retentionDays
+      --max-count <n>   Keep at most n sessions during prune; overrides sessions.maxCount
   -h, --help            Show this help
 `)
 	return err
+}
+
+func parseOlderThanDuration(value string) (time.Duration, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, execUsageError{"--older-than requires a value"}
+	}
+	if strings.HasSuffix(trimmed, "d") {
+		days, err := strconv.Atoi(strings.TrimSpace(strings.TrimSuffix(trimmed, "d")))
+		if err != nil || days <= 0 {
+			return 0, execUsageError{fmt.Sprintf("invalid --older-than %q", value)}
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(trimmed)
+	if err != nil || d <= 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid --older-than %q; expected a duration like 7d or 24h", value)}
+	}
+	return d, nil
+}
+
+func runSessionsPrune(store *sessions.Store, options sessionCommandOptions, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	policy, err := sessionsPrunePolicy(options, deps)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if !policy.Enabled() {
+		msg := "Session pruning is off: sessions.retentionDays and sessions.maxCount are unset or 0, so existing sessions are kept.\nSet a policy in config.json or pass --older-than / --max-count."
+		if options.json {
+			if err := writePrettyJSON(stdout, map[string]any{"deleted": []any{}, "skipped": []any{}, "dryRun": options.dryRun, "enabled": false, "message": msg}); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		if _, err := fmt.Fprintln(stdout, msg); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	result, err := store.Prune(policy)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(result, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, formatPruneResult(result)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func sessionsPrunePolicy(options sessionCommandOptions, deps appDeps) (sessions.PrunePolicy, error) {
+	cfg, err := loadSessionsConfig(deps)
+	if err != nil {
+		return sessions.PrunePolicy{}, err
+	}
+	policy := sessions.PrunePolicy{
+		RetentionDays: cfg.RetentionDays,
+		MaxCount:      cfg.MaxCount,
+		DryRun:        options.dryRun,
+	}
+	if options.olderThanSet {
+		policy.OlderThan = options.olderThan
+		policy.RetentionDays = 0
+	}
+	if options.maxCountSet {
+		policy.MaxCount = options.maxCount
+	}
+	return policy, nil
+}
+
+func loadSessionsConfig(deps appDeps) (config.SessionsConfig, error) {
+	if deps.resolveConfig == nil {
+		return config.SessionsConfig{}, nil
+	}
+	workspace := ""
+	if deps.getwd != nil {
+		if cwd, err := deps.getwd(); err == nil {
+			workspace = cwd
+		}
+	}
+	resolved, err := deps.resolveConfig(workspace, config.Overrides{})
+	if err != nil {
+		return config.SessionsConfig{}, err
+	}
+	return resolved.Sessions, nil
+}
+
+func formatPruneResult(result sessions.PruneResult) string {
+	if len(result.Deleted) == 0 && len(result.Skipped) == 0 {
+		return "No sessions to prune."
+	}
+	lines := []string{sessions.FormatPruneSummary(result)}
+	for _, item := range result.Deleted {
+		label := "deleted"
+		if result.DryRun {
+			label = "would delete"
+		}
+		lines = append(lines, fmt.Sprintf("  - %s %s (%s, updated %s)", label, redact(item.SessionID), item.Reason, item.UpdatedAt))
+	}
+	for _, item := range result.Skipped {
+		lines = append(lines, fmt.Sprintf("  - kept %s (%s)", redact(item.SessionID), item.Reason))
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/sessions"
 )
 
@@ -284,5 +285,103 @@ func sequenceClockCLI(values []time.Time) func() time.Time {
 		value := values[index]
 		index++
 		return value
+	}
+}
+
+func TestRunSessionsPruneDryRunDeletesNothing(t *testing.T) {
+	now := time.Date(2026, 8, 27, 18, 0, 0, 0, time.UTC)
+	old := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	clock := old
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return clock }})
+	if _, err := store.Create(sessions.CreateInput{SessionID: "stale", Title: "old"}); err != nil {
+		t.Fatal(err)
+	}
+	clock = now
+	if _, err := store.Create(sessions.CreateInput{SessionID: "fresh", Title: "current"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sessions", "prune", "--older-than", "7d", "--dry-run"}, &stdout, &stderr, appDeps{
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, nil
+		},
+		newSessionStore: func() *sessions.Store { return store },
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("sessions prune --dry-run exit = %d, stderr = %q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stale") {
+		t.Fatalf("dry-run output = %q, want stale listed", stdout.String())
+	}
+	if _, err := store.Get("stale"); err != nil {
+		t.Fatalf("dry-run must not delete stale: %v", err)
+	}
+	got, err := store.Get("stale")
+	if err != nil || got == nil {
+		t.Fatalf("dry-run deleted stale session: err=%v got=%v", err, got)
+	}
+}
+
+func TestRunSessionsPruneAppliesOlderThan(t *testing.T) {
+	now := time.Date(2026, 8, 27, 18, 0, 0, 0, time.UTC)
+	old := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	clock := old
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return clock }})
+	if _, err := store.Create(sessions.CreateInput{SessionID: "stale", Title: "old"}); err != nil {
+		t.Fatal(err)
+	}
+	clock = now
+	if _, err := store.Create(sessions.CreateInput{SessionID: "fresh", Title: "current"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sessions", "prune", "--older-than", "7d"}, &stdout, &stderr, appDeps{
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, nil
+		},
+		newSessionStore: func() *sessions.Store { return store },
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("sessions prune exit = %d, stderr = %q", exitCode, stderr.String())
+	}
+	got, err := store.Get("stale")
+	if err != nil {
+		t.Fatalf("Get stale: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("stale session still present: %#v", got)
+	}
+	fresh, err := store.Get("fresh")
+	if err != nil || fresh == nil {
+		t.Fatalf("fresh session missing: err=%v", err)
+	}
+}
+
+func TestRunSessionsPruneOffWithoutPolicy(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLITime("2026-06-04T19:30:00Z")})
+	if _, err := store.Create(sessions.CreateInput{SessionID: "keep", Title: "keep"}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sessions", "prune"}, &stdout, &stderr, appDeps{
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, nil
+		},
+		newSessionStore: func() *sessions.Store { return store },
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("sessions prune exit = %d, stderr = %q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Session pruning is off") {
+		t.Fatalf("output = %q, want off message", stdout.String())
+	}
+	got, err := store.Get("keep")
+	if err != nil || got == nil {
+		t.Fatalf("unset policy deleted session")
 	}
 }

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -119,6 +119,9 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 	if cfg.Swarm.MaxTeamSize < 0 {
 		return ResolvedConfig{}, fmt.Errorf("invalid swarm.maxTeamSize %d: must be >= 0 (0 uses the default)", cfg.Swarm.MaxTeamSize)
 	}
+	if err := validateSessionsConfig(cfg.Sessions); err != nil {
+		return ResolvedConfig{}, err
+	}
 
 	if network := strings.TrimSpace(cfg.Sandbox.Network); network != "" {
 		switch sandbox.NetworkMode(network) {
@@ -176,6 +179,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		LocalControl:        cfg.LocalControl,
 		STT:                 cfg.STT,
 		CrossSessionInbound: cfg.CrossSessionInbound,
+		Sessions:            cfg.Sessions,
 	}, nil
 }
 
@@ -286,6 +290,12 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	if inbound := strings.TrimSpace(src.CrossSessionInbound); inbound != "" {
 		dst.CrossSessionInbound = inbound
 	}
+	if src.Sessions.RetentionDays != 0 {
+		dst.Sessions.RetentionDays = src.Sessions.RetentionDays
+	}
+	if src.Sessions.MaxCount != 0 {
+		dst.Sessions.MaxCount = src.Sessions.MaxCount
+	}
 }
 
 func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
@@ -351,6 +361,10 @@ func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
 	// Local control is intentionally user-config/override only. A cloned project
 	// must not be able to make browser, desktop, or terminal automation tools
 	// appear in the model's tool surface.
+	//
+	// Sessions retention is user-config/override only. The session store lives
+	// in the user data directory; a cloned project's .zero/config.json must
+	// not prune the user's sessions.
 	return nil
 }
 
@@ -751,6 +765,12 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 	mergeSTTConfig(&cfg.STT, overrides.STT)
 	if inbound := strings.TrimSpace(overrides.CrossSessionInbound); inbound != "" {
 		cfg.CrossSessionInbound = inbound
+	}
+	if overrides.Sessions.RetentionDays != 0 {
+		cfg.Sessions.RetentionDays = overrides.Sessions.RetentionDays
+	}
+	if overrides.Sessions.MaxCount != 0 {
+		cfg.Sessions.MaxCount = overrides.Sessions.MaxCount
 	}
 	for _, provider := range overrides.Providers {
 		mergeProvider(cfg, provider)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -349,6 +349,46 @@ func (cfg *ToolsConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// SessionsConfig is the on-disk session retention policy in config.json.
+// Unset or 0 values disable pruning so existing users are not surprised:
+// Zero never deletes session directories unless a positive retentionDays
+// and/or maxCount is configured (or a CLI flag overrides).
+type SessionsConfig struct {
+	// RetentionDays deletes unprotected session directories whose UpdatedAt
+	// is older than this many days. 0 / omitted means off.
+	RetentionDays int `json:"retentionDays,omitempty"`
+	// MaxCount keeps at most this many sessions (newest UpdatedAt first) and
+	// prunes the rest. Protected (locked, active, named) sessions are never
+	// deleted, so the on-disk count may exceed MaxCount. 0 / omitted means off.
+	MaxCount int `json:"maxCount,omitempty"`
+}
+
+func (cfg SessionsConfig) Enabled() bool {
+	return cfg.RetentionDays > 0 || cfg.MaxCount > 0
+}
+
+func (cfg *SessionsConfig) UnmarshalJSON(data []byte) error {
+	type rawSessions struct {
+		RetentionDays      int `json:"retentionDays"`
+		RetentionDaysSnake int `json:"retention_days"`
+		MaxCount           int `json:"maxCount"`
+		MaxCountSnake      int `json:"max_count"`
+	}
+	var raw rawSessions
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	cfg.RetentionDays = raw.RetentionDays
+	if raw.RetentionDaysSnake != 0 && cfg.RetentionDays == 0 {
+		cfg.RetentionDays = raw.RetentionDaysSnake
+	}
+	cfg.MaxCount = raw.MaxCount
+	if raw.MaxCountSnake != 0 && cfg.MaxCount == 0 {
+		cfg.MaxCount = raw.MaxCountSnake
+	}
+	return nil
+}
+
 type FileConfig struct {
 	ActiveProvider      string             `json:"activeProvider,omitempty"`
 	Providers           []ProviderProfile  `json:"providers,omitempty"`
@@ -363,6 +403,7 @@ type FileConfig struct {
 	LocalControl        LocalControlConfig `json:"localControl,omitempty"`
 	STT                 STTConfig          `json:"stt,omitempty"`
 	CrossSessionInbound string             `json:"crossSessionInbound,omitempty"`
+	Sessions            SessionsConfig     `json:"sessions,omitempty"`
 }
 
 func (cfg FileConfig) MarshalJSON() ([]byte, error) {
@@ -380,6 +421,7 @@ func (cfg FileConfig) MarshalJSON() ([]byte, error) {
 		LocalControl        *LocalControlConfig `json:"localControl,omitempty"`
 		STT                 *STTConfig          `json:"stt,omitempty"`
 		CrossSessionInbound string              `json:"crossSessionInbound,omitempty"`
+		Sessions            SessionsConfig      `json:"sessions,omitempty"`
 	}
 	raw := rawConfig{
 		ActiveProvider:      cfg.ActiveProvider,
@@ -393,6 +435,7 @@ func (cfg FileConfig) MarshalJSON() ([]byte, error) {
 		Preferences:         cfg.Preferences,
 		KeyBindings:         cfg.KeyBindings,
 		CrossSessionInbound: cfg.CrossSessionInbound,
+		Sessions:            cfg.Sessions,
 	}
 	if !cfg.LocalControl.Empty() {
 		raw.LocalControl = &cfg.LocalControl
@@ -429,6 +472,7 @@ type Overrides struct {
 	LocalControl        LocalControlConfig
 	STT                 STTConfig
 	CrossSessionInbound string
+	Sessions            SessionsConfig
 }
 
 type ResolvedConfig struct {
@@ -446,6 +490,7 @@ type ResolvedConfig struct {
 	LocalControl        LocalControlConfig
 	STT                 STTConfig
 	CrossSessionInbound string
+	Sessions            SessionsConfig
 }
 
 type MCPConfig struct {
@@ -508,6 +553,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		LocalControl        LocalControlConfig         `json:"localControl"`
 		STT                 STTConfig                  `json:"stt"`
 		CrossSessionInbound string                     `json:"crossSessionInbound"`
+		Sessions            SessionsConfig             `json:"sessions"`
 		MCPServers          map[string]MCPServerConfig `json:"mcpServers"`
 		MCPServersSnake     map[string]MCPServerConfig `json:"mcp_servers"`
 	}
@@ -537,6 +583,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	cfg.LocalControl = raw.LocalControl
 	cfg.STT = raw.STT
 	cfg.CrossSessionInbound = raw.CrossSessionInbound
+	cfg.Sessions = raw.Sessions
 	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
 		cfg.MCP.Servers = map[string]MCPServerConfig{}
 	}

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -43,3 +43,43 @@ func TestToolsConfigPresentOnOverridesAndResolved(t *testing.T) {
 		t.Fatalf("ResolvedConfig.Tools.DeferThreshold = %d, want 4", resolved.Tools.DeferThreshold)
 	}
 }
+
+func TestSessionsConfigJSONRoundTrip(t *testing.T) {
+	var cfg FileConfig
+	if err := json.Unmarshal([]byte(`{"sessions":{"retentionDays":30,"maxCount":100}}`), &cfg); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if cfg.Sessions.RetentionDays != 30 || cfg.Sessions.MaxCount != 100 {
+		t.Fatalf("Sessions = %#v, want retentionDays=30 maxCount=100", cfg.Sessions)
+	}
+
+	var snake FileConfig
+	if err := json.Unmarshal([]byte(`{"sessions":{"retention_days":14,"max_count":20}}`), &snake); err != nil {
+		t.Fatalf("Unmarshal(snake) error = %v", err)
+	}
+	if snake.Sessions.RetentionDays != 14 || snake.Sessions.MaxCount != 20 {
+		t.Fatalf("Sessions snake = %#v, want 14/20", snake.Sessions)
+	}
+
+	emptyEncoded, err := json.Marshal(SessionsConfig{})
+	if err != nil {
+		t.Fatalf("Marshal(empty) error = %v", err)
+	}
+	if string(emptyEncoded) != `{}` {
+		t.Fatalf("Marshal(empty) = %s, want {}", emptyEncoded)
+	}
+	if (SessionsConfig{}).Enabled() {
+		t.Fatalf("zero SessionsConfig must be disabled so existing users are not pruned")
+	}
+}
+
+func TestSessionsConfigPresentOnOverridesAndResolved(t *testing.T) {
+	overrides := Overrides{Sessions: SessionsConfig{RetentionDays: 7}}
+	resolved := ResolvedConfig{Sessions: SessionsConfig{MaxCount: 12}}
+	if overrides.Sessions.RetentionDays != 7 {
+		t.Fatalf("Overrides.Sessions.RetentionDays = %d, want 7", overrides.Sessions.RetentionDays)
+	}
+	if resolved.Sessions.MaxCount != 12 {
+		t.Fatalf("ResolvedConfig.Sessions.MaxCount = %d, want 12", resolved.Sessions.MaxCount)
+	}
+}

--- a/internal/config/unknownfields.go
+++ b/internal/config/unknownfields.go
@@ -89,6 +89,9 @@ var legacyJSONAliases = map[string][]string{
 		"api_key_stored", "api_format", "auth_header", "auth_scheme",
 		"auth_header_value", "custom_headers", "model_id", "parse_think_tags",
 	},
+	"config.SessionsConfig": {
+		"retention_days", "max_count",
+	},
 }
 
 // knownJSONFields returns the JSON field names of a struct (and their Go

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -36,5 +36,18 @@ func validateSemantics(cfg FileConfig) []Issue {
 	if err := validateSTTConfig(cfg.STT); err != nil {
 		return []Issue{{FieldPath: "stt", Message: err.Error()}}
 	}
+	if err := validateSessionsConfig(cfg.Sessions); err != nil {
+		return []Issue{{FieldPath: "sessions", Message: err.Error()}}
+	}
+	return nil
+}
+
+func validateSessionsConfig(cfg SessionsConfig) error {
+	if cfg.RetentionDays < 0 {
+		return fmt.Errorf("invalid sessions.retentionDays %d: must be >= 0 (0 disables age-based pruning)", cfg.RetentionDays)
+	}
+	if cfg.MaxCount < 0 {
+		return fmt.Errorf("invalid sessions.maxCount %d: must be >= 0 (0 disables count-based pruning)", cfg.MaxCount)
+	}
 	return nil
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -259,3 +259,24 @@ func TestValidateFileAllowsLegacyProviderKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateFileRejectsNegativeSessionRetention(t *testing.T) {
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "model": "gpt-4.1"}
+		],
+		"sessions": {"retentionDays": -1}
+	}`)
+	_, issues := ValidateFile(path)
+	found := false
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, "sessions.retentionDays") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected sessions.retentionDays issue, got %#v", issues)
+	}
+}

--- a/internal/sessions/filelock_unix.go
+++ b/internal/sessions/filelock_unix.go
@@ -29,3 +29,29 @@ func (store *Store) acquireFileLock(sessionID string) (func(), error) {
 		_ = file.Close()
 	}, nil
 }
+
+// tryAcquireFileLock attempts a non-blocking exclusive flock. ok is false when
+// another process already holds session.lock.
+func (store *Store) tryAcquireFileLock(sessionID string) (func(), bool, error) {
+	path := store.lockPath(sessionID)
+	file, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No session.lock means nobody holds it. Do not create one: prune
+			// --dry-run must not write, and a missing lock is not a holder.
+			return func() {}, true, nil
+		}
+		return nil, false, fmt.Errorf("open zero session lock: %w", err)
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = file.Close()
+		if err == unix.EAGAIN || err == unix.EWOULDBLOCK {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("lock zero session: %w", err)
+	}
+	return func() {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+	}, true, nil
+}

--- a/internal/sessions/filelock_windows.go
+++ b/internal/sessions/filelock_windows.go
@@ -33,3 +33,27 @@ func (store *Store) acquireFileLock(sessionID string) (func(), error) {
 		_ = file.Close()
 	}, nil
 }
+
+// tryAcquireFileLock attempts a non-blocking exclusive LockFileEx. ok is false
+// when another process already holds session.lock.
+func (store *Store) tryAcquireFileLock(sessionID string) (func(), bool, error) {
+	path := store.lockPath(sessionID)
+	file, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return func() {}, true, nil
+		}
+		return nil, false, fmt.Errorf("open zero session lock: %w", err)
+	}
+	handle := windows.Handle(file.Fd())
+	overlapped := new(windows.Overlapped)
+	flags := windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, overlapped); err != nil {
+		_ = file.Close()
+		return nil, false, nil
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, overlapped)
+		_ = file.Close()
+	}, true, nil
+}

--- a/internal/sessions/prune.go
+++ b/internal/sessions/prune.go
@@ -1,0 +1,232 @@
+package sessions
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PrunePolicy is the on-disk session retention policy. Unset or 0 values
+// disable the corresponding limit so existing users are not surprised: Zero
+// never deletes session directories unless a positive RetentionDays,
+// MaxCount, or OlderThan is set.
+type PrunePolicy struct {
+	// RetentionDays deletes unprotected sessions whose UpdatedAt is older than
+	// this many days. 0 means off.
+	RetentionDays int
+	// MaxCount keeps at most this many sessions (newest UpdatedAt first),
+	// never deleting protected ones. 0 means off.
+	MaxCount int
+	// OlderThan, when > 0, is an explicit age cutoff that replaces
+	// RetentionDays (used by `zero sessions prune --older-than`).
+	OlderThan time.Duration
+	// DryRun reports what would be deleted without removing anything.
+	DryRun bool
+}
+
+// Enabled reports whether the policy would prune anything. 0 / unset is off.
+func (p PrunePolicy) Enabled() bool {
+	return p.RetentionDays > 0 || p.MaxCount > 0 || p.OlderThan > 0
+}
+
+func (p PrunePolicy) cutoff(now time.Time) (time.Time, bool) {
+	if p.OlderThan > 0 {
+		return now.Add(-p.OlderThan), true
+	}
+	if p.RetentionDays > 0 {
+		return now.AddDate(0, 0, -p.RetentionDays), true
+	}
+	return time.Time{}, false
+}
+
+// PruneItem is one session directory considered by Prune.
+type PruneItem struct {
+	SessionID string
+	Title     string
+	UpdatedAt string
+	Reason    string
+}
+
+// PruneResult summarizes a prune pass.
+type PruneResult struct {
+	Deleted []PruneItem
+	Skipped []PruneItem
+	DryRun  bool
+}
+
+const (
+	pruneReasonAge    = "older than retention"
+	pruneReasonCount  = "over max_count"
+	pruneReasonLocked = "locked"
+	pruneReasonNamed  = "named"
+	pruneReasonActive = "active"
+)
+
+// Prune removes unprotected session directories according to policy.
+//
+// A session is never deleted when it:
+//   - holds session.lock (another process has the exclusive lock),
+//   - is the active resumable session (LatestResumable), or
+//   - is explicitly saved/named/bookmarked (non-empty Tag).
+//
+// Checkpoint/rewind blobs live under the session directory (checkpoints/blobs),
+// so removing the directory also drops unreferenced blobs for that session.
+func (store *Store) Prune(policy PrunePolicy) (PruneResult, error) {
+	result := PruneResult{DryRun: policy.DryRun}
+	if !policy.Enabled() {
+		return result, nil
+	}
+
+	sessions, err := store.List()
+	if err != nil {
+		return result, err
+	}
+	if len(sessions) == 0 {
+		return result, nil
+	}
+
+	activeID := ""
+	if active, err := store.LatestResumable(); err != nil {
+		return result, err
+	} else if active != nil {
+		activeID = active.SessionID
+	} else if latest, err := store.Latest(); err != nil {
+		return result, err
+	} else if latest != nil {
+		activeID = latest.SessionID
+	}
+
+	now := store.now().UTC()
+	cutoff, hasCutoff := policy.cutoff(now)
+
+	type ranked struct {
+		meta      Metadata
+		updatedAt time.Time
+		protected string
+	}
+	items := make([]ranked, 0, len(sessions))
+	protectedCount := 0
+	for _, session := range sessions {
+		updatedAt, ok := parseSessionTime(session.UpdatedAt)
+		if !ok {
+			updatedAt, ok = parseSessionTime(session.CreatedAt)
+		}
+		if !ok {
+			// Unparseable timestamps are treated as current so we never
+			// delete a session we cannot date.
+			updatedAt = now
+		}
+		item := ranked{meta: session, updatedAt: updatedAt}
+		switch {
+		case strings.TrimSpace(session.SessionID) == activeID:
+			item.protected = pruneReasonActive
+		case sessionIsNamed(session):
+			item.protected = pruneReasonNamed
+		}
+		if item.protected != "" {
+			protectedCount++
+		}
+		items = append(items, item)
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].updatedAt.Equal(items[j].updatedAt) {
+			return items[i].meta.SessionID < items[j].meta.SessionID
+		}
+		return items[i].updatedAt.After(items[j].updatedAt)
+	})
+
+	unprotectedSlots := 0
+	if policy.MaxCount > 0 {
+		unprotectedSlots = policy.MaxCount - protectedCount
+		if unprotectedSlots < 0 {
+			unprotectedSlots = 0
+		}
+	}
+
+	type candidate struct {
+		ranked
+		reason string
+	}
+	var deleteList []candidate
+	keptUnprotected := 0
+	for _, item := range items {
+		if item.protected != "" {
+			result.Skipped = append(result.Skipped, pruneItemFrom(item.meta, item.protected))
+			continue
+		}
+		if hasCutoff && item.updatedAt.Before(cutoff) {
+			deleteList = append(deleteList, candidate{ranked: item, reason: pruneReasonAge})
+			continue
+		}
+		if policy.MaxCount > 0 && keptUnprotected >= unprotectedSlots {
+			deleteList = append(deleteList, candidate{ranked: item, reason: pruneReasonCount})
+			continue
+		}
+		keptUnprotected++
+	}
+
+	for _, cand := range deleteList {
+		unlock, ok, err := store.tryLockSession(cand.meta.SessionID)
+		if err != nil {
+			result.Skipped = append(result.Skipped, pruneItemFrom(cand.meta, err.Error()))
+			continue
+		}
+		if !ok {
+			result.Skipped = append(result.Skipped, pruneItemFrom(cand.meta, pruneReasonLocked))
+			continue
+		}
+		if policy.DryRun {
+			unlock()
+			result.Deleted = append(result.Deleted, pruneItemFrom(cand.meta, cand.reason))
+			continue
+		}
+		// Release session.lock before RemoveAll so Windows can delete the lock
+		// file. tryLockSession already confirmed no other holder.
+		unlock()
+		if err := os.RemoveAll(store.sessionPath(cand.meta.SessionID)); err != nil {
+			result.Skipped = append(result.Skipped, pruneItemFrom(cand.meta, err.Error()))
+			continue
+		}
+		result.Deleted = append(result.Deleted, pruneItemFrom(cand.meta, cand.reason))
+	}
+	return result, nil
+}
+
+func sessionIsNamed(session Metadata) bool {
+	return strings.TrimSpace(session.Tag) != ""
+}
+
+func pruneItemFrom(session Metadata, reason string) PruneItem {
+	return PruneItem{
+		SessionID: session.SessionID,
+		Title:     session.Title,
+		UpdatedAt: session.UpdatedAt,
+		Reason:    reason,
+	}
+}
+
+func parseSessionTime(raw string) (time.Time, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return time.Time{}, false
+	}
+	if ts, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return ts.UTC(), true
+	}
+	if ts, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
+		return ts.UTC(), true
+	}
+	return time.Time{}, false
+}
+
+// FormatPruneSummary is a stable one-line description used by tests and logs.
+func FormatPruneSummary(result PruneResult) string {
+	verb := "Deleted"
+	if result.DryRun {
+		verb = "Would delete"
+	}
+	return fmt.Sprintf("%s %d session(s), skipped %d", verb, len(result.Deleted), len(result.Skipped))
+}

--- a/internal/sessions/prune_test.go
+++ b/internal/sessions/prune_test.go
@@ -1,0 +1,156 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPruneDryRunDeletesNothing(t *testing.T) {
+	store, ids := setupPruneFixture(t)
+	result, err := store.Prune(PrunePolicy{RetentionDays: 7, DryRun: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(result.Deleted) == 0 {
+		t.Fatalf("dry-run should report the unlocked old session as deletable, got %#v", result)
+	}
+	if !result.DryRun {
+		t.Fatalf("DryRun = false, want true")
+	}
+	for _, id := range []string{ids.old, ids.named, ids.locked, ids.active} {
+		if !sessionDirExists(store, id) {
+			t.Fatalf("dry-run deleted %s", id)
+		}
+	}
+}
+
+func TestPruneKeepsLockedAndNamedSessions(t *testing.T) {
+	store, ids := setupPruneFixture(t)
+	unlock, err := store.lockSession(ids.locked)
+	if err != nil {
+		t.Fatalf("lockSession: %v", err)
+	}
+	defer unlock()
+
+	result, err := store.Prune(PrunePolicy{RetentionDays: 7})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if !sessionDirExists(store, ids.locked) {
+		t.Fatalf("locked session %s was deleted", ids.locked)
+	}
+	if !sessionDirExists(store, ids.named) {
+		t.Fatalf("named session %s was deleted", ids.named)
+	}
+	if !sessionDirExists(store, ids.active) {
+		t.Fatalf("active session %s was deleted", ids.active)
+	}
+	if sessionDirExists(store, ids.old) {
+		t.Fatalf("old unlocked session %s was kept", ids.old)
+	}
+	if !hasSkipReason(result, ids.locked, pruneReasonLocked) {
+		t.Fatalf("locked skip missing: %#v", result.Skipped)
+	}
+	if !hasSkipReason(result, ids.named, pruneReasonNamed) {
+		t.Fatalf("named skip missing: %#v", result.Skipped)
+	}
+	if !hasSkipReason(result, ids.active, pruneReasonActive) {
+		t.Fatalf("active skip missing: %#v", result.Skipped)
+	}
+}
+
+func TestPruneRemovesOldUnlockedSessions(t *testing.T) {
+	store, ids := setupPruneFixture(t)
+	result, err := store.Prune(PrunePolicy{RetentionDays: 7})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if sessionDirExists(store, ids.old) {
+		t.Fatalf("old unlocked session %s was not removed", ids.old)
+	}
+	if sessionDirExists(store, ids.locked) {
+		t.Fatalf("old unlocked session %s (lock not held) was not removed", ids.locked)
+	}
+	if !sessionDirExists(store, ids.active) {
+		t.Fatalf("active session %s was removed", ids.active)
+	}
+	if !sessionDirExists(store, ids.named) {
+		t.Fatalf("named session %s was removed", ids.named)
+	}
+	deleted := map[string]string{}
+	for _, item := range result.Deleted {
+		deleted[item.SessionID] = item.Reason
+	}
+	if deleted[ids.old] != pruneReasonAge || deleted[ids.locked] != pruneReasonAge {
+		t.Fatalf("deleted = %#v, want %s and %s for age", result.Deleted, ids.old, ids.locked)
+	}
+}
+
+func TestPruneRetentionDaysZeroMeansOff(t *testing.T) {
+	store, ids := setupPruneFixture(t)
+	result, err := store.Prune(PrunePolicy{RetentionDays: 0, MaxCount: 0})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(result.Deleted) != 0 {
+		t.Fatalf("retentionDays=0 deleted %#v", result.Deleted)
+	}
+	for _, id := range []string{ids.old, ids.named, ids.locked, ids.active} {
+		if !sessionDirExists(store, id) {
+			t.Fatalf("retentionDays=0 removed %s", id)
+		}
+	}
+}
+
+type pruneIDs struct {
+	old, named, locked, active string
+}
+
+func setupPruneFixture(t *testing.T) (*Store, pruneIDs) {
+	t.Helper()
+	now := time.Date(2026, 8, 27, 18, 0, 0, 0, time.UTC)
+	old := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	clock := old
+	store := NewStore(StoreOptions{
+		RootDir: t.TempDir(),
+		Now:     func() time.Time { return clock },
+	})
+	ids := pruneIDs{
+		old:    "old_unlocked",
+		named:  "named_saved",
+		locked: "locked_old",
+		active: "active_now",
+	}
+	if _, err := store.Create(CreateInput{SessionID: ids.old, Title: "old run"}); err != nil {
+		t.Fatalf("Create old: %v", err)
+	}
+	clock = old.Add(time.Second)
+	if _, err := store.Create(CreateInput{SessionID: ids.named, Title: "bookmarked", Tag: "keep"}); err != nil {
+		t.Fatalf("Create named: %v", err)
+	}
+	clock = old.Add(2 * time.Second)
+	if _, err := store.Create(CreateInput{SessionID: ids.locked, Title: "held lock"}); err != nil {
+		t.Fatalf("Create locked: %v", err)
+	}
+	clock = now
+	if _, err := store.Create(CreateInput{SessionID: ids.active, Title: "current"}); err != nil {
+		t.Fatalf("Create active: %v", err)
+	}
+	return store, ids
+}
+
+func sessionDirExists(store *Store, sessionID string) bool {
+	info, err := os.Stat(filepath.Join(store.RootDir, sessionID))
+	return err == nil && info.IsDir()
+}
+
+func hasSkipReason(result PruneResult, sessionID, reason string) bool {
+	for _, item := range result.Skipped {
+		if item.SessionID == sessionID && item.Reason == reason {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -228,9 +228,9 @@ type Store struct {
 	// it, which would break mutual exclusion). The cost of leaving them is a
 	// single *sync.Mutex per distinct session id touched by this Store's
 	// lifetime, which is small and bounded in practice — the CLI process is
-	// short-lived and the TUI works with a bounded set of sessions. There is no
-	// session-close/delete lifecycle hook to prune against, so unbounded growth
-	// is accepted deliberately rather than risk an unsafe eviction.
+	// short-lived and the TUI works with a bounded set of sessions. Prune
+	// deletes session directories on disk but leaves these mutexes in the map;
+	// unbounded growth is accepted rather than risk an unsafe eviction.
 	sessionLocks map[string]*sync.Mutex
 	idCounter    atomic.Uint64
 }
@@ -899,6 +899,25 @@ func (store *Store) lockSession(sessionID string) (func(), error) {
 		release()
 		mu.Unlock()
 	}, nil
+}
+
+// tryLockSession is the non-blocking counterpart of lockSession. ok is false
+// when the session is already locked in-process or by another process holding
+// session.lock. The caller must invoke the returned unlock function when ok.
+func (store *Store) tryLockSession(sessionID string) (func(), bool, error) {
+	mu := store.sessionLock(sessionID)
+	if !mu.TryLock() {
+		return nil, false, nil
+	}
+	release, ok, err := store.tryAcquireFileLock(sessionID)
+	if err != nil || !ok {
+		mu.Unlock()
+		return nil, false, err
+	}
+	return func() {
+		release()
+		mu.Unlock()
+	}, true, nil
 }
 
 func (store *Store) lockPath(sessionID string) string {


### PR DESCRIPTION
Fixes #971.

Session directories under the user data dir were never pruned. This adds a focused first slice: a user-scoped retention policy, `zero sessions prune` (alias `clean`), and safety guards so locked/active/named sessions stay.

**Config** (`config.json`):
- `sessions.retentionDays` / `sessions.maxCount` (snake aliases `retention_days` / `max_count` also accepted)
- `0` or omitted means off, so existing users are not surprised
- Negative values fail validation
- Policy is user-config/override only; a cloned project's `.zero/config.json` cannot prune the user session store

**CLI:** `zero sessions prune`
- Flags omitted → apply the configured policy
- `--older-than` (e.g. `7d`, `24h`) overrides `retentionDays`
- `--max-count` overrides `maxCount`
- `--dry-run` prints what would be deleted and writes nothing
- If the policy is off, prints that unset/0 keeps sessions

**Safety:** never deletes a session that holds `session.lock`, is the active resumable session, or has a non-empty tag (saved/named/bookmarked). Removing a session directory also drops that session's checkpoint/rewind blobs (`checkpoints/blobs` lives inside the dir).

Not issue-approved; proceeding at euxaristia's request to take more of their unclaimed issues. `go test` was not run locally.