### PR TITLE
ci: run the action-summary test suite in zero-action-smoke

### DIFF
--- a/.github/workflows/zero-action-smoke.yml
+++ b/.github/workflows/zero-action-smoke.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - action.yml
       - docs/GITHUB_ACTION.md
+      - scripts/action-summary.mjs
+      - scripts/action-summary.test.mjs
       - .github/workflows/zero-action-smoke.yml
   push:
     branches:
@@ -12,6 +14,8 @@ on:
     paths:
       - action.yml
       - docs/GITHUB_ACTION.md
+      - scripts/action-summary.mjs
+      - scripts/action-summary.test.mjs
       - .github/workflows/zero-action-smoke.yml
 
 permissions:
@@ -26,6 +30,14 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
+      - name: Run action-summary test suite
+        run: node --test scripts/action-summary.test.mjs
 
       - name: Parse action.yml and assert documented inputs
         shell: bash


### PR DESCRIPTION
## Summary

`scripts/action-summary.mjs` is invoked by the composite action in `action.yml` on every action run and ships with a 12-test suite in `scripts/action-summary.test.mjs`, but neither `.github/workflows/zero-action-smoke.yml` nor the main `ci.yml` (Go-only pipeline) ever executes that suite, and the action-smoke workflow's `paths` filters didn't even include those two script files. A change limited to the helper or its tests triggered no CI job at all.

This adds `scripts/action-summary.mjs` and `scripts/action-summary.test.mjs` to both the `pull_request` and `push` `paths` filters in `zero-action-smoke.yml`, and adds a `Setup Node` + `node --test scripts/action-summary.test.mjs` step to the validate job, ahead of the existing `action.yml` validation steps.

## Linked issue

Fixes #1030

## Checklist

- [x] The linked issue already has the `issue-approved` label.
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally. (Not applicable to this change — it only touches a GitHub Actions workflow file, no Go code.)
- [x] `gofmt` clean. (Not applicable — no Go files changed.)
- [x] Tests added/updated for the change (and run under `-race` where relevant). (No new tests added; wired the existing 12-test `scripts/action-summary.test.mjs` suite into CI as requested by the issue. Ran `node --test scripts/action-summary.test.mjs` locally: 12/12 pass. Verified the gate works by breaking an assertion in a scratch copy and confirming `node --test` fails with a non-zero exit.)
- [ ] UI changes include screenshots or a short recording where possible. (Not applicable — no UI changes.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated smoke testing to run the action’s test suite alongside existing validation checks.
  * Added coverage for relevant changes submitted through pull requests and updates to the main branch.
* **Chores**
  * Updated the testing environment to use Node.js 24, improving consistency in automated verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->