### PR TITLE
fix(redaction): redact credentials split by control bytes

### DIFF
--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -377,37 +377,68 @@ func RedactString(value string, options Options) string {
 	return redacted
 }
 
-func firstControlIndex(s string) int {
+type controlSpan struct {
+	start int
+	end   int
+}
+
+func findControlSpans(s string) []controlSpan {
+	var spans []controlSpan
 	for i := 0; i < len(s); {
 		c := s[i]
 		if c < 0x80 {
 			if c != '\t' && c != '\n' && c != '\r' && (c < 0x20 || c == 0x7F) {
-				return i
+				start := i
+				for i < len(s) && s[i] < 0x80 && s[i] != '\t' && s[i] != '\n' && s[i] != '\r' && (s[i] < 0x20 || s[i] == 0x7F) {
+					i++
+				}
+				spans = append(spans, controlSpan{start: start, end: i})
+				continue
 			}
 			i++
 			continue
 		}
 		if c <= 0x9F {
-			return i
+			start := i
+			for i < len(s) && s[i] >= 0x80 && s[i] <= 0x9F {
+				i++
+			}
+			spans = append(spans, controlSpan{start: start, end: i})
+			continue
 		}
 		r, size := utf8.DecodeRuneInString(s[i:])
-		if unicode.IsControl(r) {
-			return i
+		if unicode.IsControl(r) || r == utf8.RuneError {
+			start := i
+			i += size
+			for i < len(s) {
+				nr, nsize := utf8.DecodeRuneInString(s[i:])
+				if unicode.IsControl(nr) || nr == utf8.RuneError {
+					i += nsize
+				} else {
+					break
+				}
+			}
+			spans = append(spans, controlSpan{start: start, end: i})
+			continue
 		}
 		i += size
 	}
-	return -1
+	return spans
 }
 
 func redactMatchedPattern(match string, pattern *regexp.Regexp, replacement string, isValid func(string) bool) string {
+	spans := findControlSpans(match)
+	for _, span := range spans {
+		pre := match[:span.start]
+		if pre == "" {
+			continue
+		}
+		if validSecretControlGaps(pre) && pattern.MatchString(pre) && (isValid == nil || isValid(pre)) {
+			return replacement + match[span.start:]
+		}
+	}
 	if !validSecretControlGaps(match) {
 		return match
-	}
-	if ctrlIdx := firstControlIndex(match); ctrlIdx >= 0 {
-		pre := match[:ctrlIdx]
-		if pattern.MatchString(pre) && (isValid == nil || isValid(pre)) {
-			return replacement + match[ctrlIdx:]
-		}
 	}
 	if isValid != nil && !isValid(match) {
 		return match

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -325,7 +325,6 @@ func stripControlBytesFrom(s string, start int) string {
 	return b.String()
 }
 
-
 func RedactString(value string, options Options) string {
 	replacement := replacement(options)
 	// Match on the original string. Shape patterns allow C0/C1 gaps between

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -498,7 +498,33 @@ func extractLogicalCandidate(s string) logicalCandidate {
 	}
 }
 
-func findCredentialBoundary(match string, shape secretShape, isOpenAI bool, isValid func(string) bool) (int, bool) {
+func startsNewCredential(s string, isJWT bool) bool {
+	if strings.HasPrefix(s, "sk-") ||
+		strings.HasPrefix(s, "ghp_") ||
+		strings.HasPrefix(s, "gho_") ||
+		strings.HasPrefix(s, "ghu_") ||
+		strings.HasPrefix(s, "ghs_") ||
+		strings.HasPrefix(s, "ghr_") ||
+		strings.HasPrefix(s, "github_pat_") ||
+		strings.HasPrefix(s, "glpat-") ||
+		strings.HasPrefix(s, "AIza") ||
+		strings.HasPrefix(s, "xoxb-") ||
+		strings.HasPrefix(s, "xoxa-") ||
+		strings.HasPrefix(s, "xoxp-") ||
+		strings.HasPrefix(s, "xoxr-") ||
+		strings.HasPrefix(s, "xoxs-") ||
+		strings.HasPrefix(s, "AKIA") ||
+		strings.HasPrefix(s, "ASIA") {
+		return true
+	}
+	if !isJWT && strings.HasPrefix(s, "eyJ") {
+		return true
+	}
+	return false
+}
+
+func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretShape, isOpenAI bool, hasTrailingPath bool, isValid func(string) bool) (int, bool) {
+	match := src[matchStart:matchEnd]
 	cand := extractLogicalCandidate(match)
 	if len(cand.spans) == 0 {
 		if isValid != nil && !isValid(match) {
@@ -524,8 +550,9 @@ func findCredentialBoundary(match string, shape secretShape, isOpenAI bool, isVa
 
 	runningDots := 0
 	logCursor := 0
+	lastValidEnd := 0
 
-	for _, span := range cand.spans {
+	for i, span := range cand.spans {
 		if span.start == 0 {
 			continue
 		}
@@ -537,9 +564,9 @@ func findCredentialBoundary(match string, shape secretShape, isOpenAI bool, isVa
 		}
 		logLen := logCursor
 
-		// If scanning OpenAI keys and text after span starts with "sk-",
-		// this span is a delimiter before a new key.
-		if isOpenAI && strings.HasPrefix(match[span.end:], "sk-") {
+		// If text in src after span starts a new credential, this span is a delimiter between credentials.
+		tailInSrc := src[matchStart+span.end:]
+		if startsNewCredential(tailInSrc, shape.requireDots) {
 			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
 				logPre := logicalStr[:logLen]
 				if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
@@ -549,26 +576,35 @@ func findCredentialBoundary(match string, shape secretShape, isOpenAI bool, isVa
 			return span.start, false
 		}
 
-		if !isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-			if !span.validGap {
-				return span.start, false
-			}
-			continue
-		}
-		logPre := logicalStr[:logLen]
-		if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
-			return span.start, true
-		}
 		if !span.validGap {
+			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
+				logPre := logicalStr[:logLen]
+				if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+					return span.start, true
+				}
+			}
 			return span.start, false
 		}
-		// If logPre is a kebab false positive, check if the remaining suffix in match
-		// has fewer than 4 characters. If so, logPre was an independent kebab token
-		// followed by a delimiter (e.g. "sk-my-kebab\x00v2/file.go").
-		if isValid != nil && !isValid(logPre) {
-			suffixLen := len(logicalStr) - logLen
-			if suffixLen < 4 {
-				return span.start, false
+
+		// If match is followed by a path separator in source and this span precedes the trailing path,
+		// the span is a terminal delimiter if the prefix is already a valid credential.
+		if hasTrailingPath && i == len(cand.spans)-1 {
+			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
+				logPre := logicalStr[:logLen]
+				if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+					return span.start, true
+				}
+			}
+			return span.start, false
+		}
+
+		// Continue consuming control-separated credential bytes across valid gaps.
+		// Track the last valid boundary for fail-closed fallback if subsequent
+		// bytes invalidate the full candidate.
+		if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
+			logPre := logicalStr[:logLen]
+			if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+				lastValidEnd = span.start
 			}
 		}
 	}
@@ -587,14 +623,23 @@ func findCredentialBoundary(match string, shape secretShape, isOpenAI bool, isVa
 	}
 
 	if !isCandidateLength(len(logicalStr), shape.minLen, shape.requireDots, runningDots) {
+		if lastValidEnd > 0 {
+			return lastValidEnd, true
+		}
 		return len(match), false
 	}
 
 	if !shape.plainPattern.MatchString(logicalStr) {
+		if lastValidEnd > 0 {
+			return lastValidEnd, true
+		}
 		return len(match), false
 	}
 
 	if isValid != nil && !isValid(logicalStr) {
+		if lastValidEnd > 0 {
+			return lastValidEnd, true
+		}
 		return len(match), false
 	}
 
@@ -624,9 +669,9 @@ func replaceAllSecretMatches(src string, shape secretShape, replacement string, 
 
 		matchStart := lastIndex + loc[0]
 		matchEnd := lastIndex + loc[1]
-		match := src[matchStart:matchEnd]
+		hasTrailingPath := matchEnd < len(src) && (src[matchEnd] == '/' || src[matchEnd] == '\\')
 
-		advanceLen, shouldRedact := findCredentialBoundary(match, shape, isOpenAI, isValid)
+		advanceLen, shouldRedact := findCredentialBoundary(src, matchStart, matchEnd, shape, isOpenAI, hasTrailingPath, isValid)
 
 		b.WriteString(src[lastIndex:matchStart])
 		if shouldRedact {

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -550,6 +550,9 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 
 	runningDots := 0
 	logCursor := 0
+	hasDigit := false
+	hasInteriorHyphen := false
+	hasKnownPrefix := isOpenAI && knownOpenAIKeyPrefix(logicalStr)
 	lastValidEnd := 0
 
 	for i, span := range cand.spans {
@@ -557,19 +560,33 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 			continue
 		}
 		for logCursor < len(cand.origEnds) && cand.origEnds[logCursor] <= span.start {
-			if shape.requireDots && logicalStr[logCursor] == '.' {
+			c := logicalStr[logCursor]
+			if shape.requireDots && c == '.' {
 				runningDots++
+			}
+			if isOpenAI {
+				if c >= '0' && c <= '9' {
+					hasDigit = true
+				}
+				if c == '-' && logCursor >= 3 {
+					hasInteriorHyphen = true
+				}
 			}
 			logCursor++
 		}
 		logLen := logCursor
+		logPreValid := !isOpenAI || hasKnownPrefix || hasDigit || !hasInteriorHyphen
 
 		// If text in src after span starts a new credential, this span is a delimiter between credentials.
 		tailInSrc := src[matchStart+span.end:]
 		if startsNewCredential(tailInSrc, shape.requireDots) {
 			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-				logPre := logicalStr[:logLen]
-				if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+				valid := logPreValid
+				if valid && !isOpenAI && shape.plainPattern != nil {
+					logPre := logicalStr[:logLen]
+					valid = shape.plainPattern.MatchString(logPre)
+				}
+				if valid {
 					return span.start, true
 				}
 			}
@@ -578,8 +595,12 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 
 		if !span.validGap {
 			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-				logPre := logicalStr[:logLen]
-				if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+				valid := logPreValid
+				if valid && !isOpenAI && shape.plainPattern != nil {
+					logPre := logicalStr[:logLen]
+					valid = shape.plainPattern.MatchString(logPre)
+				}
+				if valid {
 					return span.start, true
 				}
 			}
@@ -590,20 +611,24 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 		// the span is a terminal delimiter if the prefix is already a valid credential.
 		if hasTrailingPath && i == len(cand.spans)-1 {
 			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-				logPre := logicalStr[:logLen]
-				if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+				valid := logPreValid
+				if valid && !isOpenAI && shape.plainPattern != nil {
+					logPre := logicalStr[:logLen]
+					valid = shape.plainPattern.MatchString(logPre)
+				}
+				if valid {
 					return span.start, true
 				}
 			}
 			return span.start, false
 		}
-
-		// Continue consuming control-separated credential bytes across valid gaps.
-		// Track the last valid boundary for fail-closed fallback if subsequent
-		// bytes invalidate the full candidate.
 		if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-			logPre := logicalStr[:logLen]
-			if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+			valid := logPreValid
+			if valid && !isOpenAI && shape.plainPattern != nil {
+				logPre := logicalStr[:logLen]
+				valid = shape.plainPattern.MatchString(logPre)
+			}
+			if valid {
 				lastValidEnd = span.start
 			}
 		}
@@ -616,8 +641,17 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 	}
 
 	for logCursor < len(cand.origEnds) {
-		if shape.requireDots && logicalStr[logCursor] == '.' {
+		c := logicalStr[logCursor]
+		if shape.requireDots && c == '.' {
 			runningDots++
+		}
+		if isOpenAI {
+			if c >= '0' && c <= '9' {
+				hasDigit = true
+			}
+			if c == '-' && logCursor >= 3 {
+				hasInteriorHyphen = true
+			}
 		}
 		logCursor++
 	}
@@ -629,7 +663,14 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 		return len(match), false
 	}
 
-	if !shape.plainPattern.MatchString(logicalStr) {
+	if isOpenAI {
+		if !hasKnownPrefix && !hasDigit && hasInteriorHyphen {
+			if lastValidEnd > 0 {
+				return lastValidEnd, true
+			}
+			return len(match), false
+		}
+	} else if !shape.plainPattern.MatchString(logicalStr) {
 		if lastValidEnd > 0 {
 			return lastValidEnd, true
 		}

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -73,24 +74,46 @@ var sensitiveKeys = map[string]struct{}{
 // between characters of a secret shape. Matching stays on the original string:
 // a deleted control is never a join, so \b still treats wordchar+control as a
 // boundary and tokens that were never adjacent stay that way. Tab/LF/CR are
-// excluded so log line structure is unchanged. \x{FFFD} is how Go's regexp
-// engine reports a lone invalid UTF-8 C1 byte such as 0x9B.
+// excluded so log line structure is unchanged. \x{FFFD} lets the regexp locate
+// a lone invalid UTF-8 byte; validSecretControlGaps subsequently accepts only
+// raw C1 bytes and rejects a real, valid UTF-8 U+FFFD rune.
 const ctrlGap = `[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\x80-\x9f\x{FFFD}]*`
 
-// ctrlLit quotes s as a regexp literal with ctrlGap after every rune, so a
-// NUL/ESC/C1 may split the literal without breaking the match.
+// ctrlLit quotes s as a regexp literal with ctrlGap strictly between runes, so
+// a NUL/ESC/C1 may split the literal without letting a match end on a gap.
 func ctrlLit(s string) string {
 	var b strings.Builder
 	b.Grow(len(s) * (1 + len(ctrlGap)))
+	first := true
 	for _, r := range s {
+		if !first {
+			b.WriteString(ctrlGap)
+		}
 		b.WriteString(regexp.QuoteMeta(string(r)))
-		b.WriteString(ctrlGap)
+		first = false
 	}
 	return b.String()
 }
 
-func secretBody(class, quant string) string {
-	return `(?:` + class + ctrlGap + `)` + quant
+func ctrlJoin(parts ...string) string {
+	return strings.Join(parts, ctrlGap)
+}
+
+// secretBody keeps gaps strictly between the minimum required body characters.
+// Once an unbounded shape has reached that high-confidence minimum, its
+// optional tail stays contiguous: a later control is a suffix delimiter rather
+// than permission to absorb the following token into the secret (which could
+// feed unrelated suffix text into the OpenAI kebab-case exception).
+func secretBody(class string, minimum int, unbounded bool) string {
+	if minimum <= 0 {
+		return ""
+	}
+	quantifier := strconv.Itoa(minimum - 1)
+	body := class + `(?:` + ctrlGap + class + `){` + quantifier + `}`
+	if unbounded {
+		body += class + `*`
+	}
+	return body
 }
 
 // openaiKeyPattern mirrors secrets.Scan's broad sk- body. Known OpenAI
@@ -98,7 +121,7 @@ func secretBody(class, quant string) string {
 // digit-free matches with an interior hyphen are left alone (kebab-case false
 // positives), while digit-free legacy sk- credentials are still redacted.
 // Applied via ReplaceAllStringFunc rather than the plain list below.
-var openaiKeyPattern = regexp.MustCompile(`\b` + ctrlLit("sk-") + secretBody(`[A-Za-z0-9_-]`, `{20,}`))
+var openaiKeyPattern = regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("sk-"), secretBody(`[A-Za-z0-9_-]`, 20, true)))
 
 // textSecretPatterns mirror secrets.Scan for end-boundary behavior and the
 // shared high-confidence shapes. A leading \b keeps each pattern from firing
@@ -112,15 +135,15 @@ var openaiKeyPattern = regexp.MustCompile(`\b` + ctrlLit("sk-") + secretBody(`[A
 // ctrlGap between shape characters keeps NUL/ESC/C1 split secrets matching
 // without stripping those bytes out of the subject first.
 var textSecretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\b` + ctrlLit("sk-ant-") + `(?:` + ctrlLit("api") + `\d` + ctrlGap + `\d` + ctrlGap + ctrlLit("-") + `)?` + secretBody(`[A-Za-z0-9_-]`, `{20,}`)),
-	regexp.MustCompile(`\b` + ctrlLit("github_pat_") + secretBody(`[A-Za-z0-9_]`, `{22,}`)),
-	regexp.MustCompile(`\b` + ctrlLit("gh") + `[pousr]` + ctrlGap + `_` + ctrlGap + secretBody(`[A-Za-z0-9]`, `{36,}`)),
-	regexp.MustCompile(`\b` + ctrlLit("glpat-") + secretBody(`[A-Za-z0-9_-]`, `{12,}`)),
-	regexp.MustCompile(`\b` + ctrlLit("AIza") + secretBody(`[0-9A-Za-z\-_]`, `{35,}`)),
-	regexp.MustCompile(`\b` + ctrlLit("xox") + `[baprs]` + ctrlGap + `-` + ctrlGap + secretBody(`[A-Za-z0-9-]`, `{10,}`)),
-	regexp.MustCompile(`\b(?:` + ctrlLit("AKIA") + `|` + ctrlLit("ASIA") + `)` + secretBody(`[A-Z0-9]`, `{16}`)),
-	regexp.MustCompile(`\b` + ctrlLit("eyJ") + secretBody(`[A-Za-z0-9_-]`, `{10,}`) + `\.` + ctrlGap + ctrlLit("eyJ") + secretBody(`[A-Za-z0-9_-]`, `{10,}`) + `\.` + ctrlGap + secretBody(`[A-Za-z0-9_-]`, `{10,}`)),
-	regexp.MustCompile(`\b` + ctrlLit("eyJ") + secretBody(`[A-Za-z0-9_-]`, `{10,}`) + `\.` + ctrlGap + secretBody(`[A-Za-z0-9_-]`, `{10,}`) + `\.` + ctrlGap + secretBody(`[A-Za-z0-9_-]`, `{10,}`)),
+	regexp.MustCompile(`\b` + ctrlLit("sk-ant-") + ctrlGap + `(?:` + ctrlJoin(ctrlLit("api"), `\d`, `\d`, `-`) + ctrlGap + `)?` + secretBody(`[A-Za-z0-9_-]`, 20, true)),
+	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("github_pat_"), secretBody(`[A-Za-z0-9_]`, 22, true))),
+	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("gh"), `[pousr]`, `_`, secretBody(`[A-Za-z0-9]`, 36, true))),
+	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("glpat-"), secretBody(`[A-Za-z0-9_-]`, 12, true))),
+	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("AIza"), secretBody(`[0-9A-Za-z\-_]`, 35, true))),
+	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("xox"), `[baprs]`, `-`, secretBody(`[A-Za-z0-9-]`, 10, true))),
+	regexp.MustCompile(`\b` + ctrlJoin(`(?:`+ctrlLit("AKIA")+`|`+ctrlLit("ASIA")+`)`, secretBody(`[A-Z0-9]`, 16, false))),
+	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true))),
+	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true))),
 }
 
 var (
@@ -256,6 +279,26 @@ func stripControlBytesFrom(s string, start int) string {
 	return b.String()
 }
 
+// validSecretControlGaps disambiguates RuneError matches at the byte boundary.
+// Go's regexp engine represents both a malformed single byte and a legitimate
+// U+FFFD rune as RuneError. Only raw invalid C1 bytes (0x80-0x9F) are supported
+// gaps; a valid UTF-8 replacement rune, or another malformed byte, must keep
+// the candidate split and prevent redaction.
+func validSecretControlGaps(match string) bool {
+	for i := 0; i < len(match); {
+		r, size := utf8.DecodeRuneInString(match[i:])
+		if r != utf8.RuneError {
+			i += size
+			continue
+		}
+		if size != 1 || match[i] < 0x80 || match[i] > 0x9F {
+			return false
+		}
+		i++
+	}
+	return true
+}
+
 func RedactString(value string, options Options) string {
 	replacement := replacement(options)
 	// Match on the original string. Shape patterns allow C0/C1 gaps between
@@ -313,9 +356,24 @@ func RedactString(value string, options Options) string {
 		}
 		return parts[1] + parts[2] + "=" + replacement
 	})
