### PR TITLE
docs: name the five supported targets and drop Plan 9 as a review gate

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,7 +31,7 @@ reviews:
         Review tests for Bun test idioms, deterministic behavior, and meaningful coverage of safety decisions, provider/runtime flows, session events, and TUI command behavior.
     - path: "**/*.go"
       instructions: |
-        Do not request Plan 9 or other unsupported GOOS/GOARCH shims. Supported targets are the five release platforms (linux-x64, linux-arm64, macos-arm64, macos-x64, windows-x64). Other GOOS/GOARCH combinations are not a review criterion.
+        Do not request Plan 9 or other unsupported GOOS/GOARCH shims. The five native prebuilt release targets are linux-x64, linux-arm64, macos-arm64, macos-x64, and windows-x64. Android/Termux is also a supported runtime through the documented android-arm64 source build and Linux artifact fallback. Other GOOS/GOARCH combinations are not a review criterion.
   tools:
     github-checks:
       timeout_ms: 300000

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,7 +31,7 @@ reviews:
         Review tests for Bun test idioms, deterministic behavior, and meaningful coverage of safety decisions, provider/runtime flows, session events, and TUI command behavior.
     - path: "**/*.go"
       instructions: |
-        Do not request Plan 9 or other unsupported GOOS shims. Supported targets are the five release platforms (linux-x64, linux-arm64, macos-arm64, macos-x64, windows-x64). Other GOOS values are not a review criterion.
+        Do not request Plan 9 or other unsupported GOOS/GOARCH shims. Supported targets are the five release platforms (linux-x64, linux-arm64, macos-arm64, macos-x64, windows-x64). Other GOOS/GOARCH combinations are not a review criterion.
   tools:
     github-checks:
       timeout_ms: 300000

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -29,6 +29,9 @@ reviews:
     - path: "tests/**/*.ts"
       instructions: |
         Review tests for Bun test idioms, deterministic behavior, and meaningful coverage of safety decisions, provider/runtime flows, session events, and TUI command behavior.
+    - path: "**/*.go"
+      instructions: |
+        Do not request Plan 9 or other unsupported GOOS shims. Supported targets are the five release platforms (linux-x64, linux-arm64, macos-arm64, macos-x64, windows-x64). Other GOOS values are not a review criterion.
   tools:
     github-checks:
       timeout_ms: 300000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,11 @@ These classes drive multi-round reviews. Fix them before requesting review:
   assert raw `t.TempDir()` spellings (`/var` vs `/private/var` on macOS, short
   paths on Windows). Prefer one cross-platform function with small `GOOS`
   checks over duplicated helpers that drift.
+- **Supported targets only:** The five release platforms in CONTRIBUTING.md
+  (`linux-x64`, `linux-arm64`, `macos-arm64`, `macos-x64`, `windows-x64`) are
+  the supported set. Other `GOOS` values, including `plan9`, are unsupported
+  and are not a review criterion. Do not block a PR for failing to compile on
+  an unsupported `GOOS`. Tests may use `plan9` as a fixture for "unsupported".
 - **Security edges:** Keep secrets out of argv, env dumps, and logs. Redact
   success and error paths (including stderr). Fail closed on ownership, lease,
   and permission checks. Do not rely on pre-open path resolution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,10 @@ These classes drive multi-round reviews. Fix them before requesting review:
   checks over duplicated helpers that drift.
 - **Supported targets only:** The five release platforms in CONTRIBUTING.md
   (`linux-x64`, `linux-arm64`, `macos-arm64`, `macos-x64`, `windows-x64`) are
-  the supported set. Other `GOOS` values, including `plan9`, are unsupported
-  and are not a review criterion. Do not block a PR for failing to compile on
-  an unsupported `GOOS`. Tests may use `plan9` as a fixture for "unsupported".
+  the supported set. Other `GOOS`/`GOARCH` combinations, including `plan9`,
+  are unsupported and are not a review criterion. Do not block a PR for
+  failing to compile on an unsupported `GOOS`/`GOARCH`. Tests may use `plan9`
+  as a fixture for "unsupported".
 - **Security edges:** Keep secrets out of argv, env dumps, and logs. Redact
   success and error paths (including stderr). Fail closed on ownership, lease,
   and permission checks. Do not rely on pre-open path resolution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,12 +81,13 @@ These classes drive multi-round reviews. Fix them before requesting review:
   assert raw `t.TempDir()` spellings (`/var` vs `/private/var` on macOS, short
   paths on Windows). Prefer one cross-platform function with small `GOOS`
   checks over duplicated helpers that drift.
