### PR TITLE
feat(exec): default headless runs to the turn-budget ceiling

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -49,6 +49,14 @@ const (
 	exitInterrupted = 130
 )
 
+// defaultExecMaxTurns is the headless tool-turn budget when no source sets one.
+// An interactive run can be continued past the shared interactive default by the
+// user; an exec run has nobody to unstick it, so evals and automation would
+// truncate mid-task at 80 turns. The ceiling is the already-justified bound —
+// still finite against a genuinely runaway loop, which the loop's empty-turn
+// guard also cuts independently of this budget.
+const defaultExecMaxTurns = config.MaxTurnsCeiling
+
 type execOutputFormat string
 type execInputFormat string
 
@@ -319,6 +327,15 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			}
 		}
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
+	}
+	// A headless run has no interactive user to continue past the shared
+	// interactive turn default, so an unconfigured budget starts at the
+	// documented ceiling instead of truncating mid-task. Explicit sources
+	// (--max-turns, mode presets, ZERO_MAX_TURNS, config files) resolved as
+	// MaxTurnsSet and keep their value; an exec-profile budget still wins via
+	// applyProfileTurnBudget below.
+	if !resolved.MaxTurnsSet {
+		resolved.MaxTurns = defaultExecMaxTurns
 	}
 	var displacedMaxTurns int
 	resolved.MaxTurns, displacedMaxTurns = applyProfileTurnBudget(execProfile, options.maxTurns, resolved.MaxTurns)

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -328,15 +328,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		}
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
 	}
-	// A headless run has no interactive user to continue past the shared
-	// interactive turn default, so an unconfigured budget starts at the
-	// documented ceiling instead of truncating mid-task. Explicit sources
-	// (--max-turns, mode presets, ZERO_MAX_TURNS, config files) resolved as
-	// MaxTurnsSet and keep their value; an exec-profile budget still wins via
-	// applyProfileTurnBudget below.
-	if !resolved.MaxTurnsSet {
-		resolved.MaxTurns = defaultExecMaxTurns
-	}
+	resolved.MaxTurns = execTurnBudget(resolved)
 	var displacedMaxTurns int
 	resolved.MaxTurns, displacedMaxTurns = applyProfileTurnBudget(execProfile, options.maxTurns, resolved.MaxTurns)
 	execScope, err := sandbox.NewScope(workspaceRoot, append(append([]string{}, resolved.Sandbox.AdditionalWriteRoots...), options.addDirs...))
@@ -1237,6 +1229,20 @@ func applyExecProfile(options *execOptions) (execprofile.Profile, bool, error) {
 // there: escalation must never clear an effort the user pinned by hand.
 func specProfileEffortFilled(effortFilled bool, specReasoningEffort string) bool {
 	return effortFilled && strings.TrimSpace(specReasoningEffort) == ""
+}
+
+// execTurnBudget applies the headless default to the resolved turn budget: an
+// interactive run can be continued past the shared default by the user, but an
+// exec run has nobody to unstick it, so an unconfigured budget starts at the
+// documented ceiling instead of truncating mid-task. Explicit sources
+// (--max-turns, mode presets, ZERO_MAX_TURNS, config files) resolve as
+// MaxTurnsSet and pass through; an exec-profile budget still wins via
+// applyProfileTurnBudget afterward.
+func execTurnBudget(resolved config.ResolvedConfig) int {
+	if resolved.MaxTurnsSet {
+		return resolved.MaxTurns
+	}
+	return defaultExecMaxTurns
 }
 
 // applyProfileTurnBudget decides the run's turn budget once config is resolved.

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1975,3 +1975,23 @@ func TestRunExecTopTierDeclineNoSwitch(t *testing.T) {
 		t.Fatalf("provider model = %q, want claude-opus-4.1", providerModels[0])
 	}
 }
