### PR TITLE
test(cli): skip the serve-scope symlink test when the platform refuses the link

### DIFF
--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -168,11 +168,18 @@ func TestBuildServeScopeKeepsLexicalPaths(t *testing.T) {
 	}
 	linkWorkspace := filepath.Join(base, "link-workspace")
 	linkExtra := filepath.Join(base, "link-extra")
+	// SKIPPED, NOT FAILED, WHEN THE PLATFORM WILL NOT MAKE THE LINK. Creating a
+	// symlink on Windows needs SeCreateSymbolicLinkPrivilege, which an ordinary
+	// developer account does not hold, so this reported a failure with nothing
+	// wrong in the code: "A required privilege is not held by the client". CI
+	// runners are elevated, so it only ever showed up locally, where it cost a
+	// round of triage before being ruled environmental. The sibling tests that
+	// need a link already answer this way.
 	if err := os.Symlink(realWorkspace, linkWorkspace); err != nil {
-		t.Fatal(err)
+		t.Skipf("symlink unavailable: %v", err)
 	}
 	if err := os.Symlink(realExtra, linkExtra); err != nil {
-		t.Fatal(err)
+		t.Skipf("symlink unavailable: %v", err)
 	}
 
 	scope, err := buildServeScope(linkWorkspace, []string{linkExtra})


### PR DESCRIPTION
Closes #1021.

`os.Symlink` on Windows needs `SeCreateSymbolicLinkPrivilege`, which an ordinary developer account does not hold. `TestBuildServeScopeKeepsLexicalPaths` called it and treated the refusal as a test failure, so on a stock Windows machine the package reported:

```
serve_test.go:172: symlink ...\real-workspace ...\link-workspace: A required privilege is not held by the client.
--- FAIL: TestBuildServeScopeKeepsLexicalPaths
```

with nothing wrong in the code. CI runners are elevated, so it never showed there. It cost a round of triage on #1003 before being ruled environmental, and it has been the only failure in `internal/cli` on my machine all week; the package is green with this.

The fix is the answer the rest of the repo already gives: skip when the platform will not make the link. Both other symlink tests in this package do exactly that, as do the ones in `internal/agent`, `internal/pathjail`, `internal/plugins`, `internal/repomap`, `internal/sandbox` and others.

I swept the remaining `os.Symlink`-then-`t.Fatal` sites rather than assuming this was the only one, and ran them:

- `internal/release` passes here.
- The one in `internal/agent/freeform_tool_test.go` is never reached on this box.
- `internal/peermsg/private_dir_unix_test.go` and `transport_unix_test.go` are unix-only files, where the call cannot fail this way.
- `internal/installtest` and `internal/npmwrapper` build node package layouts rather than exercising link semantics.

So this was the outlier, and the change stays to the one test.

A skip is the honest answer here specifically because the missing privilege is an environmental prerequisite the fixture does not control and cannot arrange. It is not a fixture-controlled condition being skipped past, which would hide a real failure. Restoring the `t.Fatal` reproduces the failure above on an unelevated account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated symlink-related test setup to skip gracefully when the required symlinks cannot be created, avoiding failures in unsupported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->