-- **Supported targets only:** The five release platforms in CONTRIBUTING.md
-  (`linux-x64`, `linux-arm64`, `macos-arm64`, `macos-x64`, `windows-x64`) are
-  the supported set. Other `GOOS`/`GOARCH` combinations, including `plan9`,
-  are unsupported and are not a review criterion. Do not block a PR for
-  failing to compile on an unsupported `GOOS`/`GOARCH`. Tests may use `plan9`
-  as a fixture for "unsupported".
+- **Supported targets only:** CONTRIBUTING.md names the five native prebuilt
+  release artifacts (`linux-x64`, `linux-arm64`, `macos-arm64`, `macos-x64`,
+  `windows-x64`) and the additional supported Android/Termux source-build and
+  artifact-fallback path. Other `GOOS`/`GOARCH` combinations, including
+  `plan9`, are unsupported and are not a review criterion. Do not block a PR
+  for failing to compile on an unsupported `GOOS`/`GOARCH`. Tests may use
+  `plan9` as a fixture for "unsupported".
 - **Security edges:** Keep secrets out of argv, env dumps, and logs. Redact
   success and error paths (including stderr). Fail closed on ownership, lease,
   and permission checks. Do not rely on pre-open path resolution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,9 +128,8 @@ an approved feature.
 
 ## Supported platforms
 
-Zero is released for the same five platforms that `scripts/install.sh`,
-`scripts/install.ps1`, and the npm wrapper resolve, and that
-`.github/workflows/release-artifacts.yml` packages:
+Zero publishes five native prebuilt artifacts from
+`.github/workflows/release-artifacts.yml`:
 
 - `linux-x64` (`linux/amd64`)
 - `linux-arm64` (`linux/arm64`)
@@ -138,9 +137,19 @@ Zero is released for the same five platforms that `scripts/install.sh`,
 - `macos-x64` (`darwin/amd64`)
 - `windows-x64` (`windows/amd64`)
 
-Other `GOOS`/`GOARCH` values, including Plan 9, are unsupported. They are not
-a review criterion. Do not block a pull request for failing to compile on an
-unsupported `GOOS`. Tests may use `plan9` as a fixture for an unsupported OS.
+The shell installer and npm wrapper resolve the applicable artifacts from that
+list. The PowerShell installer supports the published `windows-x64` artifact;
+there is no native Windows ARM64 artifact. Windows on ARM users can run the x64
+build under emulation or build from source.
+
+Android/Termux is also supported even though it has no distinct release
+artifact. The npm wrapper maps Android to the Linux artifact, and
+`docs/INSTALL.md` documents the native `android/arm64` source build needed on
+devices whose seccomp policy blocks the Linux build's syscall path.
+
+Other `GOOS`/`GOARCH` values, including Plan 9, are unsupported. They are not a
+review criterion. Do not block a pull request for failing to compile on an
+unsupported target. Tests may use `plan9` as a fixture for an unsupported OS.
 
 ## What We Prioritize
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,22 @@ not enough. Dependency changes need a clear project benefit, such as fixing a
 specific bug, addressing a security issue, improving compatibility, or supporting
 an approved feature.
 
+## Supported platforms
+
+Zero is released for the same five platforms that `scripts/install.sh`,
+`scripts/install.ps1`, and the npm wrapper resolve, and that
+`.github/workflows/release-artifacts.yml` packages:
+
+- `linux-x64` (`linux/amd64`)
+- `linux-arm64` (`linux/arm64`)
+- `macos-arm64` (`darwin/arm64`)
+- `macos-x64` (`darwin/amd64`)
+- `windows-x64` (`windows/amd64`)
+
+Other `GOOS`/`GOARCH` values, including Plan 9, are unsupported. They are not
+a review criterion. Do not block a pull request for failing to compile on an
+unsupported `GOOS`. Tests may use `plan9` as a fixture for an unsupported OS.
+
 ## What We Prioritize
 
 The core team will prioritize:


### PR DESCRIPTION
Fixes #817

Implements option 1 from the issue: document the supported targets as the five
release platforms and state that other GOOS values are unsupported and not a
review criterion.

## What changed

- `CONTRIBUTING.md`: new Supported platforms section naming the five release
  targets (`linux-x64`, `linux-arm64`, `macos-arm64`, `macos-x64`,
  `windows-x64`) and stating that other GOOS/GOARCH values, including Plan 9,
  are not a review criterion.
- `AGENTS.md`: pointer under Common Review Blockers so reviewers stop asking
  for Plan 9 compilation.
- `.coderabbit.yaml`: path instruction for Go files not to request Plan 9 /
  unsupported GOOS shims.

No code behavior change. `retry_dialerrno_plan9.go` from #750 is left in place; dropping that
dead shim is a maintainer call (option 3 in the issue).

## Test plan

Documentation only.

- [x] Diff is CONTRIBUTING.md, AGENTS.md, and `.coderabbit.yaml` only
- [x] Platform names match `release-artifacts.yml` / `install.sh` / `install.ps1`
  (linux-x64, linux-arm64, macos-arm64, macos-x64, windows-x64)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented five supported native release platforms: Linux x64, Linux arm64, macOS arm64, macOS x64, and Windows x64.
  - Added Android/Termux guidance, including source-build requirements and Linux artifact fallback.
  - Clarified installer and npm-wrapper mappings, Windows ARM64 limitations, and unsupported platform combinations.
  - Noted that unsupported targets should not block reviews, while tests may use them as fixtures.
- **Chores**
  - Updated review guidance to align with the supported-platform policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->