+
+func TestExecTurnBudgetDefaultsToCeilingUnlessSet(t *testing.T) {
+	cases := []struct {
+		name     string
+		resolved config.ResolvedConfig
+		want     int
+	}{
+		// A headless run has no user to continue past the shared interactive
+		// default, so an unconfigured budget starts at the ceiling.
+		{"unconfigured default", config.ResolvedConfig{MaxTurns: 80, MaxTurnsSet: false}, config.MaxTurnsCeiling},
+		// A user who configured 80 on purpose (e.g. cost control in CI) keeps 80.
+		{"explicit default value", config.ResolvedConfig{MaxTurns: 80, MaxTurnsSet: true}, 80},
+		{"configured value passes through", config.ResolvedConfig{MaxTurns: 42, MaxTurnsSet: true}, 42},
+	}
+	for _, tc := range cases {
+		if got := execTurnBudget(tc.resolved); got != tc.want {
+			t.Fatalf("%s: execTurnBudget = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -166,6 +166,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		Providers:           providers,
 		Provider:            active,
 		MaxTurns:            cfg.MaxTurns,
+		MaxTurnsSet:         cfg.maxTurnsSet,
 		MCP:                 cfg.MCP,
 		Sandbox:             cfg.Sandbox,
 		Notify:              cfg.Notify,
@@ -234,6 +235,7 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	}
 	if src.MaxTurns > 0 {
 		dst.MaxTurns = src.MaxTurns
+		dst.maxTurnsSet = true
 	}
 	for _, provider := range src.Providers {
 		mergeProvider(dst, provider)
@@ -294,6 +296,7 @@ func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
 	}
 	if src.MaxTurns > 0 {
 		dst.MaxTurns = src.MaxTurns
+		dst.maxTurnsSet = true
 	}
 	for _, provider := range src.Providers {
 		candidate := providerMergeCandidate(*dst, provider)
@@ -606,6 +609,7 @@ func applyEnv(cfg *FileConfig, env map[string]string) {
 				n = MaxTurnsCeiling
 			}
 			cfg.MaxTurns = n
+			cfg.maxTurnsSet = true
 		}
 	}
 
@@ -726,6 +730,7 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 	}
 	if overrides.MaxTurns > 0 {
 		cfg.MaxTurns = overrides.MaxTurns
+		cfg.maxTurnsSet = true
 	}
 	if overrides.Sandbox.Enabled != nil {
 		cfg.Sandbox.Enabled = overrides.Sandbox.Enabled

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -2252,3 +2252,45 @@ func TestResolveRejectsInvalidCrossSessionInbound(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestResolveReportsExplicitMaxTurns(t *testing.T) {
+	const providerJSON = `{
+		"activeProvider": "p",
+		"providers": [{"name": "p", "provider_kind": "openai-compatible", "base_url": "https://x.example/v1", "apiKey": "k", "model": "m"}]
+	}`
+	providerWithTurns := strings.Replace(providerJSON, `"activeProvider": "p"`, `"activeProvider": "p", "maxTurns": 40`, 1)
+
+	cases := []struct {
+		name string
+		opts ResolveOptions
+		set  bool
+	}{
+		{"built-in default only", ResolveOptions{
+			Overrides: Overrides{Provider: ProviderProfile{Name: "p", ProviderKind: "openai-compatible", BaseURL: "https://x.example/v1", APIKey: "k", Model: "m"}},
+		}, false},
+		{"user config", ResolveOptions{UserConfigPath: writeConfig(t, providerWithTurns)}, true},
+		{"project config", ResolveOptions{
+			UserConfigPath:    writeConfig(t, providerJSON),
+			ProjectConfigPath: writeConfig(t, `{"maxTurns": 40}`),
+		}, true},
+		{"env", ResolveOptions{
+			Env:       map[string]string{MaxTurnsEnv: "120"},
+			Overrides: Overrides{Provider: ProviderProfile{Name: "p", ProviderKind: "openai-compatible", BaseURL: "https://x.example/v1", APIKey: "k", Model: "m"}},
+		}, true},
+		{"cli override", ResolveOptions{
+			Overrides: Overrides{
+				MaxTurns: 42,
+				Provider: ProviderProfile{Name: "p", ProviderKind: "openai-compatible", BaseURL: "https://x.example/v1", APIKey: "k", Model: "m"},
+			},
+		}, true},
+	}
+	for _, tc := range cases {
+		resolved, err := Resolve(tc.opts)
+		if err != nil {
+			t.Fatalf("%s: Resolve() error = %v", tc.name, err)
+		}
+		if resolved.MaxTurnsSet != tc.set {
+			t.Fatalf("%s: MaxTurnsSet = %v, want %v (MaxTurns=%d)", tc.name, resolved.MaxTurnsSet, tc.set, resolved.MaxTurns)
+		}
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -465,10 +465,10 @@ type Overrides struct {
 }
 
 type ResolvedConfig struct {
-	ActiveProvider      string
-	Providers           []ProviderProfile
-	Provider            ProviderProfile
-	MaxTurns            int
+	ActiveProvider string
+	Providers      []ProviderProfile
+	Provider       ProviderProfile
+	MaxTurns       int
 	// MaxTurnsSet reports whether MaxTurns came from an explicit source (a
 	// config file, a provider command, ZERO_MAX_TURNS, or CLI overrides) rather
 	// than the built-in default — callers that need a different default can

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -364,6 +364,10 @@ type FileConfig struct {
 	LocalControl        LocalControlConfig `json:"localControl,omitempty"`
 	STT                 STTConfig          `json:"stt,omitempty"`
 	CrossSessionInbound string             `json:"crossSessionInbound,omitempty"`
+	// maxTurnsSet records that some merge source supplied a positive maxTurns —
+	// i.e. the value is configured, not the built-in default. Unexported like
+	// Tools.deferThresholdSet: merge bookkeeping, not a config key.
+	maxTurnsSet bool
 	// Extra preserves top-level fields written by newer Zero versions or
 	// extensions so a read-modify-write through this version is non-destructive.
 	Extra map[string]json.RawMessage `json:"-"`
@@ -465,6 +469,11 @@ type ResolvedConfig struct {
 	Providers           []ProviderProfile
 	Provider            ProviderProfile
 	MaxTurns            int
+	// MaxTurnsSet reports whether MaxTurns came from an explicit source (a
+	// config file, a provider command, ZERO_MAX_TURNS, or CLI overrides) rather
+	// than the built-in default — callers that need a different default can
+	// tell the two apart.
+	MaxTurnsSet         bool
 	MCP                 MCPConfig
 	Sandbox             SandboxConfig
 	Notify              NotifyConfig


### PR DESCRIPTION
## Summary

`defaultMaxTurns` (80) is a shared tool-turn budget for the TUI and headless `zero exec`. It is sized for the TUI, where hitting it is a pause — the user says "continue" and the run resumes. A headless run has nobody to do that: running long deepswe-style benchmark tasks, runs stopped mid-implementation at 80 turns with a "remaining work" summary instead of finishing.

This change gives exec a headless-aware default only:

- `ResolvedConfig.MaxTurnsSet` now reports whether the turn budget came from an explicit source — a config file, a provider command, `ZERO_MAX_TURNS`, or CLI overrides — vs the built-in default. The flag is recorded at each merge gate so "user configured 80" and "nobody set it" are distinguishable.
- In `zero exec`, an unconfigured budget resolves to `MaxTurnsCeiling` (500) — effectively "finish the task" while still bounding a genuinely runaway loop (the empty-turn runaway guard applies independently). Every explicit source keeps its value, and exec-profile budgets still win via `applyProfileTurnBudget`.
- The TUI path is untouched: interactive sessions still default to 80.

#### Test plan

- [x] `TestResolveReportsExplicitMaxTurns` — user config, project config, `ZERO_MAX_TURNS`, CLI override all mark the budget set; bare resolve does not
- [x] `TestExecTurnBudgetDefaultsToCeilingUnlessSet` — unset resolves to the ceiling; explicit 80 and other values pass through
- [x] `go test ./internal/cli ./internal/config` and full `go test ./...` green
- [x] `make fmt-check`, `go vet`, `git diff --check`, release build + smoke, `make vulncheck` green
- [ ] `make lint-static` — 4 pre-existing advisory findings in unrelated files (installtest, proxydial, web_fetch); none from this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Exec runs now default to the configured maximum turn budget when no limit is explicitly set.
  - Explicit turn limits from command-line options, presets, environment variables, or configuration files continue to take precedence.
  - Exec profile-specific turn budgets continue to override the default when applicable.

- **Tests**
  - Added coverage verifying default and explicitly configured turn-budget behavior across supported configuration sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->