-	// openai keys first so the filter can drop kebab-case false positives
-	// before any other pattern rewrites nearby text.
+	// Match high-confidence specialized shapes first. In particular, the broad
+	// sk- pattern may reach its minimum before a control inside a longer
+	// Anthropic key; letting the Anthropic shape consume that split first avoids
+	// leaving a recognizable credential suffix behind.
+	for _, pattern := range textSecretPatterns {
+		redacted = pattern.ReplaceAllStringFunc(redacted, func(match string) string {
+			if !validSecretControlGaps(match) {
+				return match
+			}
+			return replacement
+		})
+	}
+	// Apply the broad OpenAI shape after specialized keys so its kebab-case
+	// false-positive filter considers only the matched key, never suffix text.
 	redacted = openaiKeyPattern.ReplaceAllStringFunc(redacted, func(match string) string {
+		if !validSecretControlGaps(match) {
+			return match
+		}
 		normalized := stripControlBytes(match)
 		if !knownOpenAIKeyPrefix(normalized) && !secretMatchHasDigit(normalized) &&
 			strings.Contains(strings.TrimPrefix(normalized, "sk-"), "-") {
@@ -323,9 +381,6 @@ func RedactString(value string, options Options) string {
 		}
 		return replacement
 	})
-	for _, pattern := range textSecretPatterns {
-		redacted = pattern.ReplaceAllString(redacted, replacement)
-	}
 	return redacted
 }
 

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -120,6 +120,10 @@ func secretBody(class string, minimum int, unbounded bool) string {
 // Applied via ReplaceAllStringFunc rather than the plain list below.
 var openaiKeyPattern = regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("sk-"), secretBody(`[A-Za-z0-9_-]`, 20, true)))
 
+// plainOpenaiKeyPattern is the non-gap-aware counterpart of openaiKeyPattern,
+// used for boundary resolution on logical (control-stripped) candidates.
+var plainOpenaiKeyPattern = regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}`)
+
 // textSecretPatterns mirror secrets.Scan for end-boundary behavior and the
 // shared high-confidence shapes. A leading \b keeps each pattern from firing
 // mid-word; a trailing \b is omitted so a secret followed by more word
@@ -141,6 +145,21 @@ var textSecretPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\b` + ctrlJoin(`(?:`+ctrlLit("AKIA")+`|`+ctrlLit("ASIA")+`)`, secretBody(`[A-Z0-9]`, 16, false))),
 	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true))),
 	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true))),
+}
+
+// plainSecretPatterns are non-gap-aware counterparts of textSecretPatterns,
+// used for boundary resolution on logical (control-stripped) candidates.
+// Each entry corresponds 1:1 with textSecretPatterns by index.
+var plainSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{20,}`),
+	regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`),
+	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}`),
+	regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{12,}`),
+	regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`),
+	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`),
+	regexp.MustCompile(`\b(?:AKIA|ASIA)[A-Z0-9]{16}`),
+	regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`),
+	regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`),
 }
 
 var (
@@ -357,33 +376,67 @@ func RedactString(value string, options Options) string {
 	// sk- pattern may reach its minimum before a control inside a longer
 	// Anthropic key; letting the Anthropic shape consume that split first avoids
 	// leaving a recognizable credential suffix behind.
-	for _, pattern := range textSecretPatterns {
-		redacted = pattern.ReplaceAllStringFunc(redacted, func(match string) string {
-			return redactMatchedPattern(match, pattern, replacement, nil)
-		})
+	for i, pattern := range textSecretPatterns {
+		plain := plainSecretPatterns[i]
+		minLen := minSecretLens[i]
+		redacted = replaceAllSecretMatches(redacted, i, pattern, plain, replacement, minLen, nil)
 	}
 	// Apply the broad OpenAI shape after specialized keys so its kebab-case
 	// false-positive filter considers only the matched key, never suffix text.
-	redacted = openaiKeyPattern.ReplaceAllStringFunc(redacted, func(match string) string {
-		return redactMatchedPattern(match, openaiKeyPattern, replacement, func(m string) bool {
-			normalized := stripControlBytes(m)
-			if !knownOpenAIKeyPrefix(normalized) && !secretMatchHasDigit(normalized) &&
-				strings.Contains(strings.TrimPrefix(normalized, "sk-"), "-") {
-				return false
-			}
-			return true
-		})
+	redacted = replaceAllSecretMatches(redacted, -1, openaiKeyPattern, plainOpenaiKeyPattern, replacement, minOpenAILen, func(m string) bool {
+		// m is the logical (control-stripped) candidate.
+		if !knownOpenAIKeyPrefix(m) && !secretMatchHasDigit(m) &&
+			strings.Contains(strings.TrimPrefix(m, "sk-"), "-") {
+			return false
+		}
+		return true
 	})
 	return redacted
 }
 
-type controlSpan struct {
-	start int
-	end   int
+var minSecretLens = []int{
+	27, // sk-ant- (7) + 20
+	33, // github_pat_ (11) + 22
+	40, // gh[pousr]_ (4) + 36
+	18, // glpat- (6) + 12
+	39, // AIza (4) + 35
+	15, // xox[baprs]- (5) + 10
+	20, // AKIA/ASIA (4) + 16
+	38, // JWT (3 + 10 + 1 + 3 + 10 + 1 + 10)
+	34, // JWT (3 + 10 + 1 + 10 + 1 + 10)
 }
 
-func findControlSpans(s string) []controlSpan {
+const minOpenAILen = 23 // sk- (3) + 20
+
+func isCandidateLength(logPre string, patternIndex int, minLen int) bool {
+	if len(logPre) < minLen {
+		return false
+	}
+	if patternIndex == 7 || patternIndex == 8 {
+		return strings.Count(logPre, ".") >= 2
+	}
+	return true
+}
+
+type controlSpan struct {
+	start    int
+	end      int
+	validGap bool
+}
+
+type logicalCandidate struct {
+	logical  string
+	origEnds []int
+	spans    []controlSpan
+}
+
+func extractLogicalCandidate(s string) logicalCandidate {
+	var logical strings.Builder
+	logical.Grow(len(s))
+	var origEnds []int
+	origEnds = make([]int, 0, len(s))
 	var spans []controlSpan
+
 	for i := 0; i < len(s); {
 		c := s[i]
 		if c < 0x80 {
@@ -392,58 +445,190 @@ func findControlSpans(s string) []controlSpan {
 				for i < len(s) && s[i] < 0x80 && s[i] != '\t' && s[i] != '\n' && s[i] != '\r' && (s[i] < 0x20 || s[i] == 0x7F) {
 					i++
 				}
-				spans = append(spans, controlSpan{start: start, end: i})
+				spans = append(spans, controlSpan{start: start, end: i, validGap: true})
 				continue
 			}
+			logical.WriteByte(c)
 			i++
+			origEnds = append(origEnds, i)
 			continue
 		}
-		if c <= 0x9F {
+		if c >= 0x80 && c <= 0x9F {
 			start := i
 			for i < len(s) && s[i] >= 0x80 && s[i] <= 0x9F {
 				i++
 			}
-			spans = append(spans, controlSpan{start: start, end: i})
+			spans = append(spans, controlSpan{start: start, end: i, validGap: true})
 			continue
 		}
 		r, size := utf8.DecodeRuneInString(s[i:])
-		if unicode.IsControl(r) || r == utf8.RuneError {
+		if r == utf8.RuneError {
+			start := i
+			i += size
+			spans = append(spans, controlSpan{start: start, end: i, validGap: false})
+			continue
+		}
+		if unicode.IsControl(r) && r != '\t' && r != '\n' && r != '\r' {
 			start := i
 			i += size
 			for i < len(s) {
 				nr, nsize := utf8.DecodeRuneInString(s[i:])
-				if unicode.IsControl(nr) || nr == utf8.RuneError {
+				if unicode.IsControl(nr) && nr != '\t' && nr != '\n' && nr != '\r' {
 					i += nsize
 				} else {
 					break
 				}
 			}
-			spans = append(spans, controlSpan{start: start, end: i})
+			spans = append(spans, controlSpan{start: start, end: i, validGap: true})
 			continue
 		}
+		logical.WriteRune(r)
 		i += size
+		runeLen := len(string(r))
+		for b := 0; b < runeLen; b++ {
+			origEnds = append(origEnds, i)
+		}
 	}
-	return spans
+	return logicalCandidate{
+		logical:  logical.String(),
+		origEnds: origEnds,
+		spans:    spans,
+	}
 }
 
-func redactMatchedPattern(match string, pattern *regexp.Regexp, replacement string, isValid func(string) bool) string {
-	spans := findControlSpans(match)
-	for _, span := range spans {
-		pre := match[:span.start]
-		if pre == "" {
+func findCredentialBoundary(match string, patternIndex int, plainPattern *regexp.Regexp, minLen int, isValid func(string) bool) (int, bool) {
+	cand := extractLogicalCandidate(match)
+	if len(cand.spans) == 0 {
+		if isValid != nil && !isValid(match) {
+			return len(match), false
+		}
+		return len(match), true
+	}
+
+	logicalStr := cand.logical
+
+	// Fast path for OpenAI kebab false positives: if the logical string has no digits,
+	// is not a known prefix, and the token before the first control span already contains
+	// an interior hyphen, no sub-span can ever be valid.
+	if patternIndex == -1 && isValid != nil && len(cand.spans) > 0 && cand.spans[0].start > 0 {
+		if !knownOpenAIKeyPrefix(logicalStr) && !secretMatchHasDigit(logicalStr) {
+			firstLogLen := sort.SearchInts(cand.origEnds, cand.spans[0].start+1)
+			firstPre := logicalStr[:firstLogLen]
+			if strings.Contains(strings.TrimPrefix(firstPre, "sk-"), "-") {
+				return len(match), false
+			}
+		}
+	}
+
+	for _, span := range cand.spans {
+		if span.start == 0 {
 			continue
 		}
-		if validSecretControlGaps(pre) && pattern.MatchString(pre) && (isValid == nil || isValid(pre)) {
-			return replacement + match[span.start:]
+		// If scanning OpenAI keys and text after span starts with "sk-",
+		// this span is a delimiter before a new key.
+		if patternIndex == -1 && strings.HasPrefix(match[span.end:], "sk-") {
+			logLen := sort.SearchInts(cand.origEnds, span.start+1)
+			if isCandidateLength(logicalStr[:logLen], patternIndex, minLen) {
+				logPre := logicalStr[:logLen]
+				if plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+					return span.start, true
+				}
+			}
+			return span.start, false
+		}
+
+		logLen := sort.SearchInts(cand.origEnds, span.start+1)
+		if !isCandidateLength(logicalStr[:logLen], patternIndex, minLen) {
+			if !span.validGap {
+				return span.start, false
+			}
+			continue
+		}
+		logPre := logicalStr[:logLen]
+		if plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+			return span.start, true
+		}
+		if !span.validGap {
+			return span.start, false
+		}
+		// If logPre is a kebab false positive, check if the remaining suffix in match
+		// has fewer than 4 characters. If so, logPre was an independent kebab token
+		// followed by a delimiter (e.g. "sk-my-kebab\x00v2/file.go").
+		if isValid != nil && !isValid(logPre) {
+			suffixLen := len(logicalStr) - logLen
+			if suffixLen < 4 {
+				return span.start, false
+			}
 		}
 	}
-	if !validSecretControlGaps(match) {
-		return match
+
+	for _, span := range cand.spans {
+		if !span.validGap {
+			return span.start, false
+		}
 	}
-	if isValid != nil && !isValid(match) {
-		return match
+
+	if !isCandidateLength(logicalStr, patternIndex, minLen) {
+		return len(match), false
 	}
-	return replacement
+
+	if !plainPattern.MatchString(logicalStr) {
+		return len(match), false
+	}
+
+	if isValid != nil && !isValid(logicalStr) {
+		return len(match), false
+	}
+
+	if len(cand.origEnds) > 0 {
+		lastEnd := cand.origEnds[len(cand.origEnds)-1]
+		return lastEnd, true
+	}
+	return len(match), true
+}
+
+func replaceAllSecretMatches(src string, patternIndex int, pattern *regexp.Regexp, plainPattern *regexp.Regexp, replacement string, minLen int, isValid func(string) bool) string {
+	loc := pattern.FindStringIndex(src)
+	if loc == nil {
+		return src
+	}
+
+	var b strings.Builder
+	b.Grow(len(src))
+
+	lastIndex := 0
+	for {
+		loc := pattern.FindStringIndex(src[lastIndex:])
+		if loc == nil {
+			b.WriteString(src[lastIndex:])
+			break
+		}
+
+		matchStart := lastIndex + loc[0]
+		matchEnd := lastIndex + loc[1]
+		match := src[matchStart:matchEnd]
+
+		advanceLen, shouldRedact := findCredentialBoundary(match, patternIndex, plainPattern, minLen, isValid)
+
+		b.WriteString(src[lastIndex:matchStart])
+		if shouldRedact {
+			b.WriteString(replacement)
+			lastIndex = matchStart + advanceLen
+		} else {
+			if advanceLen <= 0 {
+				advanceLen = 1
+			}
+			b.WriteString(src[matchStart : matchStart+advanceLen])
+			lastIndex = matchStart + advanceLen
+		}
+		if lastIndex <= matchStart {
+			lastIndex = matchStart + 1
+		}
+		if lastIndex >= len(src) {
+			break
+		}
+	}
+	return b.String()
 }
 
 // knownOpenAIKeyPrefix is the redaction-side twin of secrets.knownOpenAIKeyPrefix:

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -170,9 +171,69 @@ func keyLooksSensitive(normalized string) bool {
 	return false
 }
 
+// stripControlBytes removes C0/C1 controls (Cc other than tab, LF, and CR) so
+// shape matching sees a secret that was split by an embedded NUL, ESC, or C1
+// byte. Tab/LF/CR stay so log line structure is preserved. Lone Latin-1 C1
+// bytes (0x80–0x9F, invalid UTF-8) are stripped too; UTF-8 continuation bytes
+// are not, because they are not controls. Must run before any pattern match.
+func stripControlBytes(s string) string {
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c < 0x80 {
+			if c != '\t' && c != '\n' && c != '\r' && (c < 0x20 || c == 0x7F) {
+				return stripControlBytesFrom(s, i)
+			}
+			i++
+			continue
+		}
+		if c <= 0x9F {
+			// 0x80–0x9F at a rune boundary is a lone C1 byte, not UTF-8.
+			return stripControlBytesFrom(s, i)
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if unicode.IsControl(r) {
+			return stripControlBytesFrom(s, i)
+		}
+		i += size
+	}
+	return s
+}
+
+func stripControlBytesFrom(s string, start int) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	b.WriteString(s[:start])
+	for i := start; i < len(s); {
+		c := s[i]
+		if c < 0x80 {
+			if c != '\t' && c != '\n' && c != '\r' && (c < 0x20 || c == 0x7F) {
+				i++
+				continue
+			}
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		if c <= 0x9F {
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if unicode.IsControl(r) {
+			i += size
+			continue
+		}
+		b.WriteString(s[i : i+size])
+		i += size
+	}
+	return b.String()
+}
+
 func RedactString(value string, options Options) string {
 	replacement := replacement(options)
-	redacted := value
+	// Strip C0/C1 first: a NUL, ESC, or C1 byte inside a key body splits the
+	// shape so the patterns miss it, and a later strip would rejoin the secret.
+	redacted := stripControlBytes(value)
 	if len(options.ExtraSecretValues) > 0 {
 		secrets := append([]string{}, options.ExtraSecretValues...)
 		sort.SliceStable(secrets, func(i, j int) bool {

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -99,21 +99,18 @@ func ctrlJoin(parts ...string) string {
 	return strings.Join(parts, ctrlGap)
 }
 
-// secretBody keeps gaps strictly between the minimum required body characters.
-// Once an unbounded shape has reached that high-confidence minimum, its
-// optional tail stays contiguous: a later control is a suffix delimiter rather
-// than permission to absorb the following token into the secret (which could
-// feed unrelated suffix text into the OpenAI kebab-case exception).
+// secretBody generates a regex matching at least minimum body characters,
+// allowing C0/C1 control gaps between any characters. It always starts and ends
+// on a class character (never on a gap).
 func secretBody(class string, minimum int, unbounded bool) string {
 	if minimum <= 0 {
 		return ""
 	}
 	quantifier := strconv.Itoa(minimum - 1)
-	body := class + `(?:` + ctrlGap + class + `){` + quantifier + `}`
 	if unbounded {
-		body += class + `*`
+		return class + `(?:` + ctrlGap + class + `){` + quantifier + `,}`
 	}
-	return body
+	return class + `(?:` + ctrlGap + class + `){` + quantifier + `}`
 }
 
 // openaiKeyPattern mirrors secrets.Scan's broad sk- body. Known OpenAI
@@ -362,26 +359,60 @@ func RedactString(value string, options Options) string {
 	// leaving a recognizable credential suffix behind.
 	for _, pattern := range textSecretPatterns {
 		redacted = pattern.ReplaceAllStringFunc(redacted, func(match string) string {
-			if !validSecretControlGaps(match) {
-				return match
-			}
-			return replacement
+			return redactMatchedPattern(match, pattern, replacement, nil)
 		})
 	}
 	// Apply the broad OpenAI shape after specialized keys so its kebab-case
 	// false-positive filter considers only the matched key, never suffix text.
 	redacted = openaiKeyPattern.ReplaceAllStringFunc(redacted, func(match string) string {
-		if !validSecretControlGaps(match) {
-			return match
-		}
-		normalized := stripControlBytes(match)
-		if !knownOpenAIKeyPrefix(normalized) && !secretMatchHasDigit(normalized) &&
-			strings.Contains(strings.TrimPrefix(normalized, "sk-"), "-") {
-			return match
-		}
-		return replacement
+		return redactMatchedPattern(match, openaiKeyPattern, replacement, func(m string) bool {
+			normalized := stripControlBytes(m)
+			if !knownOpenAIKeyPrefix(normalized) && !secretMatchHasDigit(normalized) &&
+				strings.Contains(strings.TrimPrefix(normalized, "sk-"), "-") {
+				return false
+			}
+			return true
+		})
 	})
 	return redacted
+}
+
+func firstControlIndex(s string) int {
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c < 0x80 {
+			if c != '\t' && c != '\n' && c != '\r' && (c < 0x20 || c == 0x7F) {
+				return i
+			}
+			i++
+			continue
+		}
+		if c <= 0x9F {
+			return i
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if unicode.IsControl(r) {
+			return i
+		}
+		i += size
+	}
+	return -1
+}
+
+func redactMatchedPattern(match string, pattern *regexp.Regexp, replacement string, isValid func(string) bool) string {
+	if !validSecretControlGaps(match) {
+		return match
+	}
+	if ctrlIdx := firstControlIndex(match); ctrlIdx >= 0 {
+		pre := match[:ctrlIdx]
+		if pattern.MatchString(pre) && (isValid == nil || isValid(pre)) {
+			return replacement + match[ctrlIdx:]
+		}
+	}
+	if isValid != nil && !isValid(match) {
+		return match
+	}
+	return replacement
 }
 
 // knownOpenAIKeyPrefix is the redaction-side twin of secrets.knownOpenAIKeyPrefix:

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -69,12 +69,36 @@ var sensitiveKeys = map[string]struct{}{
 	"zero_api_key":          {},
 }
 
+// ctrlGap matches C0/C1 bytes (Cc other than tab/LF/CR, plus lone Latin-1 C1)
+// between characters of a secret shape. Matching stays on the original string:
+// a deleted control is never a join, so \b still treats wordchar+control as a
+// boundary and tokens that were never adjacent stay that way. Tab/LF/CR are
+// excluded so log line structure is unchanged. \x{FFFD} is how Go's regexp
+// engine reports a lone invalid UTF-8 C1 byte such as 0x9B.
+const ctrlGap = `[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\x80-\x9f\x{FFFD}]*`
+
+// ctrlLit quotes s as a regexp literal with ctrlGap after every rune, so a
+// NUL/ESC/C1 may split the literal without breaking the match.
+func ctrlLit(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) * (1 + len(ctrlGap)))
+	for _, r := range s {
+		b.WriteString(regexp.QuoteMeta(string(r)))
+		b.WriteString(ctrlGap)
+	}
+	return b.String()
+}
+
+func secretBody(class, quant string) string {
+	return `(?:` + class + ctrlGap + `)` + quant
+}
+
 // openaiKeyPattern mirrors secrets.Scan's broad sk- body. Known OpenAI
 // prefixes (sk-proj-/sk-svcacct-/sk-admin-) are always redacted; other sk-
 // digit-free matches with an interior hyphen are left alone (kebab-case false
 // positives), while digit-free legacy sk- credentials are still redacted.
 // Applied via ReplaceAllStringFunc rather than the plain list below.
-var openaiKeyPattern = regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}`)
+var openaiKeyPattern = regexp.MustCompile(`\b` + ctrlLit("sk-") + secretBody(`[A-Za-z0-9_-]`, `{20,}`))
 
 // textSecretPatterns mirror secrets.Scan for end-boundary behavior and the
 // shared high-confidence shapes. A leading \b keeps each pattern from firing
@@ -85,16 +109,18 @@ var openaiKeyPattern = regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}`)
 // (not in secrets.Scan); ASIA temporary access keys are kept alongside AKIA.
 // openai keys are handled separately (digit filter). JWT has a strict form
 // (both segments start with eyJ) and a looser three-segment form.
+// ctrlGap between shape characters keeps NUL/ESC/C1 split secrets matching
+// without stripping those bytes out of the subject first.
 var textSecretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{20,}`),
-	regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`),
-	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}`),
-	regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{12,}`),
-	regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`),
-	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`),
-	regexp.MustCompile(`\b(?:AKIA|ASIA)[A-Z0-9]{16}`),
-	regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`),
-	regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`),
+	regexp.MustCompile(`\b` + ctrlLit("sk-ant-") + `(?:` + ctrlLit("api") + `\d` + ctrlGap + `\d` + ctrlGap + ctrlLit("-") + `)?` + secretBody(`[A-Za-z0-9_-]`, `{20,}`)),
+	regexp.MustCompile(`\b` + ctrlLit("github_pat_") + secretBody(`[A-Za-z0-9_]`, `{22,}`)),
+	regexp.MustCompile(`\b` + ctrlLit("gh") + `[pousr]` + ctrlGap + `_` + ctrlGap + secretBody(`[A-Za-z0-9]`, `{36,}`)),
+	regexp.MustCompile(`\b` + ctrlLit("glpat-") + secretBody(`[A-Za-z0-9_-]`, `{12,}`)),
+	regexp.MustCompile(`\b` + ctrlLit("AIza") + secretBody(`[0-9A-Za-z\-_]`, `{35,}`)),
+	regexp.MustCompile(`\b` + ctrlLit("xox") + `[baprs]` + ctrlGap + `-` + ctrlGap + secretBody(`[A-Za-z0-9-]`, `{10,}`)),
+	regexp.MustCompile(`\b(?:` + ctrlLit("AKIA") + `|` + ctrlLit("ASIA") + `)` + secretBody(`[A-Z0-9]`, `{16}`)),
+	regexp.MustCompile(`\b` + ctrlLit("eyJ") + secretBody(`[A-Za-z0-9_-]`, `{10,}`) + `\.` + ctrlGap + ctrlLit("eyJ") + secretBody(`[A-Za-z0-9_-]`, `{10,}`) + `\.` + ctrlGap + secretBody(`[A-Za-z0-9_-]`, `{10,}`)),
+	regexp.MustCompile(`\b` + ctrlLit("eyJ") + secretBody(`[A-Za-z0-9_-]`, `{10,}`) + `\.` + ctrlGap + secretBody(`[A-Za-z0-9_-]`, `{10,}`) + `\.` + ctrlGap + secretBody(`[A-Za-z0-9_-]`, `{10,}`)),
 }
 
 var (
@@ -171,11 +197,12 @@ func keyLooksSensitive(normalized string) bool {
 	return false
 }
 
-// stripControlBytes removes C0/C1 controls (Cc other than tab, LF, and CR) so
-// shape matching sees a secret that was split by an embedded NUL, ESC, or C1
-// byte. Tab/LF/CR stay so log line structure is preserved. Lone Latin-1 C1
-// bytes (0x80–0x9F, invalid UTF-8) are stripped too; UTF-8 continuation bytes
-// are not, because they are not controls. Must run before any pattern match.
+// stripControlBytes removes C0/C1 controls (Cc other than tab, LF, and CR).
+// Used to normalize an already-matched secret so prefix/digit checks see the
+// rejoined shape. It is matching-time only and must not be applied to
+// RedactString's input or return value. Tab/LF/CR stay. Lone Latin-1 C1 bytes
+// (0x80–0x9F, invalid UTF-8) are stripped too; UTF-8 continuation bytes are
+// not, because they are not controls.
 func stripControlBytes(s string) string {
 	for i := 0; i < len(s); {
 		c := s[i]
@@ -231,9 +258,10 @@ func stripControlBytesFrom(s string, start int) string {
 
 func RedactString(value string, options Options) string {
 	replacement := replacement(options)
-	// Strip C0/C1 first: a NUL, ESC, or C1 byte inside a key body splits the
-	// shape so the patterns miss it, and a later strip would rejoin the secret.
-	redacted := stripControlBytes(value)
+	// Match on the original string. Shape patterns allow C0/C1 gaps between
+	// characters so a split secret still matches; stripping first would join
+	// tokens that were never adjacent and make \b miss a leading wordchar.
+	redacted := value
 	if len(options.ExtraSecretValues) > 0 {
 		secrets := append([]string{}, options.ExtraSecretValues...)
 		sort.SliceStable(secrets, func(i, j int) bool {
@@ -288,8 +316,9 @@ func RedactString(value string, options Options) string {
 	// openai keys first so the filter can drop kebab-case false positives
 	// before any other pattern rewrites nearby text.
 	redacted = openaiKeyPattern.ReplaceAllStringFunc(redacted, func(match string) string {
-		if !knownOpenAIKeyPrefix(match) && !secretMatchHasDigit(match) &&
-			strings.Contains(strings.TrimPrefix(match, "sk-"), "-") {
+		normalized := stripControlBytes(match)
+		if !knownOpenAIKeyPrefix(normalized) && !secretMatchHasDigit(normalized) &&
+			strings.Contains(strings.TrimPrefix(normalized, "sk-"), "-") {
 			return match
 		}
 		return replacement

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -266,65 +266,6 @@ func keyLooksSensitive(normalized string) bool {
 	return false
 }
 
-// stripControlBytes removes C0/C1 controls (Cc other than tab, LF, and CR).
-// Used to normalize an already-matched secret so prefix/digit checks see the
-// rejoined shape. It is matching-time only and must not be applied to
-// RedactString's input or return value. Tab/LF/CR stay. Lone Latin-1 C1 bytes
-// (0x80–0x9F, invalid UTF-8) are stripped too; UTF-8 continuation bytes are
-// not, because they are not controls.
-func stripControlBytes(s string) string {
-	for i := 0; i < len(s); {
-		c := s[i]
-		if c < 0x80 {
-			if c != '\t' && c != '\n' && c != '\r' && (c < 0x20 || c == 0x7F) {
-				return stripControlBytesFrom(s, i)
-			}
-			i++
-			continue
-		}
-		if c <= 0x9F {
-			// 0x80–0x9F at a rune boundary is a lone C1 byte, not UTF-8.
-			return stripControlBytesFrom(s, i)
-		}
-		r, size := utf8.DecodeRuneInString(s[i:])
-		if unicode.IsControl(r) {
-			return stripControlBytesFrom(s, i)
-		}
-		i += size
-	}
-	return s
-}
-
-func stripControlBytesFrom(s string, start int) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	b.WriteString(s[:start])
-	for i := start; i < len(s); {
-		c := s[i]
-		if c < 0x80 {
-			if c != '\t' && c != '\n' && c != '\r' && (c < 0x20 || c == 0x7F) {
-				i++
-				continue
-			}
-			b.WriteByte(c)
-			i++
-			continue
-		}
-		if c <= 0x9F {
-			i++
-			continue
-		}
-		r, size := utf8.DecodeRuneInString(s[i:])
-		if unicode.IsControl(r) {
-			i += size
-			continue
-		}
-		b.WriteString(s[i : i+size])
-		i += size
-	}
-	return b.String()
-}
-
 func RedactString(value string, options Options) string {
 	replacement := replacement(options)
 	// Match on the original string. Shape patterns allow C0/C1 gaps between
@@ -554,6 +495,21 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 	hasInteriorHyphen := false
 	hasKnownPrefix := isOpenAI && knownOpenAIKeyPrefix(logicalStr)
 	lastValidEnd := 0
+	plainPatternMatched := false
+
+	checkPlainPattern := func(logLen int) bool {
+		if plainPatternMatched {
+			return true
+		}
+		if shape.plainPattern == nil {
+			return true
+		}
+		if shape.plainPattern.MatchString(logicalStr[:logLen]) {
+			plainPatternMatched = true
+			return true
+		}
+		return false
+	}
 
 	for i, span := range cand.spans {
 		if span.start == 0 {
@@ -576,33 +532,28 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 		}
 		logLen := logCursor
 		logPreValid := !isOpenAI || hasKnownPrefix || hasDigit || !hasInteriorHyphen
+		validateLogPre := func() bool {
+			if !logPreValid {
+				return false
+			}
+			if isOpenAI {
+				return true
+			}
+			return checkPlainPattern(logLen)
+		}
 
 		// If text in src after span starts a new credential, this span is a delimiter between credentials.
 		tailInSrc := src[matchStart+span.end:]
 		if startsNewCredential(tailInSrc, shape.requireDots) {
-			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-				valid := logPreValid
-				if valid && !isOpenAI && shape.plainPattern != nil {
-					logPre := logicalStr[:logLen]
-					valid = shape.plainPattern.MatchString(logPre)
-				}
-				if valid {
-					return span.start, true
-				}
+			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) && validateLogPre() {
+				return span.start, true
 			}
 			return span.start, false
 		}
 
 		if !span.validGap {
-			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-				valid := logPreValid
-				if valid && !isOpenAI && shape.plainPattern != nil {
-					logPre := logicalStr[:logLen]
-					valid = shape.plainPattern.MatchString(logPre)
-				}
-				if valid {
-					return span.start, true
-				}
+			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) && validateLogPre() {
+				return span.start, true
 			}
 			return span.start, false
 		}
@@ -610,27 +561,13 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 		// If match is followed by a path separator in source and this span precedes the trailing path,
 		// the span is a terminal delimiter if the prefix is already a valid credential.
 		if hasTrailingPath && i == len(cand.spans)-1 {
-			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-				valid := logPreValid
-				if valid && !isOpenAI && shape.plainPattern != nil {
-					logPre := logicalStr[:logLen]
-					valid = shape.plainPattern.MatchString(logPre)
-				}
-				if valid {
-					return span.start, true
-				}
+			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) && validateLogPre() {
+				return span.start, true
 			}
 			return span.start, false
 		}
-		if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
-			valid := logPreValid
-			if valid && !isOpenAI && shape.plainPattern != nil {
-				logPre := logicalStr[:logLen]
-				valid = shape.plainPattern.MatchString(logPre)
-			}
-			if valid {
-				lastValidEnd = span.start
-			}
+		if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) && validateLogPre() {
+			lastValidEnd = span.start
 		}
 	}
 
@@ -670,7 +607,7 @@ func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretSh
 			}
 			return len(match), false
 		}
-	} else if !shape.plainPattern.MatchString(logicalStr) {
+	} else if !checkPlainPattern(len(logicalStr)) {
 		if lastValidEnd > 0 {
 			return lastValidEnd, true
 		}

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -135,31 +135,61 @@ var plainOpenaiKeyPattern = regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}`)
 // (both segments start with eyJ) and a looser three-segment form.
 // ctrlGap between shape characters keeps NUL/ESC/C1 split secrets matching
 // without stripping those bytes out of the subject first.
-var textSecretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\b` + ctrlLit("sk-ant-") + ctrlGap + `(?:` + ctrlJoin(ctrlLit("api"), `\d`, `\d`, `-`) + ctrlGap + `)?` + secretBody(`[A-Za-z0-9_-]`, 20, true)),
-	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("github_pat_"), secretBody(`[A-Za-z0-9_]`, 22, true))),
-	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("gh"), `[pousr]`, `_`, secretBody(`[A-Za-z0-9]`, 36, true))),
-	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("glpat-"), secretBody(`[A-Za-z0-9_-]`, 12, true))),
-	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("AIza"), secretBody(`[0-9A-Za-z\-_]`, 35, true))),
-	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("xox"), `[baprs]`, `-`, secretBody(`[A-Za-z0-9-]`, 10, true))),
-	regexp.MustCompile(`\b` + ctrlJoin(`(?:`+ctrlLit("AKIA")+`|`+ctrlLit("ASIA")+`)`, secretBody(`[A-Z0-9]`, 16, false))),
-	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true))),
-	regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true))),
+type secretShape struct {
+	textPattern  *regexp.Regexp
+	plainPattern *regexp.Regexp
+	minLen       int
+	requireDots  bool
 }
 
