### PR TITLE
fix(config): preserve unknown top-level fields

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -363,6 +364,9 @@ type FileConfig struct {
 	LocalControl        LocalControlConfig `json:"localControl,omitempty"`
 	STT                 STTConfig          `json:"stt,omitempty"`
 	CrossSessionInbound string             `json:"crossSessionInbound,omitempty"`
+	// Extra preserves top-level fields written by newer Zero versions or
+	// extensions so a read-modify-write through this version is non-destructive.
+	Extra map[string]json.RawMessage `json:"-"`
 }
 
 func (cfg FileConfig) MarshalJSON() ([]byte, error) {
@@ -400,7 +404,29 @@ func (cfg FileConfig) MarshalJSON() ([]byte, error) {
 	if !cfg.STT.Empty() {
 		raw.STT = &cfg.STT
 	}
-	return json.Marshal(raw)
+	known, err := json.Marshal(raw)
+	if err != nil || len(cfg.Extra) == 0 {
+		return known, err
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(known, &merged); err != nil {
+		return nil, err
+	}
+	for key, value := range cfg.Extra {
+		if !fileConfigKnownJSONKey(key) {
+			merged[key] = value
+		}
+	}
+	return json.Marshal(merged)
+}
+
+func fileConfigKnownJSONKey(key string) bool {
+	key = strings.ToLower(key)
+	if key == "mcpservers" || key == "mcp_servers" {
+		return true
+	}
+	_, known := knownJSONFields(reflect.TypeOf(FileConfig{}))[key]
+	return known
 }
 
 type ResolveOptions struct {
@@ -516,6 +542,18 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
+	var extra map[string]json.RawMessage
+	if err := json.Unmarshal(data, &extra); err != nil {
+		return err
+	}
+	for key := range extra {
+		if fileConfigKnownJSONKey(key) {
+			delete(extra, key)
+		}
+	}
+	if len(extra) == 0 {
+		extra = nil
+	}
 	cfg.ActiveProvider = raw.ActiveProvider
 	cfg.Providers = raw.Providers
 	// A negative maxTurns is unambiguously invalid; without this it would be
@@ -537,6 +575,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	cfg.LocalControl = raw.LocalControl
 	cfg.STT = raw.STT
 	cfg.CrossSessionInbound = raw.CrossSessionInbound
+	cfg.Extra = extra
 	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
 		cfg.MCP.Servers = map[string]MCPServerConfig{}
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -421,12 +421,15 @@ func (cfg FileConfig) MarshalJSON() ([]byte, error) {
 }
 
 func fileConfigKnownJSONKey(key string) bool {
-	key = strings.ToLower(key)
-	if key == "mcpservers" || key == "mcp_servers" {
+	if strings.EqualFold(key, "mcpServers") || strings.EqualFold(key, "mcp_servers") {
 		return true
 	}
-	_, known := knownJSONFields(reflect.TypeOf(FileConfig{}))[key]
-	return known
+	for _, field := range knownJSONFields(reflect.TypeOf(FileConfig{})) {
+		if strings.EqualFold(key, field.canonical) {
+			return true
+		}
+	}
+	return false
 }
 
 type ResolveOptions struct {

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -71,3 +71,30 @@ func TestFileConfigExtraCannotOverrideKnownFields(t *testing.T) {
 		t.Fatalf("future = %s, want preserved object", got)
 	}
 }
+
+func TestFileConfigUnicodeFoldedKnownFieldRoundTrip(t *testing.T) {
+	const data = `{"mcpſervers":{"docs":{"url":"https://example.com/mcp"}}}`
+
+	var cfg FileConfig
+	if err := json.Unmarshal([]byte(data), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := cfg.MCP.Servers["docs"]; !exists {
+		t.Fatalf("MCP.Servers = %#v, want docs server", cfg.MCP.Servers)
+	}
+	if cfg.Extra != nil {
+		t.Fatalf("Extra = %#v, want Unicode-folded known field excluded", cfg.Extra)
+	}
+
+	encoded, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var roundTripped FileConfig
+	if err := json.Unmarshal(encoded, &roundTripped); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := roundTripped.MCP.Servers["docs"]; !exists {
+		t.Fatalf("round-tripped MCP.Servers = %#v, want docs server", roundTripped.MCP.Servers)
+	}
+}

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -43,3 +43,31 @@ func TestToolsConfigPresentOnOverridesAndResolved(t *testing.T) {
 		t.Fatalf("ResolvedConfig.Tools.DeferThreshold = %d, want 4", resolved.Tools.DeferThreshold)
 	}
 }
+
+func TestFileConfigExtraCannotOverrideKnownFields(t *testing.T) {
+	cfg := FileConfig{
+		MaxTurns: 3,
+		Extra: map[string]json.RawMessage{
+			"maxTurns": json.RawMessage(`99`),
+			"MaxTurns": json.RawMessage(`100`),
+			"future":   json.RawMessage(`{"enabled":true}`),
+		},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted map[string]json.RawMessage
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(persisted["maxTurns"]); got != "3" {
+		t.Fatalf("maxTurns = %s, want 3", got)
+	}
+	if _, exists := persisted["MaxTurns"]; exists {
+		t.Fatalf("case-variant extra overrode a known field: %s", data)
+	}
+	if got := string(persisted["future"]); got != `{"enabled":true}` {
+		t.Fatalf("future = %s, want preserved object", got)
+	}
+}

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -369,6 +369,37 @@ func TestSetThemePersistsUserPreference(t *testing.T) {
 	}
 }
 
+func TestSetThemePreservesUnknownTopLevelFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	if err := os.WriteFile(path, []byte(`{
+  "preferences": {"theme": "default"},
+  "futureSetting": {"a": 1}
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := SetTheme(path, "dracula"); err != nil {
+		t.Fatalf("SetTheme() error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted map[string]json.RawMessage
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	var futureSetting struct {
+		A int `json:"a"`
+	}
+	if err := json.Unmarshal(persisted["futureSetting"], &futureSetting); err != nil {
+		t.Fatalf("unknown field was not preserved: %v\nconfig: %s", err, data)
+	}
+	if futureSetting.A != 1 {
+		t.Fatalf("futureSetting = %s, want {\"a\":1}", persisted["futureSetting"])
+	}
+}
+
 func TestRecapsPreferenceRoundTrips(t *testing.T) {
 	// Default (unset) is ON.
 	if !(PreferencesConfig{}).RecapsEnabled() {


### PR DESCRIPTION
## Summary

- retain unrecognized top-level config members as `json.RawMessage` values during `FileConfig` unmarshal
- merge those members back during marshal so all typed read-modify-write mutators preserve settings from newer Zero versions or extensions
- derive known keys from the existing JSON-tag reflection source of truth and protect known fields and legacy MCP aliases from `Extra` collisions
- add regression coverage proving `SetTheme` preserves `futureSetting`, plus coverage that extras cannot override known fields through case variants

The regression test failed before the fix because `futureSetting` disappeared from the persisted config.

## Linked issue

Fixes #964

## Checklist

- [x] The linked issue already has the `issue-approved` label.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally.
- [x] Changed Go files are `gofmt` clean.
- [x] Tests added/updated for the change.
- [x] No UI changes.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test ./internal/config -count=1`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `make lint-static` — 0 issues
- `make vulncheck` — no vulnerabilities
- `git diff HEAD --check`

`make fmt-check` remains blocked on the current base by existing formatting findings under `internal/perfbench/testdata/`; this PR does not modify those fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved unrecognized top-level configuration settings when configuration files are read and rewritten.
  * Prevented preserved settings from overriding recognized configuration fields.
  * Ensured theme updates retain custom or future configuration values.

* **Tests**
  * Added coverage for preserving unknown settings and protecting known fields from collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->