### PR TITLE
fix(config): replace deprecated reflect.Ptr with reflect.Pointer

### DIFF
--- a/internal/config/unknownfields.go
+++ b/internal/config/unknownfields.go
@@ -131,7 +131,7 @@ type knownField struct {
 }
 
 func derefType(t reflect.Type) reflect.Type {
-	for t != nil && t.Kind() == reflect.Ptr {
+	for t != nil && t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t


### PR DESCRIPTION
`derefType` compared `t.Kind()` to `reflect.Ptr`. That constant is deprecated; `reflect.Pointer` is the replacement. Behavior is unchanged.

Independent of any other open PR. Once this is on `main`, other branches no longer need to carry the same one-liner to satisfy `govet`.