-// plainSecretPatterns are non-gap-aware counterparts of textSecretPatterns,
-// used for boundary resolution on logical (control-stripped) candidates.
-// Each entry corresponds 1:1 with textSecretPatterns by index.
-var plainSecretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{20,}`),
-	regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`),
-	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}`),
-	regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{12,}`),
-	regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`),
-	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`),
-	regexp.MustCompile(`\b(?:AKIA|ASIA)[A-Z0-9]{16}`),
-	regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`),
-	regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`),
+var secretShapes = []secretShape{
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlLit("sk-ant-") + ctrlGap + `(?:` + ctrlJoin(ctrlLit("api"), `\d`, `\d`, `-`) + ctrlGap + `)?` + secretBody(`[A-Za-z0-9_-]`, 20, true)),
+		plainPattern: regexp.MustCompile(`\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{20,}`),
+		minLen:       27, // sk-ant- (7) + 20
+	},
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("github_pat_"), secretBody(`[A-Za-z0-9_]`, 22, true))),
+		plainPattern: regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`),
+		minLen:       33, // github_pat_ (11) + 22
+	},
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("gh"), `[pousr]`, `_`, secretBody(`[A-Za-z0-9]`, 36, true))),
+		plainPattern: regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}`),
+		minLen:       40, // gh[pousr]_ (4) + 36
+	},
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("glpat-"), secretBody(`[A-Za-z0-9_-]`, 12, true))),
+		plainPattern: regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{12,}`),
+		minLen:       18, // glpat- (6) + 12
+	},
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("AIza"), secretBody(`[0-9A-Za-z\-_]`, 35, true))),
+		plainPattern: regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35,}`),
+		minLen:       39, // AIza (4) + 35
+	},
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("xox"), `[baprs]`, `-`, secretBody(`[A-Za-z0-9-]`, 10, true))),
+		plainPattern: regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`),
+		minLen:       15, // xox[baprs]- (5) + 10
+	},
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(`(?:`+ctrlLit("AKIA")+`|`+ctrlLit("ASIA")+`)`, secretBody(`[A-Z0-9]`, 16, false))),
+		plainPattern: regexp.MustCompile(`\b(?:AKIA|ASIA)[A-Z0-9]{16}`),
+		minLen:       20, // AKIA/ASIA (4) + 16
+	},
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true))),
+		plainPattern: regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`),
+		minLen:       38, // JWT (3 + 10 + 1 + 3 + 10 + 1 + 10)
+		requireDots:  true,
+	},
+	{
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("eyJ"), secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true), `\.`, secretBody(`[A-Za-z0-9_-]`, 10, true))),
+		plainPattern: regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`),
+		minLen:       34, // JWT (3 + 10 + 1 + 10 + 1 + 10)
+		requireDots:  true,
+	},
 }
 
 var (
@@ -295,25 +325,6 @@ func stripControlBytesFrom(s string, start int) string {
 	return b.String()
 }
 
-// validSecretControlGaps disambiguates RuneError matches at the byte boundary.
-// Go's regexp engine represents both a malformed single byte and a legitimate
-// U+FFFD rune as RuneError. Only raw invalid C1 bytes (0x80-0x9F) are supported
-// gaps; a valid UTF-8 replacement rune, or another malformed byte, must keep
-// the candidate split and prevent redaction.
-func validSecretControlGaps(match string) bool {
-	for i := 0; i < len(match); {
-		r, size := utf8.DecodeRuneInString(match[i:])
-		if r != utf8.RuneError {
-			i += size
-			continue
-		}
-		if size != 1 || match[i] < 0x80 || match[i] > 0x9F {
-			return false
-		}
-		i++
-	}
-	return true
-}
 
 func RedactString(value string, options Options) string {
 	replacement := replacement(options)
@@ -376,14 +387,18 @@ func RedactString(value string, options Options) string {
 	// sk- pattern may reach its minimum before a control inside a longer
 	// Anthropic key; letting the Anthropic shape consume that split first avoids
 	// leaving a recognizable credential suffix behind.
-	for i, pattern := range textSecretPatterns {
-		plain := plainSecretPatterns[i]
-		minLen := minSecretLens[i]
-		redacted = replaceAllSecretMatches(redacted, i, pattern, plain, replacement, minLen, nil)
+	for _, shape := range secretShapes {
+		redacted = replaceAllSecretMatches(redacted, shape, replacement, false, nil)
 	}
 	// Apply the broad OpenAI shape after specialized keys so its kebab-case
 	// false-positive filter considers only the matched key, never suffix text.
-	redacted = replaceAllSecretMatches(redacted, -1, openaiKeyPattern, plainOpenaiKeyPattern, replacement, minOpenAILen, func(m string) bool {
+	openaiShape := secretShape{
+		textPattern:  openaiKeyPattern,
+		plainPattern: plainOpenaiKeyPattern,
+		minLen:       minOpenAILen,
+		requireDots:  false,
+	}
+	redacted = replaceAllSecretMatches(redacted, openaiShape, replacement, true, func(m string) bool {
 		// m is the logical (control-stripped) candidate.
 		if !knownOpenAIKeyPrefix(m) && !secretMatchHasDigit(m) &&
 			strings.Contains(strings.TrimPrefix(m, "sk-"), "-") {
@@ -394,26 +409,14 @@ func RedactString(value string, options Options) string {
 	return redacted
 }
 
-var minSecretLens = []int{
-	27, // sk-ant- (7) + 20
-	33, // github_pat_ (11) + 22
-	40, // gh[pousr]_ (4) + 36
-	18, // glpat- (6) + 12
-	39, // AIza (4) + 35
-	15, // xox[baprs]- (5) + 10
-	20, // AKIA/ASIA (4) + 16
-	38, // JWT (3 + 10 + 1 + 3 + 10 + 1 + 10)
-	34, // JWT (3 + 10 + 1 + 10 + 1 + 10)
-}
-
 const minOpenAILen = 23 // sk- (3) + 20
 
-func isCandidateLength(logPre string, patternIndex int, minLen int) bool {
-	if len(logPre) < minLen {
+func isCandidateLength(logLen int, minLen int, requireDots bool, runningDots int) bool {
+	if logLen < minLen {
 		return false
 	}
-	if patternIndex == 7 || patternIndex == 8 {
-		return strings.Count(logPre, ".") >= 2
+	if requireDots {
+		return runningDots >= 2
 	}
 	return true
 }
@@ -496,7 +499,7 @@ func extractLogicalCandidate(s string) logicalCandidate {
 	}
 }
 
-func findCredentialBoundary(match string, patternIndex int, plainPattern *regexp.Regexp, minLen int, isValid func(string) bool) (int, bool) {
+func findCredentialBoundary(match string, shape secretShape, isOpenAI bool, isValid func(string) bool) (int, bool) {
 	cand := extractLogicalCandidate(match)
 	if len(cand.spans) == 0 {
 		if isValid != nil && !isValid(match) {
@@ -510,7 +513,7 @@ func findCredentialBoundary(match string, patternIndex int, plainPattern *regexp
 	// Fast path for OpenAI kebab false positives: if the logical string has no digits,
 	// is not a known prefix, and the token before the first control span already contains
 	// an interior hyphen, no sub-span can ever be valid.
-	if patternIndex == -1 && isValid != nil && len(cand.spans) > 0 && cand.spans[0].start > 0 {
+	if isOpenAI && isValid != nil && len(cand.spans) > 0 && cand.spans[0].start > 0 {
 		if !knownOpenAIKeyPrefix(logicalStr) && !secretMatchHasDigit(logicalStr) {
 			firstLogLen := sort.SearchInts(cand.origEnds, cand.spans[0].start+1)
 			firstPre := logicalStr[:firstLogLen]
@@ -520,32 +523,41 @@ func findCredentialBoundary(match string, patternIndex int, plainPattern *regexp
 		}
 	}
 
+	runningDots := 0
+	logCursor := 0
+
 	for _, span := range cand.spans {
 		if span.start == 0 {
 			continue
 		}
+		for logCursor < len(cand.origEnds) && cand.origEnds[logCursor] <= span.start {
+			if shape.requireDots && logicalStr[logCursor] == '.' {
+				runningDots++
+			}
+			logCursor++
+		}
+		logLen := logCursor
+
 		// If scanning OpenAI keys and text after span starts with "sk-",
 		// this span is a delimiter before a new key.
-		if patternIndex == -1 && strings.HasPrefix(match[span.end:], "sk-") {
-			logLen := sort.SearchInts(cand.origEnds, span.start+1)
-			if isCandidateLength(logicalStr[:logLen], patternIndex, minLen) {
+		if isOpenAI && strings.HasPrefix(match[span.end:], "sk-") {
+			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
 				logPre := logicalStr[:logLen]
-				if plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+				if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
 					return span.start, true
 				}
 			}
 			return span.start, false
 		}
 
-		logLen := sort.SearchInts(cand.origEnds, span.start+1)
-		if !isCandidateLength(logicalStr[:logLen], patternIndex, minLen) {
+		if !isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) {
 			if !span.validGap {
 				return span.start, false
 			}
 			continue
 		}
 		logPre := logicalStr[:logLen]
-		if plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
+		if shape.plainPattern.MatchString(logPre) && (isValid == nil || isValid(logPre)) {
 			return span.start, true
 		}
 		if !span.validGap {
@@ -568,11 +580,18 @@ func findCredentialBoundary(match string, patternIndex int, plainPattern *regexp
 		}
 	}
 
-	if !isCandidateLength(logicalStr, patternIndex, minLen) {
+	for logCursor < len(cand.origEnds) {
+		if shape.requireDots && logicalStr[logCursor] == '.' {
+			runningDots++
+		}
+		logCursor++
+	}
+
+	if !isCandidateLength(len(logicalStr), shape.minLen, shape.requireDots, runningDots) {
 		return len(match), false
 	}
 
-	if !plainPattern.MatchString(logicalStr) {
+	if !shape.plainPattern.MatchString(logicalStr) {
 		return len(match), false
 	}
 
@@ -587,8 +606,8 @@ func findCredentialBoundary(match string, patternIndex int, plainPattern *regexp
 	return len(match), true
 }
 
-func replaceAllSecretMatches(src string, patternIndex int, pattern *regexp.Regexp, plainPattern *regexp.Regexp, replacement string, minLen int, isValid func(string) bool) string {
-	loc := pattern.FindStringIndex(src)
+func replaceAllSecretMatches(src string, shape secretShape, replacement string, isOpenAI bool, isValid func(string) bool) string {
+	loc := shape.textPattern.FindStringIndex(src)
 	if loc == nil {
 		return src
 	}
@@ -598,7 +617,7 @@ func replaceAllSecretMatches(src string, patternIndex int, pattern *regexp.Regex
 
 	lastIndex := 0
 	for {
-		loc := pattern.FindStringIndex(src[lastIndex:])
+		loc := shape.textPattern.FindStringIndex(src[lastIndex:])
 		if loc == nil {
 			b.WriteString(src[lastIndex:])
 			break
@@ -608,7 +627,7 @@ func replaceAllSecretMatches(src string, patternIndex int, pattern *regexp.Regex
 		matchEnd := lastIndex + loc[1]
 		match := src[matchStart:matchEnd]
 
-		advanceLen, shouldRedact := findCredentialBoundary(match, patternIndex, plainPattern, minLen, isValid)
+		advanceLen, shouldRedact := findCredentialBoundary(match, shape, isOpenAI, isValid)
 
 		b.WriteString(src[lastIndex:matchStart])
 		if shouldRedact {

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -329,7 +329,7 @@ func RedactString(value string, options Options) string {
 	// leaving a recognizable credential suffix behind.
 	var allSpans []span
 	for _, shape := range secretShapes {
-		allSpans = append(allSpans, findSpansForShape(redacted, shape, false, nil)...)
+		allSpans = append(allSpans, findSpansForShape(redacted, shape, false)...)
 	}
 	openaiShape := secretShape{
 		textPattern:  openaiKeyPattern,
@@ -337,20 +337,12 @@ func RedactString(value string, options Options) string {
 		minLen:       minOpenAILen,
 		requireDots:  false,
 	}
-	allSpans = append(allSpans, findSpansForShape(redacted, openaiShape, true, func(m string) bool {
-		// m is the logical (control-stripped) candidate.
-		if !knownOpenAIKeyPrefix(m) && !secretMatchHasDigit(m) &&
-			strings.Contains(strings.TrimPrefix(m, "sk-"), "-") {
-			return false
-		}
-		return true
-	})...)
+	allSpans = append(allSpans, findSpansForShape(redacted, openaiShape, true)...)
 	redacted = applySpans(redacted, allSpans, replacement)
 	return redacted
 }
 
 const minOpenAILen = 23 // sk- (3) + 20
-
 
 type controlSpan struct {
 	start    int
@@ -507,7 +499,7 @@ func startsIndependentCredential(s string) bool {
 	return false
 }
 
-func isCandidateValid(logPre string, shape secretShape, isOpenAI bool, dots, digits int, hasInteriorHyphen bool, isValid func(string) bool) bool {
+func isCandidateValid(logPre string, shape secretShape, isOpenAI bool, dots, digits int, hasInteriorHyphen bool) bool {
 	if len(logPre) < shape.minLen {
 		return false
 	}
@@ -532,13 +524,10 @@ func isCandidateValid(logPre string, shape secretShape, isOpenAI bool, dots, dig
 	if shape.plainPattern != nil && !shape.plainPattern.MatchString(logPre) {
 		return false
 	}
-	if isValid != nil && !isValid(logPre) {
-		return false
-	}
 	return true
 }
 
-func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretShape, isOpenAI bool, isValid func(string) bool) ([]span, int) {
+func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretShape, isOpenAI bool) ([]span, int) {
 	match := src[matchStart:matchEnd]
 	cand := extractLogicalCandidate(match)
 	if len(cand.logical) == 0 {
@@ -559,7 +548,7 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 			return false
 		}
 		logPre := cand.logical[candStartLog:logEnd]
-		valid := isCandidateValid(logPre, shape, isOpenAI, runningDots, runningDigits, hasInteriorHyphen, isValid)
+		valid := isCandidateValid(logPre, shape, isOpenAI, runningDots, runningDigits, hasInteriorHyphen)
 		if valid {
 			origEnd := cand.origEnds[logEnd-1]
 			spans = append(spans, span{
@@ -610,7 +599,7 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 		}
 
 		logPre := cand.logical[candStartLog:logCursor]
-		if isCandidateValid(logPre, shape, isOpenAI, runningDots, runningDigits, hasInteriorHyphen, isValid) {
+		if isCandidateValid(logPre, shape, isOpenAI, runningDots, runningDigits, hasInteriorHyphen) {
 			if idx := strings.IndexAny(tailWindow, "/\\"); idx >= 0 {
 				segment := tailWindow[:idx]
 				if len(segment) < 15 && !strings.Contains(segment, "\n") {
@@ -684,7 +673,7 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 	return spans, lastConsumedEnd
 }
 
-func findSpansForShape(src string, shape secretShape, isOpenAI bool, isValid func(string) bool) []span {
+func findSpansForShape(src string, shape secretShape, isOpenAI bool) []span {
 	var spans []span
 	lastIndex := 0
 	for lastIndex < len(src) {
@@ -711,7 +700,7 @@ func findSpansForShape(src string, shape secretShape, isOpenAI bool, isValid fun
 			}
 		}
 
-		matchSpans, consumedEnd := extractSpansFromMatch(src, matchStart, matchEnd, shape, isOpenAI, isValid)
+		matchSpans, consumedEnd := extractSpansFromMatch(src, matchStart, matchEnd, shape, isOpenAI)
 		spans = append(spans, matchSpans...)
 
 		if consumedEnd > 0 {

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -444,7 +444,7 @@ var (
 	anchoredOpenaiKeyPattern     = regexp.MustCompile(`^sk-[A-Za-z0-9_-]{20,}`)
 )
 
-func startsIndependentCredential(s string) bool {
+func startsIndependentCredential(s string, allowIncompletePrefix bool) bool {
 	if len(s) < 15 {
 		return false
 	}
@@ -492,8 +492,8 @@ func startsIndependentCredential(s string) bool {
 			}
 		}
 	}
-	if strings.HasPrefix(s, "sk-proj-") || strings.HasPrefix(s, "sk-ant-") || strings.HasPrefix(s, "github_pat_") ||
-		strings.HasPrefix(s, "glpat-") || strings.HasPrefix(s, "AIza") {
+	if allowIncompletePrefix && (strings.HasPrefix(s, "sk-proj-") || strings.HasPrefix(s, "sk-ant-") || strings.HasPrefix(s, "github_pat_") ||
+		strings.HasPrefix(s, "glpat-") || strings.HasPrefix(s, "AIza")) {
 		return true
 	}
 	return false
@@ -561,7 +561,14 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 		return false
 	}
 
-	for _, cSpan := range cand.spans {
+	for i := 0; i < len(cand.spans); i++ {
+		cSpan := cand.spans[i]
+		// Mixed C0, raw C1, and UTF-8 C1 spans form one gap. Classify the
+		// following token only after the whole run, preserving its original bytes.
+		for cSpan.validGap && i+1 < len(cand.spans) && cand.spans[i+1].validGap && cand.spans[i+1].start == cSpan.end {
+			i++
+			cSpan.end = cand.spans[i].end
+		}
 		if cSpan.start < candStartOrig {
 			continue
 		}
@@ -581,6 +588,8 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 			logCursor++
 		}
 
+		logPre := cand.logical[candStartLog:logCursor]
+		prefixValid := isCandidateValid(logPre, shape, isOpenAI, runningDots, runningDigits, hasInteriorHyphen)
 		tailInSrc := src[matchStart+cSpan.end:]
 		tailWindow := tailInSrc
 		if len(tailWindow) > 64 {
@@ -589,7 +598,9 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 		// A complete neighboring JWT may need more than 64 bytes to reach
 		// its signature. Inspect its full first token; the helper stops at
 		// the next delimiter, so successive gaps examine disjoint segments.
-		startsNew := startsIndependentCredential(tailInSrc)
+		// An incomplete prefix can separate prose from a later split secret,
+		// but cannot end an already-valid candidate and expose its suffix.
+		startsNew := startsIndependentCredential(tailInSrc, !prefixValid)
 		if startsNew {
 			checkCandidate(logCursor)
 			candStartOrig = cSpan.end
@@ -601,8 +612,7 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 			continue
 		}
 
-		logPre := cand.logical[candStartLog:logCursor]
-		if isCandidateValid(logPre, shape, isOpenAI, runningDots, runningDigits, hasInteriorHyphen) {
+		if prefixValid {
 			if idx := strings.IndexAny(tailWindow, "/\\"); idx >= 0 {
 				segment := tailWindow[:idx]
 				if len(segment) < 15 && !strings.Contains(segment, "\n") {
@@ -619,7 +629,7 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 			if spaceIdx := strings.IndexAny(firstWord, " \t\n\r"); spaceIdx >= 0 {
 				firstWord = firstWord[:spaceIdx]
 			}
-			if isOpenAI && strings.Contains(firstWord, "-") && !secretMatchHasDigit(firstWord) && !startsIndependentCredential(firstWord) {
+			if isOpenAI && strings.Contains(firstWord, "-") && !secretMatchHasDigit(firstWord) && !startsIndependentCredential(firstWord, true) {
 				checkCandidate(logCursor)
 				if lastConsumedEnd <= 0 {
 					lastConsumedEnd = cSpan.start

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -586,7 +586,10 @@ func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretSha
 		if len(tailWindow) > 64 {
 			tailWindow = tailWindow[:64]
 		}
-		startsNew := startsIndependentCredential(tailWindow)
+		// A complete neighboring JWT may need more than 64 bytes to reach
+		// its signature. Inspect its full first token; the helper stops at
+		// the next delimiter, so successive gaps examine disjoint segments.
+		startsNew := startsIndependentCredential(tailInSrc)
 		if startsNew {
 			checkCandidate(logCursor)
 			candStartOrig = cSpan.end

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -159,9 +159,9 @@ var secretShapes = []secretShape{
 		minLen:       40, // gh[pousr]_ (4) + 36
 	},
 	{
-		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("glpat-"), secretBody(`[A-Za-z0-9_-]`, 12, true))),
-		plainPattern: regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{12,}`),
-		minLen:       18, // glpat- (6) + 12
+		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("glpat-"), secretBody(`[A-Za-z0-9_-]`, 20, true))),
+		plainPattern: regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{20,}`),
+		minLen:       26, // glpat- (6) + 20
 	},
 	{
 		textPattern:  regexp.MustCompile(`\b` + ctrlJoin(ctrlLit("AIza"), secretBody(`[0-9A-Za-z\-_]`, 35, true))),
@@ -327,39 +327,30 @@ func RedactString(value string, options Options) string {
 	// sk- pattern may reach its minimum before a control inside a longer
 	// Anthropic key; letting the Anthropic shape consume that split first avoids
 	// leaving a recognizable credential suffix behind.
+	var allSpans []span
 	for _, shape := range secretShapes {
-		redacted = replaceAllSecretMatches(redacted, shape, replacement, false, nil)
+		allSpans = append(allSpans, findSpansForShape(redacted, shape, false, nil)...)
 	}
-	// Apply the broad OpenAI shape after specialized keys so its kebab-case
-	// false-positive filter considers only the matched key, never suffix text.
 	openaiShape := secretShape{
 		textPattern:  openaiKeyPattern,
 		plainPattern: plainOpenaiKeyPattern,
 		minLen:       minOpenAILen,
 		requireDots:  false,
 	}
-	redacted = replaceAllSecretMatches(redacted, openaiShape, replacement, true, func(m string) bool {
+	allSpans = append(allSpans, findSpansForShape(redacted, openaiShape, true, func(m string) bool {
 		// m is the logical (control-stripped) candidate.
 		if !knownOpenAIKeyPrefix(m) && !secretMatchHasDigit(m) &&
 			strings.Contains(strings.TrimPrefix(m, "sk-"), "-") {
 			return false
 		}
 		return true
-	})
+	})...)
+	redacted = applySpans(redacted, allSpans, replacement)
 	return redacted
 }
 
 const minOpenAILen = 23 // sk- (3) + 20
 
-func isCandidateLength(logLen int, minLen int, requireDots bool, runningDots int) bool {
-	if logLen < minLen {
-		return false
-	}
-	if requireDots {
-		return runningDots >= 2
-	}
-	return true
-}
 
 type controlSpan struct {
 	start    int
@@ -439,235 +430,345 @@ func extractLogicalCandidate(s string) logicalCandidate {
 	}
 }
 
-func startsNewCredential(s string, isJWT bool) bool {
-	if strings.HasPrefix(s, "sk-") ||
-		strings.HasPrefix(s, "ghp_") ||
-		strings.HasPrefix(s, "gho_") ||
-		strings.HasPrefix(s, "ghu_") ||
-		strings.HasPrefix(s, "ghs_") ||
-		strings.HasPrefix(s, "ghr_") ||
-		strings.HasPrefix(s, "github_pat_") ||
-		strings.HasPrefix(s, "glpat-") ||
-		strings.HasPrefix(s, "AIza") ||
-		strings.HasPrefix(s, "xoxb-") ||
-		strings.HasPrefix(s, "xoxa-") ||
-		strings.HasPrefix(s, "xoxp-") ||
-		strings.HasPrefix(s, "xoxr-") ||
-		strings.HasPrefix(s, "xoxs-") ||
-		strings.HasPrefix(s, "AKIA") ||
-		strings.HasPrefix(s, "ASIA") {
-		return true
+type span struct {
+	start int
+	end   int
+}
+
+func isWordByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+var (
+	anchoredAnthropicKeyPattern  = regexp.MustCompile(`^sk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{20,}`)
+	anchoredGitHubPatPattern     = regexp.MustCompile(`^github_pat_[A-Za-z0-9_]{22,}`)
+	anchoredGitHubClassicPattern = regexp.MustCompile(`^gh[pousr]_[A-Za-z0-9]{36,}`)
+	anchoredGitLabPatPattern     = regexp.MustCompile(`^glpat-[A-Za-z0-9_-]{20,}`)
+	anchoredGoogleApiKeyPattern  = regexp.MustCompile(`^AIza[0-9A-Za-z\-_]{35,}`)
+	anchoredSlackTokenPattern    = regexp.MustCompile(`^xox[baprs]-[A-Za-z0-9-]{10,}`)
+	anchoredAwsKeyPattern        = regexp.MustCompile(`^(?:AKIA|ASIA)[A-Z0-9]{16}`)
+	anchoredJwtStrictPattern     = regexp.MustCompile(`^eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)
+	anchoredJwtLoosePattern      = regexp.MustCompile(`^eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)
+	anchoredOpenaiKeyPattern     = regexp.MustCompile(`^sk-[A-Za-z0-9_-]{20,}`)
+)
+
+func startsIndependentCredential(s string) bool {
+	if len(s) < 15 {
+		return false
 	}
-	if !isJWT && strings.HasPrefix(s, "eyJ") {
+	tokenEnd := len(s)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c == 0x7F || c >= 0x80 || c == '/' || c == '\\' || c == ' ' {
+			tokenEnd = i
+			break
+		}
+	}
+	token := s[:tokenEnd]
+	if len(token) >= 15 {
+		if strings.HasPrefix(token, "sk-ant-") && anchoredAnthropicKeyPattern.MatchString(token) {
+			return true
+		}
+		if strings.HasPrefix(token, "github_pat_") && anchoredGitHubPatPattern.MatchString(token) {
+			return true
+		}
+		if len(token) >= 4 && token[0] == 'g' && token[1] == 'h' && (token[2] == 'p' || token[2] == 'o' || token[2] == 'u' || token[2] == 's' || token[2] == 'r') && token[3] == '_' && anchoredGitHubClassicPattern.MatchString(token) {
+			return true
+		}
+		if strings.HasPrefix(token, "glpat-") && anchoredGitLabPatPattern.MatchString(token) {
+			return true
+		}
+		if strings.HasPrefix(token, "AIza") && anchoredGoogleApiKeyPattern.MatchString(token) {
+			return true
+		}
+		if len(token) >= 5 && strings.HasPrefix(token, "xox") && (token[3] == 'b' || token[3] == 'a' || token[3] == 'p' || token[3] == 'r' || token[3] == 's') && token[4] == '-' && anchoredSlackTokenPattern.MatchString(token) {
+			return true
+		}
+		if (strings.HasPrefix(token, "AKIA") || strings.HasPrefix(token, "ASIA")) && anchoredAwsKeyPattern.MatchString(token) {
+			return true
+		}
+		if strings.HasPrefix(token, "eyJ") && (anchoredJwtStrictPattern.MatchString(token) || anchoredJwtLoosePattern.MatchString(token)) {
+			return true
+		}
+		if strings.HasPrefix(token, "sk-") {
+			loc := anchoredOpenaiKeyPattern.FindStringIndex(token)
+			if loc != nil {
+				candStr := token[:loc[1]]
+				if knownOpenAIKeyPrefix(candStr) || secretMatchHasDigit(candStr) || !strings.Contains(strings.TrimPrefix(candStr, "sk-"), "-") {
+					return true
+				}
+			}
+		}
+	}
+	if strings.HasPrefix(s, "sk-proj-") || strings.HasPrefix(s, "sk-ant-") || strings.HasPrefix(s, "github_pat_") ||
+		strings.HasPrefix(s, "glpat-") || strings.HasPrefix(s, "AIza") {
 		return true
 	}
 	return false
 }
 
-func findCredentialBoundary(src string, matchStart, matchEnd int, shape secretShape, isOpenAI bool, hasTrailingPath bool, isValid func(string) bool) (int, bool) {
+func isCandidateValid(logPre string, shape secretShape, isOpenAI bool, dots, digits int, hasInteriorHyphen bool, isValid func(string) bool) bool {
+	if len(logPre) < shape.minLen {
+		return false
+	}
+	if shape.requireDots && dots < 2 {
+		return false
+	}
+	if isOpenAI {
+		if !strings.HasPrefix(logPre, "sk-") {
+			return false
+		}
+		if knownOpenAIKeyPrefix(logPre) {
+			return true
+		}
+		if digits > 0 {
+			return true
+		}
+		if hasInteriorHyphen {
+			return false
+		}
+		return true
+	}
+	if shape.plainPattern != nil && !shape.plainPattern.MatchString(logPre) {
+		return false
+	}
+	if isValid != nil && !isValid(logPre) {
+		return false
+	}
+	return true
+}
+
+func extractSpansFromMatch(src string, matchStart, matchEnd int, shape secretShape, isOpenAI bool, isValid func(string) bool) ([]span, int) {
 	match := src[matchStart:matchEnd]
 	cand := extractLogicalCandidate(match)
-	if len(cand.spans) == 0 {
-		if isValid != nil && !isValid(match) {
-			return len(match), false
-		}
-		return len(match), true
+	if len(cand.logical) == 0 {
+		return nil, 0
 	}
 
-	logicalStr := cand.logical
-
-	// Fast path for OpenAI kebab false positives: if the logical string has no digits,
-	// is not a known prefix, and the token before the first control span already contains
-	// an interior hyphen, no sub-span can ever be valid.
-	if isOpenAI && isValid != nil && len(cand.spans) > 0 && cand.spans[0].start > 0 {
-		if !knownOpenAIKeyPrefix(logicalStr) && !secretMatchHasDigit(logicalStr) {
-			firstLogLen := sort.SearchInts(cand.origEnds, cand.spans[0].start+1)
-			firstPre := logicalStr[:firstLogLen]
-			if strings.Contains(strings.TrimPrefix(firstPre, "sk-"), "-") {
-				return len(match), false
-			}
-		}
-	}
-
-	runningDots := 0
+	var spans []span
+	candStartOrig := 0
+	candStartLog := 0
 	logCursor := 0
-	hasDigit := false
+	runningDots := 0
+	runningDigits := 0
 	hasInteriorHyphen := false
-	hasKnownPrefix := isOpenAI && knownOpenAIKeyPrefix(logicalStr)
-	lastValidEnd := 0
-	plainPatternMatched := false
+	lastConsumedEnd := 0
 
-	checkPlainPattern := func(logLen int) bool {
-		if plainPatternMatched {
-			return true
+	checkCandidate := func(logEnd int) bool {
+		if logEnd <= candStartLog {
+			return false
 		}
-		if shape.plainPattern == nil {
-			return true
-		}
-		if shape.plainPattern.MatchString(logicalStr[:logLen]) {
-			plainPatternMatched = true
+		logPre := cand.logical[candStartLog:logEnd]
+		valid := isCandidateValid(logPre, shape, isOpenAI, runningDots, runningDigits, hasInteriorHyphen, isValid)
+		if valid {
+			origEnd := cand.origEnds[logEnd-1]
+			spans = append(spans, span{
+				start: matchStart + candStartOrig,
+				end:   matchStart + origEnd,
+			})
+			lastConsumedEnd = origEnd
 			return true
 		}
 		return false
 	}
 
-	for i, span := range cand.spans {
-		if span.start == 0 {
+	for _, cSpan := range cand.spans {
+		if cSpan.start < candStartOrig {
 			continue
 		}
-		for logCursor < len(cand.origEnds) && cand.origEnds[logCursor] <= span.start {
-			c := logicalStr[logCursor]
+		for logCursor < len(cand.origEnds) && cand.origEnds[logCursor] <= cSpan.start {
+			c := cand.logical[logCursor]
 			if shape.requireDots && c == '.' {
 				runningDots++
 			}
 			if isOpenAI {
 				if c >= '0' && c <= '9' {
-					hasDigit = true
+					runningDigits++
 				}
-				if c == '-' && logCursor >= 3 {
+				if c == '-' && (logCursor-candStartLog) >= 3 {
 					hasInteriorHyphen = true
 				}
 			}
 			logCursor++
 		}
-		logLen := logCursor
-		logPreValid := !isOpenAI || hasKnownPrefix || hasDigit || !hasInteriorHyphen
-		validateLogPre := func() bool {
-			if !logPreValid {
-				return false
-			}
-			if isOpenAI {
-				return true
-			}
-			return checkPlainPattern(logLen)
+
+		tailInSrc := src[matchStart+cSpan.end:]
+		tailWindow := tailInSrc
+		if len(tailWindow) > 64 {
+			tailWindow = tailWindow[:64]
+		}
+		startsNew := startsIndependentCredential(tailWindow)
+		if startsNew {
+			checkCandidate(logCursor)
+			candStartOrig = cSpan.end
+			candStartLog = logCursor
+			runningDots = 0
+			runningDigits = 0
+			hasInteriorHyphen = false
+			lastConsumedEnd = cSpan.end
+			continue
 		}
 
-		// If text in src after span starts a new credential, this span is a delimiter between credentials.
-		tailInSrc := src[matchStart+span.end:]
-		if startsNewCredential(tailInSrc, shape.requireDots) {
-			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) && validateLogPre() {
-				return span.start, true
+		logPre := cand.logical[candStartLog:logCursor]
+		if isCandidateValid(logPre, shape, isOpenAI, runningDots, runningDigits, hasInteriorHyphen, isValid) {
+			if idx := strings.IndexAny(tailWindow, "/\\"); idx >= 0 {
+				segment := tailWindow[:idx]
+				if len(segment) < 15 && !strings.Contains(segment, "\n") {
+					if !isOpenAI || !strings.Contains(strings.TrimPrefix(logPre, "sk-"), "-") || knownOpenAIKeyPrefix(logPre) || runningDigits > 0 {
+						checkCandidate(logCursor)
+					}
+					if lastConsumedEnd <= 0 {
+						lastConsumedEnd = cSpan.start
+					}
+					return spans, lastConsumedEnd
+				}
 			}
-			return span.start, false
+			firstWord := tailWindow
+			if spaceIdx := strings.IndexAny(firstWord, " \t\n\r"); spaceIdx >= 0 {
+				firstWord = firstWord[:spaceIdx]
+			}
+			if isOpenAI && strings.Contains(firstWord, "-") && !secretMatchHasDigit(firstWord) && !startsIndependentCredential(firstWord) {
+				checkCandidate(logCursor)
+				if lastConsumedEnd <= 0 {
+					lastConsumedEnd = cSpan.start
+				}
+				return spans, lastConsumedEnd
+			}
+		} else if idx := strings.IndexAny(tailWindow, "/\\"); idx >= 0 {
+			segment := tailWindow[:idx]
+			if len(segment) < 15 && !strings.Contains(segment, "\n") {
+				if lastConsumedEnd <= 0 {
+					lastConsumedEnd = cSpan.start
+				}
+				return spans, lastConsumedEnd
+			}
 		}
 
-		if !span.validGap {
-			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) && validateLogPre() {
-				return span.start, true
-			}
-			return span.start, false
-		}
-
-		// If match is followed by a path separator in source and this span precedes the trailing path,
-		// the span is a terminal delimiter if the prefix is already a valid credential.
-		if hasTrailingPath && i == len(cand.spans)-1 {
-			if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) && validateLogPre() {
-				return span.start, true
-			}
-			return span.start, false
-		}
-		if isCandidateLength(logLen, shape.minLen, shape.requireDots, runningDots) && validateLogPre() {
-			lastValidEnd = span.start
-		}
-	}
-
-	for _, span := range cand.spans {
-		if !span.validGap {
-			return span.start, false
+		if !cSpan.validGap {
+			checkCandidate(logCursor)
+			candStartOrig = cSpan.end
+			candStartLog = logCursor
+			runningDots = 0
+			runningDigits = 0
+			hasInteriorHyphen = false
+			lastConsumedEnd = cSpan.end
+			continue
 		}
 	}
 
 	for logCursor < len(cand.origEnds) {
-		c := logicalStr[logCursor]
+		c := cand.logical[logCursor]
 		if shape.requireDots && c == '.' {
 			runningDots++
 		}
 		if isOpenAI {
 			if c >= '0' && c <= '9' {
-				hasDigit = true
+				runningDigits++
 			}
-			if c == '-' && logCursor >= 3 {
+			if c == '-' && (logCursor-candStartLog) >= 3 {
 				hasInteriorHyphen = true
 			}
 		}
 		logCursor++
 	}
-
-	if !isCandidateLength(len(logicalStr), shape.minLen, shape.requireDots, runningDots) {
-		if lastValidEnd > 0 {
-			return lastValidEnd, true
-		}
-		return len(match), false
+	if checkCandidate(logCursor) {
+		lastConsumedEnd = len(match)
 	}
 
-	if isOpenAI {
-		if !hasKnownPrefix && !hasDigit && hasInteriorHyphen {
-			if lastValidEnd > 0 {
-				return lastValidEnd, true
-			}
-			return len(match), false
-		}
-	} else if !checkPlainPattern(len(logicalStr)) {
-		if lastValidEnd > 0 {
-			return lastValidEnd, true
-		}
-		return len(match), false
+	if lastConsumedEnd <= 0 {
+		lastConsumedEnd = candStartOrig
 	}
-
-	if isValid != nil && !isValid(logicalStr) {
-		if lastValidEnd > 0 {
-			return lastValidEnd, true
-		}
-		return len(match), false
+	if lastConsumedEnd <= 0 {
+		lastConsumedEnd = len(match)
 	}
-
-	if len(cand.origEnds) > 0 {
-		lastEnd := cand.origEnds[len(cand.origEnds)-1]
-		return lastEnd, true
-	}
-	return len(match), true
+	return spans, lastConsumedEnd
 }
 
-func replaceAllSecretMatches(src string, shape secretShape, replacement string, isOpenAI bool, isValid func(string) bool) string {
-	loc := shape.textPattern.FindStringIndex(src)
-	if loc == nil {
-		return src
-	}
-
-	var b strings.Builder
-	b.Grow(len(src))
-
+func findSpansForShape(src string, shape secretShape, isOpenAI bool, isValid func(string) bool) []span {
+	var spans []span
 	lastIndex := 0
-	for {
+	for lastIndex < len(src) {
 		loc := shape.textPattern.FindStringIndex(src[lastIndex:])
 		if loc == nil {
-			b.WriteString(src[lastIndex:])
 			break
 		}
-
 		matchStart := lastIndex + loc[0]
 		matchEnd := lastIndex + loc[1]
-		hasTrailingPath := matchEnd < len(src) && (src[matchEnd] == '/' || src[matchEnd] == '\\')
 
-		advanceLen, shouldRedact := findCredentialBoundary(src, matchStart, matchEnd, shape, isOpenAI, hasTrailingPath, isValid)
-
-		b.WriteString(src[lastIndex:matchStart])
-		if shouldRedact {
-			b.WriteString(replacement)
-			lastIndex = matchStart + advanceLen
-		} else {
-			if advanceLen <= 0 {
-				advanceLen = 1
+		if matchStart > 0 && isWordByte(src[matchStart-1]) {
+			// If matchStart directly abuts the end of an already matched span,
+			// allow it so adjacent credentials like AKIA...AKIA... both match.
+			abuts := false
+			for _, s := range spans {
+				if s.end == matchStart {
+					abuts = true
+					break
+				}
 			}
-			b.WriteString(src[matchStart : matchStart+advanceLen])
-			lastIndex = matchStart + advanceLen
+			if !abuts {
+				lastIndex = matchStart + 1
+				continue
+			}
 		}
-		if lastIndex <= matchStart {
+
+		matchSpans, consumedEnd := extractSpansFromMatch(src, matchStart, matchEnd, shape, isOpenAI, isValid)
+		spans = append(spans, matchSpans...)
+
+		if consumedEnd > 0 {
+			lastIndex = matchStart + consumedEnd
+		} else if matchEnd > matchStart {
+			lastIndex = matchEnd
+		} else {
 			lastIndex = matchStart + 1
 		}
-		if lastIndex >= len(src) {
-			break
+	}
+	return spans
+}
+
+func mergeSpans(spans []span) []span {
+	if len(spans) <= 1 {
+		return spans
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
 		}
+		return spans[i].end > spans[j].end
+	})
+	merged := make([]span, 0, len(spans))
+	cur := spans[0]
+	for i := 1; i < len(spans); i++ {
+		s := spans[i]
+		if s.start < cur.end {
+			if s.end > cur.end {
+				cur.end = s.end
+			}
+		} else {
+			merged = append(merged, cur)
+			cur = s
+		}
+	}
+	merged = append(merged, cur)
+	return merged
+}
+
+func applySpans(src string, spans []span, replacement string) string {
+	if len(spans) == 0 {
+		return src
+	}
+	merged := mergeSpans(spans)
+	var b strings.Builder
+	b.Grow(len(src))
+	lastIndex := 0
+	for _, s := range merged {
+		if s.start > lastIndex {
+			b.WriteString(src[lastIndex:s.start])
+		}
+		b.WriteString(replacement)
+		lastIndex = s.end
+	}
+	if lastIndex < len(src) {
+		b.WriteString(src[lastIndex:])
 	}
 	return b.String()
 }

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -174,13 +174,7 @@ func TestRedactStringCatchesSecretsSplitByControlBytes(t *testing.T) {
 			for _, input := range inputs {
 				t.Run(input.placement, func(t *testing.T) {
 					got := RedactString(input.input, Options{})
-					if strings.Contains(got, body) {
-						t.Fatalf("secret split by %s %s leaked in %q", tc.name, input.placement, got)
-					}
-					if strings.Contains(got, prefix) {
-						t.Fatalf("secret prefix split by %s %s leaked in %q", tc.name, input.placement, got)
-					}
-					if !strings.Contains(got, RedactedSecret) {
+					if got != RedactedSecret {
 						t.Fatalf("expected %q after %s %s split, got %q", RedactedSecret, tc.name, input.placement, got)
 					}
 				})

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -144,7 +144,8 @@ func containsCircular(v any) bool {
 
 func TestRedactStringCatchesSecretsSplitByControlBytes(t *testing.T) {
 	// Unsplit passing is not coverage: a NUL/ESC/C1 in the body splits the
-	// shape so the patterns miss it unless controls are stripped first.
+	// shape so the patterns miss it unless matching allows those controls as
+	// gaps between body characters (without joining unrelated tokens).
 	const prefix = "sk-ant-api03-"
 	const body = "abcdefghijklmnopqrstuvwxyz"
 	unsplit := prefix + body
@@ -182,5 +183,45 @@ func TestRedactStringPreservesAllowedWhitespaceAndUTF8(t *testing.T) {
 	input := "safe\tline\nnext\rfinal café"
 	if got := RedactString(input, Options{}); got != input {
 		t.Fatalf("unexpected normalization: %q", got)
+	}
+}
+
+func TestRedactStringWordcharBeforeNULAnthropicKey(t *testing.T) {
+	// Matching on a control-stripped copy joins "id42" and the key, so \b in
+	// textSecretPatterns misses and the secret leaks. Matching on the original
+	// treats the NUL as a boundary; leaked must be false.
+	const secret = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+	if got := RedactString(secret, Options{}); strings.Contains(got, "sk-ant-api03-") {
+		t.Fatalf("unsplit secret not redacted (test setup): %q", got)
+	}
+	input := "id42\x00" + secret
+	got := RedactString(input, Options{})
+	leaked := strings.Contains(got, secret) || strings.Contains(got, "sk-ant-api03-")
+	if leaked {
+		t.Fatalf("wordchar-before-NUL+anthropic-key leaked=true out=%q", got)
+	}
+	if !strings.Contains(got, RedactedSecret) {
+		t.Fatalf("wordchar-before-NUL+anthropic-key leaked=false want %q, got %q", RedactedSecret, got)
+	}
+}
+
+func TestRedactStringControlBytesWithoutSecretStayIdentical(t *testing.T) {
+	// scrubResultSecrets sets Result.Redacted when RedactString's result !=
+	// Output. Stripping is matching-time only: no-secret control bytes must
+	// remain byte-identical so Redacted stays false.
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "form feed in source", input: "package main\n\ffunc main() {}\n"},
+		{name: "Windows-1252 quotes", input: "Don\x92t \x93quote\x94 me\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactString(tc.input, Options{})
+			if got != tc.input {
+				t.Fatalf("no-secret input not byte-identical:\n in=%q\nout=%q", tc.input, got)
+			}
+		})
 	}
 }

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -159,6 +159,7 @@ func TestRedactStringCatchesSecretsSplitByControlBytes(t *testing.T) {
 		{name: "NUL", split: "\x00"},
 		{name: "ESC", split: "\x1b"},
 		{name: "C1", split: "\x9b"},
+		{name: "UTF-8 C1", split: string(rune(0x9B))},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -174,5 +175,12 @@ func TestRedactStringCatchesSecretsSplitByControlBytes(t *testing.T) {
 				t.Fatalf("expected %q after %s split, got %q", RedactedSecret, tc.name, got)
 			}
 		})
+	}
+}
+
+func TestRedactStringPreservesAllowedWhitespaceAndUTF8(t *testing.T) {
+	input := "safe\tline\nnext\rfinal café"
+	if got := RedactString(input, Options{}); got != input {
+		t.Fatalf("unexpected normalization: %q", got)
 	}
 }

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -141,3 +141,38 @@ func containsCircular(v any) bool {
 	}
 	return false
 }
+
+func TestRedactStringCatchesSecretsSplitByControlBytes(t *testing.T) {
+	// Unsplit passing is not coverage: a NUL/ESC/C1 in the body splits the
+	// shape so the patterns miss it unless controls are stripped first.
+	const prefix = "sk-ant-api03-"
+	const body = "abcdefghijklmnopqrstuvwxyz"
+	unsplit := prefix + body
+	if got := RedactString(unsplit, Options{}); strings.Contains(got, body) {
+		t.Fatalf("unsplit secret not redacted (test setup): %q", got)
+	}
+
+	cases := []struct {
+		name  string
+		split string
+	}{
+		{name: "NUL", split: "\x00"},
+		{name: "ESC", split: "\x1b"},
+		{name: "C1", split: "\x9b"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := prefix + tc.split + body
+			got := RedactString(input, Options{})
+			if strings.Contains(got, body) {
+				t.Fatalf("secret split by %s leaked in %q", tc.name, got)
+			}
+			if strings.Contains(got, prefix) {
+				t.Fatalf("secret prefix split by %s leaked in %q", tc.name, got)
+			}
+			if !strings.Contains(got, RedactedSecret) {
+				t.Fatalf("expected %q after %s split, got %q", RedactedSecret, tc.name, got)
+			}
+		})
+	}
+}

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -164,18 +164,62 @@ func TestRedactStringCatchesSecretsSplitByControlBytes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			input := prefix + tc.split + body
-			got := RedactString(input, Options{})
-			if strings.Contains(got, body) {
-				t.Fatalf("secret split by %s leaked in %q", tc.name, got)
+			inputs := []struct {
+				placement string
+				input     string
+			}{
+				{placement: "prefix-body boundary", input: prefix + tc.split + body},
+				{placement: "inside body", input: prefix + body[:13] + tc.split + body[13:]},
 			}
-			if strings.Contains(got, prefix) {
-				t.Fatalf("secret prefix split by %s leaked in %q", tc.name, got)
-			}
-			if !strings.Contains(got, RedactedSecret) {
-				t.Fatalf("expected %q after %s split, got %q", RedactedSecret, tc.name, got)
+			for _, input := range inputs {
+				t.Run(input.placement, func(t *testing.T) {
+					got := RedactString(input.input, Options{})
+					if strings.Contains(got, body) {
+						t.Fatalf("secret split by %s %s leaked in %q", tc.name, input.placement, got)
+					}
+					if strings.Contains(got, prefix) {
+						t.Fatalf("secret prefix split by %s %s leaked in %q", tc.name, input.placement, got)
+					}
+					if !strings.Contains(got, RedactedSecret) {
+						t.Fatalf("expected %q after %s %s split, got %q", RedactedSecret, tc.name, input.placement, got)
+					}
+				})
 			}
 		})
+	}
+}
+
+func TestRedactStringPreservesControlAfterCredential(t *testing.T) {
+	const secret = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+	input := "key=" + secret + "\x00path/one.go\x00path/two.go"
+	want := "key=" + RedactedSecret + "\x00path/one.go\x00path/two.go"
+	if got := RedactString(input, Options{}); got != want {
+		t.Fatalf("terminal credential separator changed:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestRedactStringSuffixCannotDisableOpenAIKeyMatch(t *testing.T) {
+	const secret = "sk-aaaaaaaaaaaaaaaaaaaabcdefgh"
+	input := "key " + secret + "\x1bkebab-case tail"
+	want := "key " + RedactedSecret + "\x1bkebab-case tail"
+	if got := RedactString(input, Options{}); got != want {
+		t.Fatalf("suffix changed OpenAI key classification:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestRedactStringDistinguishesInvalidC1FromValidReplacementRune(t *testing.T) {
+	const prefix = "sk-ant-api03-"
+	const body = "abcdefghijklmnopqrstuvwxyz"
+
+	invalidC1 := prefix + body[:13] + "\x9b" + body[13:]
+	if got := RedactString(invalidC1, Options{}); got != RedactedSecret {
+		t.Fatalf("raw invalid C1 split was not redacted: %q", got)
+	}
+
+	validReplacement := prefix + body[:13] + "\uFFFD" + body[13:]
+	got := RedactString(validReplacement, Options{})
+	if !strings.Contains(got, "\uFFFD"+body[13:]) {
+		t.Fatalf("valid U+FFFD was treated as a control gap: %q", got)
 	}
 }
 

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -3,6 +3,7 @@ package redaction
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSplitRedactionHarness(t *testing.T) {
@@ -15,8 +16,8 @@ func TestSplitRedactionHarness(t *testing.T) {
 		{"OpenAI standard", "sk-abcdefghijklmnopqrstuvwxyz12345678"},
 		{"OpenAI with hyphen and digit", "sk-aaaaaaaaaa-bbbbbbbbb1234567890"},
 		{"OpenAI proj", "sk-proj-abcdefghijklmnopqrstuvwxyz12345"},
-		{"GitHub PAT", "github_pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz"},
-		{"GitHub Fine-Grained", "ghp_123456789012345678901234567890123456"},
+		{"GitHub PAT", "github_" + "pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz"},
+		{"GitHub Fine-Grained", "ghp_" + "123456789012345678901234567890123456"},
 		{"GitLab PAT", "glpat-12345678901234567890"},
 		{"Google API", "AIzaSyD-1234567890123456789012345678901"},
 		{"Slack bot", "xoxb-123456789012-abcdefghijklmno"},
@@ -123,8 +124,8 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 			key2 string
 		}{
 			{"OpenAI", "sk-aaaaaaaaaaaaaaaaaaaabcdefgh", "sk-bbbbbbbbbbbbbbbbbbbbcdefghi"},
-			{"GitHub Fine-Grained", "ghp_123456789012345678901234567890123456", "ghp_abcdefghijklmnopqrstuvwxyz1234567890"},
-			{"GitHub PAT", "github_pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz", "github_pat_22BBBBBBB0123456789abcdefghijklmnopqrstuvwxyz"},
+			{"GitHub Fine-Grained", "ghp_" + "123456789012345678901234567890123456", "ghp_" + "abcdefghijklmnopqrstuvwxyz1234567890"},
+			{"GitHub PAT", "github_" + "pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz", "github_" + "pat_22BBBBBBB0123456789abcdefghijklmnopqrstuvwxyz"},
 			{"GitLab PAT", "glpat-12345678901234567890", "glpat-abcdefghijklmnopqrst"},
 			{"Google API", "AIzaSyD-1234567890123456789012345678901", "AIzaSyD-abcdefghijklmnopqrstuvwxyz12345"},
 			{"Slack", "xox" + "b-123456789012-abcdefghijklmno", "xox" + "b-987654321098-zyxwvutsrqponml"},
@@ -231,27 +232,30 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 }
 
 func TestSplitRedactionLinearScaling(t *testing.T) {
-	sizes := []int{8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024, 128 * 1024, 800 * 1024}
+	sizes := []int{8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024, 128 * 1024}
 
 	t.Run("OpenAI kebab repeated gaps scaling", func(t *testing.T) {
 		for _, size := range sizes {
-			// Construct "sk-kebab-" + repeated "\x00a" up to size
 			var b strings.Builder
 			b.WriteString("sk-kebab-")
 			for b.Len() < size {
 				b.WriteString("\x00a")
 			}
 			input := b.String()
+			start := time.Now()
 			got := RedactString(input, Options{})
+			elapsed := time.Since(start)
 			if got != input {
 				t.Fatalf("kebab false positive was falsely redacted at size %d", size)
+			}
+			if elapsed > time.Second {
+				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)
 			}
 		}
 	})
 
 	t.Run("JWT repeated gaps scaling and correct redaction", func(t *testing.T) {
 		for _, size := range sizes {
-			// Construct "eyJ" + repeated "\x00a" + ".eyJ" + repeated "\x00b" + ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 			segLen := size / 2
 			var b strings.Builder
 			b.WriteString("eyJ")
@@ -264,12 +268,35 @@ func TestSplitRedactionLinearScaling(t *testing.T) {
 			}
 			b.WriteString(".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
 			input := b.String()
+			start := time.Now()
 			got := RedactString(input, Options{})
+			elapsed := time.Since(start)
 			if !strings.Contains(got, RedactedSecret) {
 				t.Fatalf("JWT at size %d failed to redact", size)
 			}
+			if elapsed > time.Second {
+				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)
+			}
 		}
 	})
+}
+
+func BenchmarkRedactJWTGaps800KB(b *testing.B) {
+	var builder strings.Builder
+	builder.WriteString("eyJ")
+	for builder.Len() < 400*1024 {
+		builder.WriteString("\x00a")
+	}
+	builder.WriteString(".eyJ")
+	for builder.Len() < 800*1024 {
+		builder.WriteString("\x00b")
+	}
+	builder.WriteString(".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+	input := builder.String()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = RedactString(input, Options{})
+	}
 }
 
 func BenchmarkRedactOpenAIKebabGaps128KB(b *testing.B) {

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -320,6 +320,26 @@ func TestSplitRedactionLinearScaling(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Anthropic repeated gaps scaling and correct redaction", func(t *testing.T) {
+		for _, size := range sizes {
+			var b strings.Builder
+			b.WriteString("sk-ant-api03-abcdefghijklmnopqrstuvwxyz")
+			for b.Len() < size {
+				b.WriteString("\x00a")
+			}
+			input := b.String()
+			start := time.Now()
+			got := RedactString(input, Options{})
+			elapsed := time.Since(start)
+			if got != RedactedSecret {
+				t.Fatalf("Anthropic at size %d failed to redact: got %q, want %q", size, got, RedactedSecret)
+			}
+			if elapsed > time.Second {
+				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)
+			}
+		}
+	})
 }
 
 func BenchmarkRedactJWTGaps800KB(b *testing.B) {

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -62,6 +62,82 @@ func TestSplitRedactionHarness(t *testing.T) {
 	}
 }
 
+func TestSplitRedactionMultiControlCases(t *testing.T) {
+	t.Run("Internal gap before minimum then terminal delimiter", func(t *testing.T) {
+		input := "sk-ant-api03-\x00abcdefghijklmnopqrstuvwxyz\x00path/file.go"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + "\x00path/file.go"
+		if got != want {
+			t.Fatalf("multi-control anthropic mismatch:\n got=%q\nwant=%q", got, want)
+		}
+	})
+
+	t.Run("OpenAI internal gap then terminal delimiter before kebab suffix", func(t *testing.T) {
+		input := "sk-\x00abcdefghijklmnopqrstuv\x1bkebab-case tail"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + "\x1bkebab-case tail"
+		if got != want {
+			t.Fatalf("multi-control openai mismatch:\n got=%q\nwant=%q", got, want)
+		}
+	})
+
+	t.Run("OpenAI internal gap before digit suffix then terminal delimiter", func(t *testing.T) {
+		input := "sk-aaaaaaaaaa-bbbbbbbbb\x001234567890\x00path/one.go"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + "\x00path/one.go"
+		if got != want {
+			t.Fatalf("multi-control openai with digits mismatch:\n got=%q\nwant=%q", got, want)
+		}
+	})
+
+	t.Run("JWT multiple internal gaps and terminal delimiter", func(t *testing.T) {
+		input := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\x00.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ\x1b.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\x00trailing/text"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + "\x00trailing/text"
+		if got != want {
+			t.Fatalf("multi-control jwt mismatch:\n got=%q\nwant=%q", got, want)
+		}
+	})
+
+	t.Run("Multiple internal controls in credential body", func(t *testing.T) {
+		input := "sk-ant-\x00api03-\x1babcdefghijklmnopqrstuvwxyz"
+		got := RedactString(input, Options{})
+		if got != RedactedSecret {
+			t.Fatalf("multiple internal gaps in anthropic key mismatch: got %q, want %q", got, RedactedSecret)
+		}
+	})
+
+	t.Run("Terminal delimiter separating two credentials", func(t *testing.T) {
+		input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz\x00ghp_123456789012345678901234567890123456"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + "\x00" + RedactedSecret
+		if got != want {
+			t.Fatalf("two credentials separated by delimiter mismatch: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Complete credential followed by invalid bytes", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			suffix string
+		}{
+			{"valid U+FFFD", "\uFFFDsuffix"},
+			{"malformed byte 0xFF", "\xffsuffix"},
+			{"malformed byte 0xC0", "\xc0suffix"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz" + tc.suffix
+				got := RedactString(input, Options{})
+				want := RedactedSecret + tc.suffix
+				if got != want {
+					t.Fatalf("suffix %s mismatch: got %q, want %q", tc.name, got, want)
+				}
+			})
+		}
+	})
+}
+
 func TestSplitRedactionNegativeCases(t *testing.T) {
 	controls := []string{"\x00", "\x1b", "\x9b", "\u009b"}
 

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -1,0 +1,102 @@
+package redaction
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitRedactionHarness(t *testing.T) {
+	// Representative secrets for all supported shapes
+	secrets := []struct {
+		name   string
+		secret string
+	}{
+		{"Anthropic", "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234"},
+		{"OpenAI standard", "sk-abcdefghijklmnopqrstuvwxyz12345678"},
+		{"OpenAI with hyphen and digit", "sk-aaaaaaaaaa-bbbbbbbbb1234567890"},
+		{"OpenAI proj", "sk-proj-abcdefghijklmnopqrstuvwxyz12345"},
+		{"GitHub PAT", "github_pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz"},
+		{"GitHub Fine-Grained", "ghp_123456789012345678901234567890123456"},
+		{"GitLab PAT", "glpat-12345678901234567890"},
+		{"Google API", "AIzaSyD-1234567890123456789012345678901"},
+		{"Slack bot", "xoxb-123456789012-abcdefghijklmno"},
+		{"AWS AKIA", "AKIAIOSFODNN7EXAMPLE"},
+		{"JWT", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"},
+	}
+
+	controls := []struct {
+		name string
+		char string
+	}{
+		{"NUL", "\x00"},
+		{"ESC", "\x1b"},
+		{"lone C1", "\x9b"},
+		{"UTF-8 C1", "\u009b"},
+	}
+
+	for _, s := range secrets {
+		t.Run(s.name, func(t *testing.T) {
+			// First verify unsplit redacts
+			gotUnsplit := RedactString(s.secret, Options{})
+			if strings.Contains(gotUnsplit, s.secret) || !strings.Contains(gotUnsplit, RedactedSecret) {
+				t.Fatalf("unsplit secret %q failed to redact: %q", s.secret, gotUnsplit)
+			}
+
+			// Test split at all interior positions throughout the secret
+			for _, ctrl := range controls {
+				for pos := 1; pos < len(s.secret); pos++ {
+					splitSecret := s.secret[:pos] + ctrl.char + s.secret[pos:]
+					got := RedactString(splitSecret, Options{})
+
+					// Strip controls from output and assert original secret cannot be recovered
+					strippedOutput := stripControlBytes(got)
+					if strings.Contains(strippedOutput, s.secret) {
+						t.Fatalf("split at pos %d with %s leaked secret!\n split input=%q\n got=%q\n stripped=%q", pos, ctrl.name, splitSecret, got, strippedOutput)
+					}
+					if !strings.Contains(got, RedactedSecret) {
+						t.Fatalf("split at pos %d with %s did not contain RedactedSecret!\n got=%q", pos, ctrl.name, got)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSplitRedactionNegativeCases(t *testing.T) {
+	controls := []string{"\x00", "\x1b", "\x9b", "\u009b"}
+
+	t.Run("OpenAI kebab false positive with control", func(t *testing.T) {
+		kebab := "sk-my-awesome-kebab-project"
+		for _, ctrl := range controls {
+			input := kebab[:10] + ctrl + kebab[10:]
+			got := RedactString(input, Options{})
+			if got != input {
+				t.Fatalf("digit-free kebab falsely redacted with control %q: got %q, want %q", ctrl, got, input)
+			}
+		}
+	})
+
+	t.Run("Control immediately before complete credential", func(t *testing.T) {
+		secret := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+		for _, ctrl := range controls {
+			input := "prefix" + ctrl + secret
+			got := RedactString(input, Options{})
+			want := "prefix" + ctrl + RedactedSecret
+			if got != want {
+				t.Fatalf("control before secret mutated boundary: got %q, want %q", got, want)
+			}
+		}
+	})
+
+	t.Run("Control immediately after complete credential", func(t *testing.T) {
+		secret := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+		for _, ctrl := range controls {
+			input := secret + ctrl + "suffix"
+			got := RedactString(input, Options{})
+			want := RedactedSecret + ctrl + "suffix"
+			if got != want {
+				t.Fatalf("control after secret mutated delimiter: got %q, want %q", got, want)
+			}
+		}
+	})
+}

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -49,13 +49,8 @@ func TestSplitRedactionHarness(t *testing.T) {
 					splitSecret := s.secret[:pos] + ctrl.char + s.secret[pos:]
 					got := RedactString(splitSecret, Options{})
 
-					// Strip controls from output and assert original secret cannot be recovered
-					strippedOutput := stripControlBytes(got)
-					if strings.Contains(strippedOutput, s.secret) {
-						t.Fatalf("split at pos %d with %s leaked secret!\n split input=%q\n got=%q\n stripped=%q", pos, ctrl.name, splitSecret, got, strippedOutput)
-					}
-					if !strings.Contains(got, RedactedSecret) {
-						t.Fatalf("split at pos %d with %s did not contain RedactedSecret!\n got=%q", pos, ctrl.name, got)
+					if got != RedactedSecret {
+						t.Fatalf("split at pos %d with %s did not equal RedactedSecret: got %q, want %q", pos, ctrl.name, got, RedactedSecret)
 					}
 				}
 			}
@@ -273,6 +268,26 @@ func TestSplitRedactionLinearScaling(t *testing.T) {
 			elapsed := time.Since(start)
 			if got != input {
 				t.Fatalf("kebab false positive was falsely redacted at size %d", size)
+			}
+			if elapsed > time.Second {
+				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)
+			}
+		}
+	})
+
+	t.Run("OpenAI kebab starting with bare sk- and repeated gaps scaling", func(t *testing.T) {
+		for _, size := range sizes {
+			var b strings.Builder
+			b.WriteString("sk-")
+			for b.Len() < size {
+				b.WriteString("\x00a-b")
+			}
+			input := b.String()
+			start := time.Now()
+			got := RedactString(input, Options{})
+			elapsed := time.Since(start)
+			if got != input {
+				t.Fatalf("kebab false positive with bare sk- prefix was falsely redacted at size %d", size)
 			}
 			if elapsed > time.Second {
 				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -116,6 +116,59 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 		}
 	})
 
+	t.Run("Two same-shape keys separated by control bytes", func(t *testing.T) {
+		keyPairs := []struct {
+			name string
+			key1 string
+			key2 string
+		}{
+			{"OpenAI", "sk-aaaaaaaaaaaaaaaaaaaabcdefgh", "sk-bbbbbbbbbbbbbbbbbbbbcdefghi"},
+			{"GitHub Fine-Grained", "ghp_123456789012345678901234567890123456", "ghp_abcdefghijklmnopqrstuvwxyz1234567890"},
+			{"GitHub PAT", "github_pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz", "github_pat_22BBBBBBB0123456789abcdefghijklmnopqrstuvwxyz"},
+			{"GitLab PAT", "glpat-12345678901234567890", "glpat-abcdefghijklmnopqrst"},
+			{"Google API", "AIzaSyD-1234567890123456789012345678901", "AIzaSyD-abcdefghijklmnopqrstuvwxyz12345"},
+			{"Slack", "xox" + "b-123456789012-abcdefghijklmno", "xox" + "b-987654321098-zyxwvutsrqponml"},
+		}
+		ctrls := []string{"\x00", "\x1b", "\x9b", "\u009b"}
+		for _, pair := range keyPairs {
+			for _, ctrl := range ctrls {
+				input := pair.key1 + ctrl + pair.key2
+				got := RedactString(input, Options{})
+				want := RedactedSecret + ctrl + RedactedSecret
+				if got != want {
+					t.Fatalf("two %s keys separated by %q mismatch: got %q, want %q", pair.name, ctrl, got, want)
+				}
+			}
+		}
+	})
+
+	t.Run("Three same-shape keys separated by control bytes", func(t *testing.T) {
+		input := "sk-aaaaaaaaaaaaaaaaaaaabcdefgh\x00sk-bbbbbbbbbbbbbbbbbbbbcdefghi\x1bsk-ccccccccccccccccccccdefghij"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + "\x00" + RedactedSecret + "\x1b" + RedactedSecret
+		if got != want {
+			t.Fatalf("three OpenAI keys mismatch: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Short sk- token before credential", func(t *testing.T) {
+		input := "sk-ab\x00sk-aaaaaaaaaaaaaaaaaaaabcdefgh"
+		got := RedactString(input, Options{})
+		want := "sk-ab\x00" + RedactedSecret
+		if got != want {
+			t.Fatalf("short sk- token before credential mismatch: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("OpenAI kebab false positive before path with digit", func(t *testing.T) {
+		input := "sk-my-awesome-kebab-project\x00v2/file.go"
+		got := RedactString(input, Options{})
+		want := "sk-my-awesome-kebab-project\x00v2/file.go"
+		if got != want {
+			t.Fatalf("kebab project before path with digit mismatch: got %q, want %q", got, want)
+		}
+	})
+
 	t.Run("Complete credential followed by invalid bytes", func(t *testing.T) {
 		cases := []struct {
 			name   string
@@ -175,4 +228,77 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestSplitRedactionLinearScaling(t *testing.T) {
+	sizes := []int{8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024, 128 * 1024, 800 * 1024}
+
+	t.Run("OpenAI kebab repeated gaps scaling", func(t *testing.T) {
+		for _, size := range sizes {
+			// Construct "sk-kebab-" + repeated "\x00a" up to size
+			var b strings.Builder
+			b.WriteString("sk-kebab-")
+			for b.Len() < size {
+				b.WriteString("\x00a")
+			}
+			input := b.String()
+			got := RedactString(input, Options{})
+			if got != input {
+				t.Fatalf("kebab false positive was falsely redacted at size %d", size)
+			}
+		}
+	})
+
+	t.Run("JWT repeated gaps scaling and correct redaction", func(t *testing.T) {
+		for _, size := range sizes {
+			// Construct "eyJ" + repeated "\x00a" + ".eyJ" + repeated "\x00b" + ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+			segLen := size / 2
+			var b strings.Builder
+			b.WriteString("eyJ")
+			for b.Len() < segLen {
+				b.WriteString("\x00a")
+			}
+			b.WriteString(".eyJ")
+			for b.Len() < size {
+				b.WriteString("\x00b")
+			}
+			b.WriteString(".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+			input := b.String()
+			got := RedactString(input, Options{})
+			if !strings.Contains(got, RedactedSecret) {
+				t.Fatalf("JWT at size %d failed to redact", size)
+			}
+		}
+	})
+}
+
+func BenchmarkRedactOpenAIKebabGaps128KB(b *testing.B) {
+	var builder strings.Builder
+	builder.WriteString("sk-kebab-")
+	for builder.Len() < 128*1024 {
+		builder.WriteString("\x00a")
+	}
+	input := builder.String()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = RedactString(input, Options{})
+	}
+}
+
+func BenchmarkRedactJWTGaps128KB(b *testing.B) {
+	var builder strings.Builder
+	builder.WriteString("eyJ")
+	for builder.Len() < 64*1024 {
+		builder.WriteString("\x00a")
+	}
+	builder.WriteString(".eyJ")
+	for builder.Len() < 128*1024 {
+		builder.WriteString("\x00b")
+	}
+	builder.WriteString(".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+	input := builder.String()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = RedactString(input, Options{})
+	}
 }

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -221,14 +221,40 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 	t.Run("Control immediately after complete credential", func(t *testing.T) {
 		secret := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
 		for _, ctrl := range controls {
-			input := secret + ctrl + "suffix"
+			input := secret + ctrl + "path/file"
 			got := RedactString(input, Options{})
-			want := RedactedSecret + ctrl + "suffix"
+			want := RedactedSecret + ctrl + "path/file"
 			if got != want {
 				t.Fatalf("control after secret mutated delimiter: got %q, want %q", got, want)
 			}
 		}
 	})
+}
+
+func TestSplitRedactionNoCredentialSuffixRemains(t *testing.T) {
+	// Regression test for splits before and after minimum length:
+	// ensure no credential suffix is leaked in either case.
+	key := "sk-abcdefghijklmnopqrstuvwxyz12345678" // minOpenAILen = 23, total = 37
+	splitBeforeMin := key[:10] + "\x00" + key[10:] // pos = 10 (< 23)
+	splitAfterMin := key[:28] + "\x00" + key[28:]  // pos = 28 (> 23)
+
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{"split before minimum length", splitBeforeMin},
+		{"split after minimum length", splitAfterMin},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactString(tc.input, Options{})
+			if got != RedactedSecret {
+				t.Fatalf("%s leaked: got %q, want %q", tc.name, got, RedactedSecret)
+			}
+			if strings.Contains(got, key[28:]) {
+				t.Fatalf("%s leaked suffix %q in %q", tc.name, key[28:], got)
+			}
+		})
+	}
 }
 
 func TestSplitRedactionLinearScaling(t *testing.T) {

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -304,6 +304,27 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 	})
 }
 
+func TestIncompletePrefixInsideValidOpenAIKey(t *testing.T) {
+	first := "sk-" + strings.Repeat("a", 24) + "123456"
+	for _, tail := range []string{"sk-proj-abcdefg", "sk-ant-abcdefgh", "github_pat_abcd", "glpat-abcdefghi", "AIzaabcdefghijk"} {
+		for _, gap := range []string{"\x00", "\x1b", "\x9b", "\u009b", "\x00\x1b\u009b"} {
+			if got := RedactString(first+gap+tail, Options{}); got != RedactedSecret {
+				t.Errorf("incomplete prefix %q after gap %q leaked: %q", tail, gap, got)
+			}
+		}
+	}
+	// A complete neighbor remains independent, with the original gap intact.
+	second := "sk-proj-" + strings.Repeat("b", 24)
+	if got, want := RedactString(first+"\x00"+second, Options{}), RedactedSecret+"\x00"+RedactedSecret; got != want {
+		t.Errorf("complete neighboring key: got %q, want %q", got, want)
+	}
+	// An incomplete prefix still separates non-secret prose from a split key.
+	prose := "sk-my-awesome-kebab-project"
+	if got, want := RedactString(prose+"\x00sk-proj-abcdefg\x00hijklmnop12345", Options{}), prose+"\x00"+RedactedSecret; got != want {
+		t.Errorf("prose before split key: got %q, want %q", got, want)
+	}
+}
+
 func TestNeighboringJWTLengths(t *testing.T) {
 	header := "eyJhbGciOiJIUzI1NiJ9"                                                                                     // gitleaks:allow -- synthetic redaction fixture
 	payloads := []string{"eyJzdWIiOiIxMjM0NTY3ODkwIn0", "eyJzdWIiOiJib2JieSIsIm5hbWUiOiJCIn0", strings.Repeat("a", 256)} // gitleaks:allow -- synthetic redaction fixture

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -224,6 +224,78 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Kebab project before OpenAI key separated by control", func(t *testing.T) {
+		// Finding 1: kebab before OpenAI key separated by control
+		input := "sk-my-awesome-kebab-project\x00sk-abcdefghijklmnopqrstuv123456"
+		got := RedactString(input, Options{})
+		want := "sk-my-awesome-kebab-project\x00" + RedactedSecret
+		if got != want {
+			t.Fatalf("kebab before key mismatch: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Neighboring complete JWTs separated by control", func(t *testing.T) {
+		// Finding 2: neighboring complete JWTs separated by control
+		jwt1 := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+		jwt2 := "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.4peTcaNQZNs4FcW3Usagee0"
+		for _, ctrl := range controls {
+			input := jwt1 + ctrl + jwt2
+			got := RedactString(input, Options{})
+			want := RedactedSecret + ctrl + RedactedSecret
+			if got != want {
+				t.Fatalf("neighboring JWTs with %q mismatch: got %q, want %q", ctrl, got, want)
+			}
+		}
+	})
+
+	t.Run("Split key before minimum followed by slash in path", func(t *testing.T) {
+		// Finding 4: split key before minimum followed by slash
+		input := "ghp_1234567890\x0012345678901234567890123456/file"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + "/file"
+		if got != want {
+			t.Fatalf("split before min then slash mismatch: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Split key with incidental incomplete prefix", func(t *testing.T) {
+		// Finding 5: split key with incidental incomplete prefix glpat-1234\x00AKIA56789012
+		input := "glpat-1234\x00AKIA56789012"
+		got := RedactString(input, Options{})
+		if got != input {
+			t.Fatalf("incomplete glpat with control and incomplete AKIA falsely redacted: got %q, want %q", got, input)
+		}
+	})
+
+	t.Run("Enclosing OpenAI key containing inner ghp suffix", func(t *testing.T) {
+		// Finding 6: enclosing OpenAI key containing inner ghp_
+		input := "sk-abcdefghijklmnop-ghp_123456789012345678901234567890123456"
+		got := RedactString(input, Options{})
+		if got != RedactedSecret {
+			t.Fatalf("enclosing key mismatch: got %q, want %q", got, RedactedSecret)
+		}
+	})
+
+	t.Run("Retain left context across boundaries", func(t *testing.T) {
+		// Finding 7: adjacent AKIA keys
+		input := "AKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAMPLE"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + RedactedSecret
+		if got != want {
+			t.Fatalf("adjacent AKIA keys mismatch: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Preserve entire terminal control run across encodings", func(t *testing.T) {
+		// Finding 8: terminal control run \x00\x1b[path/file
+		input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz\x00\x1b[path/file"
+		got := RedactString(input, Options{})
+		want := RedactedSecret + "\x00\x1b[path/file"
+		if got != want {
+			t.Fatalf("terminal control run mismatch: got %q, want %q", got, want)
+		}
+	})
 }
 
 func TestSplitRedactionNoCredentialSuffixRemains(t *testing.T) {

--- a/internal/redaction/split_harness_test.go
+++ b/internal/redaction/split_harness_test.go
@@ -1,10 +1,16 @@
 package redaction
 
 import (
+	"strconv"
 	"strings"
 	"testing"
-	"time"
 )
+
+// Construct deliberately synthetic tokens for shape matching without storing
+// credential-shaped Slack literals that GitHub push protection rejects.
+func syntheticSlackToken(digit, letter byte) string {
+	return "xoxb-" + strings.Repeat(string(digit), 12) + "-" + strings.Repeat(string(letter), 15)
+}
 
 func TestSplitRedactionHarness(t *testing.T) {
 	// Representative secrets for all supported shapes
@@ -12,17 +18,17 @@ func TestSplitRedactionHarness(t *testing.T) {
 		name   string
 		secret string
 	}{
-		{"Anthropic", "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234"},
-		{"OpenAI standard", "sk-abcdefghijklmnopqrstuvwxyz12345678"},
-		{"OpenAI with hyphen and digit", "sk-aaaaaaaaaa-bbbbbbbbb1234567890"},
-		{"OpenAI proj", "sk-proj-abcdefghijklmnopqrstuvwxyz12345"},
-		{"GitHub PAT", "github_" + "pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz"},
-		{"GitHub Fine-Grained", "ghp_" + "123456789012345678901234567890123456"},
-		{"GitLab PAT", "glpat-12345678901234567890"},
-		{"Google API", "AIzaSyD-1234567890123456789012345678901"},
-		{"Slack bot", "xoxb-123456789012-abcdefghijklmno"},
-		{"AWS AKIA", "AKIAIOSFODNN7EXAMPLE"},
-		{"JWT", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"},
+		{"Anthropic", "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234"},               // gitleaks:allow -- synthetic redaction fixture
+		{"OpenAI standard", "sk-abcdefghijklmnopqrstuvwxyz12345678"},               // gitleaks:allow -- synthetic redaction fixture
+		{"OpenAI with hyphen and digit", "sk-aaaaaaaaaa-bbbbbbbbb1234567890"},      // gitleaks:allow -- synthetic redaction fixture
+		{"OpenAI proj", "sk-proj-abcdefghijklmnopqrstuvwxyz12345"},                 // gitleaks:allow -- synthetic redaction fixture
+		{"GitHub PAT", "github_pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz"}, // gitleaks:allow -- synthetic redaction fixture
+		{"GitHub Fine-Grained", "ghp_123456789012345678901234567890123456"},        // gitleaks:allow -- synthetic redaction fixture
+		{"GitLab PAT", "glpat-12345678901234567890"},                               // gitleaks:allow -- synthetic redaction fixture
+		{"Google API", "AIzaSyD-1234567890123456789012345678901"},                  // gitleaks:allow -- synthetic redaction fixture
+		{"Slack bot", syntheticSlackToken('1', 'a')},
+		{"AWS AKIA", "AKIAIOSFODNN7EXAMPLE"}, // gitleaks:allow -- synthetic redaction fixture
+		{"JWT", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"}, // gitleaks:allow -- synthetic redaction fixture
 	}
 
 	controls := []struct {
@@ -60,7 +66,7 @@ func TestSplitRedactionHarness(t *testing.T) {
 
 func TestSplitRedactionMultiControlCases(t *testing.T) {
 	t.Run("Internal gap before minimum then terminal delimiter", func(t *testing.T) {
-		input := "sk-ant-api03-\x00abcdefghijklmnopqrstuvwxyz\x00path/file.go"
+		input := "sk-ant-api03-\x00abcdefghijklmnopqrstuvwxyz\x00path/file.go" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + "\x00path/file.go"
 		if got != want {
@@ -69,7 +75,7 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 	})
 
 	t.Run("OpenAI internal gap then terminal delimiter before kebab suffix", func(t *testing.T) {
-		input := "sk-\x00abcdefghijklmnopqrstuv\x1bkebab-case tail"
+		input := "sk-\x00abcdefghijklmnopqrstuv\x1bkebab-case tail" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + "\x1bkebab-case tail"
 		if got != want {
@@ -78,7 +84,7 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 	})
 
 	t.Run("OpenAI internal gap before digit suffix then terminal delimiter", func(t *testing.T) {
-		input := "sk-aaaaaaaaaa-bbbbbbbbb\x001234567890\x00path/one.go"
+		input := "sk-aaaaaaaaaa-bbbbbbbbb\x001234567890\x00path/one.go" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + "\x00path/one.go"
 		if got != want {
@@ -87,7 +93,7 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 	})
 
 	t.Run("JWT multiple internal gaps and terminal delimiter", func(t *testing.T) {
-		input := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\x00.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ\x1b.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\x00trailing/text"
+		input := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\x00.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ\x1b.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\x00trailing/text" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + "\x00trailing/text"
 		if got != want {
@@ -96,7 +102,7 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 	})
 
 	t.Run("Multiple internal controls in credential body", func(t *testing.T) {
-		input := "sk-ant-\x00api03-\x1babcdefghijklmnopqrstuvwxyz"
+		input := "sk-ant-\x00api03-\x1babcdefghijklmnopqrstuvwxyz" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		if got != RedactedSecret {
 			t.Fatalf("multiple internal gaps in anthropic key mismatch: got %q, want %q", got, RedactedSecret)
@@ -104,7 +110,7 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 	})
 
 	t.Run("Terminal delimiter separating two credentials", func(t *testing.T) {
-		input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz\x00ghp_123456789012345678901234567890123456"
+		input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz\x00ghp_123456789012345678901234567890123456" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + "\x00" + RedactedSecret
 		if got != want {
@@ -118,12 +124,12 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 			key1 string
 			key2 string
 		}{
-			{"OpenAI", "sk-aaaaaaaaaaaaaaaaaaaabcdefgh", "sk-bbbbbbbbbbbbbbbbbbbbcdefghi"},
-			{"GitHub Fine-Grained", "ghp_" + "123456789012345678901234567890123456", "ghp_" + "abcdefghijklmnopqrstuvwxyz1234567890"},
-			{"GitHub PAT", "github_" + "pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz", "github_" + "pat_22BBBBBBB0123456789abcdefghijklmnopqrstuvwxyz"},
-			{"GitLab PAT", "glpat-12345678901234567890", "glpat-abcdefghijklmnopqrst"},
-			{"Google API", "AIzaSyD-1234567890123456789012345678901", "AIzaSyD-abcdefghijklmnopqrstuvwxyz12345"},
-			{"Slack", "xox" + "b-123456789012-abcdefghijklmno", "xox" + "b-987654321098-zyxwvutsrqponml"},
+			{"OpenAI", "sk-aaaaaaaaaaaaaaaaaaaabcdefgh", "sk-bbbbbbbbbbbbbbbbbbbbcdefghi"},                                                         // gitleaks:allow -- synthetic redaction fixture
+			{"GitHub Fine-Grained", "ghp_123456789012345678901234567890123456", "ghp_abcdefghijklmnopqrstuvwxyz1234567890"},                        // gitleaks:allow -- synthetic redaction fixture
+			{"GitHub PAT", "github_pat_11AAAAAAA0123456789abcdefghijklmnopqrstuvwxyz", "github_pat_22BBBBBBB0123456789abcdefghijklmnopqrstuvwxyz"}, // gitleaks:allow -- synthetic redaction fixture
+			{"GitLab PAT", "glpat-12345678901234567890", "glpat-abcdefghijklmnopqrst"},                                                             // gitleaks:allow -- synthetic redaction fixture
+			{"Google API", "AIzaSyD-1234567890123456789012345678901", "AIzaSyD-abcdefghijklmnopqrstuvwxyz12345"},                                   // gitleaks:allow -- synthetic redaction fixture
+			{"Slack", syntheticSlackToken('1', 'a'), syntheticSlackToken('2', 'b')},
 		}
 		ctrls := []string{"\x00", "\x1b", "\x9b", "\u009b"}
 		for _, pair := range keyPairs {
@@ -139,7 +145,7 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 	})
 
 	t.Run("Three same-shape keys separated by control bytes", func(t *testing.T) {
-		input := "sk-aaaaaaaaaaaaaaaaaaaabcdefgh\x00sk-bbbbbbbbbbbbbbbbbbbbcdefghi\x1bsk-ccccccccccccccccccccdefghij"
+		input := "sk-aaaaaaaaaaaaaaaaaaaabcdefgh\x00sk-bbbbbbbbbbbbbbbbbbbbcdefghi\x1bsk-ccccccccccccccccccccdefghij" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + "\x00" + RedactedSecret + "\x1b" + RedactedSecret
 		if got != want {
@@ -148,18 +154,18 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 	})
 
 	t.Run("Short sk- token before credential", func(t *testing.T) {
-		input := "sk-ab\x00sk-aaaaaaaaaaaaaaaaaaaabcdefgh"
+		input := "sk-ab\x00sk-aaaaaaaaaaaaaaaaaaaabcdefgh" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
-		want := "sk-ab\x00" + RedactedSecret
+		want := "sk-ab\x00" + RedactedSecret // gitleaks:allow -- synthetic redaction fixture
 		if got != want {
 			t.Fatalf("short sk- token before credential mismatch: got %q, want %q", got, want)
 		}
 	})
 
 	t.Run("OpenAI kebab false positive before path with digit", func(t *testing.T) {
-		input := "sk-my-awesome-kebab-project\x00v2/file.go"
+		input := "sk-my-awesome-kebab-project\x00v2/file.go" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
-		want := "sk-my-awesome-kebab-project\x00v2/file.go"
+		want := "sk-my-awesome-kebab-project\x00v2/file.go" // gitleaks:allow -- synthetic redaction fixture
 		if got != want {
 			t.Fatalf("kebab project before path with digit mismatch: got %q, want %q", got, want)
 		}
@@ -176,7 +182,7 @@ func TestSplitRedactionMultiControlCases(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz" + tc.suffix
+				input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz" + tc.suffix // gitleaks:allow -- synthetic redaction fixture
 				got := RedactString(input, Options{})
 				want := RedactedSecret + tc.suffix
 				if got != want {
@@ -191,7 +197,7 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 	controls := []string{"\x00", "\x1b", "\x9b", "\u009b"}
 
 	t.Run("OpenAI kebab false positive with control", func(t *testing.T) {
-		kebab := "sk-my-awesome-kebab-project"
+		kebab := "sk-my-awesome-kebab-project" // gitleaks:allow -- synthetic redaction fixture
 		for _, ctrl := range controls {
 			input := kebab[:10] + ctrl + kebab[10:]
 			got := RedactString(input, Options{})
@@ -202,7 +208,7 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 	})
 
 	t.Run("Control immediately before complete credential", func(t *testing.T) {
-		secret := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+		secret := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz" // gitleaks:allow -- synthetic redaction fixture
 		for _, ctrl := range controls {
 			input := "prefix" + ctrl + secret
 			got := RedactString(input, Options{})
@@ -214,7 +220,7 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 	})
 
 	t.Run("Control immediately after complete credential", func(t *testing.T) {
-		secret := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+		secret := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz" // gitleaks:allow -- synthetic redaction fixture
 		for _, ctrl := range controls {
 			input := secret + ctrl + "path/file"
 			got := RedactString(input, Options{})
@@ -227,9 +233,9 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 
 	t.Run("Kebab project before OpenAI key separated by control", func(t *testing.T) {
 		// Finding 1: kebab before OpenAI key separated by control
-		input := "sk-my-awesome-kebab-project\x00sk-abcdefghijklmnopqrstuv123456"
+		input := "sk-my-awesome-kebab-project\x00sk-abcdefghijklmnopqrstuv123456" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
-		want := "sk-my-awesome-kebab-project\x00" + RedactedSecret
+		want := "sk-my-awesome-kebab-project\x00" + RedactedSecret // gitleaks:allow -- synthetic redaction fixture
 		if got != want {
 			t.Fatalf("kebab before key mismatch: got %q, want %q", got, want)
 		}
@@ -237,8 +243,8 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 
 	t.Run("Neighboring complete JWTs separated by control", func(t *testing.T) {
 		// Finding 2: neighboring complete JWTs separated by control
-		jwt1 := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-		jwt2 := "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.4peTcaNQZNs4FcW3Usagee0"
+		jwt1 := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" // gitleaks:allow -- synthetic redaction fixture
+		jwt2 := "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.4peTcaNQZNs4FcW3Usagee0"                                                                                    // gitleaks:allow -- synthetic redaction fixture
 		for _, ctrl := range controls {
 			input := jwt1 + ctrl + jwt2
 			got := RedactString(input, Options{})
@@ -251,7 +257,7 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 
 	t.Run("Split key before minimum followed by slash in path", func(t *testing.T) {
 		// Finding 4: split key before minimum followed by slash
-		input := "ghp_1234567890\x0012345678901234567890123456/file"
+		input := "ghp_1234567890\x0012345678901234567890123456/file" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + "/file"
 		if got != want {
@@ -261,7 +267,7 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 
 	t.Run("Split key with incidental incomplete prefix", func(t *testing.T) {
 		// Finding 5: split key with incidental incomplete prefix glpat-1234\x00AKIA56789012
-		input := "glpat-1234\x00AKIA56789012"
+		input := "glpat-1234\x00AKIA56789012" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		if got != input {
 			t.Fatalf("incomplete glpat with control and incomplete AKIA falsely redacted: got %q, want %q", got, input)
@@ -270,7 +276,7 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 
 	t.Run("Enclosing OpenAI key containing inner ghp suffix", func(t *testing.T) {
 		// Finding 6: enclosing OpenAI key containing inner ghp_
-		input := "sk-abcdefghijklmnop-ghp_123456789012345678901234567890123456"
+		input := "sk-abcdefghijklmnop-ghp_123456789012345678901234567890123456" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		if got != RedactedSecret {
 			t.Fatalf("enclosing key mismatch: got %q, want %q", got, RedactedSecret)
@@ -279,7 +285,7 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 
 	t.Run("Retain left context across boundaries", func(t *testing.T) {
 		// Finding 7: adjacent AKIA keys
-		input := "AKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAMPLE"
+		input := "AKIAIOSFODNN7EXAMPLEAKIAIOSFODNN7EXAMPLE" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + RedactedSecret
 		if got != want {
@@ -289,7 +295,7 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 
 	t.Run("Preserve entire terminal control run across encodings", func(t *testing.T) {
 		// Finding 8: terminal control run \x00\x1b[path/file
-		input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz\x00\x1b[path/file"
+		input := "sk-ant-api03-abcdefghijklmnopqrstuvwxyz\x00\x1b[path/file" // gitleaks:allow -- synthetic redaction fixture
 		got := RedactString(input, Options{})
 		want := RedactedSecret + "\x00\x1b[path/file"
 		if got != want {
@@ -298,10 +304,26 @@ func TestSplitRedactionNegativeCases(t *testing.T) {
 	})
 }
 
+func TestNeighboringJWTLengths(t *testing.T) {
+	header := "eyJhbGciOiJIUzI1NiJ9"                                                                                     // gitleaks:allow -- synthetic redaction fixture
+	payloads := []string{"eyJzdWIiOiIxMjM0NTY3ODkwIn0", "eyJzdWIiOiJib2JieSIsIm5hbWUiOiJCIn0", strings.Repeat("a", 256)} // gitleaks:allow -- synthetic redaction fixture
+	for _, firstPayload := range payloads {
+		for _, secondPayload := range payloads {
+			a := header + "." + firstPayload + ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+			b := header + "." + secondPayload + ".Qm9iYnlTaWduYXR1cmVCQkJCQkJCQkJCQg"
+			for _, gap := range []string{"\x00", "\x1b", "\x9b", "\u009b", "\x00\x1b\u009b"} {
+				if got, want := RedactString(a+gap+b, Options{}), RedactedSecret+gap+RedactedSecret; got != want {
+					t.Errorf("payload lengths %d/%d, gap %q: got %q, want %q", len(firstPayload), len(secondPayload), gap, got, want)
+				}
+			}
+		}
+	}
+}
+
 func TestSplitRedactionNoCredentialSuffixRemains(t *testing.T) {
 	// Regression test for splits before and after minimum length:
 	// ensure no credential suffix is leaked in either case.
-	key := "sk-abcdefghijklmnopqrstuvwxyz12345678" // minOpenAILen = 23, total = 37
+	key := "sk-abcdefghijklmnopqrstuvwxyz12345678" // minOpenAILen = 23, total = 37 // gitleaks:allow -- synthetic redaction fixture
 	splitBeforeMin := key[:10] + "\x00" + key[10:] // pos = 10 (< 23)
 	splitAfterMin := key[:28] + "\x00" + key[28:]  // pos = 28 (> 23)
 
@@ -324,25 +346,20 @@ func TestSplitRedactionNoCredentialSuffixRemains(t *testing.T) {
 	}
 }
 
-func TestSplitRedactionLinearScaling(t *testing.T) {
+func TestSplitRedactionLargeInputs(t *testing.T) {
 	sizes := []int{8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024, 128 * 1024}
 
 	t.Run("OpenAI kebab repeated gaps scaling", func(t *testing.T) {
 		for _, size := range sizes {
 			var b strings.Builder
-			b.WriteString("sk-kebab-")
+			b.WriteString("sk-kebab-") // gitleaks:allow -- synthetic redaction fixture
 			for b.Len() < size {
 				b.WriteString("\x00a")
 			}
 			input := b.String()
-			start := time.Now()
 			got := RedactString(input, Options{})
-			elapsed := time.Since(start)
 			if got != input {
 				t.Fatalf("kebab false positive was falsely redacted at size %d", size)
-			}
-			if elapsed > time.Second {
-				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)
 			}
 		}
 	})
@@ -350,19 +367,14 @@ func TestSplitRedactionLinearScaling(t *testing.T) {
 	t.Run("OpenAI kebab starting with bare sk- and repeated gaps scaling", func(t *testing.T) {
 		for _, size := range sizes {
 			var b strings.Builder
-			b.WriteString("sk-")
+			b.WriteString("sk-") // gitleaks:allow -- synthetic redaction fixture
 			for b.Len() < size {
 				b.WriteString("\x00a-b")
 			}
 			input := b.String()
-			start := time.Now()
 			got := RedactString(input, Options{})
-			elapsed := time.Since(start)
 			if got != input {
 				t.Fatalf("kebab false positive with bare sk- prefix was falsely redacted at size %d", size)
-			}
-			if elapsed > time.Second {
-				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)
 			}
 		}
 	})
@@ -371,7 +383,7 @@ func TestSplitRedactionLinearScaling(t *testing.T) {
 		for _, size := range sizes {
 			segLen := size / 2
 			var b strings.Builder
-			b.WriteString("eyJ")
+			b.WriteString("eyJ") // gitleaks:allow -- synthetic redaction fixture
 			for b.Len() < segLen {
 				b.WriteString("\x00a")
 			}
@@ -381,14 +393,9 @@ func TestSplitRedactionLinearScaling(t *testing.T) {
 			}
 			b.WriteString(".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
 			input := b.String()
-			start := time.Now()
 			got := RedactString(input, Options{})
-			elapsed := time.Since(start)
 			if !strings.Contains(got, RedactedSecret) {
 				t.Fatalf("JWT at size %d failed to redact", size)
-			}
-			if elapsed > time.Second {
-				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)
 			}
 		}
 	})
@@ -396,19 +403,14 @@ func TestSplitRedactionLinearScaling(t *testing.T) {
 	t.Run("Anthropic repeated gaps scaling and correct redaction", func(t *testing.T) {
 		for _, size := range sizes {
 			var b strings.Builder
-			b.WriteString("sk-ant-api03-abcdefghijklmnopqrstuvwxyz")
+			b.WriteString("sk-ant-api03-abcdefghijklmnopqrstuvwxyz") // gitleaks:allow -- synthetic redaction fixture
 			for b.Len() < size {
 				b.WriteString("\x00a")
 			}
 			input := b.String()
-			start := time.Now()
 			got := RedactString(input, Options{})
-			elapsed := time.Since(start)
 			if got != RedactedSecret {
 				t.Fatalf("Anthropic at size %d failed to redact: got %q, want %q", size, got, RedactedSecret)
-			}
-			if elapsed > time.Second {
-				t.Fatalf("redaction of size %d took %v, exceeding linear threshold of 1s", size, elapsed)
 			}
 		}
 	})
@@ -416,7 +418,7 @@ func TestSplitRedactionLinearScaling(t *testing.T) {
 
 func BenchmarkRedactJWTGaps800KB(b *testing.B) {
 	var builder strings.Builder
-	builder.WriteString("eyJ")
+	builder.WriteString("eyJ") // gitleaks:allow -- synthetic redaction fixture
 	for builder.Len() < 400*1024 {
 		builder.WriteString("\x00a")
 	}
@@ -434,7 +436,7 @@ func BenchmarkRedactJWTGaps800KB(b *testing.B) {
 
 func BenchmarkRedactOpenAIKebabGaps128KB(b *testing.B) {
 	var builder strings.Builder
-	builder.WriteString("sk-kebab-")
+	builder.WriteString("sk-kebab-") // gitleaks:allow -- synthetic redaction fixture
 	for builder.Len() < 128*1024 {
 		builder.WriteString("\x00a")
 	}
@@ -447,7 +449,7 @@ func BenchmarkRedactOpenAIKebabGaps128KB(b *testing.B) {
 
 func BenchmarkRedactJWTGaps128KB(b *testing.B) {
 	var builder strings.Builder
-	builder.WriteString("eyJ")
+	builder.WriteString("eyJ") // gitleaks:allow -- synthetic redaction fixture
 	for builder.Len() < 64*1024 {
 		builder.WriteString("\x00a")
 	}
@@ -460,5 +462,25 @@ func BenchmarkRedactJWTGaps128KB(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = RedactString(input, Options{})
+	}
+}
+
+// Keep runtime measurements out of correctness tests: race instrumentation and
+// shared CI runners make absolute wall-clock deadlines unreliable.
+func BenchmarkSplitRedactionScaling(b *testing.B) {
+	for _, size := range []int{8 << 10, 32 << 10, 128 << 10} {
+		inputs := map[string]string{
+			"anthropic":       "sk-ant-api03-" + strings.Repeat("a", 20) + strings.Repeat("\x00a", size/2),
+			"neighboringJWTs": strings.Repeat("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJib2JieSIsIm5hbWUiOiJCIn0.Qm9iYnlTaWduYXR1cmVCQkJCQkJCQkJCQg\x00", size/90), // gitleaks:allow -- synthetic redaction fixture
+		}
+		for name, input := range inputs {
+			b.Run(name+"/"+strconv.Itoa(size), func(b *testing.B) {
+				b.SetBytes(int64(len(input)))
+				b.ReportAllocs()
+				for b.Loop() {
+					_ = RedactString(input, Options{})
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
Fixes #969

## Summary

Redact credentials split by C0/C1 control bytes while preserving surrounding original text and separators. Inputs without secrets remain byte-for-byte unchanged.

## Changes

- Match across control-byte gaps while mapping redactions back to the original input. Preserve surrounding control characters, valid UTF-8, whitespace, delimiters, and suffixes.
- Recognize an independent neighboring JWT using the complete token so longer payloads and signatures are also redacted. Cover unequal JWT lengths separated by NUL, ESC, raw C1, UTF-8 C1, and mixed controls.
- Keep incomplete known prefixes inside an already-valid candidate so a suffix cannot escape redaction. Preserve genuinely complete neighboring credentials and non-secret prose before split keys.
- Treat adjacent C0, raw C1, and UTF-8 C1 spans as one gap before classifying the following token.
- Keep gap processing scalable and replace absolute one-second test deadlines with correctness assertions and scaling benchmarks.
- Preserve the accepted pattern boundaries and token minimums, including the 20-character GitLab token body minimum.
- Annotate synthetic credential fixtures with line-specific `gitleaks:allow` comments and construct synthetic Slack fixtures at runtime to avoid committing token-shaped literals.

## Test plan

Completed with Go 1.26.6:

- `make fmt-check`, `go vet ./...`, and full Linux `go test ./...`.
- `go run ./cmd/zero-release build` and `go run ./cmd/zero-release smoke`.
- Pinned golangci-lint v2.12.2: zero issues. Pinned govulncheck v1.3.0: no vulnerabilities.
- Linux race tests for `internal/redaction` and `git diff HEAD --check`.
- Unequal-length neighboring-JWT regressions run against both versions: the original code leaked the second JWT's payload and signature; the fixed code redacts both credentials and preserves their separator.

The incomplete-prefix regression failed on the previous head with `incomplete prefix ... leaked`. It covers five credential prefixes across NUL, ESC, raw C1, UTF-8 C1, and mixed controls, plus complete neighbors and non-secret prose. Full validation and race tests passed with the final fix.

## Prior reviewer feedback addressed

Addresses the applicable feedback from #978 and this PR: preserve original bytes outside redacted spans, bound gap-processing costs, annotate synthetic secrets, remove flaky wall-clock assertions, and close the unequal-length neighboring-JWT leak, and prevent incomplete known prefixes from exposing a valid candidate's suffix. Matching retains the agreed control-character scope, leaving tab, LF, CR, and Unicode format characters outside the gap-removal rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Secret redaction now detects credentials interrupted by control characters, including NUL, ESC, and C1 bytes.
  - Split and adjacent credentials are redacted independently without altering surrounding control characters or valid text.
  - Improved boundary handling reduces false positives involving short tokens, malformed suffixes, incomplete prefixes, and similar-looking text.
  - GitLab token matching now requires at least 20 body characters.
  - Inputs without secrets remain byte-for-byte unchanged.
  - Preserves allowed whitespace, UTF-8 content, delimiters, and suffixes during redaction.

- **Performance**
  - Redaction remains efficient when processing large inputs with repeated control-